### PR TITLE
Feature/check for archive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,4 @@ dmypy.json
 __pycache__/
 cache/
 output/
+.DS_Store

--- a/examples/helpers.py
+++ b/examples/helpers.py
@@ -29,8 +29,19 @@ def download_zenodo_data(
     record_id: str, output_dir: Path, filenames: Collection[str] | None = None, *, cache_overwrite: bool = False
 ) -> None:
     output_dir.mkdir(parents=True, exist_ok=True)
-    r = requests.get(f"https://zenodo.org/api/records/{record_id}", timeout=10)
-    r.raise_for_status()
+    try:
+        r = requests.get(f"https://zenodo.org/api/records/{record_id}", timeout=10)
+        r.raise_for_status()
+
+    # Catch all exceptions
+    except Exception as e:
+        logger.info(f"Failed to download Zenodo record {record_id}. Error: {e}")
+
+        if (output_dir / "SMARTEOLE-WFC-open-dataset.zip").exists():
+            logger.info("Using cached dataset.")
+            return
+
+        raise
 
     files_to_download = r.json()["files"]
     if filenames is not None:


### PR DESCRIPTION
Hi @aclerc, I'm just getting familiarized with wind-up and as one learning activity I wanted to try submitting a PR activity from my fork.  Feel free to reject the change though, the main thing this code does is allow the examples to proceed in the event the user can't connect to zenodo (it is blocked by our firewall), if the file is already located in the CACHE folder.

Then a much smaller change, I added DS_Store to the list of files to ignore (some kind of mac temp file)