### PR TITLE
fix exception when gen_df is empty

### DIFF
--- a/wind_up/plots/scada_funcs_plots.py
+++ b/wind_up/plots/scada_funcs_plots.py
@@ -187,6 +187,8 @@ def plot_ops_curve_timelines_one_wtg(wtg_df: pd.DataFrame, wtg_name: str, title_
         ]
     )
     gen_df = dropna_df[dropna_df[DataColumns.active_power_mean] > 0].copy()
+    if gen_df.empty:
+        return
 
     for descr, x_var, y_var, x_bin_width in [
         ("power curve", DataColumns.wind_speed_mean, DataColumns.active_power_mean, 1),


### PR DESCRIPTION
I was re-running an old analysis today where one turbine in the wind farm has no data at all due to long-term downtime. plot_ops_curve_timelines_one_wtg hits an exception in this case. This PR fixes the problem by skipping the plots if the dataframe is empty