### PR TITLE
Fix northing exclusion issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "res-wind-up"
-version = "0.2.1"
+version = "0.2.2"
 authors = [
     { name = "Alex Clerc", email = "alex.clerc@res-group.com" }
 ]

--- a/wind_up/northing.py
+++ b/wind_up/northing.py
@@ -67,6 +67,8 @@ def apply_northing_corrections(
     :return: wind farm SCADA data with northing corrected yaw direction
     """
     wf_df = wf_df.copy()
+    yawanglemean_nan_idx = wf_df.loc[wf_df["YawAngleMean"].isna()].index
+
     northed_col = calc_northed_col_name(north_ref_wd_col)
 
     if plot_cfg is not None:
@@ -113,6 +115,7 @@ def apply_northing_corrections(
             if "YawAngleMax" in wf_df.columns:
                 wf_df.loc[df_idx, "YawAngleMax"] = pd.NA
     logger.info(f"applied {len_corrs} northing corrections")
+    wf_df.loc[yawanglemean_nan_idx, northed_col] = np.nan
     wf_df["YawAngleMean"] = wf_df[northed_col]
     if plot_cfg is not None:
         plot_and_print_northing_error(


### PR DESCRIPTION
I noticed that the northing process undoes exclusions because it always starts from the raw version of the data. This PR fixes the issue by keeping track of what rows had nan YawAngleMean at the start of the northing process and setting those nan at the end.