### PR TITLE
avoid conversion of input dataframes that are already TZ aware

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "res-wind-up"
-version = "0.4.2"
+version = "0.4.3"
 authors = [
     { name = "Alex Clerc", email = "alex.clerc@res-group.com" }
 ]

--- a/tests/test_smart_data.py
+++ b/tests/test_smart_data.py
@@ -1,19 +1,26 @@
-import datetime as dt
+from __future__ import annotations
 
+import datetime as dt
+from typing import TYPE_CHECKING
+
+import numpy as np
 import pandas as pd
 import pytest
 
 from tests.conftest import TEST_DATA_FLD
 from wind_up.backporting import strict_zip
 from wind_up.constants import TIMESTAMP_COL
-from wind_up.models import WindUpConfig
 from wind_up.smart_data import (
     add_smart_lat_long_to_cfg,
     calc_last_xmin_datetime_in_month,
     calc_month_list_and_time_info,
+    check_and_convert_scada_raw,
     load_smart_md_from_file,
     load_smart_scada_and_md_from_file,
 )
+
+if TYPE_CHECKING:
+    from wind_up.models import WindUpConfig
 
 TIMEBASE_PD_TIMEDELTA = pd.Timedelta("10min")
 
@@ -66,13 +73,27 @@ def test_calc_month_list_and_time_info() -> None:
     assert smart_tf == "End"
 
 
-def test_load_smart_scada_and_md_from_file() -> None:
+@pytest.mark.parametrize("timezone", [None, "UTC", "Europe/Berlin", "Europe/Paris"])
+def test_load_smart_scada_and_md_from_file(timezone: str | None) -> None:
     test_data_dir = TEST_DATA_FLD / "smart_data" / "Marge Wind Farm"
-    first_datetime_utc_start = pd.Timestamp("2020-02-26 23:50:00", tz="UTC")
-    last_datetime_utc_start = pd.Timestamp("2020-02-29 23:40:00", tz="UTC")
+    first_datetime_utc_start = pd.Timestamp("2020-02-26 23:50:00").tz_localize(timezone)
+    last_datetime_utc_start = pd.Timestamp("2020-02-29 23:40:00").tz_localize(timezone)
+    first_datetime_utc_start = (
+        first_datetime_utc_start
+        if first_datetime_utc_start.tzinfo is not None
+        else first_datetime_utc_start.tz_localize("UTC")
+    )
+    last_datetime_utc_start = (
+        last_datetime_utc_start
+        if last_datetime_utc_start.tzinfo is not None
+        else last_datetime_utc_start.tz_localize("UTC")
+    )
+    scada_df = pd.concat([pd.read_parquet(i) for i in test_data_dir.glob("*.parquet")])
+    if timezone:
+        scada_df = scada_df.tz_localize(timezone)
     scada_raw, _md = load_smart_scada_and_md_from_file(
         asset_name="Marge Wind Farm",
-        scada_df=pd.concat([pd.read_parquet(i) for i in test_data_dir.glob("*.parquet")]),
+        scada_df=scada_df,
         metadata_df=pd.read_csv(test_data_dir / "Marge Wind Farm_md.csv"),
         first_datetime_utc_start=first_datetime_utc_start,
         last_datetime_utc_start=last_datetime_utc_start,
@@ -82,5 +103,42 @@ def test_load_smart_scada_and_md_from_file() -> None:
     assert scada_raw.index.name == TIMESTAMP_COL
     assert scada_raw.index.min() == first_datetime_utc_start
     assert scada_raw.index.max() == last_datetime_utc_start
-    assert scada_raw["smart_dtTimeStamp"].min() == pd.Timestamp("2020-02-27 00:00:00")
-    assert scada_raw["smart_dtTimeStamp"].max() == pd.Timestamp("2020-02-29 23:50:00")
+    assert scada_raw["smart_dtTimeStamp"].min() == pd.Timestamp("2020-02-27 00:00:00", tz=timezone)
+    assert scada_raw["smart_dtTimeStamp"].max() == pd.Timestamp("2020-02-29 23:50:00", tz=timezone)
+
+
+@pytest.mark.parametrize("timezone", ["UTC", "Europe/Berlin", "Europe/Paris"])
+def test_check_and_convert_scada_raw(timezone: str) -> None:
+    """Test that handles ambiguous and non-existent times correctly."""
+    start_date = pd.Timestamp("2023-10-28 22:00:00")
+    end_date = pd.Timestamp("2023-10-29 05:00:00")
+
+    any_column = "AnyColumnName"
+    freq = pd.Timedelta(minutes=10)
+
+    idx = pd.date_range(start_date, end_date, freq=freq)
+    scada_df = pd.DataFrame(
+        index=idx,
+        data={"TurbineName": ["Turbine01"] * len(idx), any_column: np.random.default_rng(42).random(len(idx))},
+    )
+
+    contingency_hours = pd.Timedelta(hours=3)
+    first_datetime_utc_start = pd.Timestamp(start_date - contingency_hours, tz="UTC")
+    last_datetime_utc_start = pd.Timestamp(end_date + contingency_hours, tz="UTC")
+
+    actual = check_and_convert_scada_raw(
+        scada_raw=scada_df,
+        scada_data_timezone=timezone,
+        scada_data_time_format="End",
+        first_datetime_utc_start=first_datetime_utc_start,
+        last_datetime_utc_start=last_datetime_utc_start,
+        timebase_s=freq.seconds,
+    )
+
+    assert actual.shape[0] == scada_df.shape[0]
+    assert actual.shape[1] == (
+        scada_df.shape[1] + 1
+    )  # +1 as the original timestamp column is preserved as a new column
+    assert all(
+        actual.loc[:, any_column].to_numpy() == scada_df.loc[:, any_column].to_numpy()
+    )  # check the values in the column are the same as in the input df

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.9, <4.0"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -3116,7 +3117,7 @@ wheels = [
 
 [[package]]
 name = "res-wind-up"
-version = "0.4.2"
+version = "0.4.3"
 source = { editable = "." }
 dependencies = [
     { name = "eval-type-backport" },
@@ -3219,6 +3220,7 @@ requires-dist = [
     { name = "types-tqdm", marker = "extra == 'dev'" },
     { name = "utm" },
 ]
+provides-extras = ["dev", "examples", "all"]
 
 [[package]]
 name = "rfc3339-validator"

--- a/wind_up/smart_data.py
+++ b/wind_up/smart_data.py
@@ -108,9 +108,10 @@ def check_and_convert_scada_raw(
         msg = f"scada_raw.index is not a pd.DatetimeIndex: {type(scada_raw.index)}"
         raise TypeError(msg)
 
-    if scada_raw.index.tzinfo is not None:
-        scada_raw.index = scada_raw.index.tz_localize(None)
-    scada_raw.index = scada_raw.index.tz_localize(scada_data_timezone).tz_convert("UTC")
+    try:
+        scada_raw.index = scada_raw.index.tz_convert("UTC")
+    except TypeError:
+        scada_raw.index = scada_raw.index.tz_localize(scada_data_timezone).tz_convert("UTC")
     if scada_data_time_format == "End":
         scada_raw.index = scada_raw.index - pd.Timedelta(seconds=timebase_s)
     scada_raw.index = scada_raw.index.rename(TIMESTAMP_COL)

--- a/wind_up/smart_data.py
+++ b/wind_up/smart_data.py
@@ -111,7 +111,7 @@ def check_and_convert_scada_raw(
     try:
         scada_raw.index = scada_raw.index.tz_convert("UTC")
     except TypeError:
-        scada_raw.index = scada_raw.index.tz_localize(scada_data_timezone).tz_convert("UTC")
+        scada_raw.index = scada_raw.index.tz_localize(scada_data_timezone, ambiguous=False).tz_convert("UTC")
     if scada_data_time_format == "End":
         scada_raw.index = scada_raw.index - pd.Timedelta(seconds=timebase_s)
     scada_raw.index = scada_raw.index.rename(TIMESTAMP_COL)


### PR DESCRIPTION
Without this change, a df input with Europe/Paris TZ can result in an ambiguous timestamp error