### PR TITLE
add borrow_toggle_from_wtg

### DIFF
--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -1,0 +1,56 @@
+import pandas as pd
+
+from wind_up.constants import TIMESTAMP_COL
+from wind_up.interface import PrePostSplitter
+from wind_up.models import WindUpConfig
+
+
+def _toggle_df(idx: pd.DatetimeIndex) -> pd.DataFrame:
+    """2-level (wtg_name, timestamp) toggle_df with distinct per-turbine patterns.
+
+    MRG_T01 (test wtg): on for the last 3 bins.
+    MRG_T06 (test wtg): on for the last 2 bins (its own, different pattern).
+    MRG_T02 (ref wtg):  never on (the crashing case).
+    """
+
+    def mk(on_mask: list[bool]) -> pd.DataFrame:
+        return pd.DataFrame({"toggle_on": on_mask, "toggle_off": [not x for x in on_mask]}, index=idx)
+
+    return pd.concat(
+        {
+            "MRG_T01": mk([False, False, False, True, True, True]),
+            "MRG_T06": mk([False, False, False, False, True, True]),
+            "MRG_T02": mk([False] * 6),
+        },
+        names=["wtg_name", TIMESTAMP_COL],
+    )
+
+
+def _splitter(cfg: WindUpConfig, borrow_from: str | None) -> tuple[PrePostSplitter, pd.DataFrame, pd.DatetimeIndex]:
+    cfg.toggle.toggle_change_settling_filter_seconds = 0  # keep every bin so counts are exact
+    cfg.toggle.borrow_toggle_from_wtg = borrow_from
+    idx = pd.date_range(cfg.analysis_first_dt_utc_start, periods=6, freq="10min", name=TIMESTAMP_COL)
+    splitter = PrePostSplitter(cfg=cfg, toggle_df=_toggle_df(idx))
+    wtg_scada = pd.DataFrame({"some_col": range(6)}, index=idx)
+    return splitter, wtg_scada, idx
+
+
+def test_split_borrows_toggle_for_non_test_wtg(test_marge_config: WindUpConfig) -> None:
+    splitter, wtg_scada, idx = _splitter(test_marge_config, borrow_from="MRG_T01")
+    _test_df, _pre_df, post_df = splitter.split(wtg_scada, test_wtg_name="MRG_T02")
+    # MRG_T02 has no toggle_on of its own; it borrows MRG_T01's 3 on-bins.
+    assert list(post_df.index) == list(idx[3:6])
+
+
+def test_split_uses_own_toggle_for_real_test_wtg(test_marge_config: WindUpConfig) -> None:
+    splitter, wtg_scada, idx = _splitter(test_marge_config, borrow_from="MRG_T01")
+    _test_df, _pre_df, post_df = splitter.split(wtg_scada, test_wtg_name="MRG_T06")
+    # MRG_T06 is a test wtg, so it keeps its OWN 2 on-bins, not MRG_T01's 3.
+    assert list(post_df.index) == list(idx[4:6])
+
+
+def test_split_without_borrow_leaves_non_test_wtg_post_empty(test_marge_config: WindUpConfig) -> None:
+    splitter, wtg_scada, _idx = _splitter(test_marge_config, borrow_from=None)
+    _test_df, _pre_df, post_df = splitter.split(wtg_scada, test_wtg_name="MRG_T02")
+    # Regression demo: this is the crashing case — no borrow, no post data.
+    assert post_df.empty

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -257,17 +257,17 @@ def test_borrow_toggle_from_wtg_defaults_to_none(test_marge_config: WindUpConfig
 
 
 def test_borrow_toggle_from_wtg_accepts_a_test_wtg(test_marge_config: WindUpConfig) -> None:
-    cfg = test_marge_config
-    cfg.toggle.borrow_toggle_from_wtg = "MRG_T01"  # a member of test_wtgs
-    # the after-validator returns self unchanged when the value is valid
-    assert cfg._check_borrow_toggle_from_wtg() is cfg
+    raw = test_marge_config.model_dump()
+    raw["toggle"]["borrow_toggle_from_wtg"] = "MRG_T01"  # a member of test_wtgs
+    cfg = WindUpConfig.model_validate(raw)
+    assert cfg.toggle.borrow_toggle_from_wtg == "MRG_T01"
 
 
 def test_borrow_toggle_from_wtg_rejects_non_test_wtg(test_marge_config: WindUpConfig) -> None:
-    cfg = test_marge_config
-    cfg.toggle.borrow_toggle_from_wtg = "MRG_T02"  # a ref wtg, not a test wtg
-    with pytest.raises(ValueError, match="borrow_toggle_from_wtg"):
-        cfg._check_borrow_toggle_from_wtg()
+    raw = test_marge_config.model_dump()
+    raw["toggle"]["borrow_toggle_from_wtg"] = "MRG_T02"  # a ref wtg, not a test wtg
+    with pytest.raises(ValidationError, match="borrow_toggle_from_wtg"):
+        WindUpConfig.model_validate(raw)
 
 
 class TestPrePostValidation:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -251,6 +251,25 @@ def test_windupconfig_with_extended_post_period_length() -> None:
     assert cfg.prepost.post_last_dt_utc_start == pd.Timestamp(analysis_end, tz="UTC")
 
 
+def test_borrow_toggle_from_wtg_defaults_to_none(test_marge_config: WindUpConfig) -> None:
+    assert test_marge_config.toggle is not None
+    assert test_marge_config.toggle.borrow_toggle_from_wtg is None
+
+
+def test_borrow_toggle_from_wtg_accepts_a_test_wtg(test_marge_config: WindUpConfig) -> None:
+    cfg = test_marge_config
+    cfg.toggle.borrow_toggle_from_wtg = "MRG_T01"  # a member of test_wtgs
+    # the after-validator returns self unchanged when the value is valid
+    assert cfg._check_borrow_toggle_from_wtg() is cfg
+
+
+def test_borrow_toggle_from_wtg_rejects_non_test_wtg(test_marge_config: WindUpConfig) -> None:
+    cfg = test_marge_config
+    cfg.toggle.borrow_toggle_from_wtg = "MRG_T02"  # a ref wtg, not a test wtg
+    with pytest.raises(ValueError, match="borrow_toggle_from_wtg"):
+        cfg._check_borrow_toggle_from_wtg()
+
+
 class TestPrePostValidation:
     @pytest.fixture
     def valid_dates(self) -> dict[str, dt.datetime]:

--- a/wind_up/interface.py
+++ b/wind_up/interface.py
@@ -57,7 +57,14 @@ class PrePostSplitter:
         elif (self.cfg.prepost is None) and self.cfg.toggle is not None:
             if not isinstance(self.toggle_df, pd.DataFrame):
                 raise ValueError("toggle_df must be a pd.DataFrame")  # noqa TRY003
-            test_df = add_toggle_signals(df, toggle_df=self.toggle_df, wtg_name=test_wtg_name, cfg=self.cfg)
+            toggle_wtg_name = test_wtg_name
+            borrow = self.cfg.toggle.borrow_toggle_from_wtg
+            if borrow is not None and test_wtg_name not in {x.name for x in self.cfg.test_wtgs}:
+                toggle_wtg_name = borrow
+                logger.info(
+                    f"{test_wtg_name} is not a test wtg; borrowing toggle signal from {borrow}",
+                )
+            test_df = add_toggle_signals(df, toggle_df=self.toggle_df, wtg_name=toggle_wtg_name, cfg=self.cfg)
             test_df = test_df.rename(columns={"toggle_off": "test_toggle_off", "toggle_on": "test_toggle_on"})
             pre_df = test_df[test_df["test_toggle_off"].fillna(value=False)].copy()
             post_df = test_df[test_df["test_toggle_on"].fillna(value=False)].copy()

--- a/wind_up/models.py
+++ b/wind_up/models.py
@@ -142,6 +142,12 @@ class Toggle(BaseModel):
         description="Time delta in seconds filter out after a toggle state change",
         default=10 * 60,
     )
+    borrow_toggle_from_wtg: str | None = Field(
+        default=None,
+        description="When a non-test turbine is analysed in the test role (the reference round "
+        "robin), borrow this turbine's toggle signal so it gets a real pre/post split instead of "
+        "an empty post period. Must name one of cfg.test_wtgs.",
+    )
 
 
 class PrePost(BaseModel):
@@ -379,6 +385,18 @@ class WindUpConfig(BaseModel):
                     raise ValueError(msg)
             elif len([x for x in self.asset.masts_and_lidars if x.name == non_wtg_ref]) != 1:
                 msg = f"there is not exactly 1 non_wtg_ref {non_wtg_ref} in cfg.asset.masts_and_lidars"
+                raise ValueError(msg)
+        return self
+
+    @model_validator(mode="after")
+    def _check_borrow_toggle_from_wtg(self: WindUpConfig) -> WindUpConfig:
+        if self.toggle is not None and self.toggle.borrow_toggle_from_wtg is not None:
+            test_names = {x.name for x in self.test_wtgs}
+            if self.toggle.borrow_toggle_from_wtg not in test_names:
+                msg = (
+                    f"toggle.borrow_toggle_from_wtg {self.toggle.borrow_toggle_from_wtg!r} must be "
+                    f"one of test_wtgs {sorted(test_names)}"
+                )
                 raise ValueError(msg)
         return self
 


### PR DESCRIPTION
Add `borrow_toggle_from_wtg` and associated logic to properly support analyses where each turbine has its own unique toggle pattern (in this case the references are always toggle off).