### PR TITLE
V1 issue2

### DIFF
--- a/benchmarking/harness/__init__.py
+++ b/benchmarking/harness/__init__.py
@@ -2,9 +2,6 @@
 
 Score an uplift method's P50 estimate against the known injected truth from the synthetic
 generator, reporting accuracy (bias) and precision (spread) as a function of campaign length.
-
-See the design spec
-``docs/superpowers/specs/2026-06-22-p50-evaluation-harness-design.md``.
 """
 
 from __future__ import annotations

--- a/benchmarking/harness/__init__.py
+++ b/benchmarking/harness/__init__.py
@@ -1,0 +1,41 @@
+"""P50 evaluation harness (v1 benchmarking, WS1).
+
+Score an uplift method's P50 estimate against the known injected truth from the synthetic
+generator, reporting accuracy (bias) and precision (spread) as a function of campaign length.
+
+See the design spec
+``docs/superpowers/specs/2026-06-22-p50-evaluation-harness-design.md``.
+"""
+
+from __future__ import annotations
+
+from benchmarking.harness.campaign import (
+    CampaignWindow,
+    campaign_windows,
+    treated_activity_mask,
+    window_row_mask,
+)
+from benchmarking.harness.leaderboard import leaderboard
+from benchmarking.harness.method import Method, MethodInput, MethodOutput
+from benchmarking.harness.metrics import ErrorSummary, summarize_errors
+from benchmarking.harness.plots import plot_campaign_curves
+from benchmarking.harness.replicates import Replicate, StudyConfig, build_replicates
+from benchmarking.harness.scoring import score_study
+
+__all__ = [
+    "CampaignWindow",
+    "ErrorSummary",
+    "Method",
+    "MethodInput",
+    "MethodOutput",
+    "Replicate",
+    "StudyConfig",
+    "build_replicates",
+    "campaign_windows",
+    "leaderboard",
+    "plot_campaign_curves",
+    "score_study",
+    "summarize_errors",
+    "treated_activity_mask",
+    "window_row_mask",
+]

--- a/benchmarking/harness/campaign.py
+++ b/benchmarking/harness/campaign.py
@@ -82,6 +82,7 @@ def window_row_mask(index: pd.DatetimeIndex, window: CampaignWindow) -> npt.NDAr
 def treated_activity_mask(
     index: pd.DatetimeIndex,
     upgrade_timing: pd.Timestamp | ToggleSchedule,
+    *,
     window: CampaignWindow,
 ) -> npt.NDArray[np.bool_]:
     """Boolean mask of the test turbine's treated rows within ``[treatment_start, activity_end)``.

--- a/benchmarking/harness/campaign.py
+++ b/benchmarking/harness/campaign.py
@@ -1,0 +1,94 @@
+"""Campaign-length windows and the two record selections each window implies.
+
+The short-campaign sweep varies the treatment-activity duration (post window for prepost,
+toggling duration for toggle) over a grid, e.g. ``{3, 6, 9, 12}`` months, while holding a
+fixed baseline before the treatment start. Every length shares the one
+``(treatment_start, baseline_start)`` and differs only in ``activity_end``, so shorter
+windows are strict leading prefixes of longer ones — the campaign-length curve isolates the
+effect of post-duration alone.
+
+From a window two distinct selections are derived, deliberately kept apart:
+
+- :func:`window_row_mask` — the method-facing rows (all turbines, baseline + activity).
+- :func:`treated_activity_mask` — the test turbine's treated rows within the activity window,
+  for the ground-truth comparison.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pandas as pd
+
+from benchmarking.synthetic import treated_mask
+
+if TYPE_CHECKING:
+    import numpy.typing as npt
+
+    from benchmarking.synthetic import ToggleSchedule
+
+
+@dataclass(frozen=True)
+class CampaignWindow:
+    """One campaign length: a fixed baseline then ``months`` of treatment activity."""
+
+    months: int
+    baseline_start: pd.Timestamp
+    treatment_start: pd.Timestamp
+    activity_end: pd.Timestamp
+
+
+def campaign_windows(
+    treatment_start: pd.Timestamp,
+    *,
+    min_pre_months: int,
+    campaign_months: list[int],
+    data_start: pd.Timestamp | None = None,
+    data_end: pd.Timestamp | None = None,
+) -> list[CampaignWindow]:
+    """Build one :class:`CampaignWindow` per campaign length.
+
+    ``baseline_start = treatment_start - min_pre_months`` is fixed across lengths;
+    ``activity_end = treatment_start + months`` grows with the length. When ``data_start`` /
+    ``data_end`` are given, lengths whose window would fall outside the available data are
+    dropped (infeasible ``(replicate, length)`` combinations).
+    """
+    baseline_start = treatment_start - pd.DateOffset(months=min_pre_months)
+    windows = []
+    for months in campaign_months:
+        activity_end = treatment_start + pd.DateOffset(months=months)
+        if data_start is not None and baseline_start < data_start:
+            continue
+        if data_end is not None and activity_end > data_end:
+            continue
+        windows.append(
+            CampaignWindow(
+                months=months,
+                baseline_start=baseline_start,
+                treatment_start=treatment_start,
+                activity_end=activity_end,
+            )
+        )
+    return windows
+
+
+def window_row_mask(index: pd.DatetimeIndex, window: CampaignWindow) -> npt.NDArray[np.bool_]:
+    """Boolean mask of the rows a method sees: ``[baseline_start, activity_end)``."""
+    return np.asarray((index >= window.baseline_start) & (index < window.activity_end))
+
+
+def treated_activity_mask(
+    index: pd.DatetimeIndex,
+    upgrade_timing: pd.Timestamp | ToggleSchedule,
+    window: CampaignWindow,
+) -> npt.NDArray[np.bool_]:
+    """Boolean mask of the test turbine's treated rows within ``[treatment_start, activity_end)``.
+
+    For prepost these are the post records; for toggle the on-records. The baseline is never
+    treated. ``index`` must be the test turbine's rows in time order (matches ``true_uplift``).
+    """
+    treated = treated_mask(index, upgrade_timing)
+    in_activity = np.asarray((index >= window.treatment_start) & (index < window.activity_end))
+    return treated & in_activity

--- a/benchmarking/harness/example_hot_study.py
+++ b/benchmarking/harness/example_hot_study.py
@@ -32,6 +32,7 @@ import numpy as np
 import pandas as pd
 
 from benchmarking.harness import (
+    Method,
     MethodInput,
     MethodOutput,
     StudyConfig,
@@ -89,7 +90,7 @@ def _oracle_overall_uplift(mi: MethodInput, original_df: pd.DataFrame) -> float:
 class OracleMethod:
     """Returns the injected truth; its signed error is ~0 at every campaign length."""
 
-    def __init__(self, original_df: pd.DataFrame, name: str = "oracle") -> None:
+    def __init__(self, original_df: pd.DataFrame, *, name: str = "oracle") -> None:
         """Store the no-upgrade baseline used to recover the injected truth."""
         self._original = original_df
         self.name = name
@@ -102,7 +103,7 @@ class OracleMethod:
 class BiasedMethod:
     """Returns the truth plus a fixed offset; its error sits at that offset."""
 
-    def __init__(self, original_df: pd.DataFrame, offset: float, name: str = "biased") -> None:
+    def __init__(self, original_df: pd.DataFrame, *, offset: float, name: str = "biased") -> None:
         """Store the baseline and the fixed offset added to every estimate."""
         self._original = original_df
         self._offset = offset
@@ -123,7 +124,7 @@ class ShrinkingNoiseMethod:
     this makes the plotted spread band narrow as the campaign grows.
     """
 
-    def __init__(self, original_df: pd.DataFrame, base_sigma: float = 0.03, name: str = "realistic") -> None:
+    def __init__(self, original_df: pd.DataFrame, *, base_sigma: float = 0.03, name: str = "realistic") -> None:
         """Store the baseline and the base noise level scaled by campaign length."""
         self._original = original_df
         self._base_sigma = base_sigma
@@ -183,7 +184,7 @@ def run_example_study(
         n_replicates=n_replicates,
         seed=seed,
     )
-    methods = [
+    methods: list[Method] = [
         OracleMethod(scada_df),
         BiasedMethod(scada_df, offset=0.02),
         ShrinkingNoiseMethod(scada_df, base_sigma=0.03),
@@ -198,7 +199,9 @@ def run_example_study(
         profile_name,
         delta * 100,
     )
-    results = score_study(scada_df, [ConstantCpChange(delta=delta)], methods, study, profile_name=profile_name)
+    results = score_study(
+        scada_df, profile=[ConstantCpChange(delta=delta)], methods=methods, study=study, profile_name=profile_name
+    )
     summary = leaderboard(results)
 
     results_path = out_dir / "results_tidy.csv"

--- a/benchmarking/harness/example_hot_study.py
+++ b/benchmarking/harness/example_hot_study.py
@@ -1,0 +1,257 @@
+"""Driver: run the P50 evaluation harness end-to-end on real Hill of Towie data.
+
+A runnable, inspectable companion to ``tests/.../test_hot_end_to_end.py`` (which saves to a
+pytest ``tmp_path`` and then throws it away). This wires the open Hill of Towie SCADA through
+the full harness — load -> inject a constant-Cp upgrade -> replicate ensemble -> campaign
+sweep -> score -> leaderboard -> plot — and saves the leaderboard CSV, the tidy per-replicate
+results and the campaign-length curve PNG to a directory you can open.
+
+The "methods" scored here are illustrative stand-ins (no real estimator ships in this phase):
+
+- ``oracle`` returns the injected truth, so its error is ~0 at every campaign length;
+- ``biased`` adds a fixed offset, so its error sits at that offset;
+- ``realistic`` adds noise that shrinks with campaign length, so its spread band narrows as
+  the campaign grows — the precision-vs-data-volume effect the campaign sweep exists to show.
+
+Run it::
+
+    uv run python -m benchmarking.harness.example_hot_study
+
+First run downloads and caches the Hill of Towie v2 year zips from Zenodo (a few GB; a
+12-month baseline plus a 12-month campaign spans 2016..2018). Override the window, output and
+cache directories via the ``main`` arguments or the ``WIND_UP_BENCHMARKING_*`` env vars.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from benchmarking.harness import (
+    MethodInput,
+    MethodOutput,
+    StudyConfig,
+    leaderboard,
+    plot_campaign_curves,
+    score_study,
+)
+from benchmarking.synthetic import ConstantCpChange, treated_mask
+from benchmarking.synthetic.sources.hill_of_towie import load_hot_scada
+from wind_up.constants import DataColumns
+
+logger = logging.getLogger(__name__)
+
+# A stable, no-upgrade Hill of Towie window wide enough for a 12-month baseline plus a
+# 12-month campaign with the changeover at the 2017 new year. All of 2016-2020 was previously
+# confirmed stable for these turbines (well before the real T13 AeroUp, installed Sep 2021).
+DEFAULT_START_DT = pd.Timestamp("2016-01-01", tz="UTC")
+DEFAULT_END_DT_EXCL = pd.Timestamp("2018-02-01", tz="UTC")
+# The stable south-west turbines used by the end-to-end test (T01, T03, T04, T07).
+DEFAULT_WTG_NUMBERS = [1, 3, 4, 7]
+DEFAULT_TURBINE_SUBSET = ["T01", "T03", "T04", "T07"]
+
+
+def default_output_root() -> Path:
+    """Return the directory the harness example writes its outputs under.
+
+    Overridable via the ``WIND_UP_BENCHMARKING_OUTPUT_DIR`` environment variable; defaults to
+    ``~/temp/wind-up-benchmarking/harness``.
+    """
+    root = Path(os.getenv("WIND_UP_BENCHMARKING_OUTPUT_DIR", Path.home() / "temp" / "wind-up-benchmarking"))
+    return root / "harness"
+
+
+def _oracle_overall_uplift(mi: MethodInput, original_df: pd.DataFrame) -> float:
+    """Energy-ratio uplift over the treated test-turbine rows in ``mi``'s window.
+
+    Compares the (upgraded) synthetic power against the original no-upgrade power over the
+    exact same treated records, so it recovers the injected truth. The illustrative methods
+    below wrap this to drive bias and spread.
+    """
+    syn = mi.scada_df
+    test_rows = syn[syn[DataColumns.turbine_name] == mi.test_wtg]
+    treated = treated_mask(test_rows.index, mi.upgrade_timing)
+    treated_rows = test_rows[treated]
+
+    syn_power = treated_rows[DataColumns.active_power_mean].to_numpy(dtype=float)
+    orig_test = original_df[original_df[DataColumns.turbine_name] == mi.test_wtg]
+    orig_power = orig_test.loc[treated_rows.index, DataColumns.active_power_mean].to_numpy(dtype=float)
+
+    finite = np.isfinite(syn_power) & np.isfinite(orig_power)
+    denom = orig_power[finite].sum()
+    return syn_power[finite].sum() / denom - 1.0 if denom else float("nan")
+
+
+class OracleMethod:
+    """Returns the injected truth; its signed error is ~0 at every campaign length."""
+
+    def __init__(self, original_df: pd.DataFrame, name: str = "oracle") -> None:
+        """Store the no-upgrade baseline used to recover the injected truth."""
+        self._original = original_df
+        self.name = name
+
+    def estimate(self, mi: MethodInput) -> MethodOutput:
+        """Return the injected truth as the P50 estimate."""
+        return MethodOutput(p50_overall=_oracle_overall_uplift(mi, self._original))
+
+
+class BiasedMethod:
+    """Returns the truth plus a fixed offset; its error sits at that offset."""
+
+    def __init__(self, original_df: pd.DataFrame, offset: float, name: str = "biased") -> None:
+        """Store the baseline and the fixed offset added to every estimate."""
+        self._original = original_df
+        self._offset = offset
+        self.name = name
+
+    def estimate(self, mi: MethodInput) -> MethodOutput:
+        """Return the injected truth plus the fixed offset."""
+        return MethodOutput(p50_overall=_oracle_overall_uplift(mi, self._original) + self._offset)
+
+
+class ShrinkingNoiseMethod:
+    """Returns the truth plus noise whose size shrinks with campaign length.
+
+    A crude stand-in for a real estimator: more campaign data -> a tighter estimate. The noise
+    sigma scales as ``base_sigma / sqrt(campaign_months)``, and the draw is seeded
+    deterministically from ``(test turbine, treatment start, campaign length)`` so each
+    replicate gets its own value while the whole study stays reproducible. Across the ensemble
+    this makes the plotted spread band narrow as the campaign grows.
+    """
+
+    def __init__(self, original_df: pd.DataFrame, base_sigma: float = 0.03, name: str = "realistic") -> None:
+        """Store the baseline and the base noise level scaled by campaign length."""
+        self._original = original_df
+        self._base_sigma = base_sigma
+        self.name = name
+
+    def estimate(self, mi: MethodInput) -> MethodOutput:
+        """Return the truth plus a deterministic, campaign-length-shrinking noise draw."""
+        truth = _oracle_overall_uplift(mi, self._original)
+        treatment_start = mi.upgrade_timing  # prepost: a Timestamp
+        post_days = max((mi.scada_df.index.max() - treatment_start).days, 1)
+        months = post_days / 30.4
+        sigma = self._base_sigma / np.sqrt(months)
+        wtg_term = sum(ord(c) for c in mi.test_wtg) * 1000 + round(months)
+        seed = (int(pd.Timestamp(treatment_start).value) % (2**32)) ^ wtg_term
+        rng = np.random.default_rng(seed)
+        return MethodOutput(p50_overall=truth + float(rng.normal(0.0, sigma)))
+
+
+def run_example_study(
+    scada_df: pd.DataFrame,
+    *,
+    out_root: str | Path | None = None,
+    turbine_subset: list[str] | None = None,
+    treatment_start_range: tuple[pd.Timestamp, pd.Timestamp] | None = None,
+    min_pre_months: int = 12,
+    campaign_months: list[int] | None = None,
+    n_replicates: int = 6,
+    delta: float = 0.05,
+    seed: int = 0,
+) -> pd.DataFrame:
+    """Score the illustrative methods on a constant-Cp study and save inspectable outputs.
+
+    :param scada_df: wind-up-format real SCADA (all subset turbines), the no-upgrade baseline
+    :param out_root: output directory; defaults to :func:`default_output_root`
+    :param turbine_subset: turbines kept in the study (one drawn as test per replicate)
+    :param treatment_start_range: ``(earliest, latest)`` changeover to draw from
+    :param min_pre_months: fixed baseline length before the changeover, in months
+    :param campaign_months: the campaign-length sweep grid, in months
+    :param n_replicates: ensemble size (drives the spread estimate)
+    :param delta: the injected constant-Cp uplift fraction
+    :param seed: top-level seed for reproducibility
+    :return: the leaderboard summary frame
+    """
+    out_dir = Path(out_root) if out_root is not None else default_output_root()
+    out_dir.mkdir(parents=True, exist_ok=True)
+    turbine_subset = turbine_subset if turbine_subset is not None else DEFAULT_TURBINE_SUBSET
+    if treatment_start_range is None:
+        treatment_start_range = (pd.Timestamp("2017-01-01", tz="UTC"), pd.Timestamp("2017-01-15", tz="UTC"))
+    campaign_months = campaign_months if campaign_months is not None else [3, 6, 9, 12]
+
+    study = StudyConfig(
+        mode="prepost",
+        turbine_subset=turbine_subset,
+        treatment_start_range=treatment_start_range,
+        min_pre_months=min_pre_months,
+        campaign_months=campaign_months,
+        n_replicates=n_replicates,
+        seed=seed,
+    )
+    methods = [
+        OracleMethod(scada_df),
+        BiasedMethod(scada_df, offset=0.02),
+        ShrinkingNoiseMethod(scada_df, base_sigma=0.03),
+    ]
+
+    profile_name = f"constant_cp_{delta:.0%}".replace("%", "pct")
+    logger.info(
+        "Scoring %d methods over %d replicates x campaigns %s (profile %s, true uplift %+.1f%%)",
+        len(methods),
+        n_replicates,
+        campaign_months,
+        profile_name,
+        delta * 100,
+    )
+    results = score_study(scada_df, [ConstantCpChange(delta=delta)], methods, study, profile_name=profile_name)
+    summary = leaderboard(results)
+
+    results_path = out_dir / "results_tidy.csv"
+    summary_path = out_dir / "leaderboard.csv"
+    plot_path = out_dir / "campaign_curves.png"
+    results.to_csv(results_path, index=False)
+    summary.to_csv(summary_path, index=False)
+    plot_campaign_curves(
+        summary,
+        save_path=plot_path,
+        title=f"Hill of Towie {profile_name} (Cp delta {delta:+.1%}, {n_replicates} replicates)",
+    )
+
+    logger.info("Saved leaderboard -> %s", summary_path)
+    logger.info("Saved tidy results -> %s", results_path)
+    logger.info("Saved campaign-length curve -> %s", plot_path)
+    return summary
+
+
+def main(
+    *,
+    out_root: str | Path | None = None,
+    data_dir: str | Path | None = None,
+    start_dt: pd.Timestamp = DEFAULT_START_DT,
+    end_dt_excl: pd.Timestamp = DEFAULT_END_DT_EXCL,
+    wtg_numbers: list[int] | None = None,
+) -> pd.DataFrame:
+    """Run the harness end-to-end on real Hill of Towie data and save inspectable outputs.
+
+    Downloads (and caches) the open Hill of Towie SCADA for a stable, no-upgrade window, then
+    scores the illustrative methods over a campaign-length sweep and writes the leaderboard,
+    the tidy results and the campaign-length curve under ``out_root``.
+
+    :param out_root: output directory; defaults to :func:`default_output_root`
+    :param data_dir: Hill of Towie data/cache dir; defaults to the package default
+    :param start_dt: inclusive UTC window start
+    :param end_dt_excl: exclusive UTC window end
+    :param wtg_numbers: turbine numbers to load; defaults to the stable south-west cluster
+    :return: the leaderboard summary frame
+    """
+    wtg_numbers = wtg_numbers if wtg_numbers is not None else DEFAULT_WTG_NUMBERS
+    logger.info("Loading Hill of Towie SCADA %s..%s for turbines %s", start_dt, end_dt_excl, wtg_numbers)
+    scada_df, _metadata_df = load_hot_scada(
+        start_dt=start_dt,
+        end_dt_excl=end_dt_excl,
+        wtg_numbers=wtg_numbers,
+        data_dir=Path(data_dir) if data_dir is not None else None,
+    )
+    summary = run_example_study(scada_df, out_root=out_root)
+    logger.info("Leaderboard:\n%s", summary.to_string(index=False))
+    return summary
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+    main()

--- a/benchmarking/harness/leaderboard.py
+++ b/benchmarking/harness/leaderboard.py
@@ -1,0 +1,38 @@
+"""Leaderboard: summarise tidy scoring results into a side-by-side comparison.
+
+Groups the tidy results by ``(method, profile, campaign_months)`` and reduces each group's
+signed errors to bias, spread and the combined RMSE score via :func:`metrics.summarize_errors`.
+A pure consumer of the results table; lower ``score`` is better.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from benchmarking.harness.metrics import summarize_errors
+
+_GROUP_KEYS = ["method", "profile", "campaign_months"]
+
+
+def leaderboard(results_df: pd.DataFrame) -> pd.DataFrame:
+    """Summarise scoring results into per-(method, profile, campaign-length) bias/spread/score.
+
+    Only overall-uplift rows (``condition == "overall"``) are summarised; per-condition rows are
+    excluded. Returns one row per group with ``bias``, ``spread``, ``score`` and
+    ``n_replicates``, sorted by method, profile then campaign length.
+    """
+    overall = results_df[results_df["condition"] == "overall"] if "condition" in results_df else results_df
+
+    records = []
+    for keys, group in overall.groupby(_GROUP_KEYS, sort=True):
+        summary = summarize_errors(group["signed_error"].to_numpy())
+        records.append(
+            {
+                **dict(zip(_GROUP_KEYS, keys, strict=True)),
+                "bias": summary.bias,
+                "spread": summary.spread,
+                "score": summary.score,
+                "n_replicates": summary.n,
+            }
+        )
+    return pd.DataFrame(records, columns=[*_GROUP_KEYS, "bias", "spread", "score", "n_replicates"])

--- a/benchmarking/harness/leaderboard.py
+++ b/benchmarking/harness/leaderboard.py
@@ -18,8 +18,9 @@ def leaderboard(results_df: pd.DataFrame) -> pd.DataFrame:
     """Summarise scoring results into per-(method, profile, campaign-length) bias/spread/score.
 
     Only overall-uplift rows (``condition == "overall"``) are summarised; per-condition rows are
-    excluded. Returns one row per group with ``bias``, ``spread``, ``score`` and
-    ``n_replicates``, sorted by method, profile then campaign length.
+    excluded. Returns one row per group with ``bias``, ``spread``, ``score``, the mean recovered
+    and true uplift (``mean_estimate`` / ``mean_truth``, when those columns are present in the
+    input) and ``n_replicates``, sorted by method, profile then campaign length.
     """
     overall = results_df[results_df["condition"] == "overall"] if "condition" in results_df else results_df
 
@@ -32,7 +33,10 @@ def leaderboard(results_df: pd.DataFrame) -> pd.DataFrame:
                 "bias": summary.bias,
                 "spread": summary.spread,
                 "score": summary.score,
+                "mean_estimate": float(group["estimate"].mean()) if "estimate" in group else float("nan"),
+                "mean_truth": float(group["truth"].mean()) if "truth" in group else float("nan"),
                 "n_replicates": summary.n,
             }
         )
-    return pd.DataFrame(records, columns=[*_GROUP_KEYS, "bias", "spread", "score", "n_replicates"])
+    columns = [*_GROUP_KEYS, "bias", "spread", "score", "mean_estimate", "mean_truth", "n_replicates"]
+    return pd.DataFrame(records, columns=columns)

--- a/benchmarking/harness/method.py
+++ b/benchmarking/harness/method.py
@@ -1,0 +1,56 @@
+"""The thin method seam the harness scores against.
+
+Deliberately minimal: the harness only ever sees ``MethodInput -> MethodOutput``. The mode is
+inferred from ``upgrade_timing``'s type (a timestamp is prepost; a ``ToggleSchedule`` is
+toggle). Reference selection and method-specific config are baked into each ``Method``, not
+carried on the input, so the seam bakes in no method assumptions. The Issue 4 data contract
+later enriches this behind the same seam.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+    from benchmarking.synthetic import ToggleSchedule
+
+
+@dataclass
+class MethodInput:
+    """The windowed data a method sees for one campaign.
+
+    :param scada_df: windowed synthetic SCADA (all subset turbines, baseline + activity)
+    :param test_wtg: the upgraded turbine to estimate
+    :param upgrade_timing: changeover timestamp (prepost) or schedule (toggle)
+    """
+
+    scada_df: pd.DataFrame
+    test_wtg: str
+    upgrade_timing: pd.Timestamp | ToggleSchedule
+
+
+@dataclass
+class MethodOutput:
+    """A method's P50 uplift estimate.
+
+    :param p50_overall: overall P50 uplift (energy-ratio fraction)
+    :param p50_by_condition: optional per-condition estimates (columns ``condition_bin``,
+        ``p50_uplift``); ``None`` when the method produces only an overall number
+    """
+
+    p50_overall: float
+    p50_by_condition: pd.DataFrame | None = None
+
+
+@runtime_checkable
+class Method(Protocol):
+    """A pluggable uplift estimator: a name plus ``estimate(MethodInput) -> MethodOutput``."""
+
+    name: str
+
+    def estimate(self, mi: MethodInput) -> MethodOutput:
+        """Return a P50 uplift estimate for the campaign described by ``mi``."""
+        ...

--- a/benchmarking/harness/metrics.py
+++ b/benchmarking/harness/metrics.py
@@ -1,0 +1,46 @@
+"""Accuracy, precision and combined score over a set of signed errors.
+
+A method's signed error on one campaign is ``estimate - truth``. Aggregated across an
+ensemble of replicates these give:
+
+- **accuracy / bias** = mean signed error,
+- **precision / spread** = population standard deviation (``ddof=0``),
+- **combined score** = RMSE of the signed errors = ``sqrt(mean(error**2))``.
+
+With the population spread the score is exactly ``sqrt(bias**2 + spread**2)``, so it is small
+only when *both* accuracy and precision are good.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import numpy.typing as npt
+
+
+@dataclass(frozen=True)
+class ErrorSummary:
+    """Bias, spread and combined score over ``n`` finite signed errors."""
+
+    bias: float
+    spread: float
+    score: float
+    n: int
+
+
+def summarize_errors(signed_errors: npt.ArrayLike) -> ErrorSummary:
+    """Summarise signed errors into bias, spread (population std) and RMSE score.
+
+    Non-finite errors (e.g. a replicate that produced no estimate) are dropped before
+    aggregating. An empty (or all-NaN) input yields a NaN summary with ``n == 0``.
+    """
+    errors = np.asarray(signed_errors, dtype=float).ravel()
+    errors = errors[np.isfinite(errors)]
+    n = int(errors.size)
+    if n == 0:
+        return ErrorSummary(bias=float("nan"), spread=float("nan"), score=float("nan"), n=0)
+    bias = float(errors.mean())
+    spread = float(errors.std(ddof=0))
+    score = float(np.sqrt(np.mean(errors**2)))
+    return ErrorSummary(bias=bias, spread=spread, score=score, n=n)

--- a/benchmarking/harness/plots.py
+++ b/benchmarking/harness/plots.py
@@ -1,8 +1,17 @@
 """Campaign-length curves for comparing methods.
 
-One line per method showing the combined ``score`` against campaign length, with a shaded
-bias +/- spread band so accuracy and precision are both visible. All quantities are in
-uplift-fraction units, so they share one y-axis. Consumes the leaderboard summary frame.
+Three stacked panels sharing one campaign-length x-axis:
+
+1. **Uplift recovery** — the true (injected) uplift plus each method's mean recovered uplift,
+   so over- vs under-estimation is visible and the true uplift's variation with campaign
+   length is shown.
+2. **Bias +/- spread** — one ``bias`` line per method with a shaded ``bias +/- spread`` band
+   (accuracy and precision together).
+3. **Score** — the combined ``score`` (RMSE) per method.
+
+All quantities are converted from uplift fractions to percentage points (a 0.01 fraction is
+plotted as 1 pp). Each method keeps one colour across all panels. Consumes the leaderboard
+summary frame.
 """
 
 from __future__ import annotations
@@ -10,12 +19,16 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import matplotlib.pyplot as plt
+import numpy as np
 
 if TYPE_CHECKING:
     from pathlib import Path
 
     import pandas as pd
     from matplotlib.figure import Figure
+
+# Uplift quantities are stored as fractions; plot them as percentage points.
+_FRACTION_TO_PP = 100.0
 
 
 def plot_campaign_curves(
@@ -24,31 +37,71 @@ def plot_campaign_curves(
     save_path: str | Path | None = None,
     title: str | None = None,
 ) -> Figure:
-    """Plot combined score vs campaign length, one line per method, with a bias +/- spread band.
+    """Plot uplift recovery, bias/spread and score vs campaign length, per method.
 
     :param summary_df: a leaderboard summary (columns ``method``, ``campaign_months``, ``bias``,
-        ``spread``, ``score``)
+        ``spread``, ``score``, and optionally ``mean_estimate`` / ``mean_truth`` for the top panel)
     :param save_path: if given, the figure is written here (PNG)
-    :param title: optional figure title
+    :param title: optional title for the top panel
     :return: the matplotlib Figure
     """
-    fig, ax = plt.subplots(figsize=(8, 5))
-    for method, group in summary_df.sort_values("campaign_months").groupby("method"):
-        months = group["campaign_months"].to_numpy()
-        score = group["score"].to_numpy()
-        bias = group["bias"].to_numpy()
-        spread = group["spread"].to_numpy()
-        (line,) = ax.plot(months, score, marker="o", label=str(method))
-        ax.fill_between(months, bias - spread, bias + spread, alpha=0.15, color=line.get_color())
+    methods = sorted(summary_df["method"].unique())
+    colors = {method: f"C{i}" for i, method in enumerate(methods)}
 
-    ax.axhline(0.0, color="k", linewidth=0.8)
-    ax.set_xlabel("Campaign length [months]")
-    ax.set_ylabel("Uplift error [fraction]")
-    ax.set_title(title if title is not None else "P50 accuracy/precision vs campaign length")
-    ax.grid(visible=True, alpha=0.3)
-    ax.legend()
+    fig, (ax_uplift, ax_band, ax_score) = plt.subplots(3, 1, sharex=True, figsize=(8, 11))
+
+    # Top panel: the true uplift (method-independent) and each method's mean recovered uplift.
+    if "mean_truth" in summary_df.columns:
+        truth = summary_df.groupby("campaign_months")["mean_truth"].mean().sort_index()
+        ax_uplift.plot(
+            truth.index.to_numpy(), truth.to_numpy() * _FRACTION_TO_PP, "--", marker="s", color="k", label="true uplift"
+        )
+
+    for method in methods:
+        group = summary_df[summary_df["method"] == method].sort_values("campaign_months")
+        months = group["campaign_months"].to_numpy()
+        color = colors[method]
+        bias = group["bias"].to_numpy() * _FRACTION_TO_PP
+        spread = group["spread"].to_numpy() * _FRACTION_TO_PP
+
+        if "mean_estimate" in summary_df.columns:
+            estimate = group["mean_estimate"].to_numpy() * _FRACTION_TO_PP
+            ax_uplift.plot(months, estimate, marker="o", color=color, label=method)
+            ax_uplift.fill_between(months, estimate - spread, estimate + spread, alpha=0.15, color=color)
+        ax_band.plot(months, bias, marker="o", color=color, label=method)
+        ax_band.fill_between(months, bias - spread, bias + spread, alpha=0.15, color=color)
+        ax_score.plot(months, group["score"].to_numpy() * _FRACTION_TO_PP, marker="o", color=color, label=method)
+
+    ax_uplift.set_ylabel("Measured uplift [pp]")
+    ax_uplift.set_title(title if title is not None else "P50 uplift recovery vs campaign length")
+    ax_uplift.grid(visible=True, alpha=0.3)
+    ax_uplift.legend()
+
+    ax_band.axhline(0.0, color="k", linewidth=0.8)
+    ax_band.set_ylabel("Bias +/- spread [pp]")
+    ax_band.grid(visible=True, alpha=0.3)
+
+    ax_score.set_xlabel("Campaign length [months]")
+    ax_score.set_ylabel("Score / RMSE [pp]")
+    ax_score.grid(visible=True, alpha=0.3)
+    ax_score.set_xlim(left=0.0)
+    _set_score_ylim(ax_score, summary_df["score"].to_numpy() * _FRACTION_TO_PP)
+
     fig.tight_layout()
 
     if save_path is not None:
         fig.savefig(save_path, dpi=150)
     return fig
+
+
+def _set_score_ylim(ax: plt.Axes, scores_pp: np.ndarray) -> None:
+    """Anchor the score y-axis at min(0, lowest point) minus a small margin.
+
+    Score is a non-negative RMSE, but a hard floor of 0 clips data points sitting exactly at 0
+    (e.g. an oracle). Drop the floor by a small margin so those points stay visible.
+    """
+    lo = float(np.nanmin(scores_pp))
+    hi = float(np.nanmax(scores_pp))
+    span = hi - lo
+    margin = 0.05 * span if span > 0 else max(abs(hi), 1.0) * 0.05
+    ax.set_ylim(bottom=min(0.0, lo) - margin)

--- a/benchmarking/harness/plots.py
+++ b/benchmarking/harness/plots.py
@@ -1,0 +1,54 @@
+"""Campaign-length curves for comparing methods.
+
+One line per method showing the combined ``score`` against campaign length, with a shaded
+bias +/- spread band so accuracy and precision are both visible. All quantities are in
+uplift-fraction units, so they share one y-axis. Consumes the leaderboard summary frame.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import matplotlib.pyplot as plt
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pandas as pd
+    from matplotlib.figure import Figure
+
+
+def plot_campaign_curves(
+    summary_df: pd.DataFrame,
+    *,
+    save_path: str | Path | None = None,
+    title: str | None = None,
+) -> Figure:
+    """Plot combined score vs campaign length, one line per method, with a bias +/- spread band.
+
+    :param summary_df: a leaderboard summary (columns ``method``, ``campaign_months``, ``bias``,
+        ``spread``, ``score``)
+    :param save_path: if given, the figure is written here (PNG)
+    :param title: optional figure title
+    :return: the matplotlib Figure
+    """
+    fig, ax = plt.subplots(figsize=(8, 5))
+    for method, group in summary_df.sort_values("campaign_months").groupby("method"):
+        months = group["campaign_months"].to_numpy()
+        score = group["score"].to_numpy()
+        bias = group["bias"].to_numpy()
+        spread = group["spread"].to_numpy()
+        (line,) = ax.plot(months, score, marker="o", label=str(method))
+        ax.fill_between(months, bias - spread, bias + spread, alpha=0.15, color=line.get_color())
+
+    ax.axhline(0.0, color="k", linewidth=0.8)
+    ax.set_xlabel("Campaign length [months]")
+    ax.set_ylabel("Uplift error [fraction]")
+    ax.set_title(title if title is not None else "P50 accuracy/precision vs campaign length")
+    ax.grid(visible=True, alpha=0.3)
+    ax.legend()
+    fig.tight_layout()
+
+    if save_path is not None:
+        fig.savefig(save_path, dpi=150)
+    return fig

--- a/benchmarking/harness/replicates.py
+++ b/benchmarking/harness/replicates.py
@@ -80,6 +80,7 @@ class Replicate:
 
 def build_replicates(
     base_scada: pd.DataFrame,
+    *,
     profile: list,
     study: StudyConfig,
 ) -> list[Replicate]:

--- a/benchmarking/harness/replicates.py
+++ b/benchmarking/harness/replicates.py
@@ -1,0 +1,140 @@
+"""The replicate ensemble — the precision axis of the harness.
+
+Precision needs an ensemble: a single dataset gives one estimate, hence one error. Holding
+the upgrade *profile* fixed, an ensemble is built by varying the base ingredients — the test
+turbine and the treatment-start date (the changeover for prepost; when toggling begins for
+toggle). The spread of a method's error across these replicates is its precision.
+
+The data is first subset to ``turbine_subset`` (one test turbine is drawn per replicate; the
+rest are its references) so each run stays light — important when scoring many replicates.
+Draws are a pure deterministic function of ``(StudyConfig, seed)``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Literal
+
+import numpy as np
+
+from benchmarking.synthetic import ToggleSchedule, generate_dataset
+from wind_up.constants import DataColumns
+
+if TYPE_CHECKING:
+    import numpy.typing as npt
+    import pandas as pd
+
+    from benchmarking.synthetic import SyntheticDataset, UpliftResult
+
+
+@dataclass(frozen=True)
+class StudyConfig:
+    """One study: a profile evaluated over an ensemble and a campaign-length grid.
+
+    :param mode: ``"prepost"`` or ``"toggle"``
+    :param turbine_subset: the only turbines kept in the data; per replicate one is drawn as
+        the test turbine and the rest are its references
+    :param treatment_start_range: ``(earliest, latest)`` treatment-start timestamp to draw from
+    :param min_pre_months: fixed baseline length before treatment start, in months
+    :param campaign_months: the campaign-length sweep grid, in months
+    :param toggle_period: toggle on/off cycle length (toggle mode only)
+    :param n_replicates: number of ``(turbine, treatment_start)`` instances to draw
+    :param seed: RNG seed for the draws
+    """
+
+    mode: Literal["prepost", "toggle"]
+    turbine_subset: list[str]
+    treatment_start_range: tuple[pd.Timestamp, pd.Timestamp]
+    min_pre_months: int
+    campaign_months: list[int]
+    n_replicates: int
+    toggle_period: pd.Timedelta | None = None
+    seed: int = 0
+
+    @property
+    def max_activity_months(self) -> int:
+        """The longest campaign the study scores (drives feasibility checks)."""
+        return max(self.campaign_months)
+
+
+@dataclass
+class Replicate:
+    """One generated dataset paired with the ingredients that produced it."""
+
+    dataset: SyntheticDataset
+    test_wtg: str
+    treatment_start: pd.Timestamp
+    upgrade_timing: pd.Timestamp | ToggleSchedule
+    replicate_id: int = field(default=0)
+
+    @property
+    def synthetic_df(self) -> pd.DataFrame:
+        """The method-facing synthetic SCADA (all subset turbines)."""
+        return self.dataset.synthetic_df
+
+    def true_uplift(self, **kwargs: object) -> UpliftResult:
+        """Ground-truth uplift for this replicate's test turbine (delegates to the dataset)."""
+        kwargs.setdefault("test_wtg", self.test_wtg)
+        return self.dataset.true_uplift(**kwargs)  # type: ignore[arg-type]
+
+
+def build_replicates(
+    base_scada: pd.DataFrame,
+    profile: list,
+    study: StudyConfig,
+) -> list[Replicate]:
+    """Draw ``study.n_replicates`` replicates of ``profile`` from ``base_scada``.
+
+    Subsets the data to ``turbine_subset``, then draws ``(test turbine, treatment_start)`` pairs
+    deterministically from ``seed`` and injects the profile via the synthetic generator.
+    """
+    subset = base_scada[base_scada[DataColumns.turbine_name].isin(study.turbine_subset)]
+    candidates = _candidate_starts(subset.index, study.treatment_start_range)
+
+    rng = np.random.default_rng(study.seed)
+    turbines = np.asarray(study.turbine_subset)
+    replicates = []
+    for replicate_id in range(study.n_replicates):
+        test_wtg = str(rng.choice(turbines))
+        treatment_start = candidates[int(rng.integers(len(candidates)))]
+        upgrade_timing = _upgrade_timing(study, treatment_start)
+        dataset = generate_dataset(
+            scada_df=subset,
+            test_wtgs=[test_wtg],
+            upgrades=profile,
+            mode=study.mode,
+            upgrade_timing=upgrade_timing,
+            seed=study.seed,
+        )
+        replicates.append(
+            Replicate(
+                dataset=dataset,
+                test_wtg=test_wtg,
+                treatment_start=treatment_start,
+                upgrade_timing=upgrade_timing,
+                replicate_id=replicate_id,
+            )
+        )
+    return replicates
+
+
+def _candidate_starts(
+    index: pd.DatetimeIndex, treatment_start_range: tuple[pd.Timestamp, pd.Timestamp]
+) -> npt.NDArray[np.datetime64]:
+    """Return unique on-grid timestamps within the draw range (so draws land on real records)."""
+    lo, hi = treatment_start_range
+    unique = index.unique()
+    candidates = unique[(unique >= lo) & (unique <= hi)]
+    if len(candidates) == 0:
+        msg = f"no records in treatment_start_range {treatment_start_range}"
+        raise ValueError(msg)
+    return candidates.sort_values().to_numpy()
+
+
+def _upgrade_timing(study: StudyConfig, treatment_start: pd.Timestamp) -> pd.Timestamp | ToggleSchedule:
+    if study.mode == "toggle":
+        if study.toggle_period is None:
+            msg = "toggle_period is required for mode='toggle'"
+            raise ValueError(msg)
+        return ToggleSchedule(period=study.toggle_period, start=treatment_start)
+    return treatment_start

--- a/benchmarking/harness/scoring.py
+++ b/benchmarking/harness/scoring.py
@@ -1,0 +1,112 @@
+"""The scoring orchestrator: run methods over an ensemble and a campaign-length grid.
+
+For one study it builds the replicate ensemble, materialises the ``(replicate, campaign)``
+instances **once**, and scores every method against that identical list. Two fairness
+properties follow structurally:
+
+1. **Across methods** — instances are built before any method runs, so every method sees the
+   exact same ``MethodInput``s; only the estimate differs.
+2. **Across campaign lengths** — all lengths of one replicate share its
+   ``(turbine, baseline_start, treatment_start)`` and differ only in ``activity_end``, so
+   shorter windows are leading prefixes of longer ones (a property of ``campaign_windows``).
+
+For each instance the method's estimate and the ground truth are computed over the **same
+records**, so the signed error is exact at every campaign length. Output is one tidy
+long-format DataFrame, the input to the leaderboard and plots.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pandas as pd
+
+from benchmarking.harness.campaign import campaign_windows, treated_activity_mask, window_row_mask
+from benchmarking.harness.method import MethodInput
+from benchmarking.harness.replicates import build_replicates
+from wind_up.constants import DataColumns
+
+if TYPE_CHECKING:
+    from benchmarking.harness.campaign import CampaignWindow
+    from benchmarking.harness.method import Method
+    from benchmarking.harness.replicates import Replicate, StudyConfig
+
+
+def score_study(
+    base_scada: pd.DataFrame,
+    profile: list,
+    methods: list[Method],
+    study: StudyConfig,
+    *,
+    profile_name: str = "profile",
+) -> pd.DataFrame:
+    """Score ``methods`` on ``study`` over ``profile`` injected into ``base_scada``.
+
+    Returns a tidy long-format frame: one row per method x replicate x campaign length, with
+    the P50 ``estimate``, the ground-truth ``truth`` and their ``signed_error``.
+    """
+    replicates = build_replicates(base_scada, profile, study)
+    data_start = base_scada.index.min()
+    data_end = base_scada.index.max()
+    instances = _materialise_instances(replicates, study, data_start=data_start, data_end=data_end)
+
+    rows = []
+    for method in methods:
+        for replicate, window in instances:
+            method_input = _method_input(replicate, window)
+            output = method.estimate(method_input)
+            truth = _truth_overall(replicate, window)
+            rows.append(
+                {
+                    "method": method.name,
+                    "profile": profile_name,
+                    "replicate": replicate.replicate_id,
+                    "test_wtg": replicate.test_wtg,
+                    "campaign_months": window.months,
+                    "condition": "overall",
+                    "estimate": output.p50_overall,
+                    "truth": truth,
+                    "signed_error": output.p50_overall - truth,
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def _materialise_instances(
+    replicates: list[Replicate],
+    study: StudyConfig,
+    *,
+    data_start: pd.Timestamp,
+    data_end: pd.Timestamp,
+) -> list[tuple[Replicate, CampaignWindow]]:
+    """Build the fixed ``(replicate, campaign window)`` list shared by every method."""
+    instances = []
+    for replicate in replicates:
+        windows = campaign_windows(
+            replicate.treatment_start,
+            min_pre_months=study.min_pre_months,
+            campaign_months=study.campaign_months,
+            data_start=data_start,
+            data_end=data_end,
+        )
+        instances.extend((replicate, window) for window in windows)
+    return instances
+
+
+def _method_input(replicate: Replicate, window: CampaignWindow) -> MethodInput:
+    """Return the method-facing rows: all subset turbines within ``[baseline_start, activity_end)``."""
+    synthetic = replicate.synthetic_df
+    row_mask = window_row_mask(synthetic.index, window)
+    return MethodInput(
+        scada_df=synthetic.loc[row_mask],
+        test_wtg=replicate.test_wtg,
+        upgrade_timing=replicate.upgrade_timing,
+    )
+
+
+def _truth_overall(replicate: Replicate, window: CampaignWindow) -> float:
+    """Ground-truth uplift over the test turbine's treated rows within the activity window."""
+    synthetic = replicate.synthetic_df
+    test_index = synthetic.loc[synthetic[DataColumns.turbine_name] == replicate.test_wtg].index
+    mask = treated_activity_mask(test_index, replicate.upgrade_timing, window)
+    return replicate.true_uplift(mask=mask).overall

--- a/benchmarking/harness/scoring.py
+++ b/benchmarking/harness/scoring.py
@@ -34,10 +34,10 @@ if TYPE_CHECKING:
 
 def score_study(
     base_scada: pd.DataFrame,
+    *,
     profile: list,
     methods: list[Method],
     study: StudyConfig,
-    *,
     profile_name: str = "profile",
 ) -> pd.DataFrame:
     """Score ``methods`` on ``study`` over ``profile`` injected into ``base_scada``.
@@ -45,7 +45,7 @@ def score_study(
     Returns a tidy long-format frame: one row per method x replicate x campaign length, with
     the P50 ``estimate``, the ground-truth ``truth`` and their ``signed_error``.
     """
-    replicates = build_replicates(base_scada, profile, study)
+    replicates = build_replicates(base_scada, profile=profile, study=study)
     data_start = base_scada.index.min()
     data_end = base_scada.index.max()
     instances = _materialise_instances(replicates, study, data_start=data_start, data_end=data_end)
@@ -110,5 +110,5 @@ def _truth_overall(replicate: Replicate, window: CampaignWindow) -> float:
     """Ground-truth uplift over the test turbine's treated rows within the activity window."""
     synthetic = replicate.synthetic_df
     test_index = synthetic.loc[synthetic[DataColumns.turbine_name] == replicate.test_wtg].index
-    mask = treated_activity_mask(test_index, replicate.upgrade_timing, window)
+    mask = treated_activity_mask(test_index, replicate.upgrade_timing, window=window)
     return replicate.true_uplift(mask=mask).overall

--- a/benchmarking/harness/scoring.py
+++ b/benchmarking/harness/scoring.py
@@ -49,13 +49,15 @@ def score_study(
     data_start = base_scada.index.min()
     data_end = base_scada.index.max()
     instances = _materialise_instances(replicates, study, data_start=data_start, data_end=data_end)
+    # Truth depends only on ``(replicate, window)``, so compute it once here rather than once
+    # per method (it would otherwise carry an avoidable ``len(methods)`` multiplier).
+    truths = [_truth_overall(replicate, window) for replicate, window in instances]
 
     rows = []
     for method in methods:
-        for replicate, window in instances:
+        for (replicate, window), truth in zip(instances, truths, strict=True):
             method_input = _method_input(replicate, window)
             output = method.estimate(method_input)
-            truth = _truth_overall(replicate, window)
             rows.append(
                 {
                     "method": method.name,
@@ -80,7 +82,7 @@ def _materialise_instances(
     data_end: pd.Timestamp,
 ) -> list[tuple[Replicate, CampaignWindow]]:
     """Build the fixed ``(replicate, campaign window)`` list shared by every method."""
-    instances = []
+    instances: list[tuple[Replicate, CampaignWindow]] = []
     for replicate in replicates:
         windows = campaign_windows(
             replicate.treatment_start,

--- a/benchmarking/synthetic/__init__.py
+++ b/benchmarking/synthetic/__init__.py
@@ -7,7 +7,7 @@ derivable ground-truth uplift, for objectively evaluating uplift methods.
 from __future__ import annotations
 
 from benchmarking.synthetic.cp_core import HOT_CP_MODEL, CpCore, CpParams, cp_surface
-from benchmarking.synthetic.generator import SyntheticDataset, ToggleSchedule, generate_dataset
+from benchmarking.synthetic.generator import SyntheticDataset, ToggleSchedule, generate_dataset, treated_mask
 from benchmarking.synthetic.ground_truth import UpliftResult, true_uplift
 from benchmarking.synthetic.plots import plot_power_curve_comparison
 from benchmarking.synthetic.upgrades import (
@@ -35,5 +35,6 @@ __all__ = [
     "cp_surface",
     "generate_dataset",
     "plot_power_curve_comparison",
+    "treated_mask",
     "true_uplift",
 ]

--- a/benchmarking/synthetic/generator.py
+++ b/benchmarking/synthetic/generator.py
@@ -175,7 +175,7 @@ def generate_dataset(
         if not mask.any():
             continue
         cp = CpCore(rated_power_kw=rated_power_kw, cp_params=cp_params)
-        modified = apply_upgrades(synthetic_df.loc[mask], upgrades, cp)
+        modified = apply_upgrades(synthetic_df.loc[mask], upgrades, cp=cp)
         for col in _MODIFIED_COLUMNS:
             synthetic_df.loc[mask, col] = modified[col].to_numpy()
 

--- a/benchmarking/synthetic/generator.py
+++ b/benchmarking/synthetic/generator.py
@@ -107,8 +107,14 @@ def _treated_mask(
 ) -> np.ndarray:
     """Boolean mask over ``index`` selecting the rows where the upgrade is active."""
     if mode == "prepost":
+        if isinstance(upgrade_timing, ToggleSchedule):
+            msg = "prepost mode needs a changeover Timestamp, got a ToggleSchedule"
+            raise TypeError(msg)
         return np.asarray(index >= upgrade_timing)
     if mode == "toggle":
+        if not isinstance(upgrade_timing, ToggleSchedule):
+            msg = f"toggle mode needs a ToggleSchedule, got {type(upgrade_timing).__name__}"
+            raise TypeError(msg)
         schedule = upgrade_timing
         origin = schedule.start if schedule.start is not None else index.min()
         # ``period`` is a full on/off cycle, so each on/off block is half a period.

--- a/benchmarking/synthetic/generator.py
+++ b/benchmarking/synthetic/generator.py
@@ -38,10 +38,14 @@ class ToggleSchedule:
 
     :param period: length of one full on/off cycle (half off, half on)
     :param start_on: whether the first block is treated (on); default off (pre-like)
+    :param start: when toggling begins; rows before it are untreated baseline and it is
+        the toggle origin. ``None`` (default) keeps the data's first timestamp as origin
+        with no baseline.
     """
 
     period: pd.Timedelta
     start_on: bool = False
+    start: pd.Timestamp | None = None
 
 
 @dataclass
@@ -106,12 +110,29 @@ def _treated_mask(
         return np.asarray(index >= upgrade_timing)
     if mode == "toggle":
         schedule = upgrade_timing
+        origin = schedule.start if schedule.start is not None else index.min()
         # ``period`` is a full on/off cycle, so each on/off block is half a period.
-        block = (index - index.min()) // (schedule.period / 2)
+        block = (index - origin) // (schedule.period / 2)
         on_parity = 0 if schedule.start_on else 1
-        return np.asarray((np.asarray(block) % 2) == on_parity)
+        treated = np.asarray((np.asarray(block) % 2) == on_parity)
+        if schedule.start is not None:
+            # Rows before toggling begins are untreated baseline (and their negative block
+            # index must not be allowed to alias onto an "on" parity).
+            treated &= np.asarray(index >= schedule.start)
+        return treated
     msg = f"unknown mode {mode!r}"
     raise ValueError(msg)
+
+
+def treated_mask(index: pd.DatetimeIndex, upgrade_timing: pd.Timestamp | ToggleSchedule) -> np.ndarray:
+    """Boolean mask of the rows an upgrade treats, with the mode inferred from ``upgrade_timing``.
+
+    A ``ToggleSchedule`` selects toggle mode; any other value (a changeover timestamp) selects
+    prepost mode. Shared by the generator, methods and the scoring truth path so they all agree
+    on which rows are treated.
+    """
+    mode: Literal["prepost", "toggle"] = "toggle" if isinstance(upgrade_timing, ToggleSchedule) else "prepost"
+    return _treated_mask(index, mode=mode, upgrade_timing=upgrade_timing)
 
 
 def generate_dataset(

--- a/benchmarking/synthetic/sources/hill_of_towie.py
+++ b/benchmarking/synthetic/sources/hill_of_towie.py
@@ -75,9 +75,9 @@ def get_data_dir() -> Path:
 # --------------------------------------------------------------------------------------
 def download_zenodo_data(
     record_id: str,
+    *,
     output_dir: Path | None = None,
     filenames: Collection[str] | None = None,
-    *,
     cache_overwrite: bool = False,
 ) -> None:
     """Download and cache files from zenodo.org."""

--- a/benchmarking/synthetic/upgrades.py
+++ b/benchmarking/synthetic/upgrades.py
@@ -177,7 +177,7 @@ def apply_rated_change(
     return np.minimum(lifted, new_rated_kw)
 
 
-def apply_upgrades(rows: pd.DataFrame, upgrades: list, cp: CpCore) -> pd.DataFrame:
+def apply_upgrades(rows: pd.DataFrame, upgrades: list, *, cp: CpCore) -> pd.DataFrame:
     """Resolve and apply a list of upgrades to one test turbine's treated rows.
 
     Cp ratios from all upgrades multiply together and are applied to the original power

--- a/tests/benchmarking/harness/stubs.py
+++ b/tests/benchmarking/harness/stubs.py
@@ -1,0 +1,86 @@
+"""Stub methods for exercising the scoring machinery without a real estimator.
+
+The oracle computes the true uplift from its *own* method-input window (windowed synthetic vs
+original), so if the harness ever scored truth over different records than it handed the
+method, the oracle's error would stop being zero. Biased/Noisy wrap the oracle to drive the
+bias/precision metrics; Recording captures inputs for the fairness test.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from benchmarking.harness.method import MethodInput, MethodOutput
+from benchmarking.synthetic import treated_mask
+from wind_up.constants import DataColumns
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+
+def oracle_overall_uplift(mi: MethodInput, original_df: pd.DataFrame) -> float:
+    """Energy-ratio uplift over the treated test-turbine rows in ``mi``'s window."""
+    syn = mi.scada_df
+    test_rows = syn[syn[DataColumns.turbine_name] == mi.test_wtg]
+    treated = treated_mask(test_rows.index, mi.upgrade_timing)
+    treated_rows = test_rows[treated]
+
+    syn_power = treated_rows[DataColumns.active_power_mean].to_numpy(dtype=float)
+    orig_test = original_df[original_df[DataColumns.turbine_name] == mi.test_wtg]
+    orig_power = orig_test.loc[treated_rows.index, DataColumns.active_power_mean].to_numpy(dtype=float)
+
+    finite = np.isfinite(syn_power) & np.isfinite(orig_power)
+    denom = orig_power[finite].sum()
+    return syn_power[finite].sum() / denom - 1.0 if denom else float("nan")
+
+
+class OracleMethod:
+    """Returns the true uplift; signed error should be ~0."""
+
+    def __init__(self, original_df: pd.DataFrame, name: str = "oracle") -> None:
+        self._original = original_df
+        self.name = name
+
+    def estimate(self, mi: MethodInput) -> MethodOutput:
+        return MethodOutput(p50_overall=oracle_overall_uplift(mi, self._original))
+
+
+class BiasedMethod:
+    """Returns the true uplift plus a fixed offset; signed error should equal the offset."""
+
+    def __init__(self, original_df: pd.DataFrame, offset: float, name: str = "biased") -> None:
+        self._original = original_df
+        self._offset = offset
+        self.name = name
+
+    def estimate(self, mi: MethodInput) -> MethodOutput:
+        return MethodOutput(p50_overall=oracle_overall_uplift(mi, self._original) + self._offset)
+
+
+class NoisyMethod:
+    """Returns the true uplift plus seeded Gaussian noise; error spread should track sigma."""
+
+    def __init__(self, original_df: pd.DataFrame, sigma: float, seed: int = 0, name: str = "noisy") -> None:
+        self._original = original_df
+        self._sigma = sigma
+        self._rng = np.random.default_rng(seed)
+        self.name = name
+
+    def estimate(self, mi: MethodInput) -> MethodOutput:
+        noise = float(self._rng.normal(0.0, self._sigma))
+        return MethodOutput(p50_overall=oracle_overall_uplift(mi, self._original) + noise)
+
+
+class RecordingMethod:
+    """Captures every MethodInput it is handed, for the fairness test."""
+
+    def __init__(self, name: str = "recording") -> None:
+        self.name = name
+        self.seen: list[MethodInput] = []
+
+    def estimate(self, mi: MethodInput) -> MethodOutput:
+        captured = MethodInput(scada_df=mi.scada_df.copy(), test_wtg=mi.test_wtg, upgrade_timing=mi.upgrade_timing)
+        self.seen.append(captured)
+        return MethodOutput(p50_overall=0.0)

--- a/tests/benchmarking/harness/test_campaign.py
+++ b/tests/benchmarking/harness/test_campaign.py
@@ -64,7 +64,7 @@ def test_window_row_mask_selects_baseline_through_activity_end() -> None:
 def test_prepost_truth_mask_is_the_post_rows_within_activity() -> None:
     index = pd.date_range("2017-01-01", "2019-06-01", freq="1D", tz="UTC")
     [window] = campaign_windows(T0, min_pre_months=12, campaign_months=[6])
-    mask = treated_activity_mask(index, T0, window)  # prepost: a bare timestamp
+    mask = treated_activity_mask(index, T0, window=window)  # prepost: a bare timestamp
     selected = index[mask]
     assert (selected >= T0).all()
     assert (selected < window.activity_end).all()
@@ -75,7 +75,7 @@ def test_toggle_truth_mask_excludes_baseline_and_keeps_only_on_rows() -> None:
     index = pd.date_range("2017-01-01", "2019-06-01", freq="6h", tz="UTC")
     schedule = ToggleSchedule(period=pd.Timedelta(days=14), start=T0)
     [window] = campaign_windows(T0, min_pre_months=12, campaign_months=[6])
-    mask = treated_activity_mask(index, schedule, window)
+    mask = treated_activity_mask(index, schedule, window=window)
     assert not mask[index < T0].any()  # baseline untreated
     assert mask.any()  # some on-rows inside the toggling window
     assert (index[mask] < window.activity_end).all()

--- a/tests/benchmarking/harness/test_campaign.py
+++ b/tests/benchmarking/harness/test_campaign.py
@@ -1,0 +1,94 @@
+"""Tests for campaign windows and their two derived selections."""
+
+from __future__ import annotations
+
+from itertools import pairwise
+
+import numpy as np
+import pandas as pd
+
+from benchmarking.harness.campaign import (
+    CampaignWindow,
+    campaign_windows,
+    treated_activity_mask,
+    window_row_mask,
+)
+from benchmarking.synthetic import ToggleSchedule
+
+T0 = pd.Timestamp("2018-01-01", tz="UTC")
+
+
+def test_window_bounds_use_fixed_baseline_and_activity_length() -> None:
+    [window] = campaign_windows(T0, min_pre_months=12, campaign_months=[6])
+    assert isinstance(window, CampaignWindow)
+    assert window.treatment_start == T0
+    assert window.baseline_start == T0 - pd.DateOffset(months=12)
+    assert window.activity_end == T0 + pd.DateOffset(months=6)
+    assert window.months == 6
+
+
+def test_one_window_per_campaign_length() -> None:
+    windows = campaign_windows(T0, min_pre_months=12, campaign_months=[3, 6, 9, 12])
+    assert [w.months for w in windows] == [3, 6, 9, 12]
+
+
+def test_shorter_windows_share_baseline_and_treatment_start() -> None:
+    windows = campaign_windows(T0, min_pre_months=12, campaign_months=[3, 6, 9, 12])
+    assert {w.baseline_start for w in windows} == {T0 - pd.DateOffset(months=12)}
+    assert {w.treatment_start for w in windows} == {T0}
+    activity_ends = [w.activity_end for w in windows]
+    assert activity_ends == sorted(activity_ends)  # strictly growing post window
+
+
+def test_each_windows_row_mask_is_a_prefix_subset_of_the_next() -> None:
+    index = pd.date_range("2017-01-01", "2019-01-01", freq="6h", tz="UTC")
+    windows = campaign_windows(T0, min_pre_months=12, campaign_months=[3, 6, 9, 12])
+    masks = [window_row_mask(index, w) for w in windows]
+    for shorter, longer in pairwise(masks):
+        # 3 ⊂ 6 ⊂ 9 ⊂ 12: every row in the shorter window is in the longer one
+        assert np.all(longer[shorter])
+        assert longer.sum() > shorter.sum()
+
+
+def test_window_row_mask_selects_baseline_through_activity_end() -> None:
+    index = pd.date_range("2017-01-01", "2019-01-01", freq="1D", tz="UTC")
+    [window] = campaign_windows(T0, min_pre_months=12, campaign_months=[6])
+    mask = window_row_mask(index, window)
+    selected = index[mask]
+    assert selected.min() >= window.baseline_start
+    assert selected.max() < window.activity_end
+    unselected = index[~mask]
+    assert ((unselected < window.baseline_start) | (unselected >= window.activity_end)).all()
+
+
+def test_prepost_truth_mask_is_the_post_rows_within_activity() -> None:
+    index = pd.date_range("2017-01-01", "2019-06-01", freq="1D", tz="UTC")
+    [window] = campaign_windows(T0, min_pre_months=12, campaign_months=[6])
+    mask = treated_activity_mask(index, T0, window)  # prepost: a bare timestamp
+    selected = index[mask]
+    assert (selected >= T0).all()
+    assert (selected < window.activity_end).all()
+    assert not mask[index < T0].any()  # baseline never counted as treated
+
+
+def test_toggle_truth_mask_excludes_baseline_and_keeps_only_on_rows() -> None:
+    index = pd.date_range("2017-01-01", "2019-06-01", freq="6h", tz="UTC")
+    schedule = ToggleSchedule(period=pd.Timedelta(days=14), start=T0)
+    [window] = campaign_windows(T0, min_pre_months=12, campaign_months=[6])
+    mask = treated_activity_mask(index, schedule, window)
+    assert not mask[index < T0].any()  # baseline untreated
+    assert mask.any()  # some on-rows inside the toggling window
+    assert (index[mask] < window.activity_end).all()
+    assert mask.sum() < ((index >= T0) & (index < window.activity_end)).sum()  # only on-blocks
+
+
+def test_infeasible_lengths_are_dropped_when_data_bounds_given() -> None:
+    # data ends only 4 months after t0, so 6/9/12-month campaigns do not fit
+    windows = campaign_windows(
+        T0,
+        min_pre_months=12,
+        campaign_months=[3, 6, 9, 12],
+        data_start=pd.Timestamp("2016-01-01", tz="UTC"),
+        data_end=T0 + pd.DateOffset(months=4),
+    )
+    assert [w.months for w in windows] == [3]

--- a/tests/benchmarking/harness/test_hot_end_to_end.py
+++ b/tests/benchmarking/harness/test_hot_end_to_end.py
@@ -43,7 +43,9 @@ def test_constant_cp_study_on_real_hot_data(tmp_path: Path) -> None:
     )
     methods = [OracleMethod(scada_df), BiasedMethod(scada_df, offset=0.02)]
 
-    results = score_study(scada_df, [ConstantCpChange(delta=0.05)], methods, study, profile_name="constant_cp_5pct")
+    results = score_study(
+        scada_df, profile=[ConstantCpChange(delta=0.05)], methods=methods, study=study, profile_name="constant_cp_5pct"
+    )
     summary = leaderboard(results)
 
     oracle = summary[summary["method"] == "oracle"]

--- a/tests/benchmarking/harness/test_hot_end_to_end.py
+++ b/tests/benchmarking/harness/test_hot_end_to_end.py
@@ -1,0 +1,57 @@
+"""Slow end-to-end test: a real Hill of Towie constant-Cp study through the full harness.
+
+Network- and data-heavy (downloads HoT SCADA from Zenodo on first run); excluded from the
+default offline suite via the ``slow`` marker. Proves the harness runs a real study end to
+end: load -> inject -> replicate ensemble -> campaign sweep -> score -> leaderboard -> plot.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from benchmarking.harness import StudyConfig, leaderboard, plot_campaign_curves, score_study
+from benchmarking.synthetic import ConstantCpChange
+from benchmarking.synthetic.sources.hill_of_towie import load_hot_scada
+
+from .stubs import BiasedMethod, OracleMethod
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+pytestmark = pytest.mark.slow
+
+
+def test_constant_cp_study_on_real_hot_data(tmp_path: Path) -> None:
+    scada_df, _ = load_hot_scada(
+        start_dt=pd.Timestamp("2016-01-01", tz="UTC"),
+        end_dt_excl=pd.Timestamp("2017-05-01", tz="UTC"),
+        wtg_numbers=[1, 3, 4, 7],  # the stable SW turbines T01, T03, T04, T07
+    )
+
+    study = StudyConfig(
+        mode="prepost",
+        turbine_subset=["T01", "T03", "T04", "T07"],
+        treatment_start_range=(pd.Timestamp("2017-01-01", tz="UTC"), pd.Timestamp("2017-01-31", tz="UTC")),
+        min_pre_months=12,
+        campaign_months=[3],
+        n_replicates=2,
+        seed=0,
+    )
+    methods = [OracleMethod(scada_df), BiasedMethod(scada_df, offset=0.02)]
+
+    results = score_study(scada_df, [ConstantCpChange(delta=0.05)], methods, study, profile_name="constant_cp_5pct")
+    summary = leaderboard(results)
+
+    oracle = summary[summary["method"] == "oracle"]
+    biased = summary[summary["method"] == "biased"]
+    assert np.allclose(oracle["bias"].to_numpy(), 0.0, atol=1e-6)  # recovers the injected truth
+    assert np.allclose(biased["bias"].to_numpy(), 0.02, atol=1e-6)  # off by exactly the offset
+    assert (summary["n_replicates"] == 2).all()
+
+    save_path = tmp_path / "hot_campaign_curves.png"
+    plot_campaign_curves(summary, save_path=save_path)
+    assert save_path.exists()

--- a/tests/benchmarking/harness/test_leaderboard.py
+++ b/tests/benchmarking/harness/test_leaderboard.py
@@ -54,6 +54,18 @@ def test_only_overall_condition_rows_are_summarised() -> None:
     assert row["n_replicates"] == 1
 
 
+def test_mean_estimate_and_truth_are_averaged() -> None:
+    results = _results(
+        [
+            {"campaign_months": 3, "signed_error": 0.01, "estimate": 0.06, "truth": 0.05},
+            {"campaign_months": 3, "signed_error": -0.01, "estimate": 0.04, "truth": 0.05},
+        ]
+    )
+    row = leaderboard(results).set_index("campaign_months").loc[3]
+    assert row["mean_estimate"] == pytest.approx(0.05)
+    assert row["mean_truth"] == pytest.approx(0.05)
+
+
 def test_methods_are_compared_side_by_side() -> None:
     results = pd.DataFrame(
         [

--- a/tests/benchmarking/harness/test_leaderboard.py
+++ b/tests/benchmarking/harness/test_leaderboard.py
@@ -1,0 +1,68 @@
+"""Tests for the leaderboard summary."""
+
+from __future__ import annotations
+
+import math
+
+import pandas as pd
+import pytest
+
+from benchmarking.harness.leaderboard import leaderboard
+
+
+def _results(rows: list[dict]) -> pd.DataFrame:
+    base = {"method": "m", "profile": "p", "condition": "overall"}
+    return pd.DataFrame([{**base, **r} for r in rows])
+
+
+def test_one_summary_row_per_method_profile_campaign() -> None:
+    results = _results(
+        [
+            {"campaign_months": 3, "signed_error": 1.0},
+            {"campaign_months": 3, "signed_error": 3.0},
+            {"campaign_months": 6, "signed_error": 0.5},
+        ]
+    )
+    summary = leaderboard(results)
+    assert len(summary) == 2
+    assert set(summary["campaign_months"]) == {3, 6}
+
+
+def test_bias_spread_score_and_n_match_metrics() -> None:
+    results = _results(
+        [
+            {"campaign_months": 3, "signed_error": 1.0},
+            {"campaign_months": 3, "signed_error": 3.0},
+        ]
+    )
+    row = leaderboard(results).set_index("campaign_months").loc[3]
+    assert row["bias"] == pytest.approx(2.0)
+    assert row["spread"] == pytest.approx(1.0)
+    assert row["score"] == pytest.approx(math.sqrt((1.0**2 + 3.0**2) / 2))
+    assert row["n_replicates"] == 2
+
+
+def test_only_overall_condition_rows_are_summarised() -> None:
+    results = _results(
+        [
+            {"campaign_months": 3, "signed_error": 2.0},
+            {"campaign_months": 3, "signed_error": 100.0, "condition": "(4.0, 5.0]"},
+        ]
+    )
+    row = leaderboard(results).set_index("campaign_months").loc[3]
+    assert row["bias"] == pytest.approx(2.0)  # the per-condition row is excluded
+    assert row["n_replicates"] == 1
+
+
+def test_methods_are_compared_side_by_side() -> None:
+    results = pd.DataFrame(
+        [
+            {"method": "a", "profile": "p", "condition": "overall", "campaign_months": 6, "signed_error": 0.0},
+            {"method": "b", "profile": "p", "condition": "overall", "campaign_months": 6, "signed_error": 0.1},
+        ]
+    )
+    summary = leaderboard(results)
+    assert set(summary["method"]) == {"a", "b"}
+    by_method = summary.set_index("method")
+    assert by_method.loc["a", "score"] == pytest.approx(0.0)
+    assert by_method.loc["b", "score"] == pytest.approx(0.1)

--- a/tests/benchmarking/harness/test_method.py
+++ b/tests/benchmarking/harness/test_method.py
@@ -1,0 +1,41 @@
+"""Tests for the thin method seam."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from benchmarking.harness.method import Method, MethodInput, MethodOutput
+
+
+def _input() -> MethodInput:
+    scada_df = pd.DataFrame({"x": [1.0]}, index=pd.date_range("2020-01-01", periods=1, tz="UTC"))
+    return MethodInput(scada_df=scada_df, test_wtg="T1", upgrade_timing=pd.Timestamp("2020-01-01", tz="UTC"))
+
+
+def test_method_input_carries_data_test_wtg_and_timing() -> None:
+    mi = _input()
+    assert mi.test_wtg == "T1"
+    assert mi.upgrade_timing == pd.Timestamp("2020-01-01", tz="UTC")
+    assert list(mi.scada_df.columns) == ["x"]
+
+
+def test_method_output_defaults_by_condition_to_none() -> None:
+    out = MethodOutput(p50_overall=0.03)
+    assert out.p50_overall == 0.03
+    assert out.p50_by_condition is None
+
+
+def test_a_conforming_class_satisfies_the_method_protocol() -> None:
+    class FixedMethod:
+        name = "fixed"
+
+        def estimate(self, mi: MethodInput) -> MethodOutput:  # noqa: ARG002
+            return MethodOutput(p50_overall=0.0)
+
+    method = FixedMethod()
+    assert isinstance(method, Method)
+    assert method.estimate(_input()).p50_overall == 0.0
+
+
+def test_a_non_conforming_object_is_not_a_method() -> None:
+    assert not isinstance(object(), Method)

--- a/tests/benchmarking/harness/test_metrics.py
+++ b/tests/benchmarking/harness/test_metrics.py
@@ -1,0 +1,59 @@
+"""Tests for the accuracy/precision/score metrics."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from benchmarking.harness.metrics import ErrorSummary, summarize_errors
+
+
+def test_bias_is_the_mean_signed_error() -> None:
+    summary = summarize_errors([1.0, 3.0])
+    assert summary.bias == pytest.approx(2.0)
+
+
+def test_spread_is_the_population_std() -> None:
+    # population std of {1, 3} about mean 2 is sqrt(((1-2)^2 + (3-2)^2)/2) = 1.0
+    summary = summarize_errors([1.0, 3.0])
+    assert summary.spread == pytest.approx(1.0)
+
+
+def test_score_is_rmse_and_equals_root_bias_sq_plus_spread_sq() -> None:
+    errors = [1.0, 3.0]
+    summary = summarize_errors(errors)
+    expected_rmse = math.sqrt((1.0**2 + 3.0**2) / 2)
+    assert summary.score == pytest.approx(expected_rmse)
+    assert summary.score == pytest.approx(math.hypot(summary.bias, summary.spread))
+
+
+def test_single_error_has_zero_spread_and_abs_score() -> None:
+    summary = summarize_errors([-0.4])
+    assert summary.bias == pytest.approx(-0.4)
+    assert summary.spread == pytest.approx(0.0)
+    assert summary.score == pytest.approx(0.4)
+    assert summary.n == 1
+
+
+def test_empty_errors_give_nan_summary_with_zero_n() -> None:
+    summary = summarize_errors([])
+    assert summary.n == 0
+    assert math.isnan(summary.bias)
+    assert math.isnan(summary.spread)
+    assert math.isnan(summary.score)
+
+
+def test_nan_errors_are_ignored() -> None:
+    # a replicate that produced no estimate (NaN) must not poison the summary
+    summary = summarize_errors([1.0, np.nan, 3.0])
+    assert summary.n == 2
+    assert summary.bias == pytest.approx(2.0)
+
+
+def test_summary_is_a_frozen_dataclass() -> None:
+    summary = summarize_errors([1.0, 3.0])
+    assert isinstance(summary, ErrorSummary)
+    with pytest.raises(AttributeError):
+        summary.bias = 0.0  # type: ignore[misc]

--- a/tests/benchmarking/harness/test_plots.py
+++ b/tests/benchmarking/harness/test_plots.py
@@ -1,0 +1,49 @@
+"""Tests for the harness campaign-length plots."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import matplotlib as mpl
+
+mpl.use("Agg")  # headless: no display needed for tests
+
+import pandas as pd
+
+from benchmarking.harness.plots import plot_campaign_curves
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _summary() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "method": ["v0", "v0", "rlearner", "rlearner"],
+            "profile": "p",
+            "campaign_months": [3, 6, 3, 6],
+            "bias": [0.02, 0.01, 0.0, 0.0],
+            "spread": [0.03, 0.02, 0.02, 0.01],
+            "score": [0.036, 0.022, 0.02, 0.01],
+            "n_replicates": 5,
+        }
+    )
+
+
+def test_one_score_line_per_method() -> None:
+    fig = plot_campaign_curves(_summary())
+    ax = fig.axes[0]
+    _, labels = ax.get_legend_handles_labels()
+    assert set(labels) == {"v0", "rlearner"}
+
+
+def test_x_axis_is_campaign_length() -> None:
+    fig = plot_campaign_curves(_summary())
+    assert "campaign" in fig.axes[0].get_xlabel().lower()
+
+
+def test_saves_file(tmp_path: Path) -> None:
+    save_path = tmp_path / "campaign_curves.png"
+    plot_campaign_curves(_summary(), save_path=save_path)
+    assert save_path.exists()
+    assert save_path.stat().st_size > 0

--- a/tests/benchmarking/harness/test_plots.py
+++ b/tests/benchmarking/harness/test_plots.py
@@ -25,21 +25,65 @@ def _summary() -> pd.DataFrame:
             "bias": [0.02, 0.01, 0.0, 0.0],
             "spread": [0.03, 0.02, 0.02, 0.01],
             "score": [0.036, 0.022, 0.02, 0.01],
+            "mean_truth": [0.05, 0.05, 0.05, 0.05],
+            "mean_estimate": [0.07, 0.06, 0.05, 0.05],
             "n_replicates": 5,
         }
     )
 
 
-def test_one_score_line_per_method() -> None:
+# fig.axes order matches the stacked panels top-to-bottom.
+_UPLIFT, _BAND, _SCORE = 0, 1, 2
+
+
+def test_three_panels() -> None:
     fig = plot_campaign_curves(_summary())
-    ax = fig.axes[0]
-    _, labels = ax.get_legend_handles_labels()
+    assert len(fig.axes) == 3
+
+
+def test_one_line_per_method_in_bias_panel() -> None:
+    fig = plot_campaign_curves(_summary())
+    _, labels = fig.axes[_BAND].get_legend_handles_labels()
     assert set(labels) == {"v0", "rlearner"}
+
+
+def test_top_panel_shows_true_uplift_and_each_method() -> None:
+    fig = plot_campaign_curves(_summary())
+    _, labels = fig.axes[_UPLIFT].get_legend_handles_labels()
+    assert set(labels) == {"true uplift", "v0", "rlearner"}
+    true_line = next(line for line in fig.axes[_UPLIFT].get_lines() if line.get_label() == "true uplift")
+    assert true_line.get_ydata().tolist() == [5.0, 5.0]  # 0.05 fraction -> 5.0 pp
+
+
+def test_top_panel_has_spread_band() -> None:
+    fig = plot_campaign_curves(_summary())
+    # fill_between adds a PolyCollection per method; the band makes the estimate's spread visible.
+    assert len(fig.axes[_UPLIFT].collections) >= 1
 
 
 def test_x_axis_is_campaign_length() -> None:
     fig = plot_campaign_curves(_summary())
-    assert "campaign" in fig.axes[0].get_xlabel().lower()
+    # x-axis is shared; the label lives on the bottom panel.
+    assert "campaign" in fig.axes[_SCORE].get_xlabel().lower()
+
+
+def test_x_axis_starts_at_zero() -> None:
+    fig = plot_campaign_curves(_summary())
+    assert fig.axes[_SCORE].get_xlim()[0] == 0.0
+
+
+def test_y_axis_in_percentage_points() -> None:
+    fig = plot_campaign_curves(_summary())
+    # v0 bias of 0.02/0.01 (fractions) should be plotted as 2.0/1.0 percentage points.
+    v0_line = next(line for line in fig.axes[_BAND].get_lines() if line.get_label() == "v0")
+    assert v0_line.get_ydata().tolist() == [2.0, 1.0]
+
+
+def test_score_y_axis_floor_below_zero_so_zero_points_show() -> None:
+    summary = _summary()
+    summary.loc[summary["method"] == "rlearner", "score"] = 0.0  # an oracle-like method at 0
+    fig = plot_campaign_curves(summary)
+    assert fig.axes[_SCORE].get_ylim()[0] < 0.0
 
 
 def test_saves_file(tmp_path: Path) -> None:

--- a/tests/benchmarking/harness/test_public_api.py
+++ b/tests/benchmarking/harness/test_public_api.py
@@ -1,0 +1,24 @@
+"""The harness package exposes its main entry points at the package root."""
+
+from __future__ import annotations
+
+from benchmarking import harness
+
+
+def test_public_api_exports_core_entry_points() -> None:
+    for name in (
+        "StudyConfig",
+        "Replicate",
+        "build_replicates",
+        "Method",
+        "MethodInput",
+        "MethodOutput",
+        "score_study",
+        "leaderboard",
+        "summarize_errors",
+        "ErrorSummary",
+        "CampaignWindow",
+        "campaign_windows",
+        "plot_campaign_curves",
+    ):
+        assert hasattr(harness, name), name

--- a/tests/benchmarking/harness/test_replicates.py
+++ b/tests/benchmarking/harness/test_replicates.py
@@ -1,0 +1,131 @@
+"""Tests for the replicate ensemble (the precision axis)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from benchmarking.harness.replicates import Replicate, StudyConfig, build_replicates
+from benchmarking.synthetic import ConstantCpChange, ToggleSchedule
+from wind_up.constants import TIMESTAMP_COL, DataColumns
+
+PROFILE = [ConstantCpChange(delta=0.05)]
+
+
+def _base_scada(turbines: tuple[str, ...] = ("T1", "T3", "T4", "T7", "T99")) -> pd.DataFrame:
+    """A small multi-turbine wind farm spanning three years of daily records."""
+    index = pd.date_range("2016-01-01", "2018-12-31", freq="1D", tz="UTC")
+    frames = [
+        pd.DataFrame(
+            {
+                DataColumns.turbine_name: turbine,
+                DataColumns.active_power_mean: 1000.0,
+                DataColumns.wind_speed_mean: 8.0,
+                DataColumns.wind_speed_sd: 0.8,
+                DataColumns.gen_rpm_mean: 1400.0,
+            },
+            index=index,
+        )
+        for turbine in turbines
+    ]
+    wf_df = pd.concat(frames)
+    wf_df.index.name = TIMESTAMP_COL
+    return wf_df
+
+
+def _study(mode: str = "prepost", n_replicates: int = 5, seed: int = 0) -> StudyConfig:
+    return StudyConfig(
+        mode=mode,
+        turbine_subset=["T1", "T3", "T4", "T7"],
+        treatment_start_range=(pd.Timestamp("2017-01-01", tz="UTC"), pd.Timestamp("2017-12-31", tz="UTC")),
+        min_pre_months=12,
+        campaign_months=[3, 6],
+        toggle_period=pd.Timedelta(days=14),
+        n_replicates=n_replicates,
+        seed=seed,
+    )
+
+
+def test_max_activity_months_is_the_longest_campaign() -> None:
+    assert _study().max_activity_months == 6
+
+
+def test_build_replicates_returns_n_replicate_records() -> None:
+    reps = build_replicates(_base_scada(), PROFILE, _study(n_replicates=5))
+    assert len(reps) == 5
+    assert all(isinstance(r, Replicate) for r in reps)
+
+
+def test_data_is_subset_to_turbine_subset() -> None:
+    reps = build_replicates(_base_scada(), PROFILE, _study())
+    present = set(reps[0].dataset.synthetic_df[DataColumns.turbine_name].unique())
+    assert present == {"T1", "T3", "T4", "T7"}  # the other ~17 turbines dropped
+
+
+def test_each_replicate_draws_a_test_turbine_from_the_subset() -> None:
+    reps = build_replicates(_base_scada(), PROFILE, _study())
+    assert all(r.test_wtg in {"T1", "T3", "T4", "T7"} for r in reps)
+
+
+def test_treatment_start_is_a_pandas_timestamp_supporting_offset_arithmetic() -> None:
+    # campaign.py does `treatment_start - pd.DateOffset(...)`, which needs a pd.Timestamp
+    reps = build_replicates(_base_scada(), PROFILE, _study())
+    start = reps[0].treatment_start
+    assert isinstance(start, pd.Timestamp)
+    assert start.tz is not None  # tz-aware, matching the SCADA index
+    _ = start - pd.DateOffset(months=12)  # must not raise
+
+
+def test_treatment_start_falls_within_the_configured_range() -> None:
+    study = _study()
+    reps = build_replicates(_base_scada(), PROFILE, study)
+    lo, hi = study.treatment_start_range
+    for r in reps:
+        assert lo <= r.treatment_start <= hi
+
+
+def test_draws_are_deterministic_by_seed() -> None:
+    base = _base_scada()
+    reps_a = build_replicates(base, PROFILE, _study(seed=42))
+    reps_b = build_replicates(base, PROFILE, _study(seed=42))
+    assert [(r.test_wtg, r.treatment_start) for r in reps_a] == [(r.test_wtg, r.treatment_start) for r in reps_b]
+
+
+def test_different_seed_changes_the_draws() -> None:
+    base = _base_scada()
+    reps_a = build_replicates(base, PROFILE, _study(seed=1))
+    reps_b = build_replicates(base, PROFILE, _study(seed=2))
+    assert [(r.test_wtg, r.treatment_start) for r in reps_a] != [(r.test_wtg, r.treatment_start) for r in reps_b]
+
+
+def test_prepost_replicate_upgrade_timing_is_the_treatment_start() -> None:
+    reps = build_replicates(_base_scada(), PROFILE, _study(mode="prepost"))
+    r = reps[0]
+    assert r.upgrade_timing == r.treatment_start
+
+
+def test_toggle_replicate_builds_schedule_with_start_and_period() -> None:
+    study = _study(mode="toggle")
+    reps = build_replicates(_base_scada(), PROFILE, study)
+    timing = reps[0].upgrade_timing
+    assert isinstance(timing, ToggleSchedule)
+    assert timing.start == reps[0].treatment_start
+    assert timing.period == study.toggle_period
+
+
+def test_replicate_true_uplift_delegates_to_its_dataset() -> None:
+    reps = build_replicates(_base_scada(), PROFILE, _study())
+    r = reps[0]
+    via_replicate = r.true_uplift()
+    via_dataset = r.dataset.true_uplift(test_wtg=r.test_wtg)
+    assert via_replicate.overall == via_dataset.overall
+
+
+def test_injected_upgrade_actually_changed_the_test_turbine() -> None:
+    reps = build_replicates(_base_scada(), PROFILE, _study())
+    r = reps[0]
+    syn = r.dataset.synthetic_df
+    orig = r.dataset.original_df
+    test_syn = syn[syn[DataColumns.turbine_name] == r.test_wtg][DataColumns.active_power_mean].to_numpy()
+    test_orig = orig[orig[DataColumns.turbine_name] == r.test_wtg][DataColumns.active_power_mean].to_numpy()
+    assert np.any(test_syn != test_orig)  # the profile left a mark

--- a/tests/benchmarking/harness/test_replicates.py
+++ b/tests/benchmarking/harness/test_replicates.py
@@ -51,25 +51,25 @@ def test_max_activity_months_is_the_longest_campaign() -> None:
 
 
 def test_build_replicates_returns_n_replicate_records() -> None:
-    reps = build_replicates(_base_scada(), PROFILE, _study(n_replicates=5))
+    reps = build_replicates(_base_scada(), profile=PROFILE, study=_study(n_replicates=5))
     assert len(reps) == 5
     assert all(isinstance(r, Replicate) for r in reps)
 
 
 def test_data_is_subset_to_turbine_subset() -> None:
-    reps = build_replicates(_base_scada(), PROFILE, _study())
+    reps = build_replicates(_base_scada(), profile=PROFILE, study=_study())
     present = set(reps[0].dataset.synthetic_df[DataColumns.turbine_name].unique())
     assert present == {"T1", "T3", "T4", "T7"}  # the other ~17 turbines dropped
 
 
 def test_each_replicate_draws_a_test_turbine_from_the_subset() -> None:
-    reps = build_replicates(_base_scada(), PROFILE, _study())
+    reps = build_replicates(_base_scada(), profile=PROFILE, study=_study())
     assert all(r.test_wtg in {"T1", "T3", "T4", "T7"} for r in reps)
 
 
 def test_treatment_start_is_a_pandas_timestamp_supporting_offset_arithmetic() -> None:
     # campaign.py does `treatment_start - pd.DateOffset(...)`, which needs a pd.Timestamp
-    reps = build_replicates(_base_scada(), PROFILE, _study())
+    reps = build_replicates(_base_scada(), profile=PROFILE, study=_study())
     start = reps[0].treatment_start
     assert isinstance(start, pd.Timestamp)
     assert start.tz is not None  # tz-aware, matching the SCADA index
@@ -78,7 +78,7 @@ def test_treatment_start_is_a_pandas_timestamp_supporting_offset_arithmetic() ->
 
 def test_treatment_start_falls_within_the_configured_range() -> None:
     study = _study()
-    reps = build_replicates(_base_scada(), PROFILE, study)
+    reps = build_replicates(_base_scada(), profile=PROFILE, study=study)
     lo, hi = study.treatment_start_range
     for r in reps:
         assert lo <= r.treatment_start <= hi
@@ -86,27 +86,27 @@ def test_treatment_start_falls_within_the_configured_range() -> None:
 
 def test_draws_are_deterministic_by_seed() -> None:
     base = _base_scada()
-    reps_a = build_replicates(base, PROFILE, _study(seed=42))
-    reps_b = build_replicates(base, PROFILE, _study(seed=42))
+    reps_a = build_replicates(base, profile=PROFILE, study=_study(seed=42))
+    reps_b = build_replicates(base, profile=PROFILE, study=_study(seed=42))
     assert [(r.test_wtg, r.treatment_start) for r in reps_a] == [(r.test_wtg, r.treatment_start) for r in reps_b]
 
 
 def test_different_seed_changes_the_draws() -> None:
     base = _base_scada()
-    reps_a = build_replicates(base, PROFILE, _study(seed=1))
-    reps_b = build_replicates(base, PROFILE, _study(seed=2))
+    reps_a = build_replicates(base, profile=PROFILE, study=_study(seed=1))
+    reps_b = build_replicates(base, profile=PROFILE, study=_study(seed=2))
     assert [(r.test_wtg, r.treatment_start) for r in reps_a] != [(r.test_wtg, r.treatment_start) for r in reps_b]
 
 
 def test_prepost_replicate_upgrade_timing_is_the_treatment_start() -> None:
-    reps = build_replicates(_base_scada(), PROFILE, _study(mode="prepost"))
+    reps = build_replicates(_base_scada(), profile=PROFILE, study=_study(mode="prepost"))
     r = reps[0]
     assert r.upgrade_timing == r.treatment_start
 
 
 def test_toggle_replicate_builds_schedule_with_start_and_period() -> None:
     study = _study(mode="toggle")
-    reps = build_replicates(_base_scada(), PROFILE, study)
+    reps = build_replicates(_base_scada(), profile=PROFILE, study=study)
     timing = reps[0].upgrade_timing
     assert isinstance(timing, ToggleSchedule)
     assert timing.start == reps[0].treatment_start
@@ -114,7 +114,7 @@ def test_toggle_replicate_builds_schedule_with_start_and_period() -> None:
 
 
 def test_replicate_true_uplift_delegates_to_its_dataset() -> None:
-    reps = build_replicates(_base_scada(), PROFILE, _study())
+    reps = build_replicates(_base_scada(), profile=PROFILE, study=_study())
     r = reps[0]
     via_replicate = r.true_uplift()
     via_dataset = r.dataset.true_uplift(test_wtg=r.test_wtg)
@@ -122,7 +122,7 @@ def test_replicate_true_uplift_delegates_to_its_dataset() -> None:
 
 
 def test_injected_upgrade_actually_changed_the_test_turbine() -> None:
-    reps = build_replicates(_base_scada(), PROFILE, _study())
+    reps = build_replicates(_base_scada(), profile=PROFILE, study=_study())
     r = reps[0]
     syn = r.dataset.synthetic_df
     orig = r.dataset.original_df

--- a/tests/benchmarking/harness/test_scoring.py
+++ b/tests/benchmarking/harness/test_scoring.py
@@ -1,0 +1,125 @@
+"""Tests for the scoring orchestrator and the two-part fairness guarantee."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from benchmarking.harness.replicates import StudyConfig
+from benchmarking.harness.scoring import score_study
+from benchmarking.synthetic import ConstantCpChange
+from wind_up.constants import TIMESTAMP_COL, DataColumns
+
+from .stubs import BiasedMethod, OracleMethod, RecordingMethod
+
+PROFILE = [ConstantCpChange(delta=0.05)]
+
+
+def _base_scada(turbines: tuple[str, ...] = ("T1", "T3", "T4", "T7")) -> pd.DataFrame:
+    index = pd.date_range("2016-01-01", "2018-12-31", freq="1D", tz="UTC")
+    frames = [
+        pd.DataFrame(
+            {
+                DataColumns.turbine_name: turbine,
+                DataColumns.active_power_mean: 1000.0,
+                DataColumns.wind_speed_mean: 8.0,
+                DataColumns.wind_speed_sd: 0.8,
+                DataColumns.gen_rpm_mean: 1400.0,
+            },
+            index=index,
+        )
+        for turbine in turbines
+    ]
+    wf_df = pd.concat(frames)
+    wf_df.index.name = TIMESTAMP_COL
+    return wf_df
+
+
+def _study(mode: str = "prepost", n_replicates: int = 4, seed: int = 0) -> StudyConfig:
+    return StudyConfig(
+        mode=mode,
+        turbine_subset=["T1", "T3", "T4", "T7"],
+        treatment_start_range=(pd.Timestamp("2017-01-01", tz="UTC"), pd.Timestamp("2017-12-31", tz="UTC")),
+        min_pre_months=12,
+        campaign_months=[3, 6],
+        toggle_period=pd.Timedelta(days=14),
+        n_replicates=n_replicates,
+        seed=seed,
+    )
+
+
+def test_results_have_one_row_per_method_replicate_and_campaign_length() -> None:
+    base = _base_scada()
+    results = score_study(base, PROFILE, [OracleMethod(base)], _study(n_replicates=4))
+    # 4 replicates x 2 campaign lengths x 1 method
+    assert len(results) == 4 * 2
+    assert set(results["campaign_months"]) == {3, 6}
+    expected_columns = {"method", "profile", "replicate", "campaign_months", "estimate", "truth", "signed_error"}
+    assert set(results.columns) >= expected_columns
+
+
+def test_oracle_method_has_near_zero_signed_error() -> None:
+    base = _base_scada()
+    results = score_study(base, PROFILE, [OracleMethod(base)], _study())
+    assert np.allclose(results["signed_error"].to_numpy(), 0.0, atol=1e-9)
+
+
+def test_biased_method_signed_error_equals_offset() -> None:
+    base = _base_scada()
+    results = score_study(base, PROFILE, [BiasedMethod(base, offset=0.02)], _study())
+    assert np.allclose(results["signed_error"].to_numpy(), 0.02, atol=1e-9)
+
+
+def test_truth_is_recomputed_per_campaign_length_not_shared() -> None:
+    base = _base_scada()
+    results = score_study(base, PROFILE, [OracleMethod(base)], _study())
+    # constant power -> uplift is ~equal across lengths, but truth must be present per row
+    assert results["truth"].notna().all()
+    assert (results["truth"] > 0).all()  # +5% Cp raises region-2 power
+
+
+def test_profile_name_is_recorded() -> None:
+    base = _base_scada()
+    results = score_study(base, PROFILE, [OracleMethod(base)], _study(), profile_name="constant_cp_5pct")
+    assert set(results["profile"]) == {"constant_cp_5pct"}
+
+
+def test_fairness_every_method_sees_identical_method_inputs() -> None:
+    base = _base_scada()
+    rec_a = RecordingMethod(name="a")
+    rec_b = RecordingMethod(name="b")
+    score_study(base, PROFILE, [rec_a, rec_b], _study())
+
+    assert len(rec_a.seen) == len(rec_b.seen) > 0
+    for mi_a, mi_b in zip(rec_a.seen, rec_b.seen, strict=True):
+        assert mi_a.test_wtg == mi_b.test_wtg
+        assert mi_a.upgrade_timing == mi_b.upgrade_timing
+        pd.testing.assert_frame_equal(mi_a.scada_df, mi_b.scada_df)
+
+
+def test_fairness_shorter_campaign_input_is_a_prefix_of_the_longer() -> None:
+    base = _base_scada()
+    rec = RecordingMethod()
+    score_study(base, PROFILE, [rec], _study(n_replicates=1))
+    # one replicate, lengths [3, 6] in order
+    short_mi, long_mi = rec.seen[0], rec.seen[1]
+    assert short_mi.scada_df.index.min() == long_mi.scada_df.index.min()  # same baseline start
+    assert short_mi.scada_df.index.max() <= long_mi.scada_df.index.max()  # shorter activity
+    assert len(short_mi.scada_df) < len(long_mi.scada_df)
+
+
+def test_toggle_study_scores_without_error() -> None:
+    base = _base_scada()
+    results = score_study(base, PROFILE, [OracleMethod(base)], _study(mode="toggle"))
+    assert len(results) == 4 * 2
+    assert np.allclose(results["signed_error"].to_numpy(), 0.0, atol=1e-9)
+
+
+def test_two_methods_scored_side_by_side() -> None:
+    base = _base_scada()
+    results = score_study(base, PROFILE, [OracleMethod(base), BiasedMethod(base, offset=0.01)], _study())
+    assert set(results["method"]) == {"oracle", "biased"}
+    oracle_err = results[results["method"] == "oracle"]["signed_error"].to_numpy()
+    biased_err = results[results["method"] == "biased"]["signed_error"].to_numpy()
+    assert np.allclose(oracle_err, 0.0, atol=1e-9)
+    assert np.allclose(biased_err, 0.01, atol=1e-9)

--- a/tests/benchmarking/harness/test_scoring.py
+++ b/tests/benchmarking/harness/test_scoring.py
@@ -50,7 +50,7 @@ def _study(mode: str = "prepost", n_replicates: int = 4, seed: int = 0) -> Study
 
 def test_results_have_one_row_per_method_replicate_and_campaign_length() -> None:
     base = _base_scada()
-    results = score_study(base, PROFILE, [OracleMethod(base)], _study(n_replicates=4))
+    results = score_study(base, profile=PROFILE, methods=[OracleMethod(base)], study=_study(n_replicates=4))
     # 4 replicates x 2 campaign lengths x 1 method
     assert len(results) == 4 * 2
     assert set(results["campaign_months"]) == {3, 6}
@@ -60,19 +60,19 @@ def test_results_have_one_row_per_method_replicate_and_campaign_length() -> None
 
 def test_oracle_method_has_near_zero_signed_error() -> None:
     base = _base_scada()
-    results = score_study(base, PROFILE, [OracleMethod(base)], _study())
+    results = score_study(base, profile=PROFILE, methods=[OracleMethod(base)], study=_study())
     assert np.allclose(results["signed_error"].to_numpy(), 0.0, atol=1e-9)
 
 
 def test_biased_method_signed_error_equals_offset() -> None:
     base = _base_scada()
-    results = score_study(base, PROFILE, [BiasedMethod(base, offset=0.02)], _study())
+    results = score_study(base, profile=PROFILE, methods=[BiasedMethod(base, offset=0.02)], study=_study())
     assert np.allclose(results["signed_error"].to_numpy(), 0.02, atol=1e-9)
 
 
 def test_truth_is_recomputed_per_campaign_length_not_shared() -> None:
     base = _base_scada()
-    results = score_study(base, PROFILE, [OracleMethod(base)], _study())
+    results = score_study(base, profile=PROFILE, methods=[OracleMethod(base)], study=_study())
     # constant power -> uplift is ~equal across lengths, but truth must be present per row
     assert results["truth"].notna().all()
     assert (results["truth"] > 0).all()  # +5% Cp raises region-2 power
@@ -80,7 +80,9 @@ def test_truth_is_recomputed_per_campaign_length_not_shared() -> None:
 
 def test_profile_name_is_recorded() -> None:
     base = _base_scada()
-    results = score_study(base, PROFILE, [OracleMethod(base)], _study(), profile_name="constant_cp_5pct")
+    results = score_study(
+        base, profile=PROFILE, methods=[OracleMethod(base)], study=_study(), profile_name="constant_cp_5pct"
+    )
     assert set(results["profile"]) == {"constant_cp_5pct"}
 
 
@@ -88,7 +90,7 @@ def test_fairness_every_method_sees_identical_method_inputs() -> None:
     base = _base_scada()
     rec_a = RecordingMethod(name="a")
     rec_b = RecordingMethod(name="b")
-    score_study(base, PROFILE, [rec_a, rec_b], _study())
+    score_study(base, profile=PROFILE, methods=[rec_a, rec_b], study=_study())
 
     assert len(rec_a.seen) == len(rec_b.seen) > 0
     for mi_a, mi_b in zip(rec_a.seen, rec_b.seen, strict=True):
@@ -100,7 +102,7 @@ def test_fairness_every_method_sees_identical_method_inputs() -> None:
 def test_fairness_shorter_campaign_input_is_a_prefix_of_the_longer() -> None:
     base = _base_scada()
     rec = RecordingMethod()
-    score_study(base, PROFILE, [rec], _study(n_replicates=1))
+    score_study(base, profile=PROFILE, methods=[rec], study=_study(n_replicates=1))
     # one replicate, lengths [3, 6] in order
     short_mi, long_mi = rec.seen[0], rec.seen[1]
     assert short_mi.scada_df.index.min() == long_mi.scada_df.index.min()  # same baseline start
@@ -110,14 +112,16 @@ def test_fairness_shorter_campaign_input_is_a_prefix_of_the_longer() -> None:
 
 def test_toggle_study_scores_without_error() -> None:
     base = _base_scada()
-    results = score_study(base, PROFILE, [OracleMethod(base)], _study(mode="toggle"))
+    results = score_study(base, profile=PROFILE, methods=[OracleMethod(base)], study=_study(mode="toggle"))
     assert len(results) == 4 * 2
     assert np.allclose(results["signed_error"].to_numpy(), 0.0, atol=1e-9)
 
 
 def test_two_methods_scored_side_by_side() -> None:
     base = _base_scada()
-    results = score_study(base, PROFILE, [OracleMethod(base), BiasedMethod(base, offset=0.01)], _study())
+    results = score_study(
+        base, profile=PROFILE, methods=[OracleMethod(base), BiasedMethod(base, offset=0.01)], study=_study()
+    )
     assert set(results["method"]) == {"oracle", "biased"}
     oracle_err = results[results["method"] == "oracle"]["signed_error"].to_numpy()
     biased_err = results[results["method"] == "biased"]["signed_error"].to_numpy()

--- a/tests/benchmarking/synthetic/test_generator.py
+++ b/tests/benchmarking/synthetic/test_generator.py
@@ -9,7 +9,12 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from benchmarking.synthetic.generator import SyntheticDataset, ToggleSchedule, generate_dataset
+from benchmarking.synthetic.generator import (
+    SyntheticDataset,
+    ToggleSchedule,
+    generate_dataset,
+    treated_mask,
+)
 from benchmarking.synthetic.upgrades import ConstantCpChange
 from wind_up.constants import TIMESTAMP_COL, DataColumns
 
@@ -99,6 +104,46 @@ def test_toggle_modifies_alternate_blocks() -> None:
     second_half = t01[(t01.index >= start + half) & (t01.index < start + 2 * half)][DataColumns.active_power_mean]
     assert np.allclose(first_half.to_numpy(), 1000.0)  # first half-period: toggle off
     assert np.all(second_half.to_numpy() > 1000.0)  # second half-period: toggle on
+
+
+def test_toggle_start_leaves_pre_start_rows_untreated() -> None:
+    """A ToggleSchedule.start places baseline before toggling: pre-start rows stay untreated."""
+    wf_df = _wf_df(periods=288)  # two days at 10-min
+    timestamps = wf_df.index.unique()
+    start = timestamps[len(timestamps) // 2]  # toggling begins at the midpoint
+
+    dataset = generate_dataset(
+        scada_df=wf_df,
+        test_wtgs=["T01"],
+        upgrades=[ConstantCpChange(delta=0.10)],
+        mode="toggle",
+        upgrade_timing=ToggleSchedule(period=pd.Timedelta(hours=12), start=start),
+    )
+    t01 = dataset.synthetic_df[dataset.synthetic_df[DataColumns.turbine_name] == "T01"]
+    before = t01[t01.index < start][DataColumns.active_power_mean]
+    assert np.allclose(before.to_numpy(), 1000.0)  # baseline before toggling: untreated
+
+    # start_on defaults False: [start, start+6h) off, [start+6h, start+12h) on.
+    half = pd.Timedelta(hours=6)
+    off_block = t01[(t01.index >= start) & (t01.index < start + half)][DataColumns.active_power_mean]
+    on_block = t01[(t01.index >= start + half) & (t01.index < start + 2 * half)][DataColumns.active_power_mean]
+    assert np.allclose(off_block.to_numpy(), 1000.0)
+    assert np.all(on_block.to_numpy() > 1000.0)
+
+
+def test_public_treated_mask_infers_mode_from_timing_type() -> None:
+    """treated_mask infers prepost vs toggle from the upgrade_timing type."""
+    wf_df = _wf_df(turbines=("T01",), periods=288)
+    index = wf_df.index
+    changeover = index[len(index) // 2]
+
+    prepost_mask = treated_mask(index, changeover)
+    assert np.array_equal(prepost_mask, np.asarray(index >= changeover))
+
+    schedule = ToggleSchedule(period=pd.Timedelta(hours=12), start=changeover)
+    toggle_mask = treated_mask(index, schedule)
+    assert not toggle_mask[np.asarray(index < changeover)].any()  # baseline untreated
+    assert toggle_mask[np.asarray(index >= changeover)].any()  # some on-rows after start
 
 
 def test_run_metadata_records_recipe() -> None:

--- a/tests/benchmarking/synthetic/test_generator.py
+++ b/tests/benchmarking/synthetic/test_generator.py
@@ -12,6 +12,7 @@ import pytest
 from benchmarking.synthetic.generator import (
     SyntheticDataset,
     ToggleSchedule,
+    _treated_mask,
     generate_dataset,
     treated_mask,
 )
@@ -144,6 +145,18 @@ def test_public_treated_mask_infers_mode_from_timing_type() -> None:
     toggle_mask = treated_mask(index, schedule)
     assert not toggle_mask[np.asarray(index < changeover)].any()  # baseline untreated
     assert toggle_mask[np.asarray(index >= changeover)].any()  # some on-rows after start
+
+
+def test_treated_mask_rejects_mode_timing_mismatch() -> None:
+    """A mode that disagrees with the upgrade_timing type fails fast with a clear TypeError."""
+    index = _wf_df(turbines=("T01",), periods=48).index
+    changeover = index[len(index) // 2]
+    schedule = ToggleSchedule(period=pd.Timedelta(hours=12), start=changeover)
+
+    with pytest.raises(TypeError, match="prepost mode needs a changeover Timestamp"):
+        _treated_mask(index, mode="prepost", upgrade_timing=schedule)
+    with pytest.raises(TypeError, match="toggle mode needs a ToggleSchedule"):
+        _treated_mask(index, mode="toggle", upgrade_timing=changeover)
 
 
 def test_run_metadata_records_recipe() -> None:

--- a/tests/benchmarking/synthetic/test_public_api.py
+++ b/tests/benchmarking/synthetic/test_public_api.py
@@ -10,6 +10,7 @@ def test_public_api_exports_core_entry_points() -> None:
         "generate_dataset",
         "SyntheticDataset",
         "ToggleSchedule",
+        "treated_mask",
         "true_uplift",
         "CpCore",
         "HOT_CP_MODEL",

--- a/tests/benchmarking/synthetic/test_upgrades.py
+++ b/tests/benchmarking/synthetic/test_upgrades.py
@@ -38,14 +38,14 @@ def _rows(
 def test_constant_cp_change_scales_region2_power() -> None:
     """At 2000 kW (region-2 fraction 0.25) a +10% Cp gives 2050 kW (not 2200 due to 25% region 2)."""
     rows = _rows([2000.0])
-    out = apply_upgrades(rows, [ConstantCpChange(delta=0.10)], CpCore(rated_power_kw=2300.0))
+    out = apply_upgrades(rows, [ConstantCpChange(delta=0.10)], cp=CpCore(rated_power_kw=2300.0))
     assert out[DataColumns.active_power_mean].iloc[0] == pytest.approx(2050.0)
 
 
 def test_empty_upgrade_list_leaves_rows_unchanged() -> None:
     """Applying no upgrades returns power identical to the original."""
     rows = _rows([500.0, 1500.0, 2200.0])
-    out = apply_upgrades(rows, [], CpCore())
+    out = apply_upgrades(rows, [], cp=CpCore())
     pd.testing.assert_series_equal(out[DataColumns.active_power_mean], rows[DataColumns.active_power_mean])
 
 
@@ -56,7 +56,7 @@ def test_constant_cp_change_only_treats_producing_below_rated_records() -> None:
     below pure rated, so idling/curtailed and at-rated records keep their original power.
     """
     rows = _rows([-5.0, 0.0, 1000.0, 2295.0])
-    out = apply_upgrades(rows, [ConstantCpChange(delta=0.03)], CpCore(rated_power_kw=2300.0))
+    out = apply_upgrades(rows, [ConstantCpChange(delta=0.03)], cp=CpCore(rated_power_kw=2300.0))
     power = out[DataColumns.active_power_mean].to_numpy()
     assert power[0] == pytest.approx(-5.0)  # negative: untouched
     assert power[1] == pytest.approx(0.0)  # zero: untouched
@@ -68,7 +68,7 @@ def test_constant_cp_change_does_not_mutate_input() -> None:
     """apply_upgrades returns a new frame and leaves the caller's rows untouched."""
     rows = _rows([1500.0])
     original = rows[DataColumns.active_power_mean].copy()
-    apply_upgrades(rows, [ConstantCpChange(delta=0.05)], CpCore())
+    apply_upgrades(rows, [ConstantCpChange(delta=0.05)], cp=CpCore())
     pd.testing.assert_series_equal(rows[DataColumns.active_power_mean], original)
 
 
@@ -76,7 +76,7 @@ def test_wind_speed_cp_change_applies_delta_by_original_wind_speed() -> None:
     """Cp delta is interpolated over the original wind speed; zero-delta bins are unchanged."""
     rows = _rows([600.0, 1000.0, 1500.0], ws=[4.0, 8.0, 12.0])
     upgrade = WindSpeedCpChange(ws_points=[4.0, 8.0, 12.0], deltas=[0.0, 0.04, 0.0])
-    out = apply_upgrades(rows, [upgrade], CpCore())
+    out = apply_upgrades(rows, [upgrade], cp=CpCore())
     power = out[DataColumns.active_power_mean].to_numpy()
     f8 = region2_fraction(1000.0)
     assert power[0] == pytest.approx(600.0)  # ws 4: zero delta
@@ -89,7 +89,7 @@ def test_condition_cp_change_varies_by_original_turbulence_intensity() -> None:
     # ws 8 m/s with sd 0.8 and 1.6 -> TI 0.10 and 0.20
     rows = _rows([1000.0, 1000.0], ws=[8.0, 8.0], sd=[0.8, 1.6])
     upgrade = ConditionCpChange(by="ti", points=[0.10, 0.20], deltas=[0.0, 0.05])
-    out = apply_upgrades(rows, [upgrade], CpCore())
+    out = apply_upgrades(rows, [upgrade], cp=CpCore())
     power = out[DataColumns.active_power_mean].to_numpy()
     f = region2_fraction(1000.0)
     assert power[0] == pytest.approx(1000.0)  # TI 0.10: zero delta
@@ -99,7 +99,7 @@ def test_condition_cp_change_varies_by_original_turbulence_intensity() -> None:
 def test_rated_power_downrate_clips_at_new_rated() -> None:
     """A downrate caps power at the new rated and leaves region-2 power unchanged."""
     rows = _rows([1000.0, 2200.0])
-    out = apply_upgrades(rows, [RatedPowerChange(new_rated_power_kw=2000.0)], CpCore(rated_power_kw=2300.0))
+    out = apply_upgrades(rows, [RatedPowerChange(new_rated_power_kw=2000.0)], cp=CpCore(rated_power_kw=2300.0))
     power = out[DataColumns.active_power_mean].to_numpy()
     assert power[0] == pytest.approx(1000.0)  # well below new rated: unchanged
     assert power[1] == pytest.approx(2000.0)  # above new rated: clipped
@@ -108,7 +108,7 @@ def test_rated_power_downrate_clips_at_new_rated() -> None:
 def test_rated_power_uprate_lifts_region3_power() -> None:
     """An uprate lifts near-rated power toward the new rated, leaving deep region 2 alone."""
     rows = _rows([1000.0, 2200.0])
-    out = apply_upgrades(rows, [RatedPowerChange(new_rated_power_kw=2400.0)], CpCore(rated_power_kw=2300.0))
+    out = apply_upgrades(rows, [RatedPowerChange(new_rated_power_kw=2400.0)], cp=CpCore(rated_power_kw=2300.0))
     power = out[DataColumns.active_power_mean].to_numpy()
     assert power[0] == pytest.approx(1000.0, rel=1e-3)  # deep region 2: ~unchanged
     assert 2200.0 < power[1] < 2400.0  # near rated: lifted but capped at new rated
@@ -117,14 +117,14 @@ def test_rated_power_uprate_lifts_region3_power() -> None:
 def test_ws_delta_scales_nacelle_wind_speed() -> None:
     """An upgrade's ws_delta scales the nacelle WindSpeedMean."""
     rows = _rows([1000.0], ws=[8.0])
-    out = apply_upgrades(rows, [ConstantCpChange(delta=0.0, ws_delta=0.02)], CpCore())
+    out = apply_upgrades(rows, [ConstantCpChange(delta=0.0, ws_delta=0.02)], cp=CpCore())
     assert out[DataColumns.wind_speed_mean].iloc[0] == pytest.approx(8.0 * 1.02)
 
 
 def test_rpm_increases_when_power_increases() -> None:
     """A positive Cp change drags generator rpm up with the power increase."""
     rows = _rows([1000.0], rpm=[1392.0])
-    out = apply_upgrades(rows, [ConstantCpChange(delta=0.10)], CpCore())
+    out = apply_upgrades(rows, [ConstantCpChange(delta=0.10)], cp=CpCore())
     assert out[DataColumns.gen_rpm_mean].iloc[0] > 1392.0
 
 
@@ -132,7 +132,7 @@ def test_upgrades_compose() -> None:
     """A Cp change and a downrate combine: region-2 power rises, near-rated power clips."""
     rows = _rows([1000.0, 2200.0])
     upgrades = [ConstantCpChange(delta=0.10), RatedPowerChange(new_rated_power_kw=2000.0)]
-    out = apply_upgrades(rows, upgrades, CpCore(rated_power_kw=2300.0))
+    out = apply_upgrades(rows, upgrades, cp=CpCore(rated_power_kw=2300.0))
     power = out[DataColumns.active_power_mean].to_numpy()
     f = region2_fraction(1000.0)
     assert power[0] == pytest.approx(1000.0 * (1.0 + f * 0.10))  # region 2: +Cp, below downrate


### PR DESCRIPTION
## Issue 2 — P50 evaluation harness & scoring (WS1)

**Goal:** score any uplift method's P50 estimate against the known injected truth,
including a short-campaign robustness sweep.

**Scope**
- Accuracy (bias) and precision (spread) metrics: recovered uplift vs injected,
  overall and (where applicable) per condition.
- Short-campaign sweep: re-score as a function of campaign length / data volume to
  quantify how accuracy and precision degrade with less data.
- A simple results format / leaderboard so methods can be compared side by side.
- **P50 only** — no uncertainty/P95 scoring in this phase.

**Done when:** given a method and a synthetic dataset, the harness emits comparable accuracy/precision numbers and a
campaign-length curve.
