### PR TITLE
V1 refactor scadadf

### DIFF
--- a/benchmarking/baselines/example_prepost_study.py
+++ b/benchmarking/baselines/example_prepost_study.py
@@ -40,6 +40,7 @@ from benchmarking.baselines.naive_ratio import NaiveRatioMethod
 from benchmarking.baselines.v0_binned import V0BinnedMethod
 from benchmarking.harness import Method, StudyConfig, leaderboard, plot_campaign_curves, score_study
 from benchmarking.harness.example_hot_study import OracleMethod
+from benchmarking.synthetic import HOT_COLUMNS
 from benchmarking.synthetic.make_example_datasets import example_profiles
 from benchmarking.synthetic.sources.hill_of_towie import load_hot_scada
 
@@ -120,7 +121,7 @@ def run_prepost_study(
         methods: list[Method] = []
         if include_oracle:
             methods.append(OracleMethod(base_scada))
-        methods.append(NaiveRatioMethod(out_dir=out_dir / "naive_runs"))
+        methods.append(NaiveRatioMethod(active_power_col=HOT_COLUMNS.active_power, out_dir=out_dir / "naive_runs"))
         methods.append(V0BinnedMethod(context, scratch_dir=scratch_dir))
         logger.info("Scoring prepost profile %s with methods %s", profile_name, [m.name for m in methods])
         results = score_study(

--- a/benchmarking/baselines/example_toggle_study.py
+++ b/benchmarking/baselines/example_toggle_study.py
@@ -41,7 +41,7 @@ from benchmarking.baselines.naive_ratio import NaiveRatioMethod
 from benchmarking.baselines.v0_binned import V0BinnedMethod
 from benchmarking.harness import Method, StudyConfig, leaderboard, plot_campaign_curves, score_study
 from benchmarking.harness.example_hot_study import OracleMethod
-from benchmarking.synthetic import ConstantCpChange
+from benchmarking.synthetic import HOT_COLUMNS, ConstantCpChange
 from benchmarking.synthetic.sources.hill_of_towie import load_hot_scada
 
 logger = logging.getLogger(__name__)
@@ -95,7 +95,7 @@ def run_toggle_study(
         methods: list[Method] = []
         if include_oracle:
             methods.append(OracleMethod(base_scada))
-        methods.append(NaiveRatioMethod(out_dir=out_dir / "naive_runs"))
+        methods.append(NaiveRatioMethod(active_power_col=HOT_COLUMNS.active_power, out_dir=out_dir / "naive_runs"))
         methods.append(V0BinnedMethod(context, scratch_dir=scratch_dir))
         logger.info("Scoring toggle profile %s with methods %s", profile_name, [m.name for m in methods])
         results = score_study(

--- a/benchmarking/baselines/inspect_naive.py
+++ b/benchmarking/baselines/inspect_naive.py
@@ -37,9 +37,8 @@ from benchmarking.harness import (
     treated_activity_mask,
     window_row_mask,
 )
-from benchmarking.synthetic import ConstantCpChange
+from benchmarking.synthetic import HOT_COLUMNS, ConstantCpChange
 from benchmarking.synthetic.sources.hill_of_towie import load_hot_scada
-from wind_up.constants import DataColumns
 
 logger = logging.getLogger(__name__)
 
@@ -79,11 +78,16 @@ def _inspect_mode(scada_df: pd.DataFrame, *, study: StudyConfig, out_dir: Path, 
             scada_df=syn.loc[window_row_mask(syn.index, window)],
             test_wtg=rep.test_wtg,
             upgrade_timing=rep.upgrade_timing,
+            turbine_col=HOT_COLUMNS.turbine,
         )
         rep_dir = out_dir / f"replicate_{rep.replicate_id:02d}_{rep.test_wtg}"
-        estimate = NaiveRatioMethod(out_dir=rep_dir, save_plots=True).estimate(mi).p50_overall
+        estimate = (
+            NaiveRatioMethod(active_power_col=HOT_COLUMNS.active_power, out_dir=rep_dir, save_plots=True)
+            .estimate(mi)
+            .p50_overall
+        )
 
-        test_index = syn.loc[syn[DataColumns.turbine_name] == rep.test_wtg].index
+        test_index = syn.loc[syn[HOT_COLUMNS.turbine] == rep.test_wtg].index
         truth = rep.true_uplift(mask=treated_activity_mask(test_index, rep.upgrade_timing, window=window)).overall
 
         logger.info(

--- a/benchmarking/baselines/inspect_v0_run.py
+++ b/benchmarking/baselines/inspect_v0_run.py
@@ -37,9 +37,8 @@ from benchmarking.harness import (
     treated_activity_mask,
     window_row_mask,
 )
-from benchmarking.synthetic import ConstantCpChange
+from benchmarking.synthetic import HOT_COLUMNS, ConstantCpChange
 from benchmarking.synthetic.sources.hill_of_towie import load_hot_scada
-from wind_up.constants import DataColumns
 
 logger = logging.getLogger(__name__)
 
@@ -114,12 +113,13 @@ def inspect_v0_run(
             scada_df=syn.loc[window_row_mask(syn.index, window)],
             test_wtg=rep.test_wtg,
             upgrade_timing=rep.upgrade_timing,
+            turbine_col=HOT_COLUMNS.turbine,
         )
         rep_dir = out_dir / f"replicate_{rep.replicate_id:02d}_{rep.test_wtg}"
         method = V0BinnedMethod(context, scratch_dir=rep_dir, save_plots=True)
         estimate = method.estimate(mi).p50_overall
 
-        test_index = syn.loc[syn[DataColumns.turbine_name] == rep.test_wtg].index
+        test_index = syn.loc[syn[HOT_COLUMNS.turbine] == rep.test_wtg].index
         truth = rep.true_uplift(mask=treated_activity_mask(test_index, rep.upgrade_timing, window=window)).overall
 
         logger.info(

--- a/benchmarking/baselines/naive_ratio.py
+++ b/benchmarking/baselines/naive_ratio.py
@@ -10,9 +10,11 @@ estimates uplift as the ratio-of-ratios ``rho(treated) / rho(baseline) - 1``. It
 source on the synthetic data is genuine pre/post covariate shift -- it applies no
 conditioning by design -- so it is the "what if you don't condition at all" leaderboard floor.
 
-It uses **only** the active-power-mean column (test and references); it never reads wind speed,
-direction, rpm or any other SCADA tag, which keeps it honest under design-note section 3 (the
-test turbine's own wind speed is post-treatment and is never touched).
+It uses **only** the configured active-power column (test and references); it never reads wind
+speed, direction, rpm or any other SCADA tag, which keeps it honest under design-note section 3
+(the test turbine's own wind speed is post-treatment and is never touched). It speaks the data
+source's own column names — the active-power column is configured and the turbine column comes
+from the seam — so it shares no code with, and makes no assumptions from, v0.
 
 Each run writes a per-run folder ``naive_<test>_<upgradestart>_<lastdate>/`` (v0-style naming)
 under ``out_dir`` (a temp dir by default), holding a per-segment data-stats CSV, a headline
@@ -36,7 +38,6 @@ from matplotlib.ticker import PercentFormatter
 
 from benchmarking.harness.method import MethodInput, MethodOutput
 from benchmarking.synthetic import ToggleSchedule, treated_mask
-from wind_up.constants import DataColumns
 
 if TYPE_CHECKING:
     import numpy.typing as npt
@@ -53,14 +54,14 @@ def _infer_timebase(index: pd.DatetimeIndex) -> pd.Timedelta:
     return pd.Timedelta(np.median(np.diff(unique.to_numpy())))
 
 
-def _wide_power(scada_df: pd.DataFrame) -> pd.DataFrame:
+def _wide_power(scada_df: pd.DataFrame, *, turbine_col: str, active_power_col: str) -> pd.DataFrame:
     """Pivot long SCADA to a timestamp x turbine table of active power (NaN where missing)."""
-    tmp = scada_df[[DataColumns.turbine_name, DataColumns.active_power_mean]].copy()
+    tmp = scada_df[[turbine_col, active_power_col]].copy()
     tmp["_ts"] = scada_df.index
     return tmp.pivot_table(
         index="_ts",
-        columns=DataColumns.turbine_name,
-        values=DataColumns.active_power_mean,
+        columns=turbine_col,
+        values=active_power_col,
         aggfunc="first",
     )
 
@@ -76,12 +77,15 @@ def _upgrade_start(upgrade_timing: pd.Timestamp | ToggleSchedule, index: pd.Date
 class NaiveRatioMethod:
     """Pluggable naive energy-ratio baseline (prepost and toggle).
 
+    :param active_power_col: the source-native active-power column to read (the only signal the
+        method touches); the turbine-identifier column comes from the seam (``MethodInput``)
     :param name: method name shown in the leaderboard
     :param out_dir: where per-run folders are written; a temp dir when ``None``
     :param save_plots: also write the three diagnostic plots under ``<run>/plots``
     :param timebase: analysis timebase; inferred from the data when ``None``
     """
 
+    active_power_col: str
     name: str = "naive_ratio"
     out_dir: Path | None = None
     save_plots: bool = False
@@ -89,7 +93,7 @@ class NaiveRatioMethod:
 
     def estimate(self, mi: MethodInput) -> MethodOutput:
         """Estimate the test turbine's P50 uplift for one campaign and write diagnostics."""
-        wide = _wide_power(mi.scada_df)
+        wide = _wide_power(mi.scada_df, turbine_col=mi.turbine_col, active_power_col=self.active_power_col)
         test = mi.test_wtg
         refs = [c for c in wide.columns if c != test]
         if not refs:
@@ -110,7 +114,15 @@ class NaiveRatioMethod:
         recoverable = np.isfinite(rho_base) and rho_base != 0 and np.isfinite(rho_up)
         uplift = rho_up / rho_base - 1.0 if recoverable else np.nan
 
-        stats = _segment_stats(mi, wide=wide, used=used, ts_treated=ts_treated, refs=refs, timebase=timebase)
+        stats = _segment_stats(
+            mi,
+            wide=wide,
+            used=used,
+            ts_treated=ts_treated,
+            refs=refs,
+            timebase=timebase,
+            active_power_col=self.active_power_col,
+        )
         self._write_outputs(
             mi,
             wide=wide,
@@ -189,6 +201,7 @@ def _segment_stats(
     ts_treated: npt.NDArray[np.bool_],
     refs: list[str],
     timebase: pd.Timedelta,
+    active_power_col: str,
 ) -> pd.DataFrame:
     """Build the per-segment (all/baseline/upgraded) diagnostics table."""
     test = mi.test_wtg
@@ -198,7 +211,7 @@ def _segment_stats(
     timebase_hours = timebase / pd.Timedelta(hours=1)
 
     row_treated = np.asarray(treated_mask(mi.scada_df.index, mi.upgrade_timing))
-    row_power = mi.scada_df[DataColumns.active_power_mean].to_numpy(dtype=float)
+    row_power = mi.scada_df[active_power_col].to_numpy(dtype=float)
 
     ts_masks = {"all": np.ones(len(wide), dtype=bool), "baseline": ~ts_treated, "upgraded": ts_treated}
     row_masks = {"all": np.ones(len(mi.scada_df), dtype=bool), "baseline": ~row_treated, "upgraded": row_treated}

--- a/benchmarking/baselines/v0_binned.py
+++ b/benchmarking/baselines/v0_binned.py
@@ -39,8 +39,8 @@ import pandas as pd
 
 from benchmarking.harness.method import MethodInput, MethodOutput
 from benchmarking.synthetic import ToggleSchedule, treated_mask
+from benchmarking.synthetic.sources.hill_of_towie import long_to_wind_up_format
 from wind_up.combine_results import combine_results
-from wind_up.constants import DataColumns
 from wind_up.interface import AssessmentInputs
 from wind_up.main_analysis import run_wind_up_analysis
 from wind_up.models import PlotConfig, WindUpConfig
@@ -111,9 +111,9 @@ def _build_toggle_df(scada_df: pd.DataFrame, schedule: ToggleSchedule) -> pd.Dat
     return pd.DataFrame({"toggle_on": toggle_on, "toggle_off": toggle_off}, index=index)
 
 
-def _subset_turbines(scada_df: pd.DataFrame) -> list[str]:
+def _subset_turbines(scada_df: pd.DataFrame, turbine_col: str) -> list[str]:
     """Return the sorted unique turbine names present in ``scada_df``."""
-    return sorted(scada_df[DataColumns.turbine_name].unique().tolist())
+    return sorted(scada_df[turbine_col].unique().tolist())
 
 
 def _extract_p50(tdf: pd.DataFrame, test_wtg: str) -> float:
@@ -153,10 +153,10 @@ class V0BinnedMethod:
         from_cfg_kwargs: dict = {
             "cfg": cfg,
             "plot_cfg": plot_cfg,
-            # wind_up mutates the SCADA frame in place (e.g. smart_data.check_and_convert_scada_raw);
-            # the harness hands us a ``.loc`` slice, so pass a defensive copy to avoid pandas'
-            # SettingWithCopyWarning (escalated to an error by the test suite's warning filter).
-            "scada_df": mi.scada_df.copy(),
+            # The harness hands us source-native SCADA; v0 needs wind-up format, so convert here
+            # (the v0 baseline is the only place that knows v0's column names). The conversion
+            # returns a fresh frame, so there is no in-place mutation of the harness's slice.
+            "scada_df": long_to_wind_up_format(mi.scada_df),
             "metadata_df": self.context.metadata_df,
             "reanalysis_datasets": self.context.reanalysis_datasets,
             "cache_dir": None,
@@ -174,7 +174,7 @@ class V0BinnedMethod:
 
     def _build_config(self, mi: MethodInput) -> WindUpConfig:
         """Render and load the per-campaign WindUpConfig, with the asset filtered to the subset."""
-        subset = _subset_turbines(mi.scada_df)
+        subset = _subset_turbines(mi.scada_df, mi.turbine_col)
         refs = [t for t in subset if t != mi.test_wtg]
         if not refs:
             msg = (

--- a/benchmarking/harness/example_hot_study.py
+++ b/benchmarking/harness/example_hot_study.py
@@ -40,9 +40,8 @@ from benchmarking.harness import (
     plot_campaign_curves,
     score_study,
 )
-from benchmarking.synthetic import ConstantCpChange, treated_mask
+from benchmarking.synthetic import HOT_COLUMNS, ConstantCpChange, treated_mask
 from benchmarking.synthetic.sources.hill_of_towie import load_hot_scada
-from wind_up.constants import DataColumns
 
 logger = logging.getLogger(__name__)
 
@@ -74,13 +73,13 @@ def _oracle_overall_uplift(mi: MethodInput, original_df: pd.DataFrame) -> float:
     below wrap this to drive bias and spread.
     """
     syn = mi.scada_df
-    test_rows = syn[syn[DataColumns.turbine_name] == mi.test_wtg]
+    test_rows = syn[syn[HOT_COLUMNS.turbine] == mi.test_wtg]
     treated = treated_mask(test_rows.index, mi.upgrade_timing)
     treated_rows = test_rows[treated]
 
-    syn_power = treated_rows[DataColumns.active_power_mean].to_numpy(dtype=float)
-    orig_test = original_df[original_df[DataColumns.turbine_name] == mi.test_wtg]
-    orig_power = orig_test.loc[treated_rows.index, DataColumns.active_power_mean].to_numpy(dtype=float)
+    syn_power = treated_rows[HOT_COLUMNS.active_power].to_numpy(dtype=float)
+    orig_test = original_df[original_df[HOT_COLUMNS.turbine] == mi.test_wtg]
+    orig_power = orig_test.loc[treated_rows.index, HOT_COLUMNS.active_power].to_numpy(dtype=float)
 
     finite = np.isfinite(syn_power) & np.isfinite(orig_power)
     denom = orig_power[finite].sum()

--- a/benchmarking/harness/method.py
+++ b/benchmarking/harness/method.py
@@ -22,14 +22,21 @@ if TYPE_CHECKING:
 class MethodInput:
     """The windowed data a method sees for one campaign.
 
+    The frame carries **source-native** SCADA column names (the real tag names of the data
+    source). Identifying turbines is a property of the data, not a method choice, so the seam
+    names the turbine-identifier column here; methods read any value columns (e.g. active power)
+    by their own source-native config.
+
     :param scada_df: windowed synthetic SCADA (all subset turbines, baseline + activity)
     :param test_wtg: the upgraded turbine to estimate
     :param upgrade_timing: changeover timestamp (prepost) or schedule (toggle)
+    :param turbine_col: the turbine-identifier column in ``scada_df``
     """
 
     scada_df: pd.DataFrame
     test_wtg: str
     upgrade_timing: pd.Timestamp | ToggleSchedule
+    turbine_col: str = "TurbineName"
 
 
 @dataclass

--- a/benchmarking/harness/replicates.py
+++ b/benchmarking/harness/replicates.py
@@ -17,14 +17,13 @@ from typing import TYPE_CHECKING, Literal
 
 import numpy as np
 
-from benchmarking.synthetic import ToggleSchedule, generate_dataset
-from wind_up.constants import DataColumns
+from benchmarking.synthetic import HOT_COLUMNS, ToggleSchedule, generate_dataset
 
 if TYPE_CHECKING:
     import numpy.typing as npt
     import pandas as pd
 
-    from benchmarking.synthetic import SyntheticDataset, UpliftResult
+    from benchmarking.synthetic import ColumnSchema, SyntheticDataset, UpliftResult
 
 
 @dataclass(frozen=True)
@@ -83,13 +82,16 @@ def build_replicates(
     *,
     profile: list,
     study: StudyConfig,
+    columns: ColumnSchema = HOT_COLUMNS,
 ) -> list[Replicate]:
     """Draw ``study.n_replicates`` replicates of ``profile`` from ``base_scada``.
 
     Subsets the data to ``turbine_subset``, then draws ``(test turbine, treatment_start)`` pairs
     deterministically from ``seed`` and injects the profile via the synthetic generator.
+
+    :param columns: the source-native column schema ``base_scada`` is keyed by
     """
-    subset = base_scada[base_scada[DataColumns.turbine_name].isin(study.turbine_subset)]
+    subset = base_scada[base_scada[columns.turbine].isin(study.turbine_subset)]
     candidates = _candidate_starts(subset.index, study.treatment_start_range)
 
     rng = np.random.default_rng(study.seed)
@@ -105,6 +107,7 @@ def build_replicates(
             upgrades=profile,
             mode=study.mode,
             upgrade_timing=upgrade_timing,
+            columns=columns,
             seed=study.seed,
         )
         replicates.append(

--- a/benchmarking/harness/scoring.py
+++ b/benchmarking/harness/scoring.py
@@ -24,7 +24,7 @@ import pandas as pd
 from benchmarking.harness.campaign import campaign_windows, treated_activity_mask, window_row_mask
 from benchmarking.harness.method import MethodInput
 from benchmarking.harness.replicates import build_replicates
-from wind_up.constants import DataColumns
+from benchmarking.synthetic import HOT_COLUMNS
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
     from benchmarking.harness.campaign import CampaignWindow
     from benchmarking.harness.method import Method
     from benchmarking.harness.replicates import Replicate, StudyConfig
+    from benchmarking.synthetic import ColumnSchema
 
 
 def score_study(
@@ -41,6 +42,7 @@ def score_study(
     methods: list[Method],
     study: StudyConfig,
     profile_name: str = "profile",
+    columns: ColumnSchema = HOT_COLUMNS,
     on_method_complete: Callable[[str, pd.DataFrame], None] | None = None,
 ) -> pd.DataFrame:
     """Score ``methods`` on ``study`` over ``profile`` injected into ``base_scada``.
@@ -50,13 +52,14 @@ def score_study(
     carries the window it was tested over — ``treatment_start`` (the upgrade start),
     ``baseline_start`` and ``activity_end`` — so a result is self-describing.
 
+    :param columns: the source-native column schema ``base_scada`` is keyed by
     :param on_method_complete: optional hook called as each method finishes its full instance
         sweep, with ``(method_name, that_method's_rows)`` (the same rows it contributes to the
         returned frame). Lets a caller act on a method's results early — e.g. plot them — instead
         of waiting for every method, useful when a slow method runs last. It never changes the
         returned frame; order methods fastest-first to get the earliest feedback.
     """
-    replicates = build_replicates(base_scada, profile=profile, study=study)
+    replicates = build_replicates(base_scada, profile=profile, study=study, columns=columns)
     data_start = base_scada.index.min()
     data_end = base_scada.index.max()
     instances = _materialise_instances(replicates, study, data_start=data_start, data_end=data_end)
@@ -121,12 +124,13 @@ def _method_input(replicate: Replicate, window: CampaignWindow) -> MethodInput:
         scada_df=synthetic.loc[row_mask],
         test_wtg=replicate.test_wtg,
         upgrade_timing=replicate.upgrade_timing,
+        turbine_col=replicate.dataset.columns.turbine,
     )
 
 
 def _truth_overall(replicate: Replicate, window: CampaignWindow) -> float:
     """Ground-truth uplift over the test turbine's treated rows within the activity window."""
     synthetic = replicate.synthetic_df
-    test_index = synthetic.loc[synthetic[DataColumns.turbine_name] == replicate.test_wtg].index
+    test_index = synthetic.loc[synthetic[replicate.dataset.columns.turbine] == replicate.test_wtg].index
     mask = treated_activity_mask(test_index, replicate.upgrade_timing, window=window)
     return replicate.true_uplift(mask=mask).overall

--- a/benchmarking/synthetic/__init__.py
+++ b/benchmarking/synthetic/__init__.py
@@ -10,6 +10,8 @@ from benchmarking.synthetic.cp_core import HOT_CP_MODEL, CpCore, CpParams, cp_su
 from benchmarking.synthetic.generator import SyntheticDataset, ToggleSchedule, generate_dataset, treated_mask
 from benchmarking.synthetic.ground_truth import UpliftResult, true_uplift
 from benchmarking.synthetic.plots import plot_power_curve_comparison
+from benchmarking.synthetic.schema import ColumnSchema
+from benchmarking.synthetic.sources.hill_of_towie import HOT_COLUMNS
 from benchmarking.synthetic.upgrades import (
     ConditionCpChange,
     ConstantCpChange,
@@ -20,7 +22,9 @@ from benchmarking.synthetic.upgrades import (
 )
 
 __all__ = [
+    "HOT_COLUMNS",
     "HOT_CP_MODEL",
+    "ColumnSchema",
     "ConditionCpChange",
     "ConstantCpChange",
     "CpCore",

--- a/benchmarking/synthetic/generator.py
+++ b/benchmarking/synthetic/generator.py
@@ -17,19 +17,15 @@ import numpy as np
 
 from benchmarking.synthetic.cp_core import HOT_CP_MODEL, CpCore, CpParams
 from benchmarking.synthetic.ground_truth import UpliftResult, true_uplift
+from benchmarking.synthetic.sources.hill_of_towie import HOT_COLUMNS
 from benchmarking.synthetic.upgrades import apply_upgrades
-from wind_up.constants import DataColumns
 
 if TYPE_CHECKING:
     import pandas as pd
 
-_GROUND_TRUTH_WS_BINS = list(np.arange(0.0, 26.0, 1.0))
+    from benchmarking.synthetic.schema import ColumnSchema
 
-_MODIFIED_COLUMNS = (
-    DataColumns.active_power_mean,
-    DataColumns.gen_rpm_mean,
-    DataColumns.wind_speed_mean,
-)
+_GROUND_TRUTH_WS_BINS = list(np.arange(0.0, 26.0, 1.0))
 
 
 @dataclass(frozen=True)
@@ -55,6 +51,7 @@ class SyntheticDataset:
     synthetic_df: pd.DataFrame
     original_df: pd.DataFrame
     run_metadata: dict = field(default_factory=dict)
+    columns: ColumnSchema = HOT_COLUMNS
 
     def true_uplift(
         self,
@@ -70,7 +67,9 @@ class SyntheticDataset:
         """
         if test_wtg is None:
             test_wtg = self.run_metadata["test_wtgs"][0]
-        return true_uplift(self.synthetic_df, self.original_df, test_wtg=test_wtg, mask=mask, by=by, bins=bins)
+        return true_uplift(
+            self.synthetic_df, self.original_df, test_wtg=test_wtg, mask=mask, by=by, bins=bins, columns=self.columns
+        )
 
     def save(self, out_dir: str | Path) -> Path:
         """Write synthetic.parquet, original.parquet and run_metadata.json to ``out_dir``.
@@ -150,33 +149,36 @@ def generate_dataset(
     upgrade_timing: pd.Timestamp | ToggleSchedule,
     cp_params: CpParams = HOT_CP_MODEL,
     rated_power_kw: float = 2300.0,
+    columns: ColumnSchema = HOT_COLUMNS,
     seed: int = 0,
 ) -> SyntheticDataset:
     """Generate a synthetic dataset by injecting an upgrade into the test turbine(s).
 
-    :param scada_df: wind-up-format real SCADA (all turbines), the no-upgrade baseline
+    :param scada_df: source-native long real SCADA (all turbines), the no-upgrade baseline
     :param test_wtgs: turbine name(s) to upgrade
     :param upgrades: upgrade callables applied to each test turbine's treated rows
     :param mode: ``"prepost"`` (changeover date) or ``"toggle"``
     :param upgrade_timing: changeover timestamp (prepost) or toggle schedule
     :param cp_params: Cp surface parameters for the test turbines
     :param rated_power_kw: baseline rated power for the test turbines
+    :param columns: the source-native column schema ``scada_df`` is keyed by
     :param seed: recorded in run metadata for provenance; generation is fully
         deterministic and does not otherwise consume it
     :return: the synthetic dataset, original reference and run metadata
     """
     original_df = scada_df.copy()
     synthetic_df = scada_df.copy()
+    modified_columns = (columns.active_power, columns.gen_rpm, columns.wind_speed)
 
     treated = _treated_mask(synthetic_df.index, mode=mode, upgrade_timing=upgrade_timing)
     for wtg in test_wtgs:
-        is_test = (synthetic_df[DataColumns.turbine_name] == wtg).to_numpy()
+        is_test = (synthetic_df[columns.turbine] == wtg).to_numpy()
         mask = is_test & treated
         if not mask.any():
             continue
         cp = CpCore(rated_power_kw=rated_power_kw, cp_params=cp_params)
-        modified = apply_upgrades(synthetic_df.loc[mask], upgrades, cp=cp)
-        for col in _MODIFIED_COLUMNS:
+        modified = apply_upgrades(synthetic_df.loc[mask], upgrades, cp=cp, columns=columns)
+        for col in modified_columns:
             synthetic_df.loc[mask, col] = modified[col].to_numpy()
 
     run_metadata = {
@@ -188,4 +190,6 @@ def generate_dataset(
         "cp_params": asdict(cp_params),
         "seed": seed,
     }
-    return SyntheticDataset(synthetic_df=synthetic_df, original_df=original_df, run_metadata=run_metadata)
+    return SyntheticDataset(
+        synthetic_df=synthetic_df, original_df=original_df, run_metadata=run_metadata, columns=columns
+    )

--- a/benchmarking/synthetic/ground_truth.py
+++ b/benchmarking/synthetic/ground_truth.py
@@ -14,21 +14,23 @@ from typing import TYPE_CHECKING
 import numpy as np
 import pandas as pd
 
-from wind_up.constants import DataColumns
+from benchmarking.synthetic.sources.hill_of_towie import HOT_COLUMNS
 
 if TYPE_CHECKING:
     import numpy.typing as npt
 
+    from benchmarking.synthetic.schema import ColumnSchema
 
-def _condition_series(rows: pd.DataFrame, by: str) -> npt.NDArray[np.float64]:
+
+def _condition_series(rows: pd.DataFrame, by: str, columns: ColumnSchema) -> npt.NDArray[np.float64]:
     """Resolve a treatment-invariant condition signal from the original rows."""
     if by == "ti":
-        ws = rows[DataColumns.wind_speed_mean].to_numpy(dtype=float)
-        sd = rows[DataColumns.wind_speed_sd].to_numpy(dtype=float)
+        ws = rows[columns.wind_speed].to_numpy(dtype=float)
+        sd = rows[columns.wind_speed_sd].to_numpy(dtype=float)
         # NaN (not inf/0-division warning) for calm rows; warnings are errors in tests.
         return np.divide(sd, ws, out=np.full_like(sd, np.nan), where=ws != 0)
     if by == "ws":
-        return rows[DataColumns.wind_speed_mean].to_numpy(dtype=float)
+        return rows[columns.wind_speed].to_numpy(dtype=float)
     return rows[by].to_numpy(dtype=float)
 
 
@@ -48,6 +50,7 @@ def true_uplift(
     mask: npt.ArrayLike | None = None,
     by: str | None = None,
     bins: npt.ArrayLike | None = None,
+    columns: ColumnSchema = HOT_COLUMNS,
 ) -> UpliftResult:
     """Compute the true uplift of the test turbine, synthetic vs original.
 
@@ -59,17 +62,18 @@ def true_uplift(
     :param by: optional treatment-invariant condition for a per-condition breakdown
         (``"ws"``, ``"ti"`` or an original column name)
     :param bins: bin edges for the ``by`` condition
+    :param columns: the source-native column schema the frames are keyed by
     :return: the overall energy-ratio uplift, and a per-condition table when ``by`` is set
     """
     if by is not None and bins is None:
         msg = "bins must be provided when by is set (per-condition breakdown needs explicit edges)"
         raise ValueError(msg)
 
-    original_wtg = original_df[original_df[DataColumns.turbine_name] == test_wtg]
-    synthetic_power = synthetic_df.loc[
-        synthetic_df[DataColumns.turbine_name] == test_wtg, DataColumns.active_power_mean
-    ].to_numpy(dtype=float)
-    original_power = original_wtg[DataColumns.active_power_mean].to_numpy(dtype=float)
+    original_wtg = original_df[original_df[columns.turbine] == test_wtg]
+    synthetic_power = synthetic_df.loc[synthetic_df[columns.turbine] == test_wtg, columns.active_power].to_numpy(
+        dtype=float
+    )
+    original_power = original_wtg[columns.active_power].to_numpy(dtype=float)
 
     row_mask = changed_record_mask(synthetic_power, original_power) if mask is None else np.asarray(mask, dtype=bool)
     # Real SCADA carries NaN power (downtime/missing); such records have no usable energy
@@ -82,7 +86,7 @@ def true_uplift(
     by_condition = None
     if by is not None:
         by_condition = _uplift_by_condition(
-            condition=_condition_series(original_wtg, by)[effective],
+            condition=_condition_series(original_wtg, by, columns)[effective],
             synthetic_power=synthetic_power[effective],
             original_power=original_power[effective],
             bins=bins,

--- a/benchmarking/synthetic/plots.py
+++ b/benchmarking/synthetic/plots.py
@@ -50,8 +50,8 @@ def plot_power_curve_comparison(
     against wind speed for the treated records. Records the upgrade actually changed
     (NaN-safe) are highlighted in the first two panels.
 
-    :param synthetic_df: wind-up-format synthetic SCADA (all turbines)
-    :param original_df: the untouched original SCADA (all turbines)
+    :param synthetic_df: source-native synthetic SCADA (all turbines), keyed by ``columns``
+    :param original_df: the untouched source-native original SCADA (all turbines)
     :param test_wtg: turbine to plot
     :param save_path: if given, the figure is written here (PNG)
     :param title: optional overall figure title

--- a/benchmarking/synthetic/plots.py
+++ b/benchmarking/synthetic/plots.py
@@ -20,13 +20,15 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from benchmarking.synthetic.ground_truth import changed_record_mask
-from wind_up.constants import DataColumns
+from benchmarking.synthetic.sources.hill_of_towie import HOT_COLUMNS
 
 if TYPE_CHECKING:
     from pathlib import Path
 
     import pandas as pd
     from matplotlib.figure import Figure
+
+    from benchmarking.synthetic.schema import ColumnSchema
 
 _BASELINE_STYLE = {"s": 6, "alpha": 0.4, "color": "tab:blue", "label": "baseline rows"}
 _TREATED_STYLE = {"s": 6, "alpha": 0.5, "color": "tab:red", "label": "treated rows"}
@@ -39,6 +41,7 @@ def plot_power_curve_comparison(
     test_wtg: str,
     save_path: str | Path | None = None,
     title: str | None = None,
+    columns: ColumnSchema = HOT_COLUMNS,
 ) -> Figure:
     """Plot the test turbine's original vs synthetic power curve plus the kW change.
 
@@ -52,14 +55,15 @@ def plot_power_curve_comparison(
     :param test_wtg: turbine to plot
     :param save_path: if given, the figure is written here (PNG)
     :param title: optional overall figure title
+    :param columns: the source-native column schema the frames are keyed by
     :return: the matplotlib Figure
     """
-    original = original_df[original_df[DataColumns.turbine_name] == test_wtg]
-    synthetic = synthetic_df[synthetic_df[DataColumns.turbine_name] == test_wtg]
+    original = original_df[original_df[columns.turbine] == test_wtg]
+    synthetic = synthetic_df[synthetic_df[columns.turbine] == test_wtg]
 
-    ws = original[DataColumns.wind_speed_mean].to_numpy(dtype=float)
-    original_power = original[DataColumns.active_power_mean].to_numpy(dtype=float)
-    synthetic_power = synthetic[DataColumns.active_power_mean].to_numpy(dtype=float)
+    ws = original[columns.wind_speed].to_numpy(dtype=float)
+    original_power = original[columns.active_power].to_numpy(dtype=float)
+    synthetic_power = synthetic[columns.active_power].to_numpy(dtype=float)
 
     # Treated = records genuinely modified by the upgrade (NaN downtime rows excluded).
     treated = changed_record_mask(synthetic_power, original_power)

--- a/benchmarking/synthetic/schema.py
+++ b/benchmarking/synthetic/schema.py
@@ -1,0 +1,34 @@
+"""The column vocabulary the synthetic pipeline and harness speak.
+
+The benchmarking layer is deliberately independent of v0: the synthetic generator, the
+ground-truth comparison and the harness all operate on **source-native** SCADA column names
+(the real tag names a data source ships), never on v0's :class:`~wind_up.constants.DataColumns`
+aliases. A :class:`ColumnSchema` names the handful of semantic roles those components need, so
+the only place that knows a source's actual column names is the source adapter, which provides
+its own :class:`ColumnSchema` (e.g. ``HOT_COLUMNS`` for Hill of Towie).
+
+v0-specific aliasing is therefore not a pipeline concern at all: it lives entirely inside the
+v0 baseline (which converts the source-native frame to wind-up format on the way in).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ColumnSchema:
+    """The source-native column names for the semantic roles the pipeline reads.
+
+    :param turbine: the turbine-identifier column of the long-format SCADA frame
+    :param active_power: mean active power
+    :param wind_speed: mean nacelle wind speed
+    :param wind_speed_sd: nacelle wind-speed standard deviation (turbulence intensity input)
+    :param gen_rpm: mean generator rpm
+    """
+
+    turbine: str
+    active_power: str
+    wind_speed: str
+    wind_speed_sd: str
+    gen_rpm: str

--- a/benchmarking/synthetic/sources/hill_of_towie.py
+++ b/benchmarking/synthetic/sources/hill_of_towie.py
@@ -6,15 +6,18 @@ wind-up-format SCADA end to end:
 
 - the Zenodo fetcher (``ensure_hot_data_files`` / ``download_zenodo_data``) that
   downloads and caches the Hill of Towie v2 datapack (Zenodo record ``20204946``);
-- the 10-minute SCADA loader (``load_hot_10min_data``) and the wide-to-narrow
-  wind-up-format conversion (``scada_df_to_wind_up_df``);
-- ``load_hot_scada`` that ties them together and returns wind-up-format SCADA plus
-  turbine metadata.
+- the 10-minute SCADA loader (``load_hot_10min_data``) and the wide-to-long reshape
+  (``scada_wide_to_long``) that keeps source-native ``wtc_*`` tag names;
+- ``load_hot_scada`` that ties them together and returns source-native long SCADA plus
+  turbine metadata;
+- ``long_to_wind_up_format``, the v0-only on-ramp that aliases the source columns to
+  :class:`~wind_up.constants.DataColumns` names and derives ``PitchAngleMean`` /
+  ``ShutdownDuration``.
 
 Copied rather than imported so ``benchmarking`` stays hermetic and depends on
-``wind_up`` only for :class:`~wind_up.constants.DataColumns`. ``requests`` and
-``tqdm`` are imported lazily inside the network/IO functions so the pure transforms
-import without them.
+``wind_up`` only for :class:`~wind_up.constants.DataColumns` (used by the v0 on-ramp).
+``requests`` and ``tqdm`` are imported lazily inside the network/IO functions so the pure
+transforms import without them.
 """
 
 from __future__ import annotations
@@ -31,6 +34,7 @@ from zipfile import ZipFile
 
 import pandas as pd
 
+from benchmarking.synthetic.schema import ColumnSchema
 from wind_up.constants import DataColumns
 
 if TYPE_CHECKING:
@@ -357,6 +361,20 @@ hill_of_towie_fields = [
     WPSBackupFileField(alias="PowerReference", field_name="wtc_PowerRef_endvalue", table_name="tblSCTurbine"),
 ]
 
+# The Hill of Towie source-native column schema the synthetic pipeline and methods see. The
+# raw 10-min tag names (``wtc_*``) are kept as-is (no v0 aliasing); the long-format turbine
+# identifier is ``TurbineName`` (assigned by :func:`scada_wide_to_long`). Derived from
+# ``hill_of_towie_fields`` so the source's tag names live in exactly one place.
+_FIELD_BY_ALIAS = {f.alias: f.field_name for f in hill_of_towie_fields}
+HOT_TURBINE_COL = "TurbineName"
+HOT_COLUMNS = ColumnSchema(
+    turbine=HOT_TURBINE_COL,
+    active_power=_FIELD_BY_ALIAS[DataColumns.active_power_mean],
+    wind_speed=_FIELD_BY_ALIAS[DataColumns.wind_speed_mean],
+    wind_speed_sd=_FIELD_BY_ALIAS[DataColumns.wind_speed_sd],
+    gen_rpm=_FIELD_BY_ALIAS[DataColumns.gen_rpm_mean],
+)
+
 
 def _unpack_hot_10min_year(
     *,
@@ -364,14 +382,14 @@ def _unpack_hot_10min_year(
     year: int,
     serial_numbers: Sequence[int],
     fields_to_load: Sequence[WPSBackupFileField],
-    rename_cols_using_aliases: bool,
 ) -> pd.DataFrame:
     """Unpack one full year zip into a wide, serial-keyed 10-min dataframe (the slow step).
 
     This is the expensive part of :func:`load_hot_10min_data` (reading and pivoting every monthly
     CSV in the year zip); it is cached per (year, turbine) by :func:`_load_unpacked_hot_10min`.
     The result covers the whole year (no window clipping), is keyed on serial numbers (not turbine
-    names), and only includes the requested ``serial_numbers``.
+    names), and only includes the requested ``serial_numbers``. Columns keep their source-native
+    tag names (the ``wtc_*`` field names); any v0 aliasing is the v0 baseline's concern.
     """
     from tqdm import tqdm  # noqa: PLC0415  (lazy: keep network deps out of the import path)
 
@@ -388,8 +406,6 @@ def _unpack_hot_10min_year(
                 _df = pd.read_csv(zip_file.open(fname), index_col=0, parse_dates=True)[
                     ["StationId", *[x.field_name for x in fields_to_load if x.table_name == _table]]
                 ]
-                if rename_cols_using_aliases:
-                    _df = _df.rename(columns={x.field_name: x.alias for x in fields_to_load if x.table_name == _table})
                 if _df.index.name != "TimeStamp":
                     msg = f"unexpected index name, {_df.index.name =}"
                     raise ValueError(msg)
@@ -421,7 +437,6 @@ def _year_turbine_cache_path(
     year: int,
     serial_number: int,
     fields_to_load: Sequence[WPSBackupFileField],
-    rename_cols_using_aliases: bool,
     cache_dir: Path,
 ) -> Path:
     """Build the deterministic parquet path for one (year, turbine).
@@ -432,10 +447,7 @@ def _year_turbine_cache_path(
     the requested window or the rest of the turbine subset, so any study reuses these files.
     """
     fields_blob = json.dumps(
-        {
-            "fields": sorted(f"{x.table_name}.{x.field_name}->{x.alias}" for x in fields_to_load),
-            "rename_cols_using_aliases": rename_cols_using_aliases,
-        },
+        {"fields": sorted(f"{x.table_name}.{x.field_name}->{x.alias}" for x in fields_to_load)},
         sort_keys=True,
     )
     fields_hash = hashlib.sha256(fields_blob.encode("utf-8")).hexdigest()[:16]
@@ -449,7 +461,6 @@ def _load_unpacked_hot_10min(
     years_to_load: Sequence[int],
     serial_numbers: Sequence[int],
     fields_to_load: Sequence[WPSBackupFileField],
-    rename_cols_using_aliases: bool,
     cache_dir: Path,
 ) -> pd.DataFrame:
     """Return the full-year, serial-keyed 10-min df for the requested years and turbines.
@@ -467,7 +478,6 @@ def _load_unpacked_hot_10min(
                 year=year,
                 serial_number=serial,
                 fields_to_load=fields_to_load,
-                rename_cols_using_aliases=rename_cols_using_aliases,
                 cache_dir=cache_dir,
             )
             for serial in serial_numbers
@@ -480,7 +490,6 @@ def _load_unpacked_hot_10min(
                 year=year,
                 serial_numbers=missing,
                 fields_to_load=fields_to_load,
-                rename_cols_using_aliases=rename_cols_using_aliases,
             )
             for serial in missing:
                 serial_df = unpacked.loc[:, unpacked.columns.get_level_values(0) == serial]
@@ -498,11 +507,13 @@ def load_hot_10min_data(
     start_dt: pd.Timestamp,
     end_dt_excl: pd.Timestamp,
     use_turbine_names: bool = True,
-    rename_cols_using_aliases: bool = False,
     custom_fields: Sequence[WPSBackupFileField] | None = None,
     cache_dir: Path | None = None,
 ) -> pd.DataFrame:
     """Return a wide 10-min SCADA dataframe for Hill of Towie (downloading year zips).
+
+    Columns keep their source-native ``wtc_*`` tag names; the level-0 turbine key is the serial
+    number, or the ``T01``-style turbine name when ``use_turbine_names``.
 
     The slow zip-unpacking step is cached as parquet under ``cache_dir`` (defaults to
     ``data_dir / "unpacked_cache"``), one file per (year, turbine). Because the Zenodo record is a
@@ -528,7 +539,6 @@ def load_hot_10min_data(
         years_to_load=years_to_load,
         serial_numbers=serial_numbers,
         fields_to_load=fields_to_load,
-        rename_cols_using_aliases=rename_cols_using_aliases,
         cache_dir=cache_dir if cache_dir is not None else data_dir / "unpacked_cache",
     )
     if use_turbine_names:
@@ -585,13 +595,14 @@ def calc_shutdown_duration(wind_up_df: pd.DataFrame) -> pd.DataFrame:
     return wind_up_df
 
 
-def scada_df_to_wind_up_df(scada_df: pd.DataFrame, *, shutdown_duration_df: pd.DataFrame | None = None) -> pd.DataFrame:
-    """Convert wide two-level ``scada_df`` to narrow wind-up-format ``wind_up_df``.
+def scada_wide_to_long(scada_df: pd.DataFrame, *, columns: ColumnSchema = HOT_COLUMNS) -> pd.DataFrame:
+    """Convert wide two-level ``scada_df`` to a narrow, source-native long frame.
 
-    ``scada_df`` has two column levels (turbine, field); ``wind_up_df`` has one column
-    level plus a ``TurbineName`` column. ``PitchAngleMean`` is derived from the three
-    per-blade pitch columns when absent. If ``shutdown_duration_df`` is given its
-    ``ShutdownDuration`` is merged in; otherwise it is computed.
+    ``scada_df`` has two column levels (turbine, field); the result has one column level plus a
+    ``columns.turbine`` identifier column, and keeps the source-native ``wtc_*`` field names. This
+    is the method-facing layout: v0-specific aliasing and the derived ``PitchAngleMean`` /
+    ``ShutdownDuration`` columns are added later by :func:`long_to_wind_up_format`, which only the
+    v0 baseline needs.
     """
     # future_stack=True only exists in pandas >= 2.1; without it >= 2.1 emits a
     # FutureWarning (an error under the test config). Fall back for pandas 2.0.x.
@@ -599,19 +610,23 @@ def scada_df_to_wind_up_df(scada_df: pd.DataFrame, *, shutdown_duration_df: pd.D
         stacked = scada_df.stack(level=0, future_stack=True)  # noqa: PD013
     except TypeError:
         stacked = scada_df.stack(level=0, dropna=False)  # noqa: PD013
-    wind_up_df = stacked.reset_index(level=1).rename(columns={"StationId": "TurbineName"})
+    return stacked.reset_index(level=1).rename(columns={"StationId": columns.turbine})
 
+
+def long_to_wind_up_format(long_df: pd.DataFrame) -> pd.DataFrame:
+    """Convert a source-native long frame (see :func:`scada_wide_to_long`) to wind-up format.
+
+    Renames the Hill of Towie ``wtc_*`` tag names to their v0 :class:`DataColumns` aliases, derives
+    ``PitchAngleMean`` from the three per-blade pitch columns when absent, and computes
+    ``ShutdownDuration``. This is the v0 baseline's on-ramp; the rest of the pipeline never needs it.
+    """
+    alias_by_field = {f.field_name: f.alias for f in hill_of_towie_fields}
+    wind_up_df = long_df.rename(columns=alias_by_field)
     if DataColumns.pitch_angle_mean not in wind_up_df.columns:
         wind_up_df[DataColumns.pitch_angle_mean] = wind_up_df[["pitch_angle_a", "pitch_angle_b", "pitch_angle_c"]].mean(
             axis=1
         )
-    if shutdown_duration_df is not None:
-        # pandas merge accepts the named index level TimeStamp_StartFormat alongside the
-        # TurbineName column and preserves the index, so no reset is needed.
-        wind_up_df = wind_up_df.merge(shutdown_duration_df, how="left", on=["TimeStamp_StartFormat", "TurbineName"])
-    else:
-        wind_up_df = calc_shutdown_duration(wind_up_df)
-    return wind_up_df
+    return calc_shutdown_duration(wind_up_df)
 
 
 # --------------------------------------------------------------------------------------
@@ -643,11 +658,12 @@ def load_hot_scada(
     wtg_names: Sequence[str] | None = None,
     data_dir: Path | None = None,
 ) -> tuple[pd.DataFrame, pd.DataFrame]:
-    """Download (if needed) and load wind-up-format Hill of Towie SCADA plus metadata.
+    """Download (if needed) and load source-native long Hill of Towie SCADA plus metadata.
 
-    Downloads and caches the v2 datapack year zips from Zenodo, unpacks the requested
-    window, and converts to wind-up format (computing ``ShutdownDuration``). Returns
-    ``(scada_df, metadata_df)`` ready for the synthetic generator.
+    Downloads and caches the v2 datapack year zips from Zenodo, unpacks the requested window, and
+    reshapes to a long frame with source-native ``wtc_*`` tag names (see :data:`HOT_COLUMNS`).
+    Returns ``(scada_df, metadata_df)`` ready for the synthetic generator. v0-specific aliasing is
+    applied later, only by the v0 baseline (see :func:`long_to_wind_up_format`).
 
     :param start_dt: inclusive UTC window start
     :param end_dt_excl: exclusive UTC window end
@@ -662,7 +678,6 @@ def load_hot_scada(
         wtg_numbers=wtg_numbers,
         start_dt=start_dt,
         end_dt_excl=end_dt_excl,
-        rename_cols_using_aliases=True,
     )
-    scada_df = scada_df_to_wind_up_df(wide_scada_df)
+    scada_df = scada_wide_to_long(wide_scada_df)
     return scada_df, metadata_df

--- a/benchmarking/synthetic/sources/hill_of_towie.py
+++ b/benchmarking/synthetic/sources/hill_of_towie.py
@@ -193,6 +193,7 @@ def _download_one_file(
             file_mode = "ab" if resume else "wb"
             remaining_bytes = max(0, _file_size - existing_size)
             with (
+                result,  # close the streamed response (and its socket) deterministically, not at GC
                 Path.open(dst_fpath, file_mode) as f,
                 tqdm(
                     total=remaining_bytes,

--- a/benchmarking/synthetic/sources/hill_of_towie.py
+++ b/benchmarking/synthetic/sources/hill_of_towie.py
@@ -340,16 +340,28 @@ class WPSBackupFileField(NamedTuple):
     table_name: str
 
 
+# Source-native Hill of Towie tag names referenced by ``HOT_COLUMNS`` (the source-native schema
+# methods see). Defined once here and reused below in ``hill_of_towie_fields`` so each tag string
+# lives in exactly one place, while ``HOT_COLUMNS`` is built directly from these tags rather than
+# routed through the v0 ``DataColumns`` vocabulary (which stays confined to the on-ramp aliases).
+_TAG_ACTIVE_POWER_MEAN = "wtc_ActPower_mean"
+_TAG_WIND_SPEED_MEAN = "wtc_AcWindSp_mean"
+_TAG_WIND_SPEED_SD = "wtc_AcWindSp_stddev"
+_TAG_GEN_RPM_MEAN = "wtc_GenRpm_mean"
+
+
 hill_of_towie_fields = [
-    WPSBackupFileField(alias=DataColumns.active_power_mean, field_name="wtc_ActPower_mean", table_name="tblSCTurGrid"),
+    WPSBackupFileField(
+        alias=DataColumns.active_power_mean, field_name=_TAG_ACTIVE_POWER_MEAN, table_name="tblSCTurGrid"
+    ),
     WPSBackupFileField(alias=DataColumns.active_power_sd, field_name="wtc_ActPower_stddev", table_name="tblSCTurGrid"),
     WPSBackupFileField(alias="ReactivePowerMean", field_name="wtc_ReactPwr_mean", table_name="tblSCTurGrid"),
-    WPSBackupFileField(alias=DataColumns.wind_speed_mean, field_name="wtc_AcWindSp_mean", table_name="tblSCTurbine"),
-    WPSBackupFileField(alias=DataColumns.wind_speed_sd, field_name="wtc_AcWindSp_stddev", table_name="tblSCTurbine"),
+    WPSBackupFileField(alias=DataColumns.wind_speed_mean, field_name=_TAG_WIND_SPEED_MEAN, table_name="tblSCTurbine"),
+    WPSBackupFileField(alias=DataColumns.wind_speed_sd, field_name=_TAG_WIND_SPEED_SD, table_name="tblSCTurbine"),
     WPSBackupFileField(alias=DataColumns.yaw_angle_mean, field_name="wtc_NacelPos_mean", table_name="tblSCTurbine"),
     WPSBackupFileField(alias=DataColumns.yaw_angle_min, field_name="wtc_NacelPos_min", table_name="tblSCTurbine"),
     WPSBackupFileField(alias=DataColumns.yaw_angle_max, field_name="wtc_NacelPos_max", table_name="tblSCTurbine"),
-    WPSBackupFileField(alias=DataColumns.gen_rpm_mean, field_name="wtc_GenRpm_mean", table_name="tblSCTurbine"),
+    WPSBackupFileField(alias=DataColumns.gen_rpm_mean, field_name=_TAG_GEN_RPM_MEAN, table_name="tblSCTurbine"),
     WPSBackupFileField(alias="pitch_angle_a", field_name="wtc_PitcPosA_mean", table_name="tblSCTurbine"),
     WPSBackupFileField(alias="pitch_angle_b", field_name="wtc_PitcPosB_mean", table_name="tblSCTurbine"),
     WPSBackupFileField(alias="pitch_angle_c", field_name="wtc_PitcPosC_mean", table_name="tblSCTurbine"),
@@ -363,16 +375,15 @@ hill_of_towie_fields = [
 
 # The Hill of Towie source-native column schema the synthetic pipeline and methods see. The
 # raw 10-min tag names (``wtc_*``) are kept as-is (no v0 aliasing); the long-format turbine
-# identifier is ``TurbineName`` (assigned by :func:`scada_wide_to_long`). Derived from
-# ``hill_of_towie_fields`` so the source's tag names live in exactly one place.
-_FIELD_BY_ALIAS = {f.alias: f.field_name for f in hill_of_towie_fields}
+# identifier is ``TurbineName`` (assigned by :func:`scada_wide_to_long`). Built directly from
+# the source-native tag constants above, so the schema carries no v0 vocabulary.
 HOT_TURBINE_COL = "TurbineName"
 HOT_COLUMNS = ColumnSchema(
     turbine=HOT_TURBINE_COL,
-    active_power=_FIELD_BY_ALIAS[DataColumns.active_power_mean],
-    wind_speed=_FIELD_BY_ALIAS[DataColumns.wind_speed_mean],
-    wind_speed_sd=_FIELD_BY_ALIAS[DataColumns.wind_speed_sd],
-    gen_rpm=_FIELD_BY_ALIAS[DataColumns.gen_rpm_mean],
+    active_power=_TAG_ACTIVE_POWER_MEAN,
+    wind_speed=_TAG_WIND_SPEED_MEAN,
+    wind_speed_sd=_TAG_WIND_SPEED_SD,
+    gen_rpm=_TAG_GEN_RPM_MEAN,
 )
 
 

--- a/benchmarking/synthetic/upgrades.py
+++ b/benchmarking/synthetic/upgrades.py
@@ -20,12 +20,13 @@ import numpy as np
 import numpy.typing as npt
 
 from benchmarking.synthetic.cp_core import power_from_cp_change, region2_fraction, rpm_from_power_change
-from wind_up.constants import DataColumns
+from benchmarking.synthetic.sources.hill_of_towie import HOT_COLUMNS
 
 if TYPE_CHECKING:
     import pandas as pd
 
     from benchmarking.synthetic.cp_core import CpCore
+    from benchmarking.synthetic.schema import ColumnSchema
 
 
 @dataclass
@@ -54,7 +55,7 @@ class ConstantCpChange:
         """Return serialisable provenance describing this upgrade."""
         return {"kind": "constant_cp", "delta": self.delta, "ws_delta": self.ws_delta}
 
-    def __call__(self, rows: pd.DataFrame) -> UpgradeEffect:  # noqa: ARG002
+    def __call__(self, rows: pd.DataFrame, columns: ColumnSchema) -> UpgradeEffect:  # noqa: ARG002
         """Return this upgrade's effect on the given rows."""
         return UpgradeEffect(cp_ratio=1.0 + self.delta, ws_factor=1.0 + self.ws_delta)
 
@@ -81,22 +82,22 @@ class WindSpeedCpChange:
             "ws_delta": self.ws_delta,
         }
 
-    def __call__(self, rows: pd.DataFrame) -> UpgradeEffect:
+    def __call__(self, rows: pd.DataFrame, columns: ColumnSchema) -> UpgradeEffect:
         """Return this upgrade's effect on the given rows."""
-        original_ws = rows[DataColumns.wind_speed_mean].to_numpy(dtype=float)
+        original_ws = rows[columns.wind_speed].to_numpy(dtype=float)
         delta = np.interp(original_ws, self.ws_points, self.deltas)
         return UpgradeEffect(cp_ratio=1.0 + delta, ws_factor=1.0 + self.ws_delta)
 
 
-def _condition_series(rows: pd.DataFrame, by: str) -> npt.NDArray[np.float64]:
+def _condition_series(rows: pd.DataFrame, by: str, columns: ColumnSchema) -> npt.NDArray[np.float64]:
     """Compute a treatment-invariant condition signal from the original rows.
 
-    ``by="ti"`` is turbulence intensity (WindSpeedSD / WindSpeedMean); any other value is
+    ``by="ti"`` is turbulence intensity (wind-speed SD / wind-speed mean); any other value is
     treated as the name of a column already present in ``rows``.
     """
     if by == "ti":
-        ws = rows[DataColumns.wind_speed_mean].to_numpy(dtype=float)
-        sd = rows[DataColumns.wind_speed_sd].to_numpy(dtype=float)
+        ws = rows[columns.wind_speed].to_numpy(dtype=float)
+        sd = rows[columns.wind_speed_sd].to_numpy(dtype=float)
         # NaN (not inf/0-division warning) for calm rows; warnings are errors in tests.
         return np.divide(sd, ws, out=np.full_like(sd, np.nan), where=ws != 0)
     return rows[by].to_numpy(dtype=float)
@@ -127,9 +128,9 @@ class ConditionCpChange:
             "ws_delta": self.ws_delta,
         }
 
-    def __call__(self, rows: pd.DataFrame) -> UpgradeEffect:
+    def __call__(self, rows: pd.DataFrame, columns: ColumnSchema) -> UpgradeEffect:
         """Return this upgrade's effect on the given rows."""
-        condition = _condition_series(rows, self.by)
+        condition = _condition_series(rows, self.by, columns)
         delta = np.interp(condition, self.points, self.deltas)
         return UpgradeEffect(cp_ratio=1.0 + delta, ws_factor=1.0 + self.ws_delta)
 
@@ -151,7 +152,7 @@ class RatedPowerChange:
         """Return serialisable provenance describing this upgrade."""
         return {"kind": "rated_power", "new_rated_power_kw": self.new_rated_power_kw}
 
-    def __call__(self, rows: pd.DataFrame) -> UpgradeEffect:  # noqa: ARG002
+    def __call__(self, rows: pd.DataFrame, columns: ColumnSchema) -> UpgradeEffect:  # noqa: ARG002
         """Return this upgrade's effect on the given rows."""
         return UpgradeEffect(new_rated_power_kw=self.new_rated_power_kw)
 
@@ -177,7 +178,9 @@ def apply_rated_change(
     return np.minimum(lifted, new_rated_kw)
 
 
-def apply_upgrades(rows: pd.DataFrame, upgrades: list, *, cp: CpCore) -> pd.DataFrame:
+def apply_upgrades(
+    rows: pd.DataFrame, upgrades: list, *, cp: CpCore, columns: ColumnSchema = HOT_COLUMNS
+) -> pd.DataFrame:
     """Resolve and apply a list of upgrades to one test turbine's treated rows.
 
     Cp ratios from all upgrades multiply together and are applied to the original power
@@ -188,19 +191,20 @@ def apply_upgrades(rows: pd.DataFrame, upgrades: list, *, cp: CpCore) -> pd.Data
     :param rows: treated rows for one test turbine, carrying the original SCADA tags
     :param upgrades: upgrade callables to resolve
     :param cp: the turbine's Cp core (rated power and Cp parameters)
+    :param columns: the source-native column schema ``rows`` is keyed by
     :return: a new frame with modified power, rpm and wind-speed columns
     """
     out = rows.copy()
     n = len(rows)
-    baseline_power = rows[DataColumns.active_power_mean].to_numpy(dtype=float)
-    baseline_rpm = rows[DataColumns.gen_rpm_mean].to_numpy(dtype=float)
-    baseline_ws = rows[DataColumns.wind_speed_mean].to_numpy(dtype=float)
+    baseline_power = rows[columns.active_power].to_numpy(dtype=float)
+    baseline_rpm = rows[columns.gen_rpm].to_numpy(dtype=float)
+    baseline_ws = rows[columns.wind_speed].to_numpy(dtype=float)
 
     cp_ratio = np.ones(n)
     ws_factor = 1.0
     new_rated_power_kw: float | None = None
     for upgrade in upgrades:
-        effect = upgrade(rows)
+        effect = upgrade(rows, columns)
         cp_ratio = cp_ratio * np.asarray(effect.cp_ratio, dtype=float)
         ws_factor *= effect.ws_factor
         if effect.new_rated_power_kw is not None:
@@ -216,7 +220,7 @@ def apply_upgrades(rows: pd.DataFrame, upgrades: list, *, cp: CpCore) -> pd.Data
         )
     new_rpm = rpm_from_power_change(baseline_rpm=baseline_rpm, baseline_power_kw=baseline_power, new_power_kw=new_power)
 
-    out[DataColumns.active_power_mean] = new_power
-    out[DataColumns.gen_rpm_mean] = new_rpm
-    out[DataColumns.wind_speed_mean] = baseline_ws * ws_factor
+    out[columns.active_power] = new_power
+    out[columns.gen_rpm] = new_rpm
+    out[columns.wind_speed] = baseline_ws * ws_factor
     return out

--- a/tests/benchmarking/baselines/test_naive_ratio.py
+++ b/tests/benchmarking/baselines/test_naive_ratio.py
@@ -8,12 +8,14 @@ written diagnostics, and the error/degenerate paths.
 
 from __future__ import annotations
 
+import ast
 from pathlib import Path
 
 import numpy as np
 import pandas as pd
 import pytest
 
+from benchmarking.baselines import naive_ratio
 from benchmarking.baselines.naive_ratio import (
     NaiveRatioMethod,
     _daily_segment_coverage,
@@ -23,18 +25,23 @@ from benchmarking.baselines.naive_ratio import (
 )
 from benchmarking.harness.method import MethodInput, MethodOutput
 from benchmarking.synthetic import ToggleSchedule, treated_mask
-from wind_up.constants import TIMESTAMP_COL, DataColumns
+
+# Deliberately non-v0 column names: the method is source-agnostic, so the active-power column
+# is configured and the turbine column comes from the seam. Using names that are nothing like
+# v0's ``DataColumns`` proves the method never reaches for wind_up's vocabulary.
+_TURBINE_COL = "asset_id"
+_POWER_COL = "kw"
 
 
 def _index(n: int, *, freq: str = "10min", start: str = "2020-01-01") -> pd.DatetimeIndex:
-    return pd.date_range(start=start, periods=n, freq=freq, tz="UTC", name=TIMESTAMP_COL)
+    return pd.date_range(start=start, periods=n, freq=freq, tz="UTC", name="timestamp")
 
 
 def _scada(power_by_turbine: dict[str, np.ndarray], index: pd.DatetimeIndex) -> pd.DataFrame:
     """Long-format SCADA: one block of rows per turbine, sharing ``index``."""
     frames = [
         pd.DataFrame(
-            {DataColumns.turbine_name: name, DataColumns.active_power_mean: np.asarray(vals, dtype=float)},
+            {_TURBINE_COL: name, _POWER_COL: np.asarray(vals, dtype=float)},
             index=index,
         )
         for name, vals in power_by_turbine.items()
@@ -68,13 +75,24 @@ class TestInferTimebase:
         assert _infer_timebase(doubled) == pd.Timedelta(minutes=10)
 
 
+def test_naive_ratio_shares_no_wind_up_code() -> None:
+    """The naive method is an independent, source-native baseline: it must not import wind_up."""
+    tree = ast.parse(Path(naive_ratio.__file__).read_text())
+    modules = {alias.name for node in ast.walk(tree) if isinstance(node, ast.Import) for alias in node.names}
+    modules |= {node.module for node in ast.walk(tree) if isinstance(node, ast.ImportFrom) and node.module}
+    offenders = {m for m in modules if m == "wind_up" or m.startswith("wind_up.")}
+    assert not offenders, f"naive_ratio must not depend on wind_up, found imports: {offenders}"
+
+
 class TestRecovery:
     def test_prepost_recovers_known_uplift(self) -> None:
         idx = _index(20)
         upgrade = idx[10]
         treated = np.asarray(idx >= upgrade)
         scada = _recovery_scada(idx, treated=treated, uplift=0.07)
-        out = NaiveRatioMethod().estimate(MethodInput(scada_df=scada, test_wtg="T1", upgrade_timing=upgrade))
+        out = NaiveRatioMethod(active_power_col=_POWER_COL).estimate(
+            MethodInput(scada_df=scada, test_wtg="T1", upgrade_timing=upgrade, turbine_col=_TURBINE_COL)
+        )
         assert isinstance(out, MethodOutput)
         assert out.p50_overall == pytest.approx(0.07)
         assert out.p50_by_condition is None
@@ -84,7 +102,9 @@ class TestRecovery:
         schedule = ToggleSchedule(period=pd.Timedelta(minutes=20), start=idx[0])
         treated = treated_mask(idx, schedule)
         scada = _recovery_scada(idx, treated=treated, uplift=0.03)
-        out = NaiveRatioMethod().estimate(MethodInput(scada_df=scada, test_wtg="T1", upgrade_timing=schedule))
+        out = NaiveRatioMethod(active_power_col=_POWER_COL).estimate(
+            MethodInput(scada_df=scada, test_wtg="T1", upgrade_timing=schedule, turbine_col=_TURBINE_COL)
+        )
         assert out.p50_overall == pytest.approx(0.03)
 
 
@@ -94,14 +114,18 @@ class TestCompleteCase:
         upgrade = idx[10]
         treated = np.asarray(idx >= upgrade)
         scada = _recovery_scada(idx, treated=treated, uplift=0.05)
-        clean = NaiveRatioMethod().estimate(MethodInput(scada_df=scada, test_wtg="T1", upgrade_timing=upgrade))
+        clean = NaiveRatioMethod(active_power_col=_POWER_COL).estimate(
+            MethodInput(scada_df=scada, test_wtg="T1", upgrade_timing=upgrade, turbine_col=_TURBINE_COL)
+        )
 
         # NaN one reference at a used baseline timestamp: that timestamp must be excluded, but
         # since the ratio is identical at every row the estimate is unchanged.
         corrupted = scada.copy()
-        mask = (corrupted[DataColumns.turbine_name] == "R1") & (corrupted.index == idx[3])
-        corrupted.loc[mask, DataColumns.active_power_mean] = np.nan
-        out = NaiveRatioMethod().estimate(MethodInput(scada_df=corrupted, test_wtg="T1", upgrade_timing=upgrade))
+        mask = (corrupted[_TURBINE_COL] == "R1") & (corrupted.index == idx[3])
+        corrupted.loc[mask, _POWER_COL] = np.nan
+        out = NaiveRatioMethod(active_power_col=_POWER_COL).estimate(
+            MethodInput(scada_df=corrupted, test_wtg="T1", upgrade_timing=upgrade, turbine_col=_TURBINE_COL)
+        )
         assert out.p50_overall == pytest.approx(clean.p50_overall)
 
     def test_nan_at_unused_timestamp_does_not_change_estimate(self) -> None:
@@ -111,15 +135,15 @@ class TestCompleteCase:
         scada = _recovery_scada(idx, treated=treated, uplift=0.05)
         # make idx[2] already unused (test NaN), then add a second NaN at the same timestamp
         base = scada.copy()
-        base.loc[(base[DataColumns.turbine_name] == "T1") & (base.index == idx[2]), DataColumns.active_power_mean] = (
-            np.nan
+        base.loc[(base[_TURBINE_COL] == "T1") & (base.index == idx[2]), _POWER_COL] = np.nan
+        before = NaiveRatioMethod(active_power_col=_POWER_COL).estimate(
+            MethodInput(scada_df=base, test_wtg="T1", upgrade_timing=upgrade, turbine_col=_TURBINE_COL)
         )
-        before = NaiveRatioMethod().estimate(MethodInput(scada_df=base, test_wtg="T1", upgrade_timing=upgrade))
         after_df = base.copy()
-        after_df.loc[
-            (after_df[DataColumns.turbine_name] == "R1") & (after_df.index == idx[2]), DataColumns.active_power_mean
-        ] = np.nan
-        after = NaiveRatioMethod().estimate(MethodInput(scada_df=after_df, test_wtg="T1", upgrade_timing=upgrade))
+        after_df.loc[(after_df[_TURBINE_COL] == "R1") & (after_df.index == idx[2]), _POWER_COL] = np.nan
+        after = NaiveRatioMethod(active_power_col=_POWER_COL).estimate(
+            MethodInput(scada_df=after_df, test_wtg="T1", upgrade_timing=upgrade, turbine_col=_TURBINE_COL)
+        )
         assert after.p50_overall == pytest.approx(before.p50_overall)
 
 
@@ -135,8 +159,8 @@ class TestTimebaseInvariance:
                 treated10 = treated
             scada = _recovery_scada(idx, treated=treated, uplift=0.04)
             results.append(
-                NaiveRatioMethod()
-                .estimate(MethodInput(scada_df=scada, test_wtg="T1", upgrade_timing=upgrade))
+                NaiveRatioMethod(active_power_col=_POWER_COL)
+                .estimate(MethodInput(scada_df=scada, test_wtg="T1", upgrade_timing=upgrade, turbine_col=_TURBINE_COL))
                 .p50_overall
             )
         assert results[0] == pytest.approx(results[1])
@@ -146,8 +170,8 @@ class TestTimebaseInvariance:
         upgrade = idx[10]
         treated = np.asarray(idx >= upgrade)
         scada = _recovery_scada(idx, treated=treated, uplift=0.05)
-        method = NaiveRatioMethod(out_dir=tmp_path, timebase=pd.Timedelta(minutes=30))
-        method.estimate(MethodInput(scada_df=scada, test_wtg="T1", upgrade_timing=upgrade))
+        method = NaiveRatioMethod(active_power_col=_POWER_COL, out_dir=tmp_path, timebase=pd.Timedelta(minutes=30))
+        method.estimate(MethodInput(scada_df=scada, test_wtg="T1", upgrade_timing=upgrade, turbine_col=_TURBINE_COL))
         stats = _read_only_csv(tmp_path, "data_stats")
         all_row = stats[stats["segment"] == "all"].iloc[0]
         # MWh = sum(power_kw) * timebase_hours / 1000; check it used 0.5h not 1/6h
@@ -161,13 +185,17 @@ class TestActivePowerOnly:
         upgrade = idx[10]
         treated = np.asarray(idx >= upgrade)
         scada = _recovery_scada(idx, treated=treated, uplift=0.05)
-        plain = NaiveRatioMethod().estimate(MethodInput(scada_df=scada, test_wtg="T1", upgrade_timing=upgrade))
+        plain = NaiveRatioMethod(active_power_col=_POWER_COL).estimate(
+            MethodInput(scada_df=scada, test_wtg="T1", upgrade_timing=upgrade, turbine_col=_TURBINE_COL)
+        )
 
         with_extra = scada.copy()
         rng = np.random.default_rng(0)
-        with_extra[DataColumns.wind_speed_mean] = rng.normal(size=len(with_extra))
-        with_extra[DataColumns.gen_rpm_mean] = rng.normal(size=len(with_extra))
-        out = NaiveRatioMethod().estimate(MethodInput(scada_df=with_extra, test_wtg="T1", upgrade_timing=upgrade))
+        with_extra["ws"] = rng.normal(size=len(with_extra))
+        with_extra["rpm"] = rng.normal(size=len(with_extra))
+        out = NaiveRatioMethod(active_power_col=_POWER_COL).estimate(
+            MethodInput(scada_df=with_extra, test_wtg="T1", upgrade_timing=upgrade, turbine_col=_TURBINE_COL)
+        )
         assert out.p50_overall == pytest.approx(plain.p50_overall)
 
 
@@ -177,7 +205,9 @@ class TestErrors:
         upgrade = idx[10]
         scada = _scada({"T1": np.ones(len(idx))}, idx)
         with pytest.raises(ValueError, match="reference"):
-            NaiveRatioMethod().estimate(MethodInput(scada_df=scada, test_wtg="T1", upgrade_timing=upgrade))
+            NaiveRatioMethod(active_power_col=_POWER_COL).estimate(
+                MethodInput(scada_df=scada, test_wtg="T1", upgrade_timing=upgrade, turbine_col=_TURBINE_COL)
+            )
 
     def test_no_used_baseline_returns_nan(self) -> None:
         idx = _index(20)
@@ -185,9 +215,11 @@ class TestErrors:
         treated = np.asarray(idx >= upgrade)
         scada = _recovery_scada(idx, treated=treated, uplift=0.05)
         # NaN the test turbine across the whole baseline -> no used baseline timestamps
-        is_baseline_test = (scada[DataColumns.turbine_name] == "T1") & np.asarray(scada.index < upgrade)
-        scada.loc[is_baseline_test, DataColumns.active_power_mean] = np.nan
-        out = NaiveRatioMethod().estimate(MethodInput(scada_df=scada, test_wtg="T1", upgrade_timing=upgrade))
+        is_baseline_test = (scada[_TURBINE_COL] == "T1") & np.asarray(scada.index < upgrade)
+        scada.loc[is_baseline_test, _POWER_COL] = np.nan
+        out = NaiveRatioMethod(active_power_col=_POWER_COL).estimate(
+            MethodInput(scada_df=scada, test_wtg="T1", upgrade_timing=upgrade, turbine_col=_TURBINE_COL)
+        )
         assert np.isnan(out.p50_overall)
 
 
@@ -200,9 +232,7 @@ class TestPlotSeries:
         upgrade = idx[144]
         treated = np.asarray(idx >= upgrade)
         scada = _recovery_scada(idx, treated=treated, uplift=0.05)
-        wide = scada.pivot_table(
-            index=scada.index, columns=DataColumns.turbine_name, values=DataColumns.active_power_mean
-        )
+        wide = scada.pivot_table(index=scada.index, columns=_TURBINE_COL, values=_POWER_COL)
         test_pw = wide["T1"].to_numpy()
         ref_total = wide[["R1", "R2"]].sum(axis=1).to_numpy()
         used = np.ones(len(wide), dtype=bool)
@@ -221,9 +251,7 @@ class TestPlotSeries:
         upgrade = idx[144]
         treated = np.asarray(idx >= upgrade)
         scada = _recovery_scada(idx, treated=treated, uplift=0.05)
-        wide = scada.pivot_table(
-            index=scada.index, columns=DataColumns.turbine_name, values=DataColumns.active_power_mean
-        )
+        wide = scada.pivot_table(index=scada.index, columns=_TURBINE_COL, values=_POWER_COL)
         used = np.ones(len(wide), dtype=bool)
         used[10] = used[200] = False  # drop one timestamp in each day
 
@@ -245,9 +273,7 @@ class TestPlotSeries:
         schedule = ToggleSchedule(period=pd.Timedelta(minutes=40), start=idx[0])
         treated = np.asarray(treated_mask(idx, schedule))
         scada = _recovery_scada(idx, treated=treated, uplift=0.05)
-        wide = scada.pivot_table(
-            index=scada.index, columns=DataColumns.turbine_name, values=DataColumns.active_power_mean
-        )
+        wide = scada.pivot_table(index=scada.index, columns=_TURBINE_COL, values=_POWER_COL)
         used = np.ones(len(wide), dtype=bool)
 
         expected = _expected_per_day(wide.index, _infer_timebase(wide.index))
@@ -271,8 +297,10 @@ class TestDiagnostics:
         upgrade = idx[10]
         treated = np.asarray(idx >= upgrade)
         scada = _recovery_scada(idx, treated=treated, uplift=0.06)
-        method = NaiveRatioMethod(out_dir=tmp_path, save_plots=save_plots)
-        out = method.estimate(MethodInput(scada_df=scada, test_wtg="T1", upgrade_timing=upgrade))
+        method = NaiveRatioMethod(active_power_col=_POWER_COL, out_dir=tmp_path, save_plots=save_plots)
+        out = method.estimate(
+            MethodInput(scada_df=scada, test_wtg="T1", upgrade_timing=upgrade, turbine_col=_TURBINE_COL)
+        )
         return out, idx, upgrade
 
     def test_writes_both_csvs(self, tmp_path) -> None:  # noqa: ANN001

--- a/tests/benchmarking/baselines/test_toggle_end_to_end.py
+++ b/tests/benchmarking/baselines/test_toggle_end_to_end.py
@@ -18,7 +18,7 @@ from benchmarking.baselines.naive_ratio import NaiveRatioMethod
 from benchmarking.baselines.v0_binned import V0BinnedMethod
 from benchmarking.harness import StudyConfig, score_study
 from benchmarking.harness.example_hot_study import OracleMethod
-from benchmarking.synthetic import ConstantCpChange
+from benchmarking.synthetic import HOT_COLUMNS, ConstantCpChange
 from benchmarking.synthetic.sources.hill_of_towie import load_hot_scada
 
 
@@ -46,7 +46,7 @@ def test_naive_and_v0_recover_toggle_uplift(tmp_path) -> None:  # noqa: ANN001
         profile=[ConstantCpChange(delta=0.05)],
         methods=[
             V0BinnedMethod(context, scratch_dir=tmp_path / "windup_runs"),
-            NaiveRatioMethod(out_dir=tmp_path / "naive_runs"),
+            NaiveRatioMethod(active_power_col=HOT_COLUMNS.active_power, out_dir=tmp_path / "naive_runs"),
             OracleMethod(scada_df),
         ],
         study=study,

--- a/tests/benchmarking/baselines/test_toggle_end_to_end.py
+++ b/tests/benchmarking/baselines/test_toggle_end_to_end.py
@@ -1,10 +1,12 @@
-"""Slow end-to-end test: v0 and the naive ratio method on a HoT-derived synthetic toggle dataset.
+"""Slow end-to-end test: the naive ratio method on a HoT-derived synthetic toggle dataset.
 
-Downloads the Hill of Towie v2 SCADA (Zenodo) and ERA5 reanalysis (Open-Meteo), injects a known
-constant-Cp uplift under a fast 20-min-on/20-min-off toggle, and scores ``V0BinnedMethod`` (via
-wind_up's native toggle assessment), ``NaiveRatioMethod`` and an oracle through the harness. This
-is the sanity that the toggle path composes end to end; it is marked ``slow`` (network + a heavy
-wind_up run) and skipped by ``-m "not slow"``.
+Downloads the Hill of Towie v2 SCADA (Zenodo), injects a known constant-Cp uplift under a fast
+20-min-on/20-min-off toggle, and scores ``NaiveRatioMethod`` and an oracle through the harness on
+real data. This is the sanity that the toggle path composes end to end for a lightweight method;
+it is marked ``slow`` (network download) and skipped by ``-m "not slow"``.
+
+v0 is deliberately *not* exercised here: a real wind_up run per campaign is far too slow for an
+e2e test. The v0 integration has its own (env-gated) end-to-end test in ``test_v0_end_to_end``.
 """
 
 from __future__ import annotations
@@ -13,9 +15,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from benchmarking.baselines.hot_context import build_hot_v0_context
 from benchmarking.baselines.naive_ratio import NaiveRatioMethod
-from benchmarking.baselines.v0_binned import V0BinnedMethod
 from benchmarking.harness import StudyConfig, score_study
 from benchmarking.harness.example_hot_study import OracleMethod
 from benchmarking.synthetic import HOT_COLUMNS, ConstantCpChange
@@ -23,13 +23,12 @@ from benchmarking.synthetic.sources.hill_of_towie import load_hot_scada
 
 
 @pytest.mark.slow
-def test_naive_and_v0_recover_toggle_uplift(tmp_path) -> None:  # noqa: ANN001
+def test_naive_recovers_toggle_uplift(tmp_path) -> None:  # noqa: ANN001
     scada_df, _metadata_df = load_hot_scada(
         start_dt=pd.Timestamp("2016-01-01", tz="UTC"),
         end_dt_excl=pd.Timestamp("2018-09-01", tz="UTC"),
         wtg_numbers=[1, 3, 4, 7],
     )
-    context = build_hot_v0_context(wtg_names=["T01", "T03", "T04", "T07"])
     study = StudyConfig(
         mode="toggle",
         turbine_subset=["T01", "T03", "T04", "T07"],
@@ -45,7 +44,6 @@ def test_naive_and_v0_recover_toggle_uplift(tmp_path) -> None:  # noqa: ANN001
         scada_df,
         profile=[ConstantCpChange(delta=0.05)],
         methods=[
-            V0BinnedMethod(context, scratch_dir=tmp_path / "windup_runs"),
             NaiveRatioMethod(active_power_col=HOT_COLUMNS.active_power, out_dir=tmp_path / "naive_runs"),
             OracleMethod(scada_df),
         ],
@@ -55,13 +53,10 @@ def test_naive_and_v0_recover_toggle_uplift(tmp_path) -> None:  # noqa: ANN001
 
     oracle_row = results.loc[results["method"] == "oracle"].iloc[0]
     naive_row = results.loc[results["method"] == "naive_ratio"].iloc[0]
-    v0_row = results.loc[results["method"] == "v0_binned"].iloc[0]
 
     # the harness toggle path is wired correctly: the oracle recovers the injected truth exactly
     assert abs(oracle_row["signed_error"]) < 1e-6
-    # a real constant-Cp uplift is positive; both methods recover it to within a few pp.
+    # a real constant-Cp uplift is positive; the naive method recovers it to within a few pp.
     assert naive_row["truth"] > 0
     assert np.isfinite(naive_row["estimate"])
     assert abs(naive_row["signed_error"]) < 0.03
-    assert np.isfinite(v0_row["estimate"])
-    assert abs(v0_row["signed_error"]) < 0.03

--- a/tests/benchmarking/baselines/test_v0_binned.py
+++ b/tests/benchmarking/baselines/test_v0_binned.py
@@ -15,18 +15,41 @@ from benchmarking.baselines import v0_binned
 from benchmarking.baselines.hot_context import HotV0Context
 from benchmarking.baselines.v0_binned import V0BinnedMethod, _extract_p50, _subset_turbines
 from benchmarking.harness.method import MethodInput, MethodOutput
-from benchmarking.synthetic import ToggleSchedule, treated_mask
-from wind_up.constants import DataColumns
+from benchmarking.synthetic import HOT_COLUMNS, ToggleSchedule, treated_mask
+from benchmarking.synthetic.sources.hill_of_towie import long_to_wind_up_format
+
+# The harness hands v0 source-native SCADA, so the fixtures carry the source-native tag names and
+# the full field set the v0 on-ramp (``long_to_wind_up_format``) needs (pitch blades, yaw, the
+# time-ready signal) to derive ``PitchAngleMean`` / ``ShutdownDuration``.
+_SOURCE_FIELDS = (
+    HOT_COLUMNS.active_power,
+    HOT_COLUMNS.wind_speed,
+    HOT_COLUMNS.wind_speed_sd,
+    HOT_COLUMNS.gen_rpm,
+    "wtc_ActPower_stddev",
+    "wtc_NacelPos_mean",
+    "wtc_PitcPosA_mean",
+    "wtc_PitcPosB_mean",
+    "wtc_PitcPosC_mean",
+)
 
 
-def _make_scada(turbines: list[str], *, start: pd.Timestamp, end: pd.Timestamp) -> pd.DataFrame:
-    """Minimal scada whose only meaningful content is the turbine names and the index span."""
-    index = pd.DatetimeIndex([start, end], name="TimeStamp_StartFormat")
+def _long_scada(turbines: list[str], index: pd.DatetimeIndex) -> pd.DataFrame:
+    """A source-native long SCADA frame complete enough for the v0 on-ramp to convert."""
     frames = [
-        pd.DataFrame({DataColumns.turbine_name: t, DataColumns.active_power_mean: [1.0, 1.0]}, index=index)
+        pd.DataFrame(
+            {HOT_COLUMNS.turbine: t, **dict.fromkeys(_SOURCE_FIELDS, 1.0), "wtc_ScReToOp_timeon": 600.0},
+            index=index,
+        )
         for t in turbines
     ]
     return pd.concat(frames)
+
+
+def _make_scada(turbines: list[str], *, start: pd.Timestamp, end: pd.Timestamp) -> pd.DataFrame:
+    """Minimal-span scada (two timestamps) whose meaningful content is the turbines and span."""
+    index = pd.DatetimeIndex([start, end], name="TimeStamp_StartFormat")
+    return _long_scada(turbines, index)
 
 
 def _context() -> HotV0Context:
@@ -44,7 +67,7 @@ def _method_input(turbines: list[str], test_wtg: str) -> MethodInput:
 class TestSubsetTurbines:
     def test_returns_sorted_unique_names(self) -> None:
         scada = _make_scada(["T04", "T01", "T03"], start=UPGRADE, end=UPGRADE + pd.DateOffset(months=1))
-        assert _subset_turbines(scada) == ["T01", "T03", "T04"]
+        assert _subset_turbines(scada, HOT_COLUMNS.turbine) == ["T01", "T03", "T04"]
 
 
 class TestBuildConfig:
@@ -78,12 +101,9 @@ class TestBuildConfig:
 
 
 def _dense_scada(turbines: list[str], *, start: pd.Timestamp, end: pd.Timestamp, freq: str = "1D") -> pd.DataFrame:
-    """Long-format scada on a regular grid (enough rows for a toggle split)."""
+    """Source-native long scada on a regular grid (enough rows for a toggle split)."""
     index = pd.date_range(start, end, freq=freq, tz="UTC", name="TimeStamp_StartFormat")
-    frames = [
-        pd.DataFrame({DataColumns.turbine_name: t, DataColumns.active_power_mean: 1.0}, index=index) for t in turbines
-    ]
-    return pd.concat(frames)
+    return _long_scada(turbines, index)
 
 
 class TestBuildToggleDf:
@@ -187,9 +207,11 @@ class TestEstimateWiring:
         assert captured["run_inputs"] == "inputs-sentinel"
         assert captured["combine_trdf"] == "trdf-sentinel"
         assert captured["combine_kwargs"]["auto_choose_refs"] is False
-        # the same scada/metadata/reanalysis from the context are handed to the pipeline
+        # the source-native scada is converted to wind-up format on the way into the pipeline,
+        # and the metadata/reanalysis from the context are handed through unchanged
         kwargs = captured["from_cfg_kwargs"]
-        assert kwargs["scada_df"].equals(_method_input(["T01", "T02", "T03", "T04"], "T01").scada_df)
+        expected_scada = long_to_wind_up_format(_method_input(["T01", "T02", "T03", "T04"], "T01").scada_df)
+        assert kwargs["scada_df"].equals(expected_scada)
         assert kwargs["reanalysis_datasets"] == []
 
     def test_save_plots_defaults_off(self, tmp_path, monkeypatch) -> None:  # noqa: ANN001

--- a/tests/benchmarking/baselines/test_v0_end_to_end.py
+++ b/tests/benchmarking/baselines/test_v0_end_to_end.py
@@ -1,13 +1,18 @@
-"""Slow end-to-end test: a real v0 run on a HoT-derived synthetic constant-Cp dataset.
+"""End-to-end test: a real v0 run on a HoT-derived synthetic constant-Cp dataset.
 
 Downloads the Hill of Towie v2 SCADA (Zenodo) and ERA5 reanalysis (Open-Meteo), injects a
 known constant-Cp uplift, runs the full wind_up pre/post analysis through ``V0BinnedMethod``
 behind the harness, and checks the recovered P50 lands near the injected truth. This is the
-sanity that the whole Issue 3 stack composes; it is marked ``slow`` (network + a heavy
-wind_up run) and skipped by ``-m "not slow"``.
+sanity that the v0 stack (incl. the source-native -> wind-up-format on-ramp) composes end to end.
+
+A real wind_up run per campaign is very slow, so this test is **opt-in**: it is skipped unless
+``RUN_V0_E2E`` is set in the environment (e.g. ``RUN_V0_E2E=1 uv run pytest <this file>``). It is
+also marked ``slow`` so it never runs in the ``-m "not slow"`` fast gate even when opted in.
 """
 
 from __future__ import annotations
+
+import os
 
 import numpy as np
 import pandas as pd
@@ -22,6 +27,7 @@ from benchmarking.synthetic.sources.hill_of_towie import load_hot_scada
 
 
 @pytest.mark.slow
+@pytest.mark.skipif(not os.environ.get("RUN_V0_E2E"), reason="v0 e2e is very slow; set RUN_V0_E2E=1 to run it")
 def test_v0_recovers_constant_cp_uplift(tmp_path) -> None:  # noqa: ANN001
     # A lighter window than the driver (three Zenodo year zips): a 24-month baseline before an
     # early-2018 upgrade plus a 6-month campaign, enough to exercise the full stack on one campaign.

--- a/tests/benchmarking/harness/stubs.py
+++ b/tests/benchmarking/harness/stubs.py
@@ -13,8 +13,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 from benchmarking.harness.method import MethodInput, MethodOutput
-from benchmarking.synthetic import treated_mask
-from wind_up.constants import DataColumns
+from benchmarking.synthetic import HOT_COLUMNS, treated_mask
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -23,13 +22,13 @@ if TYPE_CHECKING:
 def oracle_overall_uplift(mi: MethodInput, original_df: pd.DataFrame) -> float:
     """Energy-ratio uplift over the treated test-turbine rows in ``mi``'s window."""
     syn = mi.scada_df
-    test_rows = syn[syn[DataColumns.turbine_name] == mi.test_wtg]
+    test_rows = syn[syn[mi.turbine_col] == mi.test_wtg]
     treated = treated_mask(test_rows.index, mi.upgrade_timing)
     treated_rows = test_rows[treated]
 
-    syn_power = treated_rows[DataColumns.active_power_mean].to_numpy(dtype=float)
-    orig_test = original_df[original_df[DataColumns.turbine_name] == mi.test_wtg]
-    orig_power = orig_test.loc[treated_rows.index, DataColumns.active_power_mean].to_numpy(dtype=float)
+    syn_power = treated_rows[HOT_COLUMNS.active_power].to_numpy(dtype=float)
+    orig_test = original_df[original_df[mi.turbine_col] == mi.test_wtg]
+    orig_power = orig_test.loc[treated_rows.index, HOT_COLUMNS.active_power].to_numpy(dtype=float)
 
     finite = np.isfinite(syn_power) & np.isfinite(orig_power)
     denom = orig_power[finite].sum()
@@ -81,6 +80,11 @@ class RecordingMethod:
         self.seen: list[MethodInput] = []
 
     def estimate(self, mi: MethodInput) -> MethodOutput:
-        captured = MethodInput(scada_df=mi.scada_df.copy(), test_wtg=mi.test_wtg, upgrade_timing=mi.upgrade_timing)
+        captured = MethodInput(
+            scada_df=mi.scada_df.copy(),
+            test_wtg=mi.test_wtg,
+            upgrade_timing=mi.upgrade_timing,
+            turbine_col=mi.turbine_col,
+        )
         self.seen.append(captured)
         return MethodOutput(p50_overall=0.0)

--- a/tests/benchmarking/harness/test_replicates.py
+++ b/tests/benchmarking/harness/test_replicates.py
@@ -6,8 +6,8 @@ import numpy as np
 import pandas as pd
 
 from benchmarking.harness.replicates import Replicate, StudyConfig, build_replicates
-from benchmarking.synthetic import ConstantCpChange, ToggleSchedule
-from wind_up.constants import TIMESTAMP_COL, DataColumns
+from benchmarking.synthetic import HOT_COLUMNS, ConstantCpChange, ToggleSchedule
+from wind_up.constants import TIMESTAMP_COL
 
 PROFILE = [ConstantCpChange(delta=0.05)]
 
@@ -18,11 +18,11 @@ def _base_scada(turbines: tuple[str, ...] = ("T1", "T3", "T4", "T7", "T99")) -> 
     frames = [
         pd.DataFrame(
             {
-                DataColumns.turbine_name: turbine,
-                DataColumns.active_power_mean: 1000.0,
-                DataColumns.wind_speed_mean: 8.0,
-                DataColumns.wind_speed_sd: 0.8,
-                DataColumns.gen_rpm_mean: 1400.0,
+                HOT_COLUMNS.turbine: turbine,
+                HOT_COLUMNS.active_power: 1000.0,
+                HOT_COLUMNS.wind_speed: 8.0,
+                HOT_COLUMNS.wind_speed_sd: 0.8,
+                HOT_COLUMNS.gen_rpm: 1400.0,
             },
             index=index,
         )
@@ -58,7 +58,7 @@ def test_build_replicates_returns_n_replicate_records() -> None:
 
 def test_data_is_subset_to_turbine_subset() -> None:
     reps = build_replicates(_base_scada(), profile=PROFILE, study=_study())
-    present = set(reps[0].dataset.synthetic_df[DataColumns.turbine_name].unique())
+    present = set(reps[0].dataset.synthetic_df[HOT_COLUMNS.turbine].unique())
     assert present == {"T1", "T3", "T4", "T7"}  # the other ~17 turbines dropped
 
 
@@ -126,6 +126,6 @@ def test_injected_upgrade_actually_changed_the_test_turbine() -> None:
     r = reps[0]
     syn = r.dataset.synthetic_df
     orig = r.dataset.original_df
-    test_syn = syn[syn[DataColumns.turbine_name] == r.test_wtg][DataColumns.active_power_mean].to_numpy()
-    test_orig = orig[orig[DataColumns.turbine_name] == r.test_wtg][DataColumns.active_power_mean].to_numpy()
+    test_syn = syn[syn[HOT_COLUMNS.turbine] == r.test_wtg][HOT_COLUMNS.active_power].to_numpy()
+    test_orig = orig[orig[HOT_COLUMNS.turbine] == r.test_wtg][HOT_COLUMNS.active_power].to_numpy()
     assert np.any(test_syn != test_orig)  # the profile left a mark

--- a/tests/benchmarking/harness/test_scoring.py
+++ b/tests/benchmarking/harness/test_scoring.py
@@ -7,8 +7,8 @@ import pandas as pd
 
 from benchmarking.harness.replicates import StudyConfig
 from benchmarking.harness.scoring import score_study
-from benchmarking.synthetic import ConstantCpChange
-from wind_up.constants import TIMESTAMP_COL, DataColumns
+from benchmarking.synthetic import HOT_COLUMNS, ConstantCpChange
+from wind_up.constants import TIMESTAMP_COL
 
 from .stubs import BiasedMethod, OracleMethod, RecordingMethod
 
@@ -20,11 +20,11 @@ def _base_scada(turbines: tuple[str, ...] = ("T1", "T3", "T4", "T7")) -> pd.Data
     frames = [
         pd.DataFrame(
             {
-                DataColumns.turbine_name: turbine,
-                DataColumns.active_power_mean: 1000.0,
-                DataColumns.wind_speed_mean: 8.0,
-                DataColumns.wind_speed_sd: 0.8,
-                DataColumns.gen_rpm_mean: 1400.0,
+                HOT_COLUMNS.turbine: turbine,
+                HOT_COLUMNS.active_power: 1000.0,
+                HOT_COLUMNS.wind_speed: 8.0,
+                HOT_COLUMNS.wind_speed_sd: 0.8,
+                HOT_COLUMNS.gen_rpm: 1400.0,
             },
             index=index,
         )

--- a/tests/benchmarking/synthetic/sources/test_hill_of_towie.py
+++ b/tests/benchmarking/synthetic/sources/test_hill_of_towie.py
@@ -1,8 +1,10 @@
 """Offline tests for the Hill of Towie source adapter.
 
-These cover the wind-up-format contract of the pure SCADA transforms. The network
-path (Zenodo download via ``load_hot_scada``) is exercised separately by a
-``slow``-marked test that is excluded from the default offline suite.
+These cover the pure SCADA transforms: the source-native wide-to-long reshape
+(:func:`scada_wide_to_long`) the rest of the pipeline sees, and the v0-only wind-up-format
+on-ramp (:func:`long_to_wind_up_format`) that aliases the columns and derives ``PitchAngleMean``
+/ ``ShutdownDuration``. The network path (Zenodo download via ``load_hot_scada``) is exercised
+separately by a ``slow``-marked test that is excluded from the default offline suite.
 """
 
 from __future__ import annotations
@@ -10,36 +12,49 @@ from __future__ import annotations
 import numpy as np
 import pandas as pd
 
-from benchmarking.synthetic.sources.hill_of_towie import scada_df_to_wind_up_df
+from benchmarking.synthetic import HOT_COLUMNS
+from benchmarking.synthetic.sources.hill_of_towie import long_to_wind_up_format, scada_wide_to_long
 from wind_up.constants import TIMESTAMP_COL, DataColumns
 
 TIMEBASE_S = 600
+
+# Source-native 10-min tag names, as the loader emits them before any v0 aliasing.
+_F_ACTIVE_POWER = "wtc_ActPower_mean"
+_F_ACTIVE_POWER_SD = "wtc_ActPower_stddev"
+_F_WIND_SPEED = "wtc_AcWindSp_mean"
+_F_WIND_SPEED_SD = "wtc_AcWindSp_stddev"
+_F_YAW_MEAN = "wtc_NacelPos_mean"
+_F_YAW_MIN = "wtc_NacelPos_min"
+_F_YAW_MAX = "wtc_NacelPos_max"
+_F_GEN_RPM = "wtc_GenRpm_mean"
+_F_PITCH_A = "wtc_PitcPosA_mean"
+_F_PITCH_B = "wtc_PitcPosB_mean"
+_F_PITCH_C = "wtc_PitcPosC_mean"
+_F_TIME_READY = "wtc_ScReToOp_timeon"
 
 
 def _wide_scada_df(*, turbines: tuple[str, ...] = ("T01", "T02"), periods: int = 6) -> pd.DataFrame:
     """Build a fabricated wide two-level SCADA frame as ``load_hot_10min_data`` emits it.
 
-    Level 0 of the columns is the turbine name (index name ``StationId``); level 1 is
-    the wind-up field alias. The row index is the start-format timestamp.
+    Level 0 of the columns is the turbine name (index name ``StationId``); level 1 is the
+    source-native ``wtc_*`` tag name. The row index is the start-format timestamp.
     """
     index = pd.date_range("2020-01-01", periods=periods, freq="10min", tz="UTC")
     index.name = TIMESTAMP_COL
 
     fields = {
-        DataColumns.active_power_mean: np.linspace(100.0, 600.0, periods),
-        DataColumns.active_power_sd: np.full(periods, 10.0),
-        "ReactivePowerMean": np.full(periods, 5.0),
-        DataColumns.wind_speed_mean: np.linspace(5.0, 10.0, periods),
-        DataColumns.wind_speed_sd: np.full(periods, 1.0),
-        DataColumns.yaw_angle_mean: np.full(periods, 180.0),
-        DataColumns.yaw_angle_min: np.full(periods, 175.0),
-        DataColumns.yaw_angle_max: np.full(periods, 185.0),
-        DataColumns.gen_rpm_mean: np.linspace(1000.0, 1500.0, periods),
-        "pitch_angle_a": np.full(periods, 1.0),
-        "pitch_angle_b": np.full(periods, 2.0),
-        "pitch_angle_c": np.full(periods, 3.0),
-        DataColumns.ambient_temp: np.full(periods, 8.0),
-        "Time ready to operate in period": np.full(periods, float(TIMEBASE_S)),
+        _F_ACTIVE_POWER: np.linspace(100.0, 600.0, periods),
+        _F_ACTIVE_POWER_SD: np.full(periods, 10.0),
+        _F_WIND_SPEED: np.linspace(5.0, 10.0, periods),
+        _F_WIND_SPEED_SD: np.full(periods, 1.0),
+        _F_YAW_MEAN: np.full(periods, 180.0),
+        _F_YAW_MIN: np.full(periods, 175.0),
+        _F_YAW_MAX: np.full(periods, 185.0),
+        _F_GEN_RPM: np.linspace(1000.0, 1500.0, periods),
+        _F_PITCH_A: np.full(periods, 1.0),
+        _F_PITCH_B: np.full(periods, 2.0),
+        _F_PITCH_C: np.full(periods, 3.0),
+        _F_TIME_READY: np.full(periods, float(TIMEBASE_S)),
     }
     # Both turbines share identical values at each timestamp but vary over time. Stuck
     # detection must compare each turbine to its OWN previous record (grouped by turbine),
@@ -50,25 +65,25 @@ def _wide_scada_df(*, turbines: tuple[str, ...] = ("T01", "T02"), periods: int =
     return wide
 
 
-def test_scada_df_to_wind_up_df_emits_wind_up_format() -> None:
-    """The wide two-level frame becomes a single-level wind-up frame with TurbineName."""
-    wind_up_df = scada_df_to_wind_up_df(_wide_scada_df())
+def test_scada_wide_to_long_emits_source_native_long_format() -> None:
+    """The wide two-level frame becomes a single-level long frame keyed by the source schema."""
+    long_df = scada_wide_to_long(_wide_scada_df())
 
-    assert wind_up_df.columns.nlevels == 1
-    assert wind_up_df.index.name == TIMESTAMP_COL
-    assert set(wind_up_df[DataColumns.turbine_name].unique()) == {"T01", "T02"}
-    for col in (
-        DataColumns.active_power_mean,
-        DataColumns.wind_speed_mean,
-        DataColumns.wind_speed_sd,
-        DataColumns.gen_rpm_mean,
-    ):
-        assert col in wind_up_df.columns
+    assert long_df.columns.nlevels == 1
+    assert long_df.index.name == TIMESTAMP_COL
+    assert set(long_df[HOT_COLUMNS.turbine].unique()) == {"T01", "T02"}
+    for col in (HOT_COLUMNS.active_power, HOT_COLUMNS.wind_speed, HOT_COLUMNS.wind_speed_sd, HOT_COLUMNS.gen_rpm):
+        assert col in long_df.columns
+    # The v0-only derived columns are not added by the source-native reshape.
+    assert DataColumns.pitch_angle_mean not in long_df.columns
+    assert DataColumns.shutdown_duration not in long_df.columns
 
 
-def test_scada_df_to_wind_up_df_computes_mean_pitch() -> None:
-    """PitchAngleMean is the mean of the three per-blade pitch columns."""
-    wind_up_df = scada_df_to_wind_up_df(_wide_scada_df())
+def test_long_to_wind_up_format_aliases_and_computes_mean_pitch() -> None:
+    """The v0 on-ramp aliases the source columns and derives PitchAngleMean."""
+    wind_up_df = long_to_wind_up_format(scada_wide_to_long(_wide_scada_df()))
+
+    assert DataColumns.active_power_mean in wind_up_df.columns
     assert np.allclose(wind_up_df[DataColumns.pitch_angle_mean], 2.0)
 
 
@@ -78,7 +93,7 @@ def test_calc_shutdown_duration_zero_when_fully_available() -> None:
     Stuck detection compares each turbine to its own previous record, so turbines that
     merely match each other at the same timestamp are not flagged as frozen.
     """
-    wind_up_df = scada_df_to_wind_up_df(_wide_scada_df())
+    wind_up_df = long_to_wind_up_format(scada_wide_to_long(_wide_scada_df()))
     assert DataColumns.shutdown_duration in wind_up_df.columns
     assert np.allclose(wind_up_df[DataColumns.shutdown_duration], 0.0)
 
@@ -89,7 +104,7 @@ def test_calc_shutdown_duration_flags_stuck_data() -> None:
     # Freeze T01 to identical values across all rows (stuck), at a wind speed above 1.5 m/s.
     for field in wide.columns.get_level_values(1).unique():
         wide.loc[:, ("T01", field)] = wide.iloc[0].loc[("T01", field)]
-    wind_up_df = scada_df_to_wind_up_df(wide)
+    wind_up_df = long_to_wind_up_format(scada_wide_to_long(wide))
     # First row has no prior to diff against; subsequent stuck rows are full downtime.
     assert np.allclose(wind_up_df[DataColumns.shutdown_duration].iloc[1:], TIMEBASE_S)
 
@@ -100,7 +115,7 @@ def test_calc_shutdown_duration_flags_only_the_frozen_turbine() -> None:
     # Freeze T01 across all rows (stuck); T02 keeps varying over time.
     for field in wide.columns.get_level_values(1).unique():
         wide.loc[:, ("T01", field)] = wide.iloc[0].loc[("T01", field)]
-    wind_up_df = scada_df_to_wind_up_df(wide)
+    wind_up_df = long_to_wind_up_format(scada_wide_to_long(wide))
     t01 = wind_up_df.loc[wind_up_df[DataColumns.turbine_name] == "T01", DataColumns.shutdown_duration].to_numpy()
     t02 = wind_up_df.loc[wind_up_df[DataColumns.turbine_name] == "T02", DataColumns.shutdown_duration].to_numpy()
     assert np.allclose(t01[1:], TIMEBASE_S)  # frozen turbine -> downtime after the first row

--- a/tests/benchmarking/synthetic/sources/test_hill_of_towie_cache.py
+++ b/tests/benchmarking/synthetic/sources/test_hill_of_towie_cache.py
@@ -1,0 +1,109 @@
+"""Tests for the per-(year, turbine) parquet cache in the Hill of Towie loader.
+
+The Hill of Towie Zenodo record is fixed as one zip per year, so the loader caches each
+*turbine-year* once and reuses it for any window or turbine subset. These tests fabricate
+minimal year zips (so they run offline, no Zenodo) and check that:
+
+- one parquet is written per (year, requested turbine), and only for the requested turbines;
+- a repeat call reads the cache and does not re-unpack;
+- growing the turbine subset only unpacks the newly requested turbines.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+from zipfile import ZipFile
+
+import pandas as pd
+
+from benchmarking.synthetic.sources import hill_of_towie as hot
+from wind_up.constants import DataColumns
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_APM_FIELD = hot.WPSBackupFileField(
+    alias=DataColumns.active_power_mean, field_name="wtc_ActPower_mean", table_name="tblSCTurGrid"
+)
+_WINDOW = {
+    "start_dt": pd.Timestamp("2020-01-01", tz="UTC"),
+    "end_dt_excl": pd.Timestamp("2020-03-01", tz="UTC"),
+}
+
+
+def _month_csv(*, year: int, month: int, serials: list[int]) -> str:
+    """An end-format SCADA CSV for one month of one table, a few timestamps per turbine."""
+    end_times = pd.date_range(f"{year}-{month:02d}-01 00:10", periods=4, freq="10min")
+    rows = [
+        {"TimeStamp": ts, "StationId": s, "wtc_ActPower_mean": 100.0 + i + s}
+        for i, ts in enumerate(end_times)
+        for s in serials
+    ]
+    return pd.DataFrame(rows).to_csv(index=False)
+
+
+def _write_year_zip(*, data_dir: Path, year: int, months: list[int], serials: list[int]) -> None:
+    """Write a fabricated ``{year}.zip`` holding one ``tblSCTurGrid`` CSV per month."""
+    with ZipFile(data_dir / f"{year}.zip", "w") as zf:
+        for m in months:
+            zf.writestr(f"tblSCTurGrid_{year}_{m:02d}.csv", _month_csv(year=year, month=m, serials=serials))
+
+
+def _load(*, data_dir: Path, cache_dir: Path, wtg_numbers: list[int]) -> pd.DataFrame:
+    return hot.load_hot_10min_data(
+        data_dir=data_dir,
+        wtg_numbers=wtg_numbers,
+        custom_fields=[_APM_FIELD],
+        cache_dir=cache_dir,
+        **_WINDOW,
+    )
+
+
+def _dirs(tmp_path: Path) -> tuple[Path, Path]:
+    data_dir = tmp_path / "data"
+    cache_dir = tmp_path / "cache"
+    data_dir.mkdir()
+    serials = [hot._HOT_SERIAL_OFFSET + n for n in (1, 3)]  # noqa: SLF001
+    _write_year_zip(data_dir=data_dir, year=2020, months=[1, 2], serials=serials)
+    return data_dir, cache_dir
+
+
+def test_writes_one_cache_file_per_requested_turbine(tmp_path: Path) -> None:
+    """Loading only T01 caches T01's year and leaves the other turbine's year un-cached."""
+    data_dir, cache_dir = _dirs(tmp_path)
+
+    wide = _load(data_dir=data_dir, cache_dir=cache_dir, wtg_numbers=[1])
+
+    assert list(cache_dir.glob("hot10min_2020_T01_*.parquet"))
+    assert not list(cache_dir.glob("hot10min_2020_T03_*.parquet"))
+    assert {col[0] for col in wide.columns} == {"T01"}
+    # Columns keep their source-native tag names (no v0 aliasing at load time).
+    assert (("T01", _APM_FIELD.field_name)) in wide.columns
+
+
+def test_repeat_call_reuses_cache_without_unpacking(tmp_path: Path) -> None:
+    """A second identical call serves the parquet cache and never re-reads the zip."""
+    data_dir, cache_dir = _dirs(tmp_path)
+    _load(data_dir=data_dir, cache_dir=cache_dir, wtg_numbers=[1])
+
+    # wraps= keeps the real unpack behaviour; the spy only records whether it was called.
+    with patch.object(hot, "_unpack_hot_10min_year", wraps=hot._unpack_hot_10min_year) as spy:  # noqa: SLF001
+        _load(data_dir=data_dir, cache_dir=cache_dir, wtg_numbers=[1])
+
+    assert spy.call_count == 0
+
+
+def test_growing_subset_only_unpacks_the_new_turbine(tmp_path: Path) -> None:
+    """Adding T03 to an existing T01 cache unpacks only T03 and reuses T01."""
+    data_dir, cache_dir = _dirs(tmp_path)
+    _load(data_dir=data_dir, cache_dir=cache_dir, wtg_numbers=[1])
+
+    with patch.object(hot, "_unpack_hot_10min_year", wraps=hot._unpack_hot_10min_year) as spy:  # noqa: SLF001
+        wide = _load(data_dir=data_dir, cache_dir=cache_dir, wtg_numbers=[1, 3])
+
+    spy.assert_called_once()
+    assert list(spy.call_args.kwargs["serial_numbers"]) == [hot._HOT_SERIAL_OFFSET + 3]  # noqa: SLF001  only the new
+    assert list(cache_dir.glob("hot10min_2020_T01_*.parquet"))
+    assert list(cache_dir.glob("hot10min_2020_T03_*.parquet"))
+    assert {col[0] for col in wide.columns} == {"T01", "T03"}

--- a/tests/benchmarking/synthetic/test_generator.py
+++ b/tests/benchmarking/synthetic/test_generator.py
@@ -9,6 +9,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from benchmarking.synthetic import HOT_COLUMNS
 from benchmarking.synthetic.generator import (
     SyntheticDataset,
     ToggleSchedule,
@@ -17,7 +18,7 @@ from benchmarking.synthetic.generator import (
     treated_mask,
 )
 from benchmarking.synthetic.upgrades import ConstantCpChange
-from wind_up.constants import TIMESTAMP_COL, DataColumns
+from wind_up.constants import TIMESTAMP_COL
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -35,11 +36,11 @@ def _wf_df(
     for turbine in turbines:
         frame = pd.DataFrame(
             {
-                DataColumns.turbine_name: turbine,
-                DataColumns.active_power_mean: float(power),
-                DataColumns.wind_speed_mean: 8.0,
-                DataColumns.wind_speed_sd: 0.8,
-                DataColumns.gen_rpm_mean: 1400.0,
+                HOT_COLUMNS.turbine: turbine,
+                HOT_COLUMNS.active_power: float(power),
+                HOT_COLUMNS.wind_speed: 8.0,
+                HOT_COLUMNS.wind_speed_sd: 0.8,
+                HOT_COLUMNS.gen_rpm: 1400.0,
             },
             index=index,
         )
@@ -64,13 +65,13 @@ def test_prepost_modifies_only_post_rows_of_test_turbine() -> None:
     )
     synthetic = dataset.synthetic_df
 
-    t01 = synthetic[synthetic[DataColumns.turbine_name] == "T01"]
-    pre = t01[t01.index < changeover][DataColumns.active_power_mean]
-    post = t01[t01.index >= changeover][DataColumns.active_power_mean]
+    t01 = synthetic[synthetic[HOT_COLUMNS.turbine] == "T01"]
+    pre = t01[t01.index < changeover][HOT_COLUMNS.active_power]
+    post = t01[t01.index >= changeover][HOT_COLUMNS.active_power]
     assert np.allclose(pre.to_numpy(), 1000.0)
     assert np.all(post.to_numpy() > 1000.0)
 
-    t02 = synthetic[synthetic[DataColumns.turbine_name] == "T02"][DataColumns.active_power_mean]
+    t02 = synthetic[synthetic[HOT_COLUMNS.turbine] == "T02"][HOT_COLUMNS.active_power]
     assert np.allclose(t02.to_numpy(), 1000.0)
 
 
@@ -98,11 +99,11 @@ def test_toggle_modifies_alternate_blocks() -> None:
         mode="toggle",
         upgrade_timing=ToggleSchedule(period=pd.Timedelta(days=1)),
     )
-    t01 = dataset.synthetic_df[dataset.synthetic_df[DataColumns.turbine_name] == "T01"]
+    t01 = dataset.synthetic_df[dataset.synthetic_df[HOT_COLUMNS.turbine] == "T01"]
     start = t01.index.min()
     half = pd.Timedelta(hours=12)
-    first_half = t01[t01.index < start + half][DataColumns.active_power_mean]
-    second_half = t01[(t01.index >= start + half) & (t01.index < start + 2 * half)][DataColumns.active_power_mean]
+    first_half = t01[t01.index < start + half][HOT_COLUMNS.active_power]
+    second_half = t01[(t01.index >= start + half) & (t01.index < start + 2 * half)][HOT_COLUMNS.active_power]
     assert np.allclose(first_half.to_numpy(), 1000.0)  # first half-period: toggle off
     assert np.all(second_half.to_numpy() > 1000.0)  # second half-period: toggle on
 
@@ -120,14 +121,14 @@ def test_toggle_start_leaves_pre_start_rows_untreated() -> None:
         mode="toggle",
         upgrade_timing=ToggleSchedule(period=pd.Timedelta(hours=12), start=start),
     )
-    t01 = dataset.synthetic_df[dataset.synthetic_df[DataColumns.turbine_name] == "T01"]
-    before = t01[t01.index < start][DataColumns.active_power_mean]
+    t01 = dataset.synthetic_df[dataset.synthetic_df[HOT_COLUMNS.turbine] == "T01"]
+    before = t01[t01.index < start][HOT_COLUMNS.active_power]
     assert np.allclose(before.to_numpy(), 1000.0)  # baseline before toggling: untreated
 
     # start_on defaults False: [start, start+6h) off, [start+6h, start+12h) on.
     half = pd.Timedelta(hours=6)
-    off_block = t01[(t01.index >= start) & (t01.index < start + half)][DataColumns.active_power_mean]
-    on_block = t01[(t01.index >= start + half) & (t01.index < start + 2 * half)][DataColumns.active_power_mean]
+    off_block = t01[(t01.index >= start) & (t01.index < start + half)][HOT_COLUMNS.active_power]
+    on_block = t01[(t01.index >= start + half) & (t01.index < start + 2 * half)][HOT_COLUMNS.active_power]
     assert np.allclose(off_block.to_numpy(), 1000.0)
     assert np.all(on_block.to_numpy() > 1000.0)
 

--- a/tests/benchmarking/synthetic/test_ground_truth.py
+++ b/tests/benchmarking/synthetic/test_ground_truth.py
@@ -6,8 +6,9 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from benchmarking.synthetic import HOT_COLUMNS
 from benchmarking.synthetic.ground_truth import true_uplift
-from wind_up.constants import TIMESTAMP_COL, DataColumns
+from wind_up.constants import TIMESTAMP_COL
 
 
 def _paired(
@@ -23,10 +24,10 @@ def _paired(
     def frame(power: list[float]) -> pd.DataFrame:
         df = pd.DataFrame(
             {
-                DataColumns.turbine_name: wtg,
-                DataColumns.active_power_mean: np.array(power, dtype=float),
-                DataColumns.wind_speed_mean: np.array(ws if ws is not None else [8.0] * n, dtype=float),
-                DataColumns.wind_speed_sd: 0.8,
+                HOT_COLUMNS.turbine: wtg,
+                HOT_COLUMNS.active_power: np.array(power, dtype=float),
+                HOT_COLUMNS.wind_speed: np.array(ws if ws is not None else [8.0] * n, dtype=float),
+                HOT_COLUMNS.wind_speed_sd: 0.8,
             },
             index=index,
         )

--- a/tests/benchmarking/synthetic/test_make_example_datasets.py
+++ b/tests/benchmarking/synthetic/test_make_example_datasets.py
@@ -9,8 +9,9 @@ import pandas as pd
 import pytest
 
 import benchmarking.synthetic.make_example_datasets as driver
+from benchmarking.synthetic import HOT_COLUMNS
 from benchmarking.synthetic.make_example_datasets import example_profiles, generate_example_datasets, main
-from wind_up.constants import TIMESTAMP_COL, DataColumns
+from wind_up.constants import TIMESTAMP_COL
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -27,11 +28,11 @@ def _swept_wf_df(
     frames = [
         pd.DataFrame(
             {
-                DataColumns.turbine_name: turbine,
-                DataColumns.active_power_mean: power,
-                DataColumns.wind_speed_mean: ws,
-                DataColumns.wind_speed_sd: 0.1 * ws,
-                DataColumns.gen_rpm_mean: 1400.0,
+                HOT_COLUMNS.turbine: turbine,
+                HOT_COLUMNS.active_power: power,
+                HOT_COLUMNS.wind_speed: ws,
+                HOT_COLUMNS.wind_speed_sd: 0.1 * ws,
+                HOT_COLUMNS.gen_rpm: 1400.0,
             },
             index=index,
         )

--- a/tests/benchmarking/synthetic/test_plots.py
+++ b/tests/benchmarking/synthetic/test_plots.py
@@ -11,10 +11,11 @@ mpl.use("Agg")  # headless: no display needed for tests
 import numpy as np
 import pandas as pd
 
+from benchmarking.synthetic import HOT_COLUMNS
 from benchmarking.synthetic.generator import generate_dataset
 from benchmarking.synthetic.plots import plot_power_curve_comparison
 from benchmarking.synthetic.upgrades import ConstantCpChange
-from wind_up.constants import TIMESTAMP_COL, DataColumns
+from wind_up.constants import TIMESTAMP_COL
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -28,11 +29,11 @@ def _swept_dataset() -> object:
     frames = [
         pd.DataFrame(
             {
-                DataColumns.turbine_name: turbine,
-                DataColumns.active_power_mean: power,
-                DataColumns.wind_speed_mean: ws,
-                DataColumns.wind_speed_sd: 0.1 * ws,
-                DataColumns.gen_rpm_mean: 1400.0,
+                HOT_COLUMNS.turbine: turbine,
+                HOT_COLUMNS.active_power: power,
+                HOT_COLUMNS.wind_speed: ws,
+                HOT_COLUMNS.wind_speed_sd: 0.1 * ws,
+                HOT_COLUMNS.gen_rpm: 1400.0,
             },
             index=index,
         )
@@ -56,9 +57,9 @@ def _paired_dfs(orig_power: list[float], syn_power: list[float], ws: list[float]
     def frame(power: list[float]) -> pd.DataFrame:
         df = pd.DataFrame(
             {
-                DataColumns.turbine_name: "T01",
-                DataColumns.active_power_mean: np.array(power, dtype=float),
-                DataColumns.wind_speed_mean: np.array(ws, dtype=float),
+                HOT_COLUMNS.turbine: "T01",
+                HOT_COLUMNS.active_power: np.array(power, dtype=float),
+                HOT_COLUMNS.wind_speed: np.array(ws, dtype=float),
             },
             index=index,
         )

--- a/tests/benchmarking/synthetic/test_upgrades.py
+++ b/tests/benchmarking/synthetic/test_upgrades.py
@@ -6,6 +6,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from benchmarking.synthetic import HOT_COLUMNS
 from benchmarking.synthetic.cp_core import CpCore, region2_fraction
 from benchmarking.synthetic.upgrades import (
     ConditionCpChange,
@@ -14,7 +15,6 @@ from benchmarking.synthetic.upgrades import (
     WindSpeedCpChange,
     apply_upgrades,
 )
-from wind_up.constants import DataColumns
 
 
 def _rows(
@@ -27,10 +27,10 @@ def _rows(
     n = len(powers)
     return pd.DataFrame(
         {
-            DataColumns.active_power_mean: np.array(powers, dtype=float),
-            DataColumns.wind_speed_mean: np.array(ws if ws is not None else [8.0] * n, dtype=float),
-            DataColumns.wind_speed_sd: np.array(sd if sd is not None else [0.8] * n, dtype=float),
-            DataColumns.gen_rpm_mean: np.array(rpm if rpm is not None else [1400.0] * n, dtype=float),
+            HOT_COLUMNS.active_power: np.array(powers, dtype=float),
+            HOT_COLUMNS.wind_speed: np.array(ws if ws is not None else [8.0] * n, dtype=float),
+            HOT_COLUMNS.wind_speed_sd: np.array(sd if sd is not None else [0.8] * n, dtype=float),
+            HOT_COLUMNS.gen_rpm: np.array(rpm if rpm is not None else [1400.0] * n, dtype=float),
         }
     )
 
@@ -39,14 +39,14 @@ def test_constant_cp_change_scales_region2_power() -> None:
     """At 2000 kW (region-2 fraction 0.25) a +10% Cp gives 2050 kW (not 2200 due to 25% region 2)."""
     rows = _rows([2000.0])
     out = apply_upgrades(rows, [ConstantCpChange(delta=0.10)], cp=CpCore(rated_power_kw=2300.0))
-    assert out[DataColumns.active_power_mean].iloc[0] == pytest.approx(2050.0)
+    assert out[HOT_COLUMNS.active_power].iloc[0] == pytest.approx(2050.0)
 
 
 def test_empty_upgrade_list_leaves_rows_unchanged() -> None:
     """Applying no upgrades returns power identical to the original."""
     rows = _rows([500.0, 1500.0, 2200.0])
     out = apply_upgrades(rows, [], cp=CpCore())
-    pd.testing.assert_series_equal(out[DataColumns.active_power_mean], rows[DataColumns.active_power_mean])
+    pd.testing.assert_series_equal(out[HOT_COLUMNS.active_power], rows[HOT_COLUMNS.active_power])
 
 
 def test_constant_cp_change_only_treats_producing_below_rated_records() -> None:
@@ -57,7 +57,7 @@ def test_constant_cp_change_only_treats_producing_below_rated_records() -> None:
     """
     rows = _rows([-5.0, 0.0, 1000.0, 2295.0])
     out = apply_upgrades(rows, [ConstantCpChange(delta=0.03)], cp=CpCore(rated_power_kw=2300.0))
-    power = out[DataColumns.active_power_mean].to_numpy()
+    power = out[HOT_COLUMNS.active_power].to_numpy()
     assert power[0] == pytest.approx(-5.0)  # negative: untouched
     assert power[1] == pytest.approx(0.0)  # zero: untouched
     assert power[2] > 1000.0  # producing region 2: still changed
@@ -67,9 +67,9 @@ def test_constant_cp_change_only_treats_producing_below_rated_records() -> None:
 def test_constant_cp_change_does_not_mutate_input() -> None:
     """apply_upgrades returns a new frame and leaves the caller's rows untouched."""
     rows = _rows([1500.0])
-    original = rows[DataColumns.active_power_mean].copy()
+    original = rows[HOT_COLUMNS.active_power].copy()
     apply_upgrades(rows, [ConstantCpChange(delta=0.05)], cp=CpCore())
-    pd.testing.assert_series_equal(rows[DataColumns.active_power_mean], original)
+    pd.testing.assert_series_equal(rows[HOT_COLUMNS.active_power], original)
 
 
 def test_wind_speed_cp_change_applies_delta_by_original_wind_speed() -> None:
@@ -77,7 +77,7 @@ def test_wind_speed_cp_change_applies_delta_by_original_wind_speed() -> None:
     rows = _rows([600.0, 1000.0, 1500.0], ws=[4.0, 8.0, 12.0])
     upgrade = WindSpeedCpChange(ws_points=[4.0, 8.0, 12.0], deltas=[0.0, 0.04, 0.0])
     out = apply_upgrades(rows, [upgrade], cp=CpCore())
-    power = out[DataColumns.active_power_mean].to_numpy()
+    power = out[HOT_COLUMNS.active_power].to_numpy()
     f8 = region2_fraction(1000.0)
     assert power[0] == pytest.approx(600.0)  # ws 4: zero delta
     assert power[1] == pytest.approx(1000.0 * (1.0 + f8 * 0.04))  # ws 8: +4% Cp in region 2
@@ -90,7 +90,7 @@ def test_condition_cp_change_varies_by_original_turbulence_intensity() -> None:
     rows = _rows([1000.0, 1000.0], ws=[8.0, 8.0], sd=[0.8, 1.6])
     upgrade = ConditionCpChange(by="ti", points=[0.10, 0.20], deltas=[0.0, 0.05])
     out = apply_upgrades(rows, [upgrade], cp=CpCore())
-    power = out[DataColumns.active_power_mean].to_numpy()
+    power = out[HOT_COLUMNS.active_power].to_numpy()
     f = region2_fraction(1000.0)
     assert power[0] == pytest.approx(1000.0)  # TI 0.10: zero delta
     assert power[1] == pytest.approx(1000.0 * (1.0 + f * 0.05))  # TI 0.20: +5% Cp in region 2
@@ -100,7 +100,7 @@ def test_rated_power_downrate_clips_at_new_rated() -> None:
     """A downrate caps power at the new rated and leaves region-2 power unchanged."""
     rows = _rows([1000.0, 2200.0])
     out = apply_upgrades(rows, [RatedPowerChange(new_rated_power_kw=2000.0)], cp=CpCore(rated_power_kw=2300.0))
-    power = out[DataColumns.active_power_mean].to_numpy()
+    power = out[HOT_COLUMNS.active_power].to_numpy()
     assert power[0] == pytest.approx(1000.0)  # well below new rated: unchanged
     assert power[1] == pytest.approx(2000.0)  # above new rated: clipped
 
@@ -109,7 +109,7 @@ def test_rated_power_uprate_lifts_region3_power() -> None:
     """An uprate lifts near-rated power toward the new rated, leaving deep region 2 alone."""
     rows = _rows([1000.0, 2200.0])
     out = apply_upgrades(rows, [RatedPowerChange(new_rated_power_kw=2400.0)], cp=CpCore(rated_power_kw=2300.0))
-    power = out[DataColumns.active_power_mean].to_numpy()
+    power = out[HOT_COLUMNS.active_power].to_numpy()
     assert power[0] == pytest.approx(1000.0, rel=1e-3)  # deep region 2: ~unchanged
     assert 2200.0 < power[1] < 2400.0  # near rated: lifted but capped at new rated
 
@@ -118,14 +118,14 @@ def test_ws_delta_scales_nacelle_wind_speed() -> None:
     """An upgrade's ws_delta scales the nacelle WindSpeedMean."""
     rows = _rows([1000.0], ws=[8.0])
     out = apply_upgrades(rows, [ConstantCpChange(delta=0.0, ws_delta=0.02)], cp=CpCore())
-    assert out[DataColumns.wind_speed_mean].iloc[0] == pytest.approx(8.0 * 1.02)
+    assert out[HOT_COLUMNS.wind_speed].iloc[0] == pytest.approx(8.0 * 1.02)
 
 
 def test_rpm_increases_when_power_increases() -> None:
     """A positive Cp change drags generator rpm up with the power increase."""
     rows = _rows([1000.0], rpm=[1392.0])
     out = apply_upgrades(rows, [ConstantCpChange(delta=0.10)], cp=CpCore())
-    assert out[DataColumns.gen_rpm_mean].iloc[0] > 1392.0
+    assert out[HOT_COLUMNS.gen_rpm].iloc[0] > 1392.0
 
 
 def test_upgrades_compose() -> None:
@@ -133,7 +133,7 @@ def test_upgrades_compose() -> None:
     rows = _rows([1000.0, 2200.0])
     upgrades = [ConstantCpChange(delta=0.10), RatedPowerChange(new_rated_power_kw=2000.0)]
     out = apply_upgrades(rows, upgrades, cp=CpCore(rated_power_kw=2300.0))
-    power = out[DataColumns.active_power_mean].to_numpy()
+    power = out[HOT_COLUMNS.active_power].to_numpy()
     f = region2_fraction(1000.0)
     assert power[0] == pytest.approx(1000.0 * (1.0 + f * 0.10))  # region 2: +Cp, below downrate
     assert power[1] == pytest.approx(2000.0)  # near rated: clipped to the downrate


### PR DESCRIPTION
Fully remove wind-up v0 method data column assumptions from the rest of the benchmarking code.