### PR TITLE
Use one Session for the whole download

### DIFF
--- a/benchmarking/synthetic/sources/hill_of_towie.py
+++ b/benchmarking/synthetic/sources/hill_of_towie.py
@@ -92,48 +92,55 @@ def download_zenodo_data(
     output_dir.mkdir(parents=True, exist_ok=True)
     metadata_fpath = output_dir / "zenodo_dataset_metadata.json"
 
-    if not cache_overwrite and metadata_fpath.is_file():
-        logger.info("Loading metadata from %s", metadata_fpath)
-        with metadata_fpath.open() as f:
-            content = json.load(f)
-    else:
-        logger.info("Fetching metadata from zenodo...")
-        r = requests.get(
-            f"https://zenodo.org/api/records/{record_id}",
-            timeout=(_CONNECT_TIMEOUT_S, _READ_TIMEOUT_S),
-        )
-        r.raise_for_status()
-        content = r.json()
-        with metadata_fpath.open("w") as f:
-            json.dump(content, f)
-        logger.info("Saved metadata to %s", metadata_fpath)
+    # One Session for the whole download so its connection pool (and every socket) is
+    # closed deterministically on exit. A per-call ``requests.get`` closes its transient
+    # pool before the streamed response's socket is released back to it, leaking the
+    # socket until GC -- which trips ``filterwarnings = error`` via ResourceWarning.
+    with requests.Session() as session:
+        if not cache_overwrite and metadata_fpath.is_file():
+            logger.info("Loading metadata from %s", metadata_fpath)
+            with metadata_fpath.open() as f:
+                content = json.load(f)
+        else:
+            logger.info("Fetching metadata from zenodo...")
+            with session.get(
+                f"https://zenodo.org/api/records/{record_id}",
+                timeout=(_CONNECT_TIMEOUT_S, _READ_TIMEOUT_S),
+            ) as r:
+                r.raise_for_status()
+                content = r.json()
+            with metadata_fpath.open("w") as f:
+                json.dump(content, f)
+            logger.info("Saved metadata to %s", metadata_fpath)
 
-    remote_files: list[dict] = content["files"]
-    if filenames is None:
-        files_to_download: list[dict] = list(remote_files)
-    else:
-        files_to_download = list(_check_name_of_files_to_download(filenames, remote_files))
-    required_keys = {f["key"] for f in files_to_download}
-    # Auto-include any small file in the record (READMEs, deployment reports, ...).
-    for rf in remote_files:
-        if rf["size"] < SMALL_FILE_THRESHOLD_BYTES and rf["key"] not in required_keys:
-            files_to_download.append(rf)
+        remote_files: list[dict] = content["files"]
+        if filenames is None:
+            files_to_download: list[dict] = list(remote_files)
+        else:
+            files_to_download = list(_check_name_of_files_to_download(filenames, remote_files))
+        required_keys = {f["key"] for f in files_to_download}
+        # Auto-include any small file in the record (READMEs, deployment reports, ...).
+        for rf in remote_files:
+            if rf["size"] < SMALL_FILE_THRESHOLD_BYTES and rf["key"] not in required_keys:
+                files_to_download.append(rf)
 
-    downloaded_files = 0
-    n_files_to_download = len(files_to_download)
-    for i_file, file_to_download in enumerate(files_to_download, start=1):
-        is_required = file_to_download["key"] in required_keys
-        downloaded_files += _download_one_file(
-            file_to_download,
-            output_dir,
-            cache_overwrite=cache_overwrite,
-            is_required=is_required,
-            progress_prefix=f"[{i_file}/{n_files_to_download}]",
-        )
+        downloaded_files = 0
+        n_files_to_download = len(files_to_download)
+        for i_file, file_to_download in enumerate(files_to_download, start=1):
+            is_required = file_to_download["key"] in required_keys
+            downloaded_files += _download_one_file(
+                session,
+                file_to_download,
+                output_dir,
+                cache_overwrite=cache_overwrite,
+                is_required=is_required,
+                progress_prefix=f"[{i_file}/{n_files_to_download}]",
+            )
     logger.info("Download finished: %s new files cached at %s", downloaded_files, output_dir)
 
 
 def _download_one_file(
+    session: requests.Session,
     file_entry: dict,
     output_dir: Path,
     *,
@@ -142,6 +149,9 @@ def _download_one_file(
     progress_prefix: str,
 ) -> int:
     """Download a single Zenodo file. Returns 1 if a new file was written, 0 otherwise.
+
+    Uses the caller's :class:`requests.Session` so its connection pool is closed once
+    by the caller, releasing every socket deterministically rather than at GC.
 
     Retries up to ``_MAX_DOWNLOAD_ATTEMPTS`` times on transient network errors with
     exponential backoff, resuming partial downloads via a ``Range`` header. Required
@@ -174,7 +184,7 @@ def _download_one_file(
         existing_size = dst_fpath.stat().st_size if dst_fpath.is_file() else 0
         headers = {"Range": f"bytes={existing_size}-"} if existing_size > 0 else {}
         try:
-            result = requests.get(
+            result = session.get(
                 _file_url,
                 stream=True,
                 timeout=(_CONNECT_TIMEOUT_S, _READ_TIMEOUT_S),

--- a/tests/benchmarking/synthetic/sources/test_hill_of_towie.py
+++ b/tests/benchmarking/synthetic/sources/test_hill_of_towie.py
@@ -9,12 +9,23 @@ separately by a ``slow``-marked test that is excluded from the default offline s
 
 from __future__ import annotations
 
+import json
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
 import numpy as np
 import pandas as pd
 
 from benchmarking.synthetic import HOT_COLUMNS
-from benchmarking.synthetic.sources.hill_of_towie import long_to_wind_up_format, scada_wide_to_long
+from benchmarking.synthetic.sources.hill_of_towie import (
+    download_zenodo_data,
+    long_to_wind_up_format,
+    scada_wide_to_long,
+)
 from wind_up.constants import TIMESTAMP_COL, DataColumns
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 TIMEBASE_S = 600
 
@@ -120,3 +131,50 @@ def test_calc_shutdown_duration_flags_only_the_frozen_turbine() -> None:
     t02 = wind_up_df.loc[wind_up_df[DataColumns.turbine_name] == "T02", DataColumns.shutdown_duration].to_numpy()
     assert np.allclose(t01[1:], TIMEBASE_S)  # frozen turbine -> downtime after the first row
     assert np.allclose(t02, 0.0)  # varying turbine -> available throughout
+
+
+def test_download_routes_through_one_session_closed_once(tmp_path: Path) -> None:
+    """Every Zenodo request goes through a single Session that is closed exactly once.
+
+    Regression guard for leaked SSL sockets: a per-call ``requests.get`` closes its
+    transient connection pool before the streamed response's socket is released back to
+    it, so the socket lingers until GC and trips ``filterwarnings = error`` via
+    ResourceWarning. A single Session whose pool is closed on exit releases every socket
+    deterministically. Asserting one Session, closed once, encodes exactly that fix.
+    """
+    # Pre-cache the metadata so this stays offline; the file-download branch (the leak
+    # source) still has to route its streamed get through the shared Session.
+    file_entry = {"key": "small.txt", "size": 10, "links": {"self": "https://zenodo.test/small.txt"}}
+    (tmp_path / "zenodo_dataset_metadata.json").write_text(json.dumps({"files": [file_entry]}))
+
+    response = MagicMock()
+    response.status_code = 200
+    response.iter_content.return_value = [b"0123456789"]
+    response.__enter__.return_value = response
+    response.__exit__.return_value = False
+
+    session = MagicMock()
+    session.get.return_value = response
+    session.__enter__.return_value = session
+    session.__exit__.return_value = False
+
+    def _banned_get(*_args: object, **_kwargs: object) -> object:
+        msg = "per-call requests.get leaks sockets; route every request through the shared Session"
+        raise AssertionError(msg)
+
+    with (
+        patch("requests.Session", return_value=session) as session_cls,
+        patch("requests.get", side_effect=_banned_get),
+    ):
+        download_zenodo_data(record_id="123", output_dir=tmp_path)
+
+    session_cls.assert_called_once()  # exactly one Session for the whole download
+    session.__enter__.assert_called_once()
+    session.__exit__.assert_called_once()  # pool (and its sockets) closed deterministically
+    session.get.assert_called_once_with(
+        file_entry["links"]["self"],
+        stream=True,
+        timeout=(10, 60),
+        headers={},
+    )
+    assert (tmp_path / "small.txt").read_bytes() == b"0123456789"


### PR DESCRIPTION
Example failing tests: https://github.com/resgroup/wind-up/actions/runs/28163240915/job/83408733375?pr=100
One Session for the whole download so its connection pool (and every socket) is closed deterministically on exit.