### PR TITLE
v1 issue 5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,4 @@ output/
 /tests/test_data/wedowind/Vortex Generator/
 # matplotlib testing
 **/result_images/
+/docs/v1/extra_docs/

--- a/benchmarking/baselines/example_prepost_study.py
+++ b/benchmarking/baselines/example_prepost_study.py
@@ -37,6 +37,7 @@ import pandas as pd
 
 from benchmarking.baselines.hot_context import build_hot_v0_context
 from benchmarking.baselines.naive_ratio import NaiveRatioMethod
+from benchmarking.baselines.rlearner import RLearnerMethod
 from benchmarking.baselines.v0_binned import V0BinnedMethod
 from benchmarking.harness import Method, StudyConfig, leaderboard, plot_campaign_curves, score_study
 from benchmarking.harness.example_hot_study import OracleMethod
@@ -96,8 +97,9 @@ def run_prepost_study(
     out_root: str | Path | None = None,
     data_dir: str | Path | None = None,
     include_oracle: bool = True,
+    include_v0: bool = True,
 ) -> pd.DataFrame:
-    """Score v0 and the naive ratio method (and an oracle anchor) over ``profiles`` and save outputs.
+    """Score the methods (oracle anchor, naive, R-learner, v0) over ``profiles`` and save outputs.
 
     :param base_scada: wind-up-format real SCADA (all subset turbines), the no-upgrade baseline
     :param profiles: mapping of profile name -> list of upgrade callables to inject
@@ -106,6 +108,8 @@ def run_prepost_study(
     :param data_dir: Hill of Towie data/cache dir for the v0 context metadata; defaults to the
         source package default (keep it the same as the dir ``base_scada`` was loaded from)
     :param include_oracle: also score an oracle that returns the injected truth (sanity anchor)
+    :param include_v0: also score the v0 binned baseline; off-able because a real wind_up run per
+        campaign is very slow, so an initial oracle+naive+R-learner pass is much quicker to review
     :return: the concatenated tidy per-replicate results across all profiles
     """
     out_dir = Path(out_root) if out_root is not None else default_output_root()
@@ -122,7 +126,21 @@ def run_prepost_study(
         if include_oracle:
             methods.append(OracleMethod(base_scada))
         methods.append(NaiveRatioMethod(active_power_col=HOT_COLUMNS.active_power, out_dir=out_dir / "naive_runs"))
-        methods.append(V0BinnedMethod(context, scratch_dir=scratch_dir))
+        # The R-learner runs after the cheap naive floor (compare to it first) and before the slow
+        # v0 run. It is given the same columns v0 sees, restricted to references, plus ERA5 (the
+        # context's hourly reanalysis frame). The HoT availability counter is not wired as a
+        # downtime filter yet (its units/full-period value need confirming); the stuck-data filter
+        # and the finite-power rule still apply.
+        methods.append(
+            RLearnerMethod(
+                active_power_col=HOT_COLUMNS.active_power,
+                wind_speed_col=HOT_COLUMNS.wind_speed,
+                era5_hourly_df=context.reanalysis_datasets[0].data,
+                out_dir=out_dir / "rlearner_runs",
+            )
+        )
+        if include_v0:
+            methods.append(V0BinnedMethod(context, scratch_dir=scratch_dir))
         logger.info("Scoring prepost profile %s with methods %s", profile_name, [m.name for m in methods])
         results = score_study(
             base_scada,
@@ -155,6 +173,7 @@ def main(
     wtg_numbers: list[int] | None = None,
     n_replicates: int = 4,
     campaign_months: list[int] | None = None,
+    include_v0: bool = True,
 ) -> pd.DataFrame:
     """Run the prepost study end-to-end on real Hill of Towie data and save outputs.
 
@@ -165,6 +184,7 @@ def main(
     :param wtg_numbers: turbine numbers to load; defaults to the stable south-west cluster
     :param n_replicates: ensemble size per profile (each replicate x campaign is a full v0 run)
     :param campaign_months: the campaign-length sweep grid, in months
+    :param include_v0: also score the slow v0 baseline (set False for a quick oracle+naive+R-learner pass)
     :return: the combined tidy results across all profiles
     """
     wtg_numbers = wtg_numbers if wtg_numbers is not None else DEFAULT_WTG_NUMBERS
@@ -186,7 +206,9 @@ def main(
         n_replicates=n_replicates,
         seed=0,
     )
-    return run_prepost_study(scada_df, profiles=example_profiles(), study=study, out_root=out_root, data_dir=data_dir)
+    return run_prepost_study(
+        scada_df, profiles=example_profiles(), study=study, out_root=out_root, data_dir=data_dir, include_v0=include_v0
+    )
 
 
 if __name__ == "__main__":

--- a/benchmarking/baselines/example_toggle_study.py
+++ b/benchmarking/baselines/example_toggle_study.py
@@ -38,6 +38,7 @@ from benchmarking.baselines.example_prepost_study import (
 )
 from benchmarking.baselines.hot_context import build_hot_v0_context
 from benchmarking.baselines.naive_ratio import NaiveRatioMethod
+from benchmarking.baselines.rlearner import RLearnerMethod
 from benchmarking.baselines.v0_binned import V0BinnedMethod
 from benchmarking.harness import Method, StudyConfig, leaderboard, plot_campaign_curves, score_study
 from benchmarking.harness.example_hot_study import OracleMethod
@@ -70,8 +71,9 @@ def run_toggle_study(
     out_root: str | Path | None = None,
     data_dir: str | Path | None = None,
     include_oracle: bool = True,
+    include_v0: bool = True,
 ) -> pd.DataFrame:
-    """Score v0 and the naive ratio method on a toggle study over ``profiles`` and save outputs.
+    """Score the methods (oracle anchor, naive, R-learner, v0) on a toggle study and save outputs.
 
     :param base_scada: wind-up-format real SCADA (all subset turbines), the no-upgrade baseline
     :param profiles: mapping of profile name -> list of upgrade callables to inject
@@ -80,6 +82,7 @@ def run_toggle_study(
     :param data_dir: Hill of Towie data/cache dir for the v0 context metadata; defaults to the
         source package default (keep it the same as the dir ``base_scada`` was loaded from)
     :param include_oracle: also score an oracle that returns the injected truth (sanity anchor)
+    :param include_v0: also score the slow v0 baseline (set False for a quick oracle+naive+R-learner pass)
     :return: the concatenated tidy per-replicate results across all profiles
     """
     out_dir = Path(out_root) if out_root is not None else default_output_root()
@@ -96,7 +99,17 @@ def run_toggle_study(
         if include_oracle:
             methods.append(OracleMethod(base_scada))
         methods.append(NaiveRatioMethod(active_power_col=HOT_COLUMNS.active_power, out_dir=out_dir / "naive_runs"))
-        methods.append(V0BinnedMethod(context, scratch_dir=scratch_dir))
+        # R-learner after the naive floor, before slow v0; same columns v0 sees (refs only) + ERA5.
+        methods.append(
+            RLearnerMethod(
+                active_power_col=HOT_COLUMNS.active_power,
+                wind_speed_col=HOT_COLUMNS.wind_speed,
+                era5_hourly_df=context.reanalysis_datasets[0].data,
+                out_dir=out_dir / "rlearner_runs",
+            )
+        )
+        if include_v0:
+            methods.append(V0BinnedMethod(context, scratch_dir=scratch_dir))
         logger.info("Scoring toggle profile %s with methods %s", profile_name, [m.name for m in methods])
         results = score_study(
             base_scada,
@@ -130,6 +143,7 @@ def main(
     n_replicates: int = 4,
     campaign_months: list[int] | None = None,
     toggle_period: pd.Timedelta = DEFAULT_TOGGLE_PERIOD,
+    include_v0: bool = True,
 ) -> pd.DataFrame:
     """Run the toggle study end-to-end on real Hill of Towie data and save outputs.
 
@@ -141,6 +155,7 @@ def main(
     :param n_replicates: ensemble size per profile
     :param campaign_months: the campaign-length (toggling-duration) sweep grid, in months
     :param toggle_period: the on/off cycle length (20 min on + 20 min off = 40 min by default)
+    :param include_v0: also score the slow v0 baseline (set False for a quick oracle+naive+R-learner pass)
     :return: the combined tidy results across all profiles
     """
     wtg_numbers = wtg_numbers if wtg_numbers is not None else DEFAULT_WTG_NUMBERS
@@ -163,7 +178,9 @@ def main(
         n_replicates=n_replicates,
         seed=0,
     )
-    return run_toggle_study(scada_df, profiles=TOGGLE_PROFILES, study=study, out_root=out_root, data_dir=data_dir)
+    return run_toggle_study(
+        scada_df, profiles=TOGGLE_PROFILES, study=study, out_root=out_root, data_dir=data_dir, include_v0=include_v0
+    )
 
 
 if __name__ == "__main__":

--- a/benchmarking/baselines/naive_ratio.py
+++ b/benchmarking/baselines/naive_ratio.py
@@ -27,7 +27,7 @@ the stats CSV as ``rho = used_test_mwh / used_ref_total_mwh`` per segment.
 from __future__ import annotations
 
 import tempfile
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -73,6 +73,21 @@ def _upgrade_start(upgrade_timing: pd.Timestamp | ToggleSchedule, index: pd.Date
     return pd.Timestamp(upgrade_timing)
 
 
+def restrict_to_campaign(mi: MethodInput, *, toggle_campaign_only: bool) -> MethodInput:
+    """Drop pre-campaign rows for a toggle campaign so the on/off comparison shares a distribution.
+
+    For toggle, the harness window also carries the pre-campaign baseline, whose distribution
+    differs from the campaign and reintroduces the covariate shift toggling exists to avoid. When
+    ``toggle_campaign_only`` (the default), restrict a toggle input to records at/after the toggle
+    start, leaving only the interleaved on/off blocks. No-op for prepost (its baseline *is* the
+    pre-campaign data) and when the flag is off.
+    """
+    timing = mi.upgrade_timing
+    if not (toggle_campaign_only and isinstance(timing, ToggleSchedule) and timing.start is not None):
+        return mi
+    return replace(mi, scada_df=mi.scada_df.loc[mi.scada_df.index >= timing.start])
+
+
 @dataclass
 class NaiveRatioMethod:
     """Pluggable naive energy-ratio baseline (prepost and toggle).
@@ -83,6 +98,8 @@ class NaiveRatioMethod:
     :param out_dir: where per-run folders are written; a temp dir when ``None``
     :param save_plots: also write the three diagnostic plots under ``<run>/plots``
     :param timebase: analysis timebase; inferred from the data when ``None``
+    :param toggle_campaign_only: for a toggle campaign, fit only on the interleaved on/off blocks
+        (drop the pre-campaign baseline) so on and off share a wind distribution; no-op for prepost
     """
 
     active_power_col: str
@@ -90,9 +107,11 @@ class NaiveRatioMethod:
     out_dir: Path | None = None
     save_plots: bool = False
     timebase: pd.Timedelta | None = None
+    toggle_campaign_only: bool = True
 
     def estimate(self, mi: MethodInput) -> MethodOutput:
         """Estimate the test turbine's P50 uplift for one campaign and write diagnostics."""
+        mi = restrict_to_campaign(mi, toggle_campaign_only=self.toggle_campaign_only)
         wide = _wide_power(mi.scada_df, turbine_col=mi.turbine_col, active_power_col=self.active_power_col)
         test = mi.test_wtg
         refs = [c for c in wide.columns if c != test]

--- a/benchmarking/baselines/overnight_common.py
+++ b/benchmarking/baselines/overnight_common.py
@@ -1,0 +1,71 @@
+"""Shared setup for the overnight prepost/toggle studies: a fresh per-run output dir and log.
+
+Each run gets its own timestamped output directory plus a ``run.log`` recording provenance (git
+commit, study config, timings), so results from different runs never overwrite or
+silently intermix (the older studies dumped everything into a single ``prepost``/``toggle`` dir,
+leaving stale ``leaderboard_all_profiles.csv`` and accumulating per-run diagnostic CSVs), and every
+output is traceable to the exact code that produced it.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from benchmarking.harness import StudyConfig
+
+logger = logging.getLogger(__name__)
+
+_REPO_DIR = Path(__file__).resolve().parent
+
+
+def _git_commit() -> str:
+    """Return the current commit (with a ``-dirty`` suffix if the tree has uncommitted changes)."""
+    try:
+        commit = subprocess.run(
+            ["git", "rev-parse", "HEAD"],  # noqa: S607
+            cwd=_REPO_DIR,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        dirty = subprocess.run(
+            ["git", "status", "--porcelain"],  # noqa: S607
+            cwd=_REPO_DIR,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+    except (subprocess.SubprocessError, OSError):
+        return "unknown"
+    return f"{commit}-dirty" if dirty else commit
+
+
+def start_overnight_run(mode: str, study: StudyConfig, output_root: Path) -> Path:
+    """Create a fresh timestamped output dir for one overnight run and wire logging into it.
+
+    :param mode: ``"prepost"`` or ``"toggle"`` (the per-mode subfolder)
+    :param study: the study configuration (logged for provenance)
+    :param output_root: the base ``WIND_UP_BENCHMARKING_OUTPUT_DIR`` (the studies' ``default_output_root``
+        already appends ``mode``; pass its ``.parent`` so we can add the timestamp under ``mode``)
+    :return: the per-run directory to pass as ``out_root`` to the study runner
+    """
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    out_dir = output_root / mode / timestamp
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+        handlers=[logging.StreamHandler(), logging.FileHandler(out_dir / "run.log")],
+        force=True,
+    )
+    logger.info("Starting %s overnight run", mode)
+    logger.info("git commit: %s", _git_commit())
+    logger.info("output dir: %s", out_dir)
+    logger.info("study config: %s", study)
+    return out_dir

--- a/benchmarking/baselines/overnight_profiles.py
+++ b/benchmarking/baselines/overnight_profiles.py
@@ -1,0 +1,36 @@
+"""The shared upgrade-profile set for the longer (overnight) prepost and toggle studies.
+
+Defined once so the prepost and toggle runs score an identical set. Seven profiles spanning
+sign, magnitude and shape:
+
+* constant Cp: -10%, 0% (placebo), +3%, +10%
+* wind-speed-dependent Cp: +10% held below 5 m/s, fading linearly to 0% by 12 m/s
+* TI-dependent Cp: +10% held below 10% turbulence intensity, fading to 0% by 30% TI
+* rated-power uprate: +5% (HoT rated = 2300 kW -> 2415 kW)
+"""
+
+from __future__ import annotations
+
+from benchmarking.synthetic import (
+    ConditionCpChange,
+    ConstantCpChange,
+    RatedPowerChange,
+    WindSpeedCpChange,
+)
+
+HOT_RATED_POWER_KW = 2300.0
+
+
+def overnight_profiles() -> dict[str, list]:
+    """Return the shared {name -> list of upgrade effects} mapping for the overnight studies."""
+    return {
+        "cp_minus_10pct": [ConstantCpChange(delta=-0.10)],
+        "cp_0pct": [ConstantCpChange(delta=0.0)],
+        "cp_plus_3pct": [ConstantCpChange(delta=0.03)],
+        "cp_plus_10pct": [ConstantCpChange(delta=0.10)],
+        # +10% Cp held below 5 m/s, fading linearly to 0% by 12 m/s (endpoints held outside range)
+        "ws_dependent_cp": [WindSpeedCpChange(ws_points=(5.0, 12.0), deltas=(0.10, 0.0))],
+        # +10% Cp held below 10% TI, fading linearly to 0% by 30% TI (TI = ws_sd / ws, a fraction)
+        "ti_dependent_cp": [ConditionCpChange(by="ti", points=(0.10, 0.30), deltas=(0.10, 0.0))],
+        "rated_plus_5pct": [RatedPowerChange(new_rated_power_kw=HOT_RATED_POWER_KW * 1.05)],
+    }

--- a/benchmarking/baselines/rlearner/__init__.py
+++ b/benchmarking/baselines/rlearner/__init__.py
@@ -1,0 +1,11 @@
+"""Cross-fit R-learner uplift method (v1 Issue 5).
+
+A pluggable, v0-independent treatment-effect estimator behind the harness ``Method`` seam.
+See ``docs/superpowers/specs/2026-06-25-rlearner-method-design.md``.
+"""
+
+from __future__ import annotations
+
+from benchmarking.baselines.rlearner.method import RLearnerMethod
+
+__all__ = ["RLearnerMethod"]

--- a/benchmarking/baselines/rlearner/__init__.py
+++ b/benchmarking/baselines/rlearner/__init__.py
@@ -1,7 +1,7 @@
 """Cross-fit R-learner uplift method (v1 Issue 5).
 
 A pluggable, v0-independent treatment-effect estimator behind the harness ``Method`` seam.
-See ``docs/superpowers/specs/2026-06-25-rlearner-method-design.md``.
+See ``docs/v1/issues.md`` (Issue 5); module docstrings cite the ML uplift design note by section.
 """
 
 from __future__ import annotations

--- a/benchmarking/baselines/rlearner/diagnostics.py
+++ b/benchmarking/baselines/rlearner/diagnostics.py
@@ -1,0 +1,237 @@
+"""Per-run diagnostics for the R-learner: CSVs, feature importance, and plots.
+
+A human reviewer must be able to confirm the right data was received and interpreted, and —
+critically — spot feature leakage (a feature that trivially predicts power, e.g. a
+post-treatment nacelle wind speed or a series-wired voltage; design note §3). Hence the
+feature-importance table and plot are first-class outputs and the top features are logged.
+
+Everything here is pure reporting; the estimate itself is computed in :mod:`method`.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_SEGMENTS = ("all", "baseline", "upgraded")
+_TOP_FEATURES_LOGGED = 10
+
+
+@dataclass
+class DiagnosticData:
+    """Everything the diagnostics need; assembled by :class:`~.method.RLearnerMethod`."""
+
+    test_wtg: str
+    mode: str
+    index: pd.DatetimeIndex  # all unique timestamps
+    treated_all: np.ndarray  # upgrade flag (0/1) over all timestamps
+    selected_all: np.ndarray  # bool: rows used in the fit
+    y_all: np.ndarray  # test power over all timestamps
+    timebase: pd.Timedelta
+    tau: np.ndarray  # per selected row
+    m_hat: np.ndarray
+    e_hat: np.ndarray
+    mu0: np.ndarray
+    y_selected: np.ndarray
+    condition_ws: np.ndarray | None  # reference mean ws over selected rows (for tau-vs-ws)
+    feature_names: list[str]
+    outcome_model: Any
+    effect_model: Any
+    overall_uplift: float
+    n_refs: int
+    era5_lag_rows: int | None
+    era5_corr: float | None
+    era5_sweep: pd.DataFrame | None
+
+
+def feature_importance_long(data: DiagnosticData) -> pd.DataFrame:
+    """Long table of LightGBM gain/split importance for the outcome and effect models."""
+    blocks = []
+    for label, model in (("outcome", data.outcome_model), ("effect", data.effect_model)):
+        booster = model.booster_
+        blocks.append(
+            pd.DataFrame(
+                {
+                    "model": label,
+                    "feature": data.feature_names,
+                    "gain": booster.feature_importance(importance_type="gain"),
+                    "split_count": booster.feature_importance(importance_type="split"),
+                }
+            )
+        )
+    return pd.concat(blocks, ignore_index=True).sort_values(["model", "gain"], ascending=[True, False])
+
+
+def log_top_features(importance: pd.DataFrame) -> None:
+    """Log the outcome model's top features so a human can spot a leaking (too-good) predictor."""
+    top = importance[importance["model"] == "outcome"].head(_TOP_FEATURES_LOGGED)
+    pairs = ", ".join(f"{r.feature} (gain={r.gain:.0f})" for r in top.itertuples())
+    logger.info("R-learner outcome-model top features by gain: %s", pairs)
+    logger.info("Review the above for leakage: a feature that trivially predicts power is a red flag.")
+
+
+def segment_stats(data: DiagnosticData) -> pd.DataFrame:
+    """Per-segment (all/baseline/upgraded) counts and energy, for a human data sanity check."""
+    timebase_hours = data.timebase / pd.Timedelta(hours=1)
+    treated = data.treated_all.astype(bool)
+    masks = {"all": np.ones(len(data.index), dtype=bool), "baseline": ~treated, "upgraded": treated}
+    rows = []
+    for segment in _SEGMENTS:
+        seg = masks[segment]
+        seg_sel = seg & data.selected_all
+        seg_power = data.y_all[seg_sel]
+        finite = seg_power[np.isfinite(seg_power)]
+        rows.append(
+            {
+                "segment": segment,
+                "first_timestamp": data.index[seg].min() if seg.any() else pd.NaT,
+                "last_timestamp": data.index[seg].max() if seg.any() else pd.NaT,
+                "n_timestamps": int(seg.sum()),
+                "n_selected": int(seg_sel.sum()),
+                "selected_fraction": float(seg_sel.sum() / seg.sum()) if seg.any() else np.nan,
+                "test_mean_power_kw": float(finite.mean()) if len(finite) else np.nan,
+                "test_mwh": float(finite.sum()) * timebase_hours / 1000.0 if len(finite) else np.nan,
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def results_row(data: DiagnosticData) -> pd.DataFrame:
+    """Single-row headline results: uplift, sizes, nuisance fit quality, ERA5 sync."""
+    treated_sel = data.treated_all[data.selected_all].astype(bool)
+    resid = data.y_selected - data.m_hat
+    ss_res = float(np.sum(resid**2))
+    ss_tot = float(np.sum((data.y_selected - data.y_selected.mean()) ** 2))
+    return pd.DataFrame(
+        [
+            {
+                "test_wtg": data.test_wtg,
+                "mode": data.mode,
+                "n_refs": data.n_refs,
+                "n_timestamps": len(data.index),
+                "n_selected": int(data.selected_all.sum()),
+                "n_selected_upgraded": int(treated_sel.sum()),
+                "n_features": len(data.feature_names),
+                "uplift_frc": data.overall_uplift,
+                "outcome_mae": float(np.mean(np.abs(resid))),
+                "outcome_r2": 1.0 - ss_res / ss_tot if ss_tot else np.nan,
+                "propensity_mean": float(np.mean(data.e_hat)),
+                "propensity_std": float(np.std(data.e_hat)),
+                "era5_lag_rows": data.era5_lag_rows,
+                "era5_corr": data.era5_corr,
+                "time_calculated": pd.Timestamp.utcnow(),
+            }
+        ]
+    )
+
+
+def write_csvs(run_dir: Path, run_name: str, ts: str, data: DiagnosticData) -> pd.DataFrame:
+    """Write the data-stats, results and feature-importance CSVs; return the importance table."""
+    segment_stats(data).to_csv(run_dir / f"{run_name}_data_stats_{ts}.csv", index=False)
+    results_row(data).to_csv(run_dir / f"{run_name}_results_{ts}.csv", index=False)
+    importance = feature_importance_long(data)
+    importance.to_csv(run_dir / f"{run_name}_feature_importance_{ts}.csv", index=False)
+    return importance
+
+
+def save_plots(plots_dir: Path, data: DiagnosticData, importance: pd.DataFrame) -> None:
+    """Write the diagnostic plots (feature importance is the headline leakage diagnostic)."""
+    plots_dir.mkdir(parents=True, exist_ok=True)
+    _plot_importance(plots_dir, importance)
+    _plot_residual_vs_prediction(plots_dir, data)
+    _plot_propensity(plots_dir, data)
+    _plot_predicted_vs_actual(plots_dir, data)
+    _plot_tau(plots_dir, data)
+    if data.era5_sweep is not None:
+        _plot_era5_sweep(plots_dir, data)
+
+
+def _plot_importance(plots_dir: Path, importance: pd.DataFrame) -> None:
+    fig, axes = plt.subplots(1, 2, figsize=(14, 6))
+    for ax, label in zip(axes, ("outcome", "effect"), strict=True):
+        top = importance[importance["model"] == label].head(15).iloc[::-1]
+        ax.barh(top["feature"], top["gain"], color="C0" if label == "outcome" else "C1")
+        ax.set_title(f"{label} model: top features by gain")
+        ax.set_xlabel("gain")
+    fig.tight_layout()
+    fig.savefig(plots_dir / "feature_importance.png", dpi=150)
+    plt.close(fig)
+
+
+def _plot_residual_vs_prediction(plots_dir: Path, data: DiagnosticData) -> None:
+    fig, ax = plt.subplots(figsize=(8, 6))
+    ax.scatter(data.m_hat, data.y_selected - data.m_hat, s=6, alpha=0.3)
+    ax.axhline(0, color="k", linewidth=1)
+    ax.set_xlabel("predicted power [kW]")
+    ax.set_ylabel("residual (actual - predicted) [kW]")
+    ax.set_title(f"{data.test_wtg}: outcome residual vs prediction (conditional-bias check)")
+    fig.tight_layout()
+    fig.savefig(plots_dir / "residual_vs_prediction.png", dpi=150)
+    plt.close(fig)
+
+
+def _plot_propensity(plots_dir: Path, data: DiagnosticData) -> None:
+    fig, ax = plt.subplots(figsize=(8, 6))
+    ax.hist(data.e_hat, bins=40, range=(0, 1), color="C2")
+    ax.set_xlabel("propensity e(x) = P(upgraded | X)")
+    ax.set_ylabel("count")
+    ax.set_title(f"{data.test_wtg}: propensity overlap (~0.5 for toggle, spread for before/after)")
+    fig.tight_layout()
+    fig.savefig(plots_dir / "propensity_hist.png", dpi=150)
+    plt.close(fig)
+
+
+def _plot_predicted_vs_actual(plots_dir: Path, data: DiagnosticData) -> None:
+    fig, ax = plt.subplots(figsize=(7, 7))
+    ax.scatter(data.y_selected, data.m_hat, s=6, alpha=0.3)
+    lim = [0, float(np.nanmax(data.y_selected))]
+    ax.plot(lim, lim, color="k", linewidth=1)
+    ax.set_xlabel("actual power [kW]")
+    ax.set_ylabel("predicted power [kW]")
+    ax.set_title(f"{data.test_wtg}: outcome model predicted vs actual")
+    fig.tight_layout()
+    fig.savefig(plots_dir / "predicted_vs_actual.png", dpi=150)
+    plt.close(fig)
+
+
+def _plot_tau(plots_dir: Path, data: DiagnosticData) -> None:
+    fig, axes = plt.subplots(1, 2, figsize=(14, 6))
+    axes[0].hist(data.tau, bins=40, color="C3")
+    axes[0].set_xlabel("tau(x): absolute uplift [kW]")
+    axes[0].set_ylabel("count")
+    axes[0].set_title(f"{data.test_wtg}: per-record uplift distribution")
+    if data.condition_ws is not None:
+        axes[1].scatter(data.condition_ws, data.tau, s=6, alpha=0.3, color="C3")
+        axes[1].set_xlabel("reference mean wind speed [m/s]")
+        axes[1].set_ylabel("tau(x) [kW]")
+        axes[1].set_title("uplift vs wind speed")
+    fig.tight_layout()
+    fig.savefig(plots_dir / "tau.png", dpi=150)
+    plt.close(fig)
+
+
+def _plot_era5_sweep(plots_dir: Path, data: DiagnosticData) -> None:
+    sweep = data.era5_sweep
+    if sweep is None:
+        return
+    fig, ax = plt.subplots(figsize=(8, 6))
+    ax.plot(sweep["shift_rows"], sweep["corr"], marker=".")
+    if data.era5_lag_rows is not None:
+        ax.axvline(data.era5_lag_rows, color="k", linestyle="--", label=f"best lag = {data.era5_lag_rows}")
+        ax.legend()
+    ax.set_xlabel("ERA5 shift [rows]")
+    ax.set_ylabel("wind-speed correlation")
+    ax.set_title(f"{data.test_wtg}: ERA5-SCADA correlation vs lag")
+    fig.tight_layout()
+    fig.savefig(plots_dir / "era5_sync.png", dpi=150)
+    plt.close(fig)

--- a/benchmarking/baselines/rlearner/era5_sync.py
+++ b/benchmarking/baselines/rlearner/era5_sync.py
@@ -1,0 +1,158 @@
+"""Align hourly ERA5 reanalysis to the 10-min SCADA grid for the R-learner.
+
+ERA5 arrives hourly; SCADA is 10-min. Two steps, adapted from the logic in
+``wind_up.reanalysis_data`` (``_reanalysis_upsample`` / ``_find_best_shift_and_corr``,
+which are private there) but kept local so this method stays v0-independent:
+
+1. :func:`upsample_era5_to_timebase` resamples ERA5 onto the analysis timebase and
+   forward-fills within each hour, renaming wind speed / direction to neutral
+   (non-v0) column names :data:`ERA5_WS` / :data:`ERA5_WD`.
+2. :func:`find_best_lag` sweeps the integer row-shift that maximises the correlation
+   between ERA5 wind speed and a reference (wind-farm) wind speed, recovering the lag
+   between the reanalysis and the site.
+
+:func:`sync_era5` combines both and returns ERA5 wind speed and direction aligned to a
+target index, plus the chosen lag and the correlation-vs-lag sweep for diagnostics.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+
+_MIN_OVERLAP = 3
+
+# Neutral, source-agnostic output names (no wind_up / v0 vocabulary).
+ERA5_WS = "era5_ws"
+ERA5_WD = "era5_wd"
+
+# Open-Meteo raw column names ERA5 ships with (see ``wind_up.era5``).
+_RAW_WS = "wind_speed_100m"
+_RAW_WD = "wind_direction_100m"
+
+_DEFAULT_MAX_LAG = pd.Timedelta(hours=24)
+
+
+@dataclass
+class Era5SyncResult:
+    """ERA5 aligned to a target index, with the recovered lag and the sweep.
+
+    :param aligned: frame indexed by the target index with columns :data:`ERA5_WS`,
+        :data:`ERA5_WD` (lag applied)
+    :param best_lag_rows: the integer row shift applied to ERA5 (positive = ERA5 shifted
+        forward to align with a lagging site signal)
+    :param best_corr: the wind-speed correlation at ``best_lag_rows``
+    :param sweep: the correlation-vs-lag table (columns ``shift_rows``, ``corr``)
+    """
+
+    aligned: pd.DataFrame
+    best_lag_rows: int
+    best_corr: float
+    sweep: pd.DataFrame
+
+
+def upsample_era5_to_timebase(era5_hourly_df: pd.DataFrame, *, timebase: pd.Timedelta) -> pd.DataFrame:
+    """Resample hourly ERA5 onto ``timebase`` and forward-fill within each source step.
+
+    Mirrors ``wind_up.reanalysis_data._reanalysis_upsample``: resample with ``last``, extend
+    the index so the final source step's trailing slots exist, then forward-fill up to one
+    source step. Wind speed and direction are renamed to :data:`ERA5_WS` / :data:`ERA5_WD`.
+    """
+    source_step = pd.Timedelta(pd.Series(era5_hourly_df.index).diff().median())
+    upsample_factor = round(source_step / timebase)
+    resampled = era5_hourly_df.resample(timebase, label="left").last()
+    if upsample_factor > 1:
+        tail = pd.DataFrame(
+            index=pd.date_range(
+                start=resampled.index[-1] + timebase,
+                periods=upsample_factor - 1,
+                freq=timebase,
+            )
+        )
+        resampled = pd.concat([resampled, tail])
+        resampled = resampled.ffill(limit=upsample_factor - 1)
+    missing = {_RAW_WS, _RAW_WD} - set(era5_hourly_df.columns)
+    if missing:
+        msg = f"ERA5 frame is missing expected columns {sorted(missing)}; have {list(era5_hourly_df.columns)}"
+        raise ValueError(msg)
+    out = resampled[[_RAW_WS, _RAW_WD]].rename(columns={_RAW_WS: ERA5_WS, _RAW_WD: ERA5_WD})
+    out.index.name = era5_hourly_df.index.name
+    return out
+
+
+def find_best_lag(
+    *,
+    reference_ws: pd.Series,
+    era5_ws: pd.Series,
+    timebase: pd.Timedelta,
+    max_lag: pd.Timedelta = _DEFAULT_MAX_LAG,
+) -> tuple[int, float, pd.DataFrame]:
+    """Find the integer row shift of ERA5 wind speed that best correlates with ``reference_ws``.
+
+    Both series must share the analysis-grid index. Sweeps shifts in ``±max_lag`` (in steps of
+    ~10 min of rows, like wind_up) and returns the shift maximising ``corr(era5_ws.shift(s),
+    reference_ws)`` — so a positive shift advances ERA5 to meet a site signal that lags it.
+    """
+    rows_per_hour = pd.Timedelta(hours=1) / timebase
+    # cap the sweep so the most extreme shift still overlaps the data (avoids empty slices)
+    max_rows = min(round(max_lag / timebase), len(era5_ws) - _MIN_OVERLAP)
+    step = max(1, math.ceil(rows_per_hour / 6))
+    shifts = list(range(-max_rows, max_rows + 1, step))
+    # a shift is only meaningful if a substantial chunk of data still overlaps; otherwise a
+    # handful of coincidentally-collinear points can score a spurious corr of 1.0.
+    min_overlap = max(_MIN_OVERLAP, len(era5_ws) // 2)
+    corrs = [_shift_corr(era5_ws=era5_ws, reference_ws=reference_ws, shift=s, min_overlap=min_overlap) for s in shifts]
+    sweep = pd.DataFrame({"shift_rows": shifts, "corr": corrs})
+    if sweep["corr"].isna().all():
+        return 0, float("nan"), sweep
+    best = sweep.loc[sweep["corr"].idxmax()]
+    return int(best["shift_rows"]), float(best["corr"]), sweep
+
+
+def _shift_corr(*, era5_ws: pd.Series, reference_ws: pd.Series, shift: int, min_overlap: int) -> float:
+    """Pearson correlation of ``era5_ws.shift(shift)`` and ``reference_ws`` over finite pairs.
+
+    Computed on the overlapping non-NaN pairs only, returning NaN below ``min_overlap`` points,
+    so extreme shifts neither raise numpy warnings (tests treat warnings as errors) nor score a
+    spurious perfect correlation off a handful of points.
+    """
+    shifted = era5_ws.shift(shift)
+    pair = pd.concat([shifted, reference_ws], axis=1).dropna()
+    if len(pair) < min_overlap:
+        return float("nan")
+    a = pair.iloc[:, 0].to_numpy()
+    b = pair.iloc[:, 1].to_numpy()
+    if a.std() == 0 or b.std() == 0:  # zero variance -> correlation undefined (and numpy warns)
+        return float("nan")
+    return float(np.corrcoef(a, b)[0, 1])
+
+
+def sync_era5(
+    era5_hourly_df: pd.DataFrame,
+    *,
+    target_index: pd.DatetimeIndex,
+    reference_ws: pd.Series,
+    timebase: pd.Timedelta | None = None,
+    max_lag: pd.Timedelta = _DEFAULT_MAX_LAG,
+) -> Era5SyncResult:
+    """Upsample ERA5, find its lag vs ``reference_ws``, and align it to ``target_index``.
+
+    :param era5_hourly_df: raw hourly ERA5 (Open-Meteo column names)
+    :param target_index: the analysis grid to align ERA5 onto (the SCADA timestamps)
+    :param reference_ws: a site wind speed on ``target_index`` (e.g. reference-turbine mean)
+    :param timebase: analysis timebase; inferred from ``target_index`` spacing when ``None``
+    """
+    if timebase is None:
+        timebase = pd.Timedelta(pd.Series(target_index).diff().median())
+    upsampled = upsample_era5_to_timebase(era5_hourly_df, timebase=timebase).reindex(target_index)
+    best_lag, best_corr, sweep = find_best_lag(
+        reference_ws=reference_ws.reindex(target_index),
+        era5_ws=upsampled[ERA5_WS],
+        timebase=timebase,
+        max_lag=max_lag,
+    )
+    aligned = upsampled.shift(best_lag)
+    return Era5SyncResult(aligned=aligned, best_lag_rows=best_lag, best_corr=best_corr, sweep=sweep)

--- a/benchmarking/baselines/rlearner/features.py
+++ b/benchmarking/baselines/rlearner/features.py
@@ -53,16 +53,16 @@ def build_reference_features(scada_df: pd.DataFrame, *, test_wtg: str, turbine_c
     value_cols = [c for c in scada_df.columns if c != turbine_col]
     index = pd.DatetimeIndex(pd.unique(scada_df.index)).sort_values()
 
+    # One pivot over all value columns (MultiIndex columns: (value_col, turbine)) rather than one
+    # pivot_table per column — much cheaper on wide SCADA frames. Then keep reference turbines only,
+    # in (value_col, ref) order, and flatten to the "<tag> @ <turbine>" names.
     tmp = scada_df.copy()
     tmp["_ts"] = scada_df.index
-    blocks = []
-    for col in value_cols:
-        wide = tmp.pivot_table(index="_ts", columns=turbine_col, values=col, aggfunc="first")
-        ref_wide = wide[[r for r in refs if r in wide.columns]]
-        ref_wide.columns = [f"{col}{QUALIFIER}{r}" for r in ref_wide.columns]
-        blocks.append(ref_wide)
-
-    features = pd.concat(blocks, axis=1).reindex(index)
+    wide = tmp.pivot_table(index="_ts", columns=turbine_col, values=value_cols, aggfunc="first")
+    keep = [(col, r) for col in value_cols for r in refs if (col, r) in wide.columns]
+    features = wide.loc[:, keep]
+    features.columns = [f"{col}{QUALIFIER}{r}" for col, r in keep]
+    features = features.reindex(index)
     features = pd.concat(
         [features, engineered_reference_features(scada_df, test_wtg=test_wtg, turbine_col=turbine_col)], axis=1
     )

--- a/benchmarking/baselines/rlearner/features.py
+++ b/benchmarking/baselines/rlearner/features.py
@@ -1,0 +1,131 @@
+"""Build the R-learner's upgrade-invariant feature matrix from long SCADA.
+
+The discipline (design note §3): every model feature must be *upgrade-invariant* — derived
+from reference turbines (or ERA5 / met-mast / LiDAR), never the test turbine's own signals,
+which the upgrade distorts. Within that rule the matrix is **maximal, not curated**: every
+source-native column of every reference turbine is used as-is, original tag names intact, so
+the model sees all the data holistically and the feature-importance diagnostics name real
+tags.
+
+The only column that must be identified by config is the **test turbine's active power**
+(the outcome ``Y``); reference turbines need no per-column configuration.
+
+Feature columns are named ``"<tag>{QUALIFIER}<turbine>"`` (e.g. ``"wtc_ActPower_mean @ R1"``)
+so the original tag name is preserved verbatim. :func:`check_upgrade_invariant` is the
+enforcement guard that rejects any test-turbine-qualified column — exercised by the
+bias-guard regression test (design note §8).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from benchmarking.baselines.rlearner.era5_sync import ERA5_WD, ERA5_WS
+from benchmarking.synthetic import ToggleSchedule, treated_mask
+
+# Separator between a source-native tag and the turbine it came from in a feature name.
+QUALIFIER = " @ "
+
+
+def _references(scada_df: pd.DataFrame, *, test_wtg: str, turbine_col: str) -> list[str]:
+    """Sorted reference turbine names (every turbine present except the test turbine)."""
+    refs = sorted(t for t in scada_df[turbine_col].unique() if t != test_wtg)
+    if not refs:
+        msg = (
+            f"no reference turbines available for test_wtg {test_wtg!r}: scada_df contains only "
+            f"{sorted(scada_df[turbine_col].unique())}. The R-learner needs at least one reference turbine."
+        )
+        raise ValueError(msg)
+    return refs
+
+
+def build_reference_features(scada_df: pd.DataFrame, *, test_wtg: str, turbine_col: str) -> pd.DataFrame:
+    """Wide upgrade-invariant features: every reference turbine's every value column, NaN-preserving.
+
+    Columns are ``"<tag>{QUALIFIER}<turbine>"`` keeping the original tag name. The test turbine
+    contributes nothing here (its outcome is extracted separately). NaNs are preserved (no
+    complete-case dropping) — LightGBM handles them natively. Includes the (currently no-op)
+    engineered-feature seam. Raises if no reference turbine is present, or (defensively) if any
+    test-turbine column would leak in.
+    """
+    refs = _references(scada_df, test_wtg=test_wtg, turbine_col=turbine_col)
+    value_cols = [c for c in scada_df.columns if c != turbine_col]
+    index = pd.DatetimeIndex(pd.unique(scada_df.index)).sort_values()
+
+    tmp = scada_df.copy()
+    tmp["_ts"] = scada_df.index
+    blocks = []
+    for col in value_cols:
+        wide = tmp.pivot_table(index="_ts", columns=turbine_col, values=col, aggfunc="first")
+        ref_wide = wide[[r for r in refs if r in wide.columns]]
+        ref_wide.columns = [f"{col}{QUALIFIER}{r}" for r in ref_wide.columns]
+        blocks.append(ref_wide)
+
+    features = pd.concat(blocks, axis=1).reindex(index)
+    features = pd.concat(
+        [features, engineered_reference_features(scada_df, test_wtg=test_wtg, turbine_col=turbine_col)], axis=1
+    )
+    features.index.name = index.name
+    check_upgrade_invariant(features.columns.tolist(), test_wtg=test_wtg)
+    return features
+
+
+def engineered_reference_features(scada_df: pd.DataFrame, *, test_wtg: str, turbine_col: str) -> pd.DataFrame:  # noqa: ARG001
+    """Feature-engineering seam — currently a no-op (returns no columns).
+
+    This is the obvious home for *derived* upgrade-invariant features. The prime future
+    candidate is **north-corrected reference yaw position** (an accurate per-record wind
+    direction and waking relationship — a key v0 value-add), alongside shear, stability
+    proxies and air density. Not implemented now: ERA5 wind direction already gives reasonable
+    directional information, and proper northing would pull in v0's machinery. Returns an empty
+    frame on the data's unique timestamps so callers can concatenate it unconditionally.
+    """
+    index = pd.DatetimeIndex(pd.unique(scada_df.index)).sort_values()
+    return pd.DataFrame(index=index)
+
+
+def extract_outcome_and_treatment(
+    scada_df: pd.DataFrame,
+    *,
+    test_wtg: str,
+    turbine_col: str,
+    active_power_col: str,
+    upgrade_timing: pd.Timestamp | ToggleSchedule,
+) -> tuple[pd.Series, pd.Series]:
+    """Return the outcome ``y`` (test turbine power) and upgrade flag ``t`` on the unique index.
+
+    ``y`` is the test turbine's active power (may contain NaN downtime). ``t`` is the integer
+    upgrade flag from :func:`treated_mask` (1 = upgraded record, 0 = baseline).
+    """
+    index = pd.DatetimeIndex(pd.unique(scada_df.index)).sort_values()
+    test_rows = scada_df[scada_df[turbine_col] == test_wtg]
+    y = test_rows[active_power_col].copy()
+    y.index = pd.DatetimeIndex(test_rows.index)
+    y = y.reindex(index)
+    t = pd.Series(np.asarray(treated_mask(index, upgrade_timing)).astype(int), index=index)
+    return y, t
+
+
+def era5_features(aligned_era5: pd.DataFrame) -> pd.DataFrame:
+    """Turn aligned ERA5 (ws + wd degrees) into model features: ws passthrough, wd as sin/cos."""
+    rad = np.deg2rad(aligned_era5[ERA5_WD].to_numpy(dtype=float))
+    return pd.DataFrame(
+        {
+            ERA5_WS: aligned_era5[ERA5_WS].to_numpy(dtype=float),
+            "era5_wd_sin": np.sin(rad),
+            "era5_wd_cos": np.cos(rad),
+        },
+        index=aligned_era5.index,
+    )
+
+
+def check_upgrade_invariant(feature_names: list[str], *, test_wtg: str) -> None:
+    """Raise if any feature is qualified with the test turbine (violating the §3 rule)."""
+    offenders = [f for f in feature_names if f.endswith(f"{QUALIFIER}{test_wtg}")]
+    if offenders:
+        msg = (
+            f"upgrade-invariant rule violated: features derived from the test turbine {test_wtg!r} "
+            f"are not allowed (the upgrade distorts its signals, design note §3): {offenders}"
+        )
+        raise ValueError(msg)

--- a/benchmarking/baselines/rlearner/filtering.py
+++ b/benchmarking/baselines/rlearner/filtering.py
@@ -1,0 +1,83 @@
+"""Test-turbine normal-operation filtering for the R-learner.
+
+The outcome ``Y`` is the test turbine's power, so abnormal operation that is unrelated to the
+upgrade — downtime, curtailment, frozen/stuck sensors — would otherwise be attributed to the
+upgrade (a downward uplift bias, worst when it clusters in the upgrade period). This module
+selects the normally-operating test-turbine rows.
+
+Two filters, both adapted from wind_up (``_filter_stuck_data`` / ``_filter_downtime``) but kept
+local so the method stays v0-independent:
+
+* **stuck data** — drop rows where every signal is unchanged from the previous record (a frozen
+  data stream), exempting genuine very-low-wind calms (where flat signals are expected).
+* **downtime / availability** — drop rows where an availability counter shows the turbine was
+  not ready to operate for the full period.
+
+The central rule is **filter on cause, not effect**: selection uses operational signals and
+finite power, never "power lower than expected" — that would drop genuine low-uplift records and
+bias the estimate. This is row selection, not a feature rule, so using the test turbine's own
+operational signals here does not violate the upgrade-invariant feature rule.
+
+References are deliberately **not** filtered: the rich reference feature set lets the model learn
+their operating modes itself (design note intent).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+# Below this wind speed a flat/constant signal is a genuine calm, not a stuck sensor.
+_VERY_LOW_WIND = 1.5
+
+
+@dataclass
+class NormalOperationFilter:
+    """Selects normally-operating test-turbine timestamps (cause, not effect).
+
+    :param active_power_col: the test turbine's active-power column (rows with NaN power are
+        always dropped — that is downtime/missing energy)
+    :param wind_speed_col: the test turbine's wind-speed column, used only to exempt very-low-wind
+        calms from the stuck filter (``None`` disables that exemption)
+    :param availability_col: an operational "ready to operate" counter (e.g. seconds in the
+        period); ``None`` disables the downtime filter
+    :param full_period_seconds: the counter value that means fully available; defaults to the
+        timebase length in seconds when ``None``
+    :param apply_stuck_filter: drop frozen/stuck rows (all signals unchanged vs the previous row)
+    """
+
+    active_power_col: str
+    wind_speed_col: str | None = None
+    availability_col: str | None = None
+    full_period_seconds: float | None = None
+    apply_stuck_filter: bool = True
+
+    def keep_mask(self, test_rows: pd.DataFrame, *, timebase: pd.Timedelta) -> pd.Series:
+        """Boolean Series (True = keep) of normally-operating test-turbine rows, index-aligned."""
+        rows = test_rows.sort_index()
+        keep = rows[self.active_power_col].notna()
+        if self.apply_stuck_filter:
+            keep &= ~self._stuck(rows)
+        if self.availability_col is not None:
+            keep &= self._available(rows, timebase=timebase)
+        return keep.astype(bool)
+
+    def _stuck(self, rows: pd.DataFrame) -> pd.Series:
+        """Return True where every numeric signal is unchanged from the previous row (not low wind)."""
+        numeric = rows.select_dtypes(include="number")
+        diffs = numeric.ffill().fillna(0).diff()
+        frozen = (diffs == 0).all(axis=1)
+        frozen.iloc[0] = False  # the first row has no predecessor to repeat
+        if self.wind_speed_col is not None:
+            calm = rows[self.wind_speed_col] < _VERY_LOW_WIND
+            frozen &= ~calm
+        return frozen
+
+    def _available(self, rows: pd.DataFrame, *, timebase: pd.Timedelta) -> pd.Series:
+        """Return True where the availability counter shows a full period (NaN -> not available)."""
+        full = self.full_period_seconds if self.full_period_seconds is not None else timebase.total_seconds()
+        counter = rows[self.availability_col]
+        return (counter >= full) & counter.notna()

--- a/benchmarking/baselines/rlearner/method.py
+++ b/benchmarking/baselines/rlearner/method.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import logging
 import tempfile
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -59,6 +59,21 @@ def _upgrade_start(upgrade_timing: pd.Timestamp | ToggleSchedule, index: pd.Date
     return pd.Timestamp(upgrade_timing)
 
 
+def _restrict_to_campaign(mi: MethodInput, *, toggle_campaign_only: bool) -> MethodInput:
+    """Drop pre-campaign rows for a toggle campaign so the on/off comparison shares a distribution.
+
+    The harness toggle window also carries the pre-campaign baseline, whose distribution differs
+    from the campaign and reintroduces the temporal confounding toggling exists to avoid. When
+    ``toggle_campaign_only`` (the default), restrict a toggle input to records at/after the toggle
+    start (the interleaved on/off blocks), giving a balanced propensity and pure variance
+    reduction. No-op for prepost and when the flag is off.
+    """
+    timing = mi.upgrade_timing
+    if not (toggle_campaign_only and isinstance(timing, ToggleSchedule) and timing.start is not None):
+        return mi
+    return replace(mi, scada_df=mi.scada_df.loc[mi.scada_df.index >= timing.start])
+
+
 @dataclass
 class RLearnerMethod:
     """Pluggable cross-fit R-learner uplift estimator (prepost and toggle).
@@ -75,6 +90,9 @@ class RLearnerMethod:
     :param seed: cross-fitting seed
     :param model_params: LightGBM overrides passed to every nuisance/effect model
     :param timebase: analysis timebase; inferred from the data when ``None``
+    :param toggle_campaign_only: for a toggle campaign, fit only on the interleaved on/off blocks
+        (drop the pre-campaign baseline) so the propensity is balanced and there is no temporal
+        confounding; no-op for prepost (whose baseline is the pre-campaign data)
     """
 
     active_power_col: str
@@ -88,9 +106,11 @@ class RLearnerMethod:
     seed: int = 0
     model_params: dict[str, Any] = field(default_factory=dict)
     timebase: pd.Timedelta | None = None
+    toggle_campaign_only: bool = True
 
     def estimate(self, mi: MethodInput) -> MethodOutput:
         """Estimate the test turbine's P50 uplift for one campaign and write diagnostics."""
+        mi = _restrict_to_campaign(mi, toggle_campaign_only=self.toggle_campaign_only)
         scada = mi.scada_df
         index = pd.DatetimeIndex(pd.unique(scada.index)).sort_values()
         timebase = self.timebase if self.timebase is not None else _infer_timebase(scada.index)

--- a/benchmarking/baselines/rlearner/method.py
+++ b/benchmarking/baselines/rlearner/method.py
@@ -1,0 +1,241 @@
+"""``RLearnerMethod``: the cross-fit R-learner behind the harness ``Method`` seam.
+
+Orchestrates the pieces (design note §4): build upgrade-invariant reference features, sync ERA5
+(optional), filter the test turbine to normal operation, cross-fit the R-learner, aggregate to a
+single P50 uplift, and write diagnostics. It is v0-independent — ERA5 is supplied as a plain
+hourly DataFrame (the driver fetches it), so this package imports nothing from ``wind_up``.
+
+Aggregation: the overall uplift is ``sum(tau) / sum(mu0)`` over the **upgraded** rows, which
+equals the ground-truth definition ``sum(upgraded power)/sum(baseline power) - 1`` because
+``mu0`` is the baseline expected power and ``mu0 + tau`` the upgraded.
+"""
+
+from __future__ import annotations
+
+import logging
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+import pandas as pd
+
+from benchmarking.baselines.rlearner import diagnostics as diag
+from benchmarking.baselines.rlearner.era5_sync import sync_era5
+from benchmarking.baselines.rlearner.features import (
+    QUALIFIER,
+    build_reference_features,
+    era5_features,
+    extract_outcome_and_treatment,
+)
+from benchmarking.baselines.rlearner.filtering import NormalOperationFilter
+from benchmarking.baselines.rlearner.nuisance import make_effect_model, make_outcome_model, make_propensity_model
+from benchmarking.baselines.rlearner.rlearner import cross_fit_rlearner
+from benchmarking.harness.method import MethodInput, MethodOutput
+from benchmarking.synthetic import ToggleSchedule
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+logger = logging.getLogger(__name__)
+
+_MIN_FOLDS = 2
+_MIN_POINTS_FOR_TIMEBASE = 2
+
+
+def _infer_timebase(index: pd.DatetimeIndex) -> pd.Timedelta:
+    """Infer the analysis timebase as the median spacing of the sorted unique timestamps."""
+    unique = pd.DatetimeIndex(pd.unique(index)).sort_values()
+    if len(unique) < _MIN_POINTS_FOR_TIMEBASE:
+        return pd.Timedelta(minutes=10)
+    return pd.Timedelta(np.median(np.diff(unique.to_numpy())))
+
+
+def _upgrade_start(upgrade_timing: pd.Timestamp | ToggleSchedule, index: pd.DatetimeIndex) -> pd.Timestamp:
+    """Return the upgrade-start timestamp (changeover for prepost; toggle origin for toggle)."""
+    if isinstance(upgrade_timing, ToggleSchedule):
+        return upgrade_timing.start if upgrade_timing.start is not None else index.min()
+    return pd.Timestamp(upgrade_timing)
+
+
+@dataclass
+class RLearnerMethod:
+    """Pluggable cross-fit R-learner uplift estimator (prepost and toggle).
+
+    :param active_power_col: the test turbine's active-power column (the outcome ``Y``)
+    :param wind_speed_col: the wind-speed tag, used for ERA5 sync (reference mean) and the
+        stuck-filter low-wind exemption; required if ``era5_hourly_df`` is given
+    :param availability_col: optional "ready to operate" counter for the downtime filter
+    :param era5_hourly_df: optional raw hourly ERA5 (Open-Meteo columns); added as features when given
+    :param name: method name shown in the leaderboard
+    :param out_dir: where per-run folders are written; a temp dir when ``None``
+    :param save_plots: also write the diagnostic plots
+    :param n_folds: cross-fitting folds
+    :param seed: cross-fitting seed
+    :param model_params: LightGBM overrides passed to every nuisance/effect model
+    :param timebase: analysis timebase; inferred from the data when ``None``
+    """
+
+    active_power_col: str
+    wind_speed_col: str | None = None
+    availability_col: str | None = None
+    era5_hourly_df: pd.DataFrame | None = None
+    name: str = "rlearner"
+    out_dir: Path | None = None
+    save_plots: bool = False
+    n_folds: int = 5
+    seed: int = 0
+    model_params: dict[str, Any] = field(default_factory=dict)
+    timebase: pd.Timedelta | None = None
+
+    def estimate(self, mi: MethodInput) -> MethodOutput:
+        """Estimate the test turbine's P50 uplift for one campaign and write diagnostics."""
+        scada = mi.scada_df
+        index = pd.DatetimeIndex(pd.unique(scada.index)).sort_values()
+        timebase = self.timebase if self.timebase is not None else _infer_timebase(scada.index)
+        n_refs = scada[mi.turbine_col].nunique() - 1
+
+        y, t = extract_outcome_and_treatment(
+            scada,
+            test_wtg=mi.test_wtg,
+            turbine_col=mi.turbine_col,
+            active_power_col=self.active_power_col,
+            upgrade_timing=mi.upgrade_timing,
+        )
+        features = build_reference_features(scada, test_wtg=mi.test_wtg, turbine_col=mi.turbine_col)
+        reference_ws = self._reference_mean_ws(features, index=index)
+        features, era5 = self._add_era5(features, index=index, reference_ws=reference_ws, timebase=timebase)
+
+        selected = self._select_rows(scada, mi=mi, index=index, y=y, timebase=timebase)
+        x_sel = features.loc[index[selected]]
+        y_sel = y.to_numpy(dtype=float)[selected]
+        t_sel = t.to_numpy(dtype=float)[selected]
+        n_folds = min(self.n_folds, int(selected.sum()))
+        if n_folds < _MIN_FOLDS:
+            msg = f"too few normally-operating rows ({int(selected.sum())}) to cross-fit the R-learner."
+            raise ValueError(msg)
+
+        fit = cross_fit_rlearner(x_sel, y=y_sel, t=t_sel, n_folds=n_folds, seed=self.seed, **self._factories())
+        overall = _aggregate_uplift(tau=fit.tau, mu0=fit.mu0, upgraded=t_sel.astype(bool))
+
+        self._write(
+            mi,
+            index=index,
+            timebase=timebase,
+            t=t,
+            selected=selected,
+            y=y,
+            fit=fit,
+            x_sel=x_sel,
+            reference_ws=reference_ws,
+            overall=overall,
+            n_refs=n_refs,
+            era5=era5,
+        )
+        return MethodOutput(p50_overall=overall)
+
+    def _factories(self) -> dict[str, Callable[[], Any]]:
+        """Nuisance/effect model factories with the configured LightGBM overrides applied."""
+        params = self.model_params
+        return {
+            "make_outcome": lambda: make_outcome_model(**params),
+            "make_propensity": lambda: make_propensity_model(**params),
+            "make_effect": lambda: make_effect_model(**params),
+        }
+
+    def _reference_mean_ws(self, features: pd.DataFrame, *, index: pd.DatetimeIndex) -> pd.Series:
+        """Mean wind speed across reference turbines (for ERA5 sync and the tau-vs-ws plot)."""
+        if self.wind_speed_col is None:
+            return pd.Series(np.nan, index=index)
+        ws_cols = [c for c in features.columns if c.startswith(f"{self.wind_speed_col}{QUALIFIER}")]
+        if not ws_cols:
+            return pd.Series(np.nan, index=index)
+        return features[ws_cols].mean(axis=1)
+
+    def _add_era5(
+        self, features: pd.DataFrame, *, index: pd.DatetimeIndex, reference_ws: pd.Series, timebase: pd.Timedelta
+    ) -> tuple[pd.DataFrame, Any]:
+        """Sync ERA5 (if supplied) and append its features; return the (features, sync-result)."""
+        if self.era5_hourly_df is None:
+            return features, None
+        if self.wind_speed_col is None:
+            msg = "wind_speed_col is required to sync ERA5 (it provides the reference wind speed)."
+            raise ValueError(msg)
+        result = sync_era5(self.era5_hourly_df, target_index=index, reference_ws=reference_ws, timebase=timebase)
+        return pd.concat([features, era5_features(result.aligned)], axis=1), result
+
+    def _select_rows(
+        self, scada: pd.DataFrame, *, mi: MethodInput, index: pd.DatetimeIndex, y: pd.Series, timebase: pd.Timedelta
+    ) -> np.ndarray:
+        """Boolean over ``index``: normally-operating test rows (cause-not-effect) with finite outcome."""
+        test_rows = scada[scada[mi.turbine_col] == mi.test_wtg].sort_index()
+        keep = NormalOperationFilter(
+            active_power_col=self.active_power_col,
+            wind_speed_col=self.wind_speed_col,
+            availability_col=self.availability_col,
+        ).keep_mask(test_rows, timebase=timebase)
+        keep = keep.reindex(index, fill_value=False)
+        return keep.to_numpy() & np.isfinite(y.to_numpy(dtype=float))
+
+    def _write(
+        self,
+        mi: MethodInput,
+        *,
+        index: pd.DatetimeIndex,
+        timebase: pd.Timedelta,
+        t: pd.Series,
+        selected: np.ndarray,
+        y: pd.Series,
+        fit: Any,  # noqa: ANN401
+        x_sel: pd.DataFrame,
+        reference_ws: pd.Series,
+        overall: float,
+        n_refs: int,
+        era5: Any,  # noqa: ANN401
+    ) -> None:
+        """Assemble the diagnostic data and write the CSVs (+ plots), logging the top features."""
+        upgrade_start = _upgrade_start(mi.upgrade_timing, index)
+        run_name = f"rlearner_{mi.test_wtg}_{upgrade_start:%Y%m%d}_{index.max():%Y%m%d}"
+        out_root = Path(self.out_dir) if self.out_dir is not None else Path(tempfile.mkdtemp(prefix="rlearner_"))
+        run_dir = out_root / run_name
+        run_dir.mkdir(parents=True, exist_ok=True)
+        ts = pd.Timestamp.utcnow().strftime("%Y%m%d_%H%M%S_%f")
+        y_arr = y.to_numpy(dtype=float)
+        data = diag.DiagnosticData(
+            test_wtg=mi.test_wtg,
+            mode="toggle" if isinstance(mi.upgrade_timing, ToggleSchedule) else "prepost",
+            index=index,
+            treated_all=t.to_numpy(),
+            selected_all=selected,
+            y_all=y_arr,
+            timebase=timebase,
+            tau=fit.tau,
+            m_hat=fit.m_hat,
+            e_hat=fit.e_hat,
+            mu0=fit.mu0,
+            y_selected=y_arr[selected],
+            condition_ws=reference_ws.to_numpy(dtype=float)[selected] if self.wind_speed_col is not None else None,
+            feature_names=list(x_sel.columns),
+            outcome_model=fit.outcome_model,
+            effect_model=fit.effect_model,
+            overall_uplift=overall,
+            n_refs=n_refs,
+            era5_lag_rows=era5.best_lag_rows if era5 is not None else None,
+            era5_corr=era5.best_corr if era5 is not None else None,
+            era5_sweep=era5.sweep if era5 is not None else None,
+        )
+        importance = diag.write_csvs(run_dir, run_name, ts, data)
+        diag.log_top_features(importance)
+        if self.save_plots:
+            diag.save_plots(run_dir / "plots", data, importance)
+
+
+def _aggregate_uplift(*, tau: np.ndarray, mu0: np.ndarray, upgraded: np.ndarray) -> float:
+    """Overall uplift = sum(tau)/sum(mu0) over the upgraded rows (the ground-truth row set)."""
+    if not upgraded.any():
+        return float("nan")
+    denom = float(np.sum(mu0[upgraded]))
+    if not np.isfinite(denom) or denom == 0:
+        return float("nan")
+    return float(np.sum(tau[upgraded]) / denom)

--- a/benchmarking/baselines/rlearner/nuisance.py
+++ b/benchmarking/baselines/rlearner/nuisance.py
@@ -1,0 +1,59 @@
+"""LightGBM nuisance/effect model factories for the R-learner.
+
+Three model roles (design note §4, Stage 1/2):
+
+* **outcome** ``m(x)=E[Y|X]`` — an L2 (or Huber) regressor. Energy is the integral of the
+  *mean*, so the energy-relevant model targets the mean, not the median (design note §2).
+* **propensity** ``e(x)=E[T|X]`` — a classifier for the upgrade flag.
+* **effect** ``tau(x)`` — a regressor fit on the R-learner pseudo-outcome.
+
+LightGBM is an optional dependency (the ``ml`` group); it is imported lazily so this package
+imports without it installed. Defaults follow the design note's common hyperparameters;
+callers (and tests) override via keyword arguments.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from lightgbm import LGBMClassifier, LGBMRegressor
+
+# Design note §6 "common" hyperparameters; native NaN handling, seconds to train.
+_COMMON: dict[str, Any] = {
+    "n_estimators": 600,
+    "learning_rate": 0.03,
+    "num_leaves": 63,
+    "min_child_samples": 200,
+    "subsample": 0.8,
+    "colsample_bytree": 0.8,
+    "verbose": -1,
+}
+
+
+def _import_lightgbm() -> Any:  # noqa: ANN401
+    """Import lightgbm lazily with a helpful error if the optional ``ml`` group is missing."""
+    try:
+        import lightgbm  # noqa: PLC0415
+    except ImportError as exc:  # pragma: no cover - exercised only without the optional dep
+        msg = "lightgbm is required for the R-learner method; install the 'ml' optional dependency group."
+        raise ImportError(msg) from exc
+    return lightgbm
+
+
+def make_outcome_model(**overrides: Any) -> LGBMRegressor:  # noqa: ANN401
+    """L2 outcome regressor for ``E[Y|X]`` (the energy-relevant mean model)."""
+    lgb = _import_lightgbm()
+    return lgb.LGBMRegressor(objective="regression", **{**_COMMON, **overrides})
+
+
+def make_propensity_model(**overrides: Any) -> LGBMClassifier:  # noqa: ANN401
+    """Binary classifier for the propensity ``E[T|X]`` (flat ~0.5 for toggle, real for before/after)."""
+    lgb = _import_lightgbm()
+    return lgb.LGBMClassifier(objective="binary", **{**_COMMON, **overrides})
+
+
+def make_effect_model(**overrides: Any) -> LGBMRegressor:  # noqa: ANN401
+    """Regressor for the effect ``tau(x)``, fit on the R-learner pseudo-outcome."""
+    lgb = _import_lightgbm()
+    return lgb.LGBMRegressor(objective="regression", **{**_COMMON, **overrides})

--- a/benchmarking/baselines/rlearner/rlearner.py
+++ b/benchmarking/baselines/rlearner/rlearner.py
@@ -26,7 +26,6 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
-from sklearn.model_selection import KFold
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -37,6 +36,19 @@ if TYPE_CHECKING:
 # Below this |t_res| the R-learner pseudo-outcome y_res/t_res is numerically unstable; such
 # rows carry ~zero R-loss weight anyway, so they are dropped from the effect fit.
 _MIN_T_RES = 1e-6
+
+
+def _import_kfold() -> Any:  # noqa: ANN401
+    """Import scikit-learn's ``KFold`` lazily with a helpful error if the optional ``ml`` group is missing.
+
+    Mirrors the lazy LightGBM import so this package imports without the optional ``ml`` dependencies.
+    """
+    try:
+        from sklearn.model_selection import KFold  # noqa: PLC0415
+    except ImportError as exc:  # pragma: no cover - exercised only without the optional dep
+        msg = "scikit-learn is required for the R-learner method; install the 'ml' optional dependency group."
+        raise ImportError(msg) from exc
+    return KFold
 
 
 @dataclass
@@ -83,7 +95,7 @@ def cross_fit_rlearner(
 
     m_hat = np.empty(n)
     e_hat = np.empty(n)
-    folds = KFold(n_splits=n_folds, shuffle=True, random_state=seed)
+    folds = _import_kfold()(n_splits=n_folds, shuffle=True, random_state=seed)
     for train_idx, test_idx in folds.split(x):
         x_tr, x_te = x.iloc[train_idx], x.iloc[test_idx]
         m_hat[test_idx] = make_outcome().fit(x_tr, y[train_idx]).predict(x_te)

--- a/benchmarking/baselines/rlearner/rlearner.py
+++ b/benchmarking/baselines/rlearner/rlearner.py
@@ -1,0 +1,108 @@
+"""The pure cross-fit R-learner core (Robinson partialling-out).
+
+No I/O, no source vocabulary: given a feature matrix ``X`` (upgrade-invariant; NaN allowed),
+outcome ``y`` and upgrade flag ``t``, it returns per-row ``tau`` (absolute effect), the
+cross-fit nuisances ``m_hat``/``e_hat``, the baseline power ``mu0`` and the fitted
+outcome/effect models for feature-importance diagnostics.
+
+Method (design note §4):
+
+1. Cross-fit the nuisances: over K folds, fit outcome ``m(x)=E[Y|X]`` and propensity
+   ``e(x)=E[T|X]`` on the training folds and predict on the held-out fold, so every row gets
+   an out-of-fold prediction it did not help train. Shuffled K-fold is valid because there are
+   no timestamp features.
+2. Residualise: ``y_res = y - m_hat``, ``t_res = t - e_hat``.
+3. Fit the effect model ``tau(x)`` on the pseudo-outcome ``y_res / t_res`` with R-loss weights
+   ``t_res**2`` (guarding the ``t_res≈0`` divide).
+4. Baseline power ``mu0 = m_hat - e_hat * tau`` (no extra model).
+
+Collapses to plain regression adjustment when the propensity is flat (toggle) and
+orthogonalises when it is not (before/after) — one code path for both modes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+from sklearn.model_selection import KFold
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    import numpy.typing as npt
+    import pandas as pd
+
+# Below this |t_res| the R-learner pseudo-outcome y_res/t_res is numerically unstable; such
+# rows carry ~zero R-loss weight anyway, so they are dropped from the effect fit.
+_MIN_T_RES = 1e-6
+
+
+@dataclass
+class RLearnerFit:
+    """Per-row R-learner outputs plus the fitted models for diagnostics.
+
+    :param tau: absolute per-row effect estimate ``tau(x)``
+    :param m_hat: cross-fit outcome prediction ``E[Y|X]``
+    :param e_hat: cross-fit propensity ``E[T|X]``
+    :param mu0: baseline (un-upgraded) expected power ``m_hat - e_hat * tau``
+    :param outcome_model: outcome model refit on all rows (for feature importance)
+    :param effect_model: the fitted effect model ``tau(x)`` (for feature importance)
+    """
+
+    tau: npt.NDArray[np.float64]
+    m_hat: npt.NDArray[np.float64]
+    e_hat: npt.NDArray[np.float64]
+    mu0: npt.NDArray[np.float64]
+    outcome_model: Any
+    effect_model: Any
+
+
+def cross_fit_rlearner(
+    x: pd.DataFrame,
+    *,
+    y: npt.ArrayLike,
+    t: npt.ArrayLike,
+    make_outcome: Callable[[], Any],
+    make_propensity: Callable[[], Any],
+    make_effect: Callable[[], Any],
+    n_folds: int = 5,
+    seed: int = 0,
+) -> RLearnerFit:
+    """Cross-fit R-learner; returns per-row ``tau``/``m_hat``/``e_hat``/``mu0`` and fitted models.
+
+    ``y`` and ``t`` must be finite (the caller filters downtime/NaN rows); ``x`` may contain NaN.
+    """
+    y = np.asarray(y, dtype=float)
+    t = np.asarray(t, dtype=float)
+    n = len(y)
+    if not (np.isfinite(y).all() and np.isfinite(t).all()):
+        msg = "cross_fit_rlearner requires finite y and t; filter NaN/downtime rows before calling."
+        raise ValueError(msg)
+
+    m_hat = np.empty(n)
+    e_hat = np.empty(n)
+    folds = KFold(n_splits=n_folds, shuffle=True, random_state=seed)
+    for train_idx, test_idx in folds.split(x):
+        x_tr, x_te = x.iloc[train_idx], x.iloc[test_idx]
+        m_hat[test_idx] = make_outcome().fit(x_tr, y[train_idx]).predict(x_te)
+        e_hat[test_idx] = make_propensity().fit(x_tr, t[train_idx]).predict_proba(x_te)[:, 1]
+
+    y_res = y - m_hat
+    t_res = t - e_hat
+    weights = t_res**2
+    usable = np.abs(t_res) >= _MIN_T_RES
+    pseudo = np.where(usable, y_res / np.where(usable, t_res, 1.0), 0.0)
+
+    effect_model = make_effect()
+    effect_model.fit(x.iloc[usable], pseudo[usable], sample_weight=weights[usable])
+    tau = effect_model.predict(x)
+
+    # Refit the outcome on all rows so feature importance reflects one model over the full data.
+    outcome_model = make_outcome().fit(x, y)
+
+    mu0 = m_hat - e_hat * tau
+    return RLearnerFit(
+        tau=tau, m_hat=m_hat, e_hat=e_hat, mu0=mu0, outcome_model=outcome_model, effect_model=effect_model
+    )

--- a/benchmarking/baselines/study_overnight_prepost.py
+++ b/benchmarking/baselines/study_overnight_prepost.py
@@ -1,0 +1,65 @@
+"""Longer (overnight) PREPOST study: oracle + naive + R-learner + v0 over seven upgrade profiles.
+
+Run on a server from the repo root::
+
+    uv run python -m benchmarking.baselines.study_overnight_prepost
+
+Outputs (per-profile leaderboards with uplift bias/spread/score and wall-time, the tidy
+per-replicate results, per-method campaign-length curves, and each method's per-run
+diagnostics) are written under ``WIND_UP_BENCHMARKING_OUTPUT_DIR`` (default
+``~/temp/wind-up-benchmarking/prepost``). The first run downloads + caches the Hill of Towie
+SCADA (Zenodo) and ERA5 (Open-Meteo, needs the ``era5`` group); install the ``ml`` group too
+for the R-learner (lightgbm).
+
+Tune runtime vs precision with the two constants below. v0 (a full wind_up run per campaign)
+and the R-learner are the cost; oracle and naive are ~free.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from benchmarking.baselines.example_prepost_study import (
+    DEFAULT_END_DT_EXCL,
+    DEFAULT_START_DT,
+    DEFAULT_TREATMENT_START_RANGE,
+    DEFAULT_TURBINE_SUBSET,
+    DEFAULT_WTG_NUMBERS,
+    MIN_PRE_MONTHS,
+    run_prepost_study,
+)
+from benchmarking.baselines.overnight_profiles import overnight_profiles
+from benchmarking.harness import StudyConfig
+from benchmarking.synthetic.sources.hill_of_towie import load_hot_scada
+
+logger = logging.getLogger(__name__)
+
+# --- tune these two for the runtime budget -------------------------------------------------
+N_REPLICATES = 4  # (turbine, treatment-start) draws per profile; the precision axis
+CAMPAIGN_MONTHS = [3, 6, 12]  # campaign-length sweep grid
+# -------------------------------------------------------------------------------------------
+
+
+def main() -> None:
+    """Load real Hill of Towie SCADA and run the overnight prepost study (incl. v0)."""
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+    scada_df, _ = load_hot_scada(
+        start_dt=DEFAULT_START_DT,
+        end_dt_excl=DEFAULT_END_DT_EXCL,
+        wtg_numbers=DEFAULT_WTG_NUMBERS,
+        wtg_names=DEFAULT_TURBINE_SUBSET,
+    )
+    study = StudyConfig(
+        mode="prepost",
+        turbine_subset=DEFAULT_TURBINE_SUBSET,
+        treatment_start_range=DEFAULT_TREATMENT_START_RANGE,
+        min_pre_months=MIN_PRE_MONTHS,
+        campaign_months=CAMPAIGN_MONTHS,
+        n_replicates=N_REPLICATES,
+        seed=0,
+    )
+    run_prepost_study(scada_df, profiles=overnight_profiles(), study=study, include_v0=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarking/baselines/study_overnight_prepost.py
+++ b/benchmarking/baselines/study_overnight_prepost.py
@@ -26,8 +26,10 @@ from benchmarking.baselines.example_prepost_study import (
     DEFAULT_TURBINE_SUBSET,
     DEFAULT_WTG_NUMBERS,
     MIN_PRE_MONTHS,
+    default_output_root,
     run_prepost_study,
 )
+from benchmarking.baselines.overnight_common import start_overnight_run
 from benchmarking.baselines.overnight_profiles import overnight_profiles
 from benchmarking.harness import StudyConfig
 from benchmarking.synthetic.sources.hill_of_towie import load_hot_scada
@@ -42,13 +44,6 @@ CAMPAIGN_MONTHS = [3, 6, 12]  # campaign-length sweep grid
 
 def main() -> None:
     """Load real Hill of Towie SCADA and run the overnight prepost study (incl. v0)."""
-    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
-    scada_df, _ = load_hot_scada(
-        start_dt=DEFAULT_START_DT,
-        end_dt_excl=DEFAULT_END_DT_EXCL,
-        wtg_numbers=DEFAULT_WTG_NUMBERS,
-        wtg_names=DEFAULT_TURBINE_SUBSET,
-    )
     study = StudyConfig(
         mode="prepost",
         turbine_subset=DEFAULT_TURBINE_SUBSET,
@@ -58,7 +53,14 @@ def main() -> None:
         n_replicates=N_REPLICATES,
         seed=0,
     )
-    run_prepost_study(scada_df, profiles=overnight_profiles(), study=study, include_v0=True)
+    out_dir = start_overnight_run("prepost", study, output_root=default_output_root().parent)
+    scada_df, _ = load_hot_scada(
+        start_dt=DEFAULT_START_DT,
+        end_dt_excl=DEFAULT_END_DT_EXCL,
+        wtg_numbers=DEFAULT_WTG_NUMBERS,
+        wtg_names=DEFAULT_TURBINE_SUBSET,
+    )
+    run_prepost_study(scada_df, profiles=overnight_profiles(), study=study, out_root=out_dir, include_v0=True)
 
 
 if __name__ == "__main__":

--- a/benchmarking/baselines/study_overnight_toggle.py
+++ b/benchmarking/baselines/study_overnight_toggle.py
@@ -1,0 +1,65 @@
+"""Longer (overnight) TOGGLE study: oracle + naive + R-learner + v0 over seven upgrade profiles.
+
+Run on a server from the repo root::
+
+    uv run python -m benchmarking.baselines.study_overnight_toggle
+
+Same seven profiles and outputs as the prepost study (see
+:mod:`benchmarking.baselines.study_overnight_prepost`), but with a 20-min-on / 20-min-off
+toggle. Outputs go under ``WIND_UP_BENCHMARKING_OUTPUT_DIR/toggle`` (default
+``~/temp/wind-up-benchmarking/toggle``). The naive and R-learner methods fit the interleaved
+on/off campaign window only (``toggle_campaign_only`` default), so on and off share a wind
+distribution.
+
+Tune runtime vs precision with the two constants below.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from benchmarking.baselines.example_prepost_study import (
+    DEFAULT_END_DT_EXCL,
+    DEFAULT_START_DT,
+    DEFAULT_TREATMENT_START_RANGE,
+    DEFAULT_TURBINE_SUBSET,
+    DEFAULT_WTG_NUMBERS,
+    MIN_PRE_MONTHS,
+)
+from benchmarking.baselines.example_toggle_study import DEFAULT_TOGGLE_PERIOD, run_toggle_study
+from benchmarking.baselines.overnight_profiles import overnight_profiles
+from benchmarking.harness import StudyConfig
+from benchmarking.synthetic.sources.hill_of_towie import load_hot_scada
+
+logger = logging.getLogger(__name__)
+
+# --- tune these two for the runtime budget -------------------------------------------------
+N_REPLICATES = 4  # (turbine, treatment-start) draws per profile; the precision axis
+CAMPAIGN_MONTHS = [3, 6, 9, 12]  # toggling-duration sweep grid
+# -------------------------------------------------------------------------------------------
+
+
+def main() -> None:
+    """Load real Hill of Towie SCADA and run the overnight toggle study (incl. v0)."""
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+    scada_df, _ = load_hot_scada(
+        start_dt=DEFAULT_START_DT,
+        end_dt_excl=DEFAULT_END_DT_EXCL,
+        wtg_numbers=DEFAULT_WTG_NUMBERS,
+        wtg_names=DEFAULT_TURBINE_SUBSET,
+    )
+    study = StudyConfig(
+        mode="toggle",
+        turbine_subset=DEFAULT_TURBINE_SUBSET,
+        treatment_start_range=DEFAULT_TREATMENT_START_RANGE,
+        min_pre_months=MIN_PRE_MONTHS,
+        campaign_months=CAMPAIGN_MONTHS,
+        toggle_period=DEFAULT_TOGGLE_PERIOD,
+        n_replicates=N_REPLICATES,
+        seed=0,
+    )
+    run_toggle_study(scada_df, profiles=overnight_profiles(), study=study, include_v0=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarking/baselines/study_overnight_toggle.py
+++ b/benchmarking/baselines/study_overnight_toggle.py
@@ -26,7 +26,12 @@ from benchmarking.baselines.example_prepost_study import (
     DEFAULT_WTG_NUMBERS,
     MIN_PRE_MONTHS,
 )
-from benchmarking.baselines.example_toggle_study import DEFAULT_TOGGLE_PERIOD, run_toggle_study
+from benchmarking.baselines.example_toggle_study import (
+    DEFAULT_TOGGLE_PERIOD,
+    default_output_root,
+    run_toggle_study,
+)
+from benchmarking.baselines.overnight_common import start_overnight_run
 from benchmarking.baselines.overnight_profiles import overnight_profiles
 from benchmarking.harness import StudyConfig
 from benchmarking.synthetic.sources.hill_of_towie import load_hot_scada
@@ -41,13 +46,6 @@ CAMPAIGN_MONTHS = [3, 6, 9, 12]  # toggling-duration sweep grid
 
 def main() -> None:
     """Load real Hill of Towie SCADA and run the overnight toggle study (incl. v0)."""
-    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
-    scada_df, _ = load_hot_scada(
-        start_dt=DEFAULT_START_DT,
-        end_dt_excl=DEFAULT_END_DT_EXCL,
-        wtg_numbers=DEFAULT_WTG_NUMBERS,
-        wtg_names=DEFAULT_TURBINE_SUBSET,
-    )
     study = StudyConfig(
         mode="toggle",
         turbine_subset=DEFAULT_TURBINE_SUBSET,
@@ -58,7 +56,14 @@ def main() -> None:
         n_replicates=N_REPLICATES,
         seed=0,
     )
-    run_toggle_study(scada_df, profiles=overnight_profiles(), study=study, include_v0=True)
+    out_dir = start_overnight_run("toggle", study, output_root=default_output_root().parent)
+    scada_df, _ = load_hot_scada(
+        start_dt=DEFAULT_START_DT,
+        end_dt_excl=DEFAULT_END_DT_EXCL,
+        wtg_numbers=DEFAULT_WTG_NUMBERS,
+        wtg_names=DEFAULT_TURBINE_SUBSET,
+    )
+    run_toggle_study(scada_df, profiles=overnight_profiles(), study=study, out_root=out_dir, include_v0=True)
 
 
 if __name__ == "__main__":

--- a/benchmarking/harness/leaderboard.py
+++ b/benchmarking/harness/leaderboard.py
@@ -20,7 +20,9 @@ def leaderboard(results_df: pd.DataFrame) -> pd.DataFrame:
     Only overall-uplift rows (``condition == "overall"``) are summarised; per-condition rows are
     excluded. Returns one row per group with ``bias``, ``spread``, ``score``, the mean recovered
     and true uplift (``mean_estimate`` / ``mean_truth``, when those columns are present in the
-    input) and ``n_replicates``, sorted by method, profile then campaign length.
+    input), ``n_replicates``, and the group's wall time (``wall_time_s_sum`` total and
+    ``wall_time_s_mean`` per run, when ``wall_time_s`` is present), sorted by method, profile then
+    campaign length.
     """
     overall = results_df[results_df["condition"] == "overall"] if "condition" in results_df else results_df
 
@@ -36,7 +38,19 @@ def leaderboard(results_df: pd.DataFrame) -> pd.DataFrame:
                 "mean_estimate": float(group["estimate"].mean()) if "estimate" in group else float("nan"),
                 "mean_truth": float(group["truth"].mean()) if "truth" in group else float("nan"),
                 "n_replicates": summary.n,
+                "wall_time_s_sum": float(group["wall_time_s"].sum()) if "wall_time_s" in group else float("nan"),
+                "wall_time_s_mean": float(group["wall_time_s"].mean()) if "wall_time_s" in group else float("nan"),
             }
         )
-    columns = [*_GROUP_KEYS, "bias", "spread", "score", "mean_estimate", "mean_truth", "n_replicates"]
+    columns = [
+        *_GROUP_KEYS,
+        "bias",
+        "spread",
+        "score",
+        "mean_estimate",
+        "mean_truth",
+        "n_replicates",
+        "wall_time_s_sum",
+        "wall_time_s_mean",
+    ]
     return pd.DataFrame(records, columns=columns)

--- a/benchmarking/harness/leaderboard.py
+++ b/benchmarking/harness/leaderboard.py
@@ -38,7 +38,9 @@ def leaderboard(results_df: pd.DataFrame) -> pd.DataFrame:
                 "mean_estimate": float(group["estimate"].mean()) if "estimate" in group else float("nan"),
                 "mean_truth": float(group["truth"].mean()) if "truth" in group else float("nan"),
                 "n_replicates": summary.n,
-                "wall_time_s_sum": float(group["wall_time_s"].sum()) if "wall_time_s" in group else float("nan"),
+                "wall_time_s_sum": float(group["wall_time_s"].sum(min_count=1))
+                if "wall_time_s" in group
+                else float("nan"),
                 "wall_time_s_mean": float(group["wall_time_s"].mean()) if "wall_time_s" in group else float("nan"),
             }
         )

--- a/benchmarking/harness/scoring.py
+++ b/benchmarking/harness/scoring.py
@@ -17,6 +17,7 @@ long-format DataFrame, the input to the leaderboard and plots.
 
 from __future__ import annotations
 
+import time
 from typing import TYPE_CHECKING
 
 import pandas as pd
@@ -72,7 +73,9 @@ def score_study(
         method_rows = []
         for (replicate, window), truth in zip(instances, truths, strict=True):
             method_input = _method_input(replicate, window)
+            start = time.perf_counter()
             output = method.estimate(method_input)
+            wall_time_s = time.perf_counter() - start
             method_rows.append(
                 {
                     "method": method.name,
@@ -87,6 +90,7 @@ def score_study(
                     "estimate": output.p50_overall,
                     "truth": truth,
                     "signed_error": output.p50_overall - truth,
+                    "wall_time_s": wall_time_s,
                 }
             )
         if on_method_complete is not None:

--- a/docs/v1/findings.md
+++ b/docs/v1/findings.md
@@ -1,0 +1,89 @@
+# wind-up v1 — findings log
+
+Empirical findings from the v1 benchmarking work. Newest first. Each entry records what was
+observed, the evidence, the root cause, and what (if anything) it implies for the method design
+or the issues list. Keep entries reproducible: name the study driver and the diagnostics they came
+from, not just conclusions.
+
+---
+
+## F1 — The R-learner is accurate in toggle but fails in prepost (overlap/confounding)
+
+*2026-06-26 — Issue 5 (cross-fit R-learner). Source: the overnight studies
+`benchmarking/baselines/study_overnight_{toggle,prepost}.py` over the seven shared
+`overnight_profiles`, `n_replicates=4`, campaign sweep 3/6/(9)/12 months, incl. v0.*
+
+### Observation
+In **toggle** the R-learner is excellent — it tracks the oracle and matches or beats v0. In
+**prepost** it is badly biased, and the error grows with the magnitude of the true effect (it
+amplifies). Mean P50 estimate vs truth, 3-month campaign:
+
+| profile | truth | toggle rlearner | prepost rlearner |
+|---|---|---|---|
+| cp_0pct (placebo) | 0.000 | +0.003 | **−0.158** |
+| cp_plus_3pct | 0.020 | 0.023 | **−0.010** |
+| cp_plus_10pct | 0.068 | 0.072 | **+0.763** |
+| cp_minus_10pct | −0.068 | −0.066 | **−0.359** |
+| ws_dependent_cp | 0.033 | 0.036 | +0.123 |
+
+Toggle bias is ~0.001–0.003 with tiny spread; prepost overshoots (+10% → +76%, −10% → −36%) and
+even the 0% placebo reads −16%. Longer campaigns shrink but do not fix it (cp_plus_10pct prepost:
+0.76 → 0.33 → 0.19 at 3/6/12 months). By contrast v0 holds prepost bias to ~−0.006 to −0.014.
+
+### Evidence — the propensity diagnostic
+From the per-run `results` / `data_stats` CSVs (same test turbine, same upgrade window):
+
+- **Toggle:** `propensity_mean ≈ 0.500`, `propensity_std ≈ 0.11`. Baseline and upgraded both span
+  the same dates (interleaved 20-on/20-off), so they share a weather distribution. Propensity ≈ 0.5
+  everywhere → the treatment residual `t − e_hat` is healthy → the R-learner collapses to clean
+  regression adjustment. This is the regime it is designed for (design note §4).
+- **Prepost:** `propensity_mean ≈ 0.11`, `propensity_std ≈ 0.27`. The `data_stats` show why:
+  **baseline ≈ 2 years (2016→2018), upgraded ≈ one 3-month season (early 2018)**. Treatment is a
+  deterministic function of calendar time, against a long, season-mismatched baseline.
+
+### Root cause
+This is an identifiability problem, not a bug. There are no timestamp features (by design — shuffled
+K-fold cross-fitting assumes it), so in prepost the only contrast available is across time. That
+breaks the estimator two ways, both visible in the diagnostics:
+
+1. **Overlap / positivity failure.** The propensity model partially reconstructs "is this the
+   upgraded season?" from seasonally-varying reference features (`std 0.27`, far from the flat 0.11
+   base rate). Where `e_hat` drifts toward the upgraded window, `t_res → 0`, the pseudo-outcome
+   `y_res / t_res` blows up, the `t_res²` weights concentrate on a few high-leverage rows, and the
+   effect model extrapolates — producing the variance explosion and the magnitude-scaling bias.
+2. **Unmodelled non-stationarity → confounding.** The outcome model `m(x) = E[Y|X]` is pooled over
+   the long baseline but never forms a *test-vs-reference contrast*. Any drift in the test turbine's
+   power relative to the references over those two years (seasonal `Y|X` shifts, air density, icing,
+   direction/wake differences between a winter-heavy baseline and the specific post season) lands in
+   the post-window residual and, because treatment ≡ time, is attributed straight to `tau`. The
+   placebo −16% is pure confounding with no real effect.
+
+v0 survives prepost precisely because it differences the test/reference power ratio and detrends,
+cancelling the common-mode drift the R-learner leaves in.
+
+### Implications / candidate directions (not yet actioned)
+In rough order of expected leverage:
+
+1. **Give the R-learner a test-vs-reference contrast** (the v0 lever): model the test/reference
+   power *ratio* (or difference) as the outcome so common-mode seasonal/long-term drift cancels
+   before the ML sees it. Largest expected win for prepost.
+2. **Match the baseline window to the post window** (same season, comparable length) rather than
+   pooling the full multi-year history — reduces non-stationarity, though it does not restore
+   within-`X` overlap.
+3. **Treat the R-learner as a randomised-treatment (toggle) method.** Consistent with the design
+   note framing (it collapses to regression adjustment when the propensity is flat), the honest
+   Phase-1 conclusion may be: R-learner for toggle, v0/reference-ratio for prepost — with the
+   prepost overlap failure documented as a finding.
+
+Relative to Issue 5's "done when" (P50 similar/better than v0 in both prepost and toggle): **met for
+toggle, not met for prepost.**
+
+### Secondary observations from these runs
+- **Stale outputs intermixed.** The earlier output directories carried `leaderboard_all_profiles.csv`
+  and several per-profile files from an older study (no rlearner rows, old profile names, a 9-month
+  grid) alongside the fresh overnight outputs. Addressed by writing each run to a fresh timestamped
+  folder with a `run.log` recording the git commit and study config
+  (`benchmarking/baselines/overnight_common.py`, wired into both overnight scripts).
+- **Both overnight runs were truncated** (ran out of wall-clock on the slow v0 step, not a crash):
+  prepost completed 5 of 7 profiles, toggle 6 of 7. With `include_v0=True`, v0 dominates the budget
+  (~hours per profile vs seconds for rlearner/naive) — see the "skip v0 in initial passes" note.

--- a/docs/v1/issues.md
+++ b/docs/v1/issues.md
@@ -127,7 +127,7 @@ its accuracy/precision appears in the leaderboard.
 - Score on the harness across all synthetic profiles and the short-campaign sweep;
   compare to naive first (fast), then the v0 baseline after naive is beaten.
 - Uncertainty/P95 explicitly **out of scope** here (Phase 3 / WS4) but keep it in mind.
-- Reporting uplift by condition (eg uplift by wind speed, direction, etc) out of scope for now but keep it in find
+- Reporting uplift by condition (eg uplift by wind speed, direction, etc) out of scope for now but keep it in mind
 
 **Done when:** the R-learner runs through a prepost and toggle study and its P50 accuracy/precision vs the baseline is recorded in the leaderboard and similar or better than v0.
 

--- a/docs/v1/issues.md
+++ b/docs/v1/issues.md
@@ -110,23 +110,26 @@ its accuracy/precision appears in the leaderboard.
 
 ## Issue 5 — First candidate: cross-fit R-learner (P50) (WS2)
 
-**Goal:** implement the design-note R-learner as the first new method behind the
-Issue 4 interface and score it against the baseline.
+**Goal:** implement the design-note R-learner as the first new method and score it against the baselines (naive and v0).
 
 **Scope**
 - Cross-fit R-learner producing a P50 uplift, per the design note
   (LightGBM outcome [L2/Huber] + propensity nuisances; effect model on residuals).
+- Be sure to provide rich csvs and diagnostic plots; look at Naive for inspiration and grow from there depending on the method details
+- There should be no restrictions / limitations on what data is provided (v0 dependency removed from harness in previous PR). To start with just provide the same data columns that v0 gets to prove the method is superior; even more data columns (eg all Min and Max fields) can be provided later
+- Provide ERA5 data to the method as well. It will need to be upsampled to 10min timebase. Use a wind speed correlation sweep to sync with the SCADA (see existing wind-up code for inspiration)
 - **Treatment-invariant reference-only features** — enforced; include a regression
   test on a deliberately treatment-corrupted nacelle wind speed proving the
   reference-only rule removes the post-treatment bias (design note §8). Reference
   turbines affected by the wakes of upgraded turbines may need to be excluded in
   certain wind directions (very relevant for wake steering).
+- Another known feature to avoid is voltage (at the turbine's external connection); if the turbines are wired in series then the voltage drop across the test turbine will be approximately proportional to its active power, so if the method can see the voltage at the two turbines either side of the test turbine then estimating power is trivial and the power estimate is not using information about the weather. The giveaway that this issue is happening is feature importance; make sure feature importance diagnostic plots and log messages are emitted.
 - Score on the harness across all synthetic profiles and the short-campaign sweep;
-  compare to the v0 baseline.
-- Uncertainty/P95 explicitly **out of scope** here (Phase 3 / WS4).
+  compare to naive first (fast), then the v0 baseline after naive is beaten.
+- Uncertainty/P95 explicitly **out of scope** here (Phase 3 / WS4) but keep it in mind.
+- Reporting uplift by condition (eg uplift by wind speed, direction, etc) out of scope for now but keep it in find
 
-**Done when:** the R-learner runs through the contract, the bias-guard test passes,
-and its P50 accuracy/precision vs the baseline is recorded in the leaderboard.
+**Done when:** the R-learner runs through a prepost and toggle study and its P50 accuracy/precision vs the baseline is recorded in the leaderboard and similar or better than v0.
 
 ---
 

--- a/docs/v1/issues.md
+++ b/docs/v1/issues.md
@@ -141,3 +141,13 @@ its accuracy/precision appears in the leaderboard.
   Phase 2).
 - Conditional/heterogeneous uplift reporting & SHAP story (G3, Phase 2).
 - Report content generation and I/O / step-independence maturation (WS5, Phase 4).
+- **Method-controlled baseline horizon / recency weighting (R-learner).** Today the R-learner
+  pools *all* pre-upgrade baseline it is given (e.g. 24 months) into the nuisance fits with equal
+  weight, and uses no timestamp features, so it cannot down-weight stale data. Since the goal is
+  usually the upgrade's *future* benefit, the most recent baseline is the most representative of
+  the farm's future state, and far-past data (turbine ageing, sensor drift, soiling, controller
+  changes) is less so. Add a method-owned horizon control — a `max_baseline_months` cap and/or an
+  exponential recency weight on the fit (via LightGBM `sample_weight`) — so the method, not the
+  harness, decides how far back to trust. Keep it compatible with the no-timestamp-feature rule
+  (weighting/selection by recency is fine; calendar features are not) and the block bootstrap.
+  Pairs naturally with the long-term ERA5 extrapolation work (representativeness weighting, WS4).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,10 @@ era5 = [
     'requests-cache',
     'retry-requests',
 ]
+ml = [
+    'lightgbm',
+    'scikit-learn',
+]
 examples = [
     'jupyterlab',
     'notebook',
@@ -80,6 +84,8 @@ dev = [
     'openmeteo-requests',
     'requests-cache',
     'retry-requests',
+    'lightgbm',
+    'scikit-learn',
 ]
 
 [tool.setuptools.packages.find]

--- a/tests/benchmarking/baselines/test_naive_ratio.py
+++ b/tests/benchmarking/baselines/test_naive_ratio.py
@@ -341,3 +341,38 @@ class TestDiagnostics:
         self._run(tmp_path)
         run_dir = next(p for p in Path(tmp_path).iterdir() if p.is_dir())
         assert not (run_dir / "plots").exists()
+
+
+class TestToggleCampaignOnly:
+    """``toggle_campaign_only`` restricts a toggle fit to the campaign window (drops pre-campaign)."""
+
+    def _toggle_scada(self) -> tuple[pd.DataFrame, ToggleSchedule, pd.Timestamp]:
+        idx = _index(300)
+        start = idx[100]  # 100 pre-campaign rows, then 200 rows of interleaved on/off
+        schedule = ToggleSchedule(period=pd.Timedelta(minutes=20), start=start)
+        treated = np.asarray(treated_mask(idx, schedule))
+        return _recovery_scada(idx, treated=treated, uplift=0.05), schedule, start
+
+    def test_campaign_only_excludes_precampaign_from_baseline(self, tmp_path) -> None:  # noqa: ANN001
+        scada, schedule, start = self._toggle_scada()
+        NaiveRatioMethod(active_power_col=_POWER_COL, out_dir=tmp_path / "on").estimate(
+            MethodInput(scada_df=scada, test_wtg="T1", upgrade_timing=schedule, turbine_col=_TURBINE_COL)
+        )
+        NaiveRatioMethod(active_power_col=_POWER_COL, out_dir=tmp_path / "off", toggle_campaign_only=False).estimate(
+            MethodInput(scada_df=scada, test_wtg="T1", upgrade_timing=schedule, turbine_col=_TURBINE_COL)
+        )
+        base_on = _read_only_csv(tmp_path / "on", "data_stats").set_index("segment").loc["baseline"]
+        base_off = _read_only_csv(tmp_path / "off", "data_stats").set_index("segment").loc["baseline"]
+        # campaign-only drops the 100 pre-campaign rows from the baseline class
+        assert base_on["n_used_timestamps"] < base_off["n_used_timestamps"]
+        assert pd.Timestamp(base_on["first_timestamp"]) >= start
+
+    def test_prepost_unaffected_by_flag(self) -> None:
+        idx = _index(20)
+        upgrade = idx[10]
+        treated = np.asarray(idx >= upgrade)
+        scada = _recovery_scada(idx, treated=treated, uplift=0.05)
+        mi = MethodInput(scada_df=scada, test_wtg="T1", upgrade_timing=upgrade, turbine_col=_TURBINE_COL)
+        a = NaiveRatioMethod(active_power_col=_POWER_COL).estimate(mi)
+        b = NaiveRatioMethod(active_power_col=_POWER_COL, toggle_campaign_only=False).estimate(mi)
+        assert a.p50_overall == pytest.approx(b.p50_overall)

--- a/tests/benchmarking/baselines/test_rlearner_bias_guard.py
+++ b/tests/benchmarking/baselines/test_rlearner_bias_guard.py
@@ -1,0 +1,119 @@
+"""The design-note §8 bias-guard regression test.
+
+The upgrade distorts the test turbine's own nacelle wind speed (a post-treatment variable,
+design note §3). This test proves the upgrade-invariant reference-only feature rule removes the
+resulting bias, and guards against anyone re-adding a test-turbine signal to the feature set:
+
+* a model that (wrongly) conditions on the corrupted test wind speed reports a materially biased
+  effect (the post-treatment signal both leaks the treatment into the covariate and destroys
+  propensity overlap);
+* the reference-only R-learner recovers the known uplift despite the same corrupted signal;
+* the feature builder's guard rejects a test-turbine-qualified feature outright.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from benchmarking.baselines.rlearner.features import QUALIFIER, build_reference_features, check_upgrade_invariant
+from benchmarking.baselines.rlearner.method import RLearnerMethod
+from benchmarking.baselines.rlearner.rlearner import cross_fit_rlearner
+from benchmarking.harness.method import MethodInput
+
+_TURBINE = "TurbineName"
+_POWER = "wtc_ActPower_mean"
+_WS = "wtc_AcWindSp_mean"
+_SMALL = {"n_estimators": 120, "num_leaves": 15, "min_child_samples": 20, "verbose": -1}
+_UPLIFT = 0.05
+
+
+def _index(n: int) -> pd.DatetimeIndex:
+    return pd.date_range("2020-01-01", periods=n, freq="10min", tz="UTC", name="timestamp")
+
+
+def _corrupted_scada(idx: pd.DatetimeIndex, treated: np.ndarray) -> pd.DataFrame:
+    """SCADA with a known uplift AND a test wind speed corrupted by the upgrade (post-treatment).
+
+    The test turbine's measured wind speed is shifted hard whenever it is upgraded, so the signal
+    effectively encodes the treatment — the textbook post-treatment trap.
+    """
+    rng = np.random.default_rng(0)
+    w = rng.uniform(4.0, 12.0, len(idx))  # true free-stream wind
+    frames = []
+    for name in ("T1", "R1", "R2"):
+        ws = w + rng.normal(0, 0.2, len(idx))
+        power = 80.0 * w + rng.normal(0, 5.0, len(idx))
+        if name == "T1":
+            power = np.where(treated, power * (1.0 + _UPLIFT), power)
+            ws = ws - 100.0 * treated  # upgrade corrupts the test anemometer (post-treatment)
+        frames.append(pd.DataFrame({_TURBINE: name, _POWER: power, _WS: ws}, index=idx))
+    return pd.concat(frames)
+
+
+def _headline(x: pd.DataFrame, *, y: np.ndarray, t: np.ndarray) -> float:
+    fit = cross_fit_rlearner(x, y=y, t=t, n_folds=4, seed=0, **_factories())
+    up = t.astype(bool)
+    return float(np.sum(fit.tau[up]) / np.sum(fit.mu0[up]))
+
+
+def _factories() -> dict:
+    from benchmarking.baselines.rlearner.nuisance import (  # noqa: PLC0415
+        make_effect_model,
+        make_outcome_model,
+        make_propensity_model,
+    )
+
+    return {
+        "make_outcome": lambda: make_outcome_model(**_SMALL),
+        "make_propensity": lambda: make_propensity_model(**_SMALL),
+        "make_effect": lambda: make_effect_model(**_SMALL),
+    }
+
+
+def test_conditioning_on_test_ws_biases_estimate() -> None:
+    # Demonstration: leaking the corrupted test wind speed gives a materially wrong uplift,
+    # while the reference-only feature set recovers the true 5%.
+    idx = _index(3000)
+    upgrade = idx[1500]
+    treated = np.asarray(idx >= upgrade)
+    scada = _corrupted_scada(idx, treated)
+
+    x_ref = build_reference_features(scada, test_wtg="T1", turbine_col=_TURBINE)
+    y = scada.loc[scada[_TURBINE] == "T1", _POWER].to_numpy(dtype=float)
+    t = treated.astype(float)
+
+    x_leaky = x_ref.copy()
+    x_leaky["LEAKED_test_ws"] = scada.loc[scada[_TURBINE] == "T1", _WS].to_numpy(dtype=float)
+
+    ref_only = _headline(x_ref, y=y, t=t)
+    leaky = _headline(x_leaky, y=y, t=t)
+
+    assert ref_only == pytest.approx(_UPLIFT, abs=0.015)  # reference-only is correct
+    assert abs(leaky - _UPLIFT) > 0.03  # leaking the post-treatment signal gives a materially wrong answer
+
+
+def test_method_recovers_uplift_despite_corrupted_test_ws(tmp_path) -> None:  # noqa: ANN001
+    # The full method never reads the test turbine's signals, so the corruption is harmless.
+    idx = _index(3000)
+    upgrade = idx[1500]
+    treated = np.asarray(idx >= upgrade)
+    scada = _corrupted_scada(idx, treated)
+    out = RLearnerMethod(
+        active_power_col=_POWER, wind_speed_col=_WS, out_dir=tmp_path, n_folds=4, model_params=_SMALL
+    ).estimate(MethodInput(scada_df=scada, test_wtg="T1", upgrade_timing=upgrade, turbine_col=_TURBINE))
+    assert out.p50_overall == pytest.approx(_UPLIFT, abs=0.015)
+
+
+def test_feature_builder_never_includes_test_turbine() -> None:
+    idx = _index(200)
+    treated = np.asarray(idx >= idx[100])
+    scada = _corrupted_scada(idx, treated)
+    x = build_reference_features(scada, test_wtg="T1", turbine_col=_TURBINE)
+    assert not any(c.endswith(f"{QUALIFIER}T1") for c in x.columns)
+
+
+def test_guard_rejects_a_test_turbine_feature() -> None:
+    with pytest.raises(ValueError, match="upgrade-invariant"):
+        check_upgrade_invariant([f"{_WS}{QUALIFIER}T1"], test_wtg="T1")

--- a/tests/benchmarking/baselines/test_rlearner_core.py
+++ b/tests/benchmarking/baselines/test_rlearner_core.py
@@ -1,0 +1,132 @@
+"""Tests for the cross-fit R-learner core and its LightGBM nuisance factories.
+
+The core is pure (no I/O): given a feature matrix ``X``, outcome ``y`` and upgrade flag ``t``
+it returns per-row ``tau``, ``m_hat``, ``e_hat`` and ``mu0`` plus the fitted outcome/effect
+models. These tests use generous synthetic data so the recovered effect is unambiguous,
+covering the toggle-like (flat propensity) and confounded (before/after-like) regimes.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from benchmarking.baselines.rlearner.nuisance import (
+    make_effect_model,
+    make_outcome_model,
+    make_propensity_model,
+)
+from benchmarking.baselines.rlearner.rlearner import RLearnerFit, cross_fit_rlearner
+
+
+def _small_models() -> dict:
+    """Fast, quiet LightGBM factories for tests (few trees, no logging)."""
+    params = {"n_estimators": 80, "num_leaves": 15, "min_child_samples": 20, "verbose": -1}
+    return {
+        "make_outcome": lambda: make_outcome_model(**params),
+        "make_propensity": lambda: make_propensity_model(**params),
+        "make_effect": lambda: make_effect_model(**params),
+    }
+
+
+class TestNuisanceFactories:
+    def test_outcome_is_regressor_that_predicts(self) -> None:
+        rng = np.random.default_rng(0)
+        x = pd.DataFrame({"f": rng.normal(size=200)})
+        y = 3.0 * x["f"]
+        model = make_outcome_model(n_estimators=50, verbose=-1).fit(x, y)
+        assert model.predict(x).shape == (200,)
+
+    def test_propensity_predicts_probability(self) -> None:
+        rng = np.random.default_rng(1)
+        x = pd.DataFrame({"f": rng.normal(size=200)})
+        t = (x["f"] > 0).astype(int)
+        model = make_propensity_model(n_estimators=50, verbose=-1).fit(x, t)
+        proba = model.predict_proba(x)[:, 1]
+        assert ((proba >= 0) & (proba <= 1)).all()
+
+
+class TestCrossFitRLearner:
+    def test_recovers_constant_effect_with_flat_propensity(self) -> None:
+        # toggle-like: t is random (propensity ~0.5); y = mu0(x) + tau*t + small noise
+        rng = np.random.default_rng(0)
+        n = 3000
+        x = rng.uniform(0, 1, size=n)
+        x_df = pd.DataFrame({"ref_ws": x})
+        mu0 = 10.0 * x
+        t = rng.binomial(1, 0.5, size=n)
+        tau_true = 2.0
+        y = mu0 + tau_true * t + rng.normal(0, 0.1, size=n)
+        fit = cross_fit_rlearner(x_df, y=y, t=t, n_folds=4, seed=0, **_small_models())
+        assert isinstance(fit, RLearnerFit)
+        assert float(np.mean(fit.tau)) == pytest.approx(tau_true, abs=0.3)
+        assert float(np.mean(fit.e_hat)) == pytest.approx(0.5, abs=0.05)
+
+    def test_recovers_effect_under_confounding(self) -> None:
+        # before/after-like: t is confounded with x but stochastic, so overlap (positivity) holds.
+        # The upgraded period over-samples high-wind conditions; a naive treated-minus-baseline
+        # difference is badly biased, but the R-learner recovers tau by partialling x out of both.
+        rng = np.random.default_rng(1)
+        n = 5000
+        x = rng.uniform(0, 1, size=n)
+        x_df = pd.DataFrame({"ref_ws": x})
+        mu0 = 10.0 * x
+        propensity = 0.2 + 0.6 * x  # in (0.2, 0.8): confounded with x but always overlapping
+        t = rng.binomial(1, propensity)
+        tau_true = 2.0
+        y = mu0 + tau_true * t + rng.normal(0, 0.1, size=n)
+        naive_diff = y[t == 1].mean() - y[t == 0].mean()
+        assert naive_diff > 3.5  # confirm the naive estimate really is badly biased high
+        fit = cross_fit_rlearner(x_df, y=y, t=t, n_folds=5, seed=0, **_small_models())
+        assert float(np.mean(fit.tau)) == pytest.approx(tau_true, abs=0.5)
+
+    def test_placebo_reports_zero_effect_flat_propensity(self) -> None:
+        # a placebo upgrade (no real effect) must report ~0 uplift, not a spurious one.
+        rng = np.random.default_rng(10)
+        n = 4000
+        x = rng.uniform(0, 1, size=n)
+        x_df = pd.DataFrame({"ref_ws": x})
+        t = rng.binomial(1, 0.5, size=n)
+        y = 10.0 * x + rng.normal(0, 0.1, size=n)  # no tau*t term
+        fit = cross_fit_rlearner(x_df, y=y, t=t, n_folds=4, seed=0, **_small_models())
+        tau_mean = float(np.mean(fit.tau))
+        assert tau_mean == pytest.approx(0.0, abs=0.2)
+        # the headline aggregation (sum tau / sum mu0) is also ~0
+        assert float(np.sum(fit.tau) / np.sum(fit.mu0)) == pytest.approx(0.0, abs=0.05)
+
+    def test_placebo_reports_zero_effect_under_confounding(self) -> None:
+        # placebo with the upgraded period over-sampling high wind: still ~0, no covariate-shift bias.
+        rng = np.random.default_rng(11)
+        n = 5000
+        x = rng.uniform(0, 1, size=n)
+        x_df = pd.DataFrame({"ref_ws": x})
+        t = rng.binomial(1, 0.2 + 0.6 * x)
+        y = 10.0 * x + rng.normal(0, 0.1, size=n)  # no real effect
+        naive_diff = y[t == 1].mean() - y[t == 0].mean()
+        assert naive_diff > 1.5  # naive would wrongly report a large positive "uplift"
+        fit = cross_fit_rlearner(x_df, y=y, t=t, n_folds=5, seed=0, **_small_models())
+        assert float(np.sum(fit.tau) / np.sum(fit.mu0)) == pytest.approx(0.0, abs=0.05)
+
+    def test_mu0_identity_holds(self) -> None:
+        rng = np.random.default_rng(2)
+        n = 1500
+        x = rng.uniform(0, 1, size=n)
+        x_df = pd.DataFrame({"ref_ws": x})
+        t = rng.binomial(1, 0.5, size=n)
+        y = 10.0 * x + 2.0 * t + rng.normal(0, 0.1, size=n)
+        fit = cross_fit_rlearner(x_df, y=y, t=t, n_folds=4, seed=0, **_small_models())
+        # mu0 = m_hat - e_hat * tau by construction
+        assert fit.mu0 == pytest.approx(fit.m_hat - fit.e_hat * fit.tau)
+
+    def test_handles_nan_features(self) -> None:
+        # LightGBM handles NaN natively; the core must not choke on NaN in X.
+        rng = np.random.default_rng(3)
+        n = 1500
+        x = rng.uniform(0, 1, size=n)
+        x_df = pd.DataFrame({"ref_ws": x, "noisy": rng.normal(size=n)})
+        x_df.loc[x_df.index[:50], "noisy"] = np.nan
+        t = rng.binomial(1, 0.5, size=n)
+        y = 10.0 * x + 2.0 * t + rng.normal(0, 0.1, size=n)
+        fit = cross_fit_rlearner(x_df, y=y, t=t, n_folds=4, seed=0, **_small_models())
+        assert np.isfinite(fit.tau).all()

--- a/tests/benchmarking/baselines/test_rlearner_end_to_end.py
+++ b/tests/benchmarking/baselines/test_rlearner_end_to_end.py
@@ -1,0 +1,101 @@
+"""Slow end-to-end tests: the R-learner on HoT-derived synthetic datasets via the harness.
+
+Downloads the Hill of Towie v2 SCADA (Zenodo) and ERA5 (Open-Meteo), injects a known
+constant-Cp uplift, and scores ``RLearnerMethod`` and an oracle through the harness on real
+data in both prepost and toggle modes. v0 is deliberately not exercised here (a real wind_up
+run per campaign is far too slow). Marked ``slow`` (network + model fitting); skipped by
+``-m "not slow"``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from benchmarking.baselines.hot_context import build_hot_v0_context
+from benchmarking.baselines.rlearner import RLearnerMethod
+from benchmarking.harness import StudyConfig, score_study
+from benchmarking.harness.example_hot_study import OracleMethod
+from benchmarking.synthetic import HOT_COLUMNS, ConstantCpChange
+from benchmarking.synthetic.sources.hill_of_towie import load_hot_scada
+
+_SUBSET = ["T01", "T03", "T04", "T07"]
+_WTG_NUMBERS = [1, 3, 4, 7]
+_FAST_MODEL = {"n_estimators": 200, "verbose": -1}
+
+
+def _rlearner(tmp_path) -> RLearnerMethod:  # noqa: ANN001
+    context = build_hot_v0_context(wtg_names=_SUBSET)
+    return RLearnerMethod(
+        active_power_col=HOT_COLUMNS.active_power,
+        wind_speed_col=HOT_COLUMNS.wind_speed,
+        era5_hourly_df=context.reanalysis_datasets[0].data,
+        out_dir=tmp_path / "rlearner_runs",
+        model_params=_FAST_MODEL,
+    )
+
+
+@pytest.mark.slow
+def test_rlearner_recovers_prepost_uplift(tmp_path) -> None:  # noqa: ANN001
+    scada_df, _ = load_hot_scada(
+        start_dt=pd.Timestamp("2016-01-01", tz="UTC"),
+        end_dt_excl=pd.Timestamp("2021-01-01", tz="UTC"),
+        wtg_numbers=_WTG_NUMBERS,
+        wtg_names=_SUBSET,
+    )
+    study = StudyConfig(
+        mode="prepost",
+        turbine_subset=_SUBSET,
+        treatment_start_range=(pd.Timestamp("2019-01-01", tz="UTC"), pd.Timestamp("2019-01-08", tz="UTC")),
+        min_pre_months=24,
+        campaign_months=[6],
+        n_replicates=1,
+        seed=0,
+    )
+    results = score_study(
+        scada_df,
+        profile=[ConstantCpChange(delta=0.05)],
+        methods=[_rlearner(tmp_path), OracleMethod(scada_df)],
+        study=study,
+        profile_name="constant_cp_prepost",
+    )
+    oracle_row = results.loc[results["method"] == "oracle"].iloc[0]
+    rlearner_row = results.loc[results["method"] == "rlearner"].iloc[0]
+    assert abs(oracle_row["signed_error"]) < 1e-6
+    assert rlearner_row["truth"] > 0
+    assert np.isfinite(rlearner_row["estimate"])
+    assert abs(rlearner_row["signed_error"]) < 0.03
+
+
+@pytest.mark.slow
+def test_rlearner_recovers_toggle_uplift(tmp_path) -> None:  # noqa: ANN001
+    scada_df, _ = load_hot_scada(
+        start_dt=pd.Timestamp("2016-01-01", tz="UTC"),
+        end_dt_excl=pd.Timestamp("2018-09-01", tz="UTC"),
+        wtg_numbers=_WTG_NUMBERS,
+        wtg_names=_SUBSET,
+    )
+    study = StudyConfig(
+        mode="toggle",
+        turbine_subset=_SUBSET,
+        treatment_start_range=(pd.Timestamp("2018-02-01", tz="UTC"), pd.Timestamp("2018-02-08", tz="UTC")),
+        min_pre_months=24,
+        campaign_months=[6],
+        toggle_period=pd.Timedelta(minutes=40),
+        n_replicates=1,
+        seed=0,
+    )
+    results = score_study(
+        scada_df,
+        profile=[ConstantCpChange(delta=0.05)],
+        methods=[_rlearner(tmp_path), OracleMethod(scada_df)],
+        study=study,
+        profile_name="constant_cp_toggle",
+    )
+    oracle_row = results.loc[results["method"] == "oracle"].iloc[0]
+    rlearner_row = results.loc[results["method"] == "rlearner"].iloc[0]
+    assert abs(oracle_row["signed_error"]) < 1e-6
+    assert rlearner_row["truth"] > 0
+    assert np.isfinite(rlearner_row["estimate"])
+    assert abs(rlearner_row["signed_error"]) < 0.03

--- a/tests/benchmarking/baselines/test_rlearner_era5_sync.py
+++ b/tests/benchmarking/baselines/test_rlearner_era5_sync.py
@@ -1,0 +1,102 @@
+"""Tests for the R-learner ERA5 sync helper.
+
+ERA5 arrives hourly; SCADA is 10-min. These cover the upsample to the analysis timebase
+and the wind-speed correlation lag sweep that aligns ERA5 to the SCADA, on small
+hand-built frames (no network).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from benchmarking.baselines.rlearner.era5_sync import (
+    ERA5_WD,
+    ERA5_WS,
+    Era5SyncResult,
+    find_best_lag,
+    sync_era5,
+    upsample_era5_to_timebase,
+)
+
+_RAW_WS = "wind_speed_100m"
+_RAW_WD = "wind_direction_100m"
+
+
+def _hourly(n: int, *, start: str = "2020-01-01") -> pd.DataFrame:
+    idx = pd.date_range(start=start, periods=n, freq="1h", tz="UTC", name="timestamp")
+    return pd.DataFrame(
+        {_RAW_WS: np.arange(n, dtype=float) + 1.0, _RAW_WD: np.linspace(0.0, 90.0, n)},
+        index=idx,
+    )
+
+
+class TestUpsample:
+    def test_expands_to_ten_minute_grid(self) -> None:
+        out = upsample_era5_to_timebase(_hourly(3), timebase=pd.Timedelta(minutes=10))
+        # 3 hours -> 00:00..02:50 on a 10-min grid = 18 rows (last hour's 5 trailing slots filled)
+        assert len(out) == 18
+        assert out.index.freq is None or len(out) == 18
+
+    def test_renames_to_neutral_columns(self) -> None:
+        out = upsample_era5_to_timebase(_hourly(2), timebase=pd.Timedelta(minutes=10))
+        assert set(out.columns) == {ERA5_WS, ERA5_WD}
+
+    def test_forward_fills_within_the_hour(self) -> None:
+        out = upsample_era5_to_timebase(_hourly(2), timebase=pd.Timedelta(minutes=10))
+        # first hour's six 10-min slots all carry the first hour's raw value (1.0)
+        assert out[ERA5_WS].to_numpy()[:6] == pytest.approx(1.0)
+        assert out[ERA5_WS].to_numpy()[6:12] == pytest.approx(2.0)
+
+
+class TestFindBestLag:
+    def test_recovers_known_positive_lag(self) -> None:
+        idx = pd.date_range("2020-01-01", periods=300, freq="10min", tz="UTC")
+        rng = np.random.default_rng(0)
+        era5_ws = pd.Series(rng.normal(8.0, 2.0, size=len(idx)), index=idx)
+        # reference lags ERA5 by 3 rows: reference[t] == era5[t-3]
+        reference_ws = era5_ws.shift(3)
+        best_lag, best_corr, sweep = find_best_lag(
+            reference_ws=reference_ws, era5_ws=era5_ws, timebase=pd.Timedelta(minutes=10)
+        )
+        assert best_lag == 3
+        assert best_corr == pytest.approx(1.0, abs=1e-6)
+        assert {"shift_rows", "corr"} <= set(sweep.columns)
+
+    def test_zero_lag_when_aligned(self) -> None:
+        idx = pd.date_range("2020-01-01", periods=300, freq="10min", tz="UTC")
+        rng = np.random.default_rng(1)
+        era5_ws = pd.Series(rng.normal(8.0, 2.0, size=len(idx)), index=idx)
+        best_lag, _, _ = find_best_lag(reference_ws=era5_ws.copy(), era5_ws=era5_ws, timebase=pd.Timedelta(minutes=10))
+        assert best_lag == 0
+
+
+class TestSyncEra5:
+    def test_returns_aligned_frame_on_target_index(self) -> None:
+        target = pd.date_range("2020-01-01 00:00", periods=120, freq="10min", tz="UTC")
+        # 24 hours of ERA5 covering the target window
+        era5 = _hourly(24)
+        rng = np.random.default_rng(2)
+        reference_ws = pd.Series(rng.normal(8.0, 2.0, size=len(target)), index=target)
+        result = sync_era5(era5, target_index=target, reference_ws=reference_ws)
+        assert isinstance(result, Era5SyncResult)
+        assert list(result.aligned.columns) == [ERA5_WS, ERA5_WD]
+        assert result.aligned.index.equals(target)
+
+    def test_applies_recovered_lag_to_columns(self) -> None:
+        target = pd.date_range("2020-01-01 00:00", periods=144, freq="10min", tz="UTC")
+        # random (non-monotonic) hourly ws so the lag is identifiable
+        hourly_idx = pd.date_range("2020-01-01", periods=36, freq="1h", tz="UTC", name="timestamp")
+        rng = np.random.default_rng(3)
+        era5 = pd.DataFrame(
+            {_RAW_WS: rng.normal(8.0, 2.0, size=36), _RAW_WD: rng.uniform(0.0, 360.0, size=36)},
+            index=hourly_idx,
+        )
+        up = upsample_era5_to_timebase(era5, timebase=pd.Timedelta(minutes=10)).reindex(target)
+        # reference lags the upsampled ERA5 ws by 2 rows -> sync should shift ERA5 forward by 2
+        reference_ws = up[ERA5_WS].shift(2)
+        result = sync_era5(era5, target_index=target, reference_ws=reference_ws)
+        assert result.best_lag_rows == 2
+        expected = up[ERA5_WS].shift(2)
+        pd.testing.assert_series_equal(result.aligned[ERA5_WS], expected, check_names=False)

--- a/tests/benchmarking/baselines/test_rlearner_features.py
+++ b/tests/benchmarking/baselines/test_rlearner_features.py
@@ -1,0 +1,129 @@
+"""Tests for the R-learner upgrade-invariant feature builder.
+
+The builder turns long source-native SCADA into a wide feature matrix from reference
+turbines only (never the test turbine's own signals), keeping original tag names, plus the
+outcome/treatment extraction, the ERA5 sin/cos transform, the enforcement guard, and the
+(currently no-op) feature-engineering seam.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from benchmarking.baselines.rlearner.era5_sync import ERA5_WD, ERA5_WS
+from benchmarking.baselines.rlearner.features import (
+    QUALIFIER,
+    build_reference_features,
+    check_upgrade_invariant,
+    engineered_reference_features,
+    era5_features,
+    extract_outcome_and_treatment,
+)
+from benchmarking.synthetic import ToggleSchedule, treated_mask
+
+_TURBINE = "TurbineName"
+_POWER = "wtc_ActPower_mean"
+_WS = "wtc_AcWindSp_mean"
+
+
+def _index(n: int) -> pd.DatetimeIndex:
+    return pd.date_range("2020-01-01", periods=n, freq="10min", tz="UTC", name="timestamp")
+
+
+def _scada(idx: pd.DatetimeIndex) -> pd.DataFrame:
+    """Long SCADA with test T1 and references R1, R2, each carrying power + wind speed."""
+    rng = np.random.default_rng(0)
+    frames = [
+        pd.DataFrame(
+            {_TURBINE: name, _POWER: rng.normal(800, 100, len(idx)), _WS: rng.normal(8, 2, len(idx))},
+            index=idx,
+        )
+        for name in ("T1", "R1", "R2")
+    ]
+    return pd.concat(frames)
+
+
+class TestBuildReferenceFeatures:
+    def test_includes_only_reference_turbines(self) -> None:
+        idx = _index(12)
+        feats = build_reference_features(_scada(idx), test_wtg="T1", turbine_col=_TURBINE)
+        # two references x two value columns = four feature columns; none for T1
+        assert len(feats.columns) == 4
+        assert not any(c.endswith(f"{QUALIFIER}T1") for c in feats.columns)
+        assert feats.index.equals(idx)
+
+    def test_keeps_original_tag_names(self) -> None:
+        idx = _index(12)
+        feats = build_reference_features(_scada(idx), test_wtg="T1", turbine_col=_TURBINE)
+        assert f"{_POWER}{QUALIFIER}R1" in feats.columns
+        assert f"{_WS}{QUALIFIER}R2" in feats.columns
+
+    def test_preserves_nan_rows(self) -> None:
+        idx = _index(12)
+        scada = _scada(idx)
+        scada.loc[(scada[_TURBINE] == "R1") & (scada.index == idx[3]), _WS] = np.nan
+        feats = build_reference_features(scada, test_wtg="T1", turbine_col=_TURBINE)
+        # the NaN is preserved (no complete-case dropping) and the row is kept
+        assert len(feats) == len(idx)
+        assert np.isnan(feats.loc[idx[3], f"{_WS}{QUALIFIER}R1"])
+
+    def test_raises_when_no_references(self) -> None:
+        idx = _index(12)
+        only_test = _scada(idx)
+        only_test = only_test[only_test[_TURBINE] == "T1"]
+        with pytest.raises(ValueError, match="reference"):
+            build_reference_features(only_test, test_wtg="T1", turbine_col=_TURBINE)
+
+
+class TestGuard:
+    def test_rejects_test_turbine_column(self) -> None:
+        names = [f"{_POWER}{QUALIFIER}R1", f"{_WS}{QUALIFIER}T1"]
+        with pytest.raises(ValueError, match="upgrade-invariant"):
+            check_upgrade_invariant(names, test_wtg="T1")
+
+    def test_passes_reference_only_columns(self) -> None:
+        names = [f"{_POWER}{QUALIFIER}R1", f"{_WS}{QUALIFIER}R2"]
+        check_upgrade_invariant(names, test_wtg="T1")  # no raise
+
+
+class TestOutcomeTreatment:
+    def test_prepost_outcome_and_treatment(self) -> None:
+        idx = _index(20)
+        scada = _scada(idx)
+        upgrade = idx[10]
+        y, t = extract_outcome_and_treatment(
+            scada, test_wtg="T1", turbine_col=_TURBINE, active_power_col=_POWER, upgrade_timing=upgrade
+        )
+        expected_y = scada.loc[scada[_TURBINE] == "T1", _POWER]
+        assert y.to_numpy() == pytest.approx(expected_y.to_numpy())
+        assert t.to_numpy().tolist() == [0] * 10 + [1] * 10
+
+    def test_toggle_treatment(self) -> None:
+        idx = _index(40)
+        scada = _scada(idx)
+        schedule = ToggleSchedule(period=pd.Timedelta(minutes=20), start=idx[0])
+        _, t = extract_outcome_and_treatment(
+            scada, test_wtg="T1", turbine_col=_TURBINE, active_power_col=_POWER, upgrade_timing=schedule
+        )
+        assert t.to_numpy().tolist() == np.asarray(treated_mask(idx, schedule)).astype(int).tolist()
+
+
+class TestEra5Features:
+    def test_wd_becomes_sin_cos(self) -> None:
+        idx = _index(4)
+        aligned = pd.DataFrame({ERA5_WS: [8.0, 9.0, 10.0, 11.0], ERA5_WD: [0.0, 90.0, 180.0, 270.0]}, index=idx)
+        feats = era5_features(aligned)
+        assert list(feats.columns) == [ERA5_WS, "era5_wd_sin", "era5_wd_cos"]
+        assert feats["era5_wd_sin"].to_numpy() == pytest.approx([0.0, 1.0, 0.0, -1.0], abs=1e-9)
+        assert feats["era5_wd_cos"].to_numpy() == pytest.approx([1.0, 0.0, -1.0, 0.0], abs=1e-9)
+
+
+class TestEngineeredSeam:
+    def test_currently_adds_no_columns(self) -> None:
+        idx = _index(12)
+        eng = engineered_reference_features(_scada(idx), test_wtg="T1", turbine_col=_TURBINE)
+        # the seam exists (north-corrected yaw etc. go here later) but adds nothing yet
+        assert list(eng.columns) == []
+        assert eng.index.equals(idx)

--- a/tests/benchmarking/baselines/test_rlearner_filtering.py
+++ b/tests/benchmarking/baselines/test_rlearner_filtering.py
@@ -1,0 +1,107 @@
+"""Tests for the R-learner test-turbine normal-operation filter.
+
+The outcome ``Y`` is the test turbine's power, so abnormal operation (downtime, curtailment,
+frozen/stuck sensors) unrelated to the upgrade would otherwise be attributed to it. These
+cover the stuck-data and downtime filters, and the central correctness rule: filter on
+*cause* (operational flags) never *effect* (low power).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from benchmarking.baselines.rlearner.filtering import NormalOperationFilter
+
+_POWER = "wtc_ActPower_mean"
+_WS = "wtc_AcWindSp_mean"
+_AVAIL = "wtc_ScReToOp_timeon"  # seconds ready to operate in the period
+_TIMEBASE = pd.Timedelta(minutes=10)
+_FULL = _TIMEBASE.total_seconds()  # 600s = fully available
+
+
+def _test_rows(n: int = 10) -> pd.DataFrame:
+    idx = pd.date_range("2020-01-01", periods=n, freq="10min", tz="UTC", name="timestamp")
+    rng = np.random.default_rng(0)
+    return pd.DataFrame(
+        {
+            _POWER: rng.uniform(200, 900, n),
+            _WS: rng.uniform(5, 12, n),
+            _AVAIL: np.full(n, _FULL),
+        },
+        index=idx,
+    )
+
+
+class TestDowntime:
+    def test_drops_partial_availability(self) -> None:
+        rows = _test_rows()
+        rows.loc[rows.index[2], _AVAIL] = 300.0  # only half the period available
+        keep = NormalOperationFilter(active_power_col=_POWER, availability_col=_AVAIL).keep_mask(
+            rows, timebase=_TIMEBASE
+        )
+        assert not keep.iloc[2]
+        assert keep.drop(rows.index[2]).all()
+
+    def test_drops_nan_availability(self) -> None:
+        rows = _test_rows()
+        rows.loc[rows.index[4], _AVAIL] = np.nan
+        keep = NormalOperationFilter(active_power_col=_POWER, availability_col=_AVAIL).keep_mask(
+            rows, timebase=_TIMEBASE
+        )
+        assert not keep.iloc[4]
+
+    def test_no_availability_col_keeps_all(self) -> None:
+        rows = _test_rows()
+        keep = NormalOperationFilter(active_power_col=_POWER, apply_stuck_filter=False).keep_mask(
+            rows, timebase=_TIMEBASE
+        )
+        assert keep.all()
+
+
+class TestStuckData:
+    def test_flags_frozen_rows_in_normal_wind(self) -> None:
+        rows = _test_rows()
+        # rows 5,6,7 frozen (every signal identical to row 4) in normal wind -> stuck
+        for i in (5, 6, 7):
+            rows.iloc[i] = rows.iloc[4]
+        keep = NormalOperationFilter(active_power_col=_POWER, wind_speed_col=_WS).keep_mask(rows, timebase=_TIMEBASE)
+        assert not keep.iloc[[5, 6, 7]].any()
+        assert keep.iloc[4]  # the first of the run is not itself a repeat
+
+    def test_low_wind_calm_is_not_stuck(self) -> None:
+        rows = _test_rows()
+        # frozen run but at very low wind: a genuine calm, must NOT be filtered as stuck
+        for i in (5, 6, 7):
+            rows.iloc[i] = rows.iloc[4]
+            rows.iloc[i, rows.columns.get_loc(_WS)] = 0.5
+        rows.iloc[4, rows.columns.get_loc(_WS)] = 0.5
+        keep = NormalOperationFilter(active_power_col=_POWER, wind_speed_col=_WS).keep_mask(rows, timebase=_TIMEBASE)
+        assert keep.iloc[[5, 6, 7]].all()
+
+
+class TestCauseNotEffect:
+    def test_low_power_but_normal_operation_is_kept(self) -> None:
+        # the key rule: a genuinely low-power record that is fully available and not stuck must be
+        # KEPT. Filtering it (because power is low) would remove real low-uplift records and bias.
+        rows = _test_rows()
+        rows.loc[rows.index[3], _POWER] = 5.0  # very low power, but available and not frozen
+        keep = NormalOperationFilter(active_power_col=_POWER, wind_speed_col=_WS, availability_col=_AVAIL).keep_mask(
+            rows, timebase=_TIMEBASE
+        )
+        assert keep.iloc[3]
+
+    def test_nan_power_is_dropped(self) -> None:
+        rows = _test_rows()
+        rows.loc[rows.index[6], _POWER] = np.nan
+        keep = NormalOperationFilter(active_power_col=_POWER).keep_mask(rows, timebase=_TIMEBASE)
+        assert not keep.iloc[6]
+
+
+class TestReturnType:
+    def test_keep_mask_is_boolean_series_on_index(self) -> None:
+        rows = _test_rows()
+        keep = NormalOperationFilter(active_power_col=_POWER).keep_mask(rows, timebase=_TIMEBASE)
+        assert isinstance(keep, pd.Series)
+        assert keep.index.equals(rows.index)
+        assert keep.dtype == bool

--- a/tests/benchmarking/baselines/test_rlearner_method.py
+++ b/tests/benchmarking/baselines/test_rlearner_method.py
@@ -1,0 +1,128 @@
+"""End-to-end tests for RLearnerMethod behind the harness Method seam.
+
+Small, weather-driven SCADA where the reference turbines predict the test turbine's power, so
+the R-learner can recover an injected uplift. Covers prepost and toggle recovery, the headline
+aggregation, the written diagnostics, and the ERA5-free path.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from benchmarking.baselines.rlearner.method import RLearnerMethod
+from benchmarking.harness.method import MethodInput, MethodOutput
+from benchmarking.synthetic import ToggleSchedule, treated_mask
+
+_TURBINE = "TurbineName"
+_POWER = "wtc_ActPower_mean"
+_WS = "wtc_AcWindSp_mean"
+_SMALL = {"n_estimators": 120, "num_leaves": 15, "min_child_samples": 20, "verbose": -1}
+
+
+def _index(n: int) -> pd.DatetimeIndex:
+    return pd.date_range("2020-01-01", periods=n, freq="10min", tz="UTC", name="timestamp")
+
+
+def _weather_scada(idx: pd.DatetimeIndex, *, treated: np.ndarray, uplift: float) -> pd.DataFrame:
+    """Long SCADA: a shared wind drives every turbine; the test turbine is lifted when treated."""
+    rng = np.random.default_rng(0)
+    w = rng.uniform(4.0, 12.0, len(idx))  # shared free-stream wind
+    frames = []
+    for name in ("T1", "R1", "R2"):
+        ws = w + rng.normal(0, 0.2, len(idx))
+        power = 80.0 * w + rng.normal(0, 5.0, len(idx))
+        if name == "T1":
+            power = np.where(treated, power * (1.0 + uplift), power)
+        frames.append(pd.DataFrame({_TURBINE: name, _POWER: power, _WS: ws}, index=idx))
+    return pd.concat(frames)
+
+
+def _method(tmp_path: Path) -> RLearnerMethod:
+    return RLearnerMethod(
+        active_power_col=_POWER,
+        wind_speed_col=_WS,
+        out_dir=tmp_path,
+        n_folds=4,
+        model_params=_SMALL,
+        seed=0,
+    )
+
+
+class TestRecovery:
+    def test_prepost_recovers_uplift(self, tmp_path: Path) -> None:
+        idx = _index(3000)
+        upgrade = idx[1500]
+        treated = np.asarray(idx >= upgrade)
+        scada = _weather_scada(idx, treated=treated, uplift=0.03)
+        out = _method(tmp_path).estimate(
+            MethodInput(scada_df=scada, test_wtg="T1", upgrade_timing=upgrade, turbine_col=_TURBINE)
+        )
+        assert isinstance(out, MethodOutput)
+        assert out.p50_overall == pytest.approx(0.03, abs=0.012)
+        assert out.p50_by_condition is None
+
+    def test_toggle_recovers_uplift(self, tmp_path: Path) -> None:
+        idx = _index(3000)
+        schedule = ToggleSchedule(period=pd.Timedelta(minutes=20), start=idx[0])
+        treated = np.asarray(treated_mask(idx, schedule))
+        scada = _weather_scada(idx, treated=treated, uplift=0.03)
+        out = _method(tmp_path).estimate(
+            MethodInput(scada_df=scada, test_wtg="T1", upgrade_timing=schedule, turbine_col=_TURBINE)
+        )
+        assert out.p50_overall == pytest.approx(0.03, abs=0.012)
+
+    def test_placebo_reports_near_zero(self, tmp_path: Path) -> None:
+        idx = _index(3000)
+        upgrade = idx[1500]
+        treated = np.asarray(idx >= upgrade)
+        scada = _weather_scada(idx, treated=treated, uplift=0.0)
+        out = _method(tmp_path).estimate(
+            MethodInput(scada_df=scada, test_wtg="T1", upgrade_timing=upgrade, turbine_col=_TURBINE)
+        )
+        assert out.p50_overall == pytest.approx(0.0, abs=0.01)
+
+
+def _read_one(folder: Path, kind: str) -> pd.DataFrame:
+    run_dirs = [p for p in Path(folder).iterdir() if p.is_dir()]
+    assert len(run_dirs) == 1, f"expected one run dir, found {run_dirs}"
+    matches = list(run_dirs[0].glob(f"*_{kind}_*.csv"))
+    assert len(matches) == 1, f"expected one {kind} csv, found {matches}"
+    return pd.read_csv(matches[0])
+
+
+class TestDiagnostics:
+    def _run(self, tmp_path: Path, *, save_plots: bool = False) -> MethodOutput:
+        idx = _index(2000)
+        upgrade = idx[1000]
+        treated = np.asarray(idx >= upgrade)
+        scada = _weather_scada(idx, treated=treated, uplift=0.03)
+        method = RLearnerMethod(
+            active_power_col=_POWER,
+            wind_speed_col=_WS,
+            out_dir=tmp_path,
+            n_folds=4,
+            model_params=_SMALL,
+            save_plots=save_plots,
+        )
+        return method.estimate(MethodInput(scada_df=scada, test_wtg="T1", upgrade_timing=upgrade, turbine_col=_TURBINE))
+
+    def test_writes_results_and_stats_and_importance(self, tmp_path: Path) -> None:
+        out = self._run(tmp_path)
+        results = _read_one(tmp_path, "results")
+        stats = _read_one(tmp_path, "data_stats")
+        importance = _read_one(tmp_path, "feature_importance")
+        assert results["uplift_frc"].iloc[0] == pytest.approx(out.p50_overall)
+        assert sorted(stats["segment"]) == ["all", "baseline", "upgraded"]
+        # feature importance names the original reference tags (no test turbine columns)
+        assert importance["feature"].str.contains("R1").any()
+        assert not importance["feature"].str.endswith("T1").any()
+
+    def test_save_plots_writes_pngs(self, tmp_path: Path) -> None:
+        self._run(tmp_path, save_plots=True)
+        run_dir = next(p for p in Path(tmp_path).iterdir() if p.is_dir())
+        pngs = {p.name for p in (run_dir / "plots").glob("*.png")}
+        assert pngs  # at least the feature-importance plot

--- a/tests/benchmarking/baselines/test_rlearner_method.py
+++ b/tests/benchmarking/baselines/test_rlearner_method.py
@@ -126,3 +126,37 @@ class TestDiagnostics:
         run_dir = next(p for p in Path(tmp_path).iterdir() if p.is_dir())
         pngs = {p.name for p in (run_dir / "plots").glob("*.png")}
         assert pngs  # at least the feature-importance plot
+
+
+class TestToggleCampaignOnly:
+    """A toggle fit restricted to the campaign window has a balanced (~0.5) propensity."""
+
+    def _toggle_scada(self) -> tuple[pd.DataFrame, ToggleSchedule]:
+        idx = _index(3000)
+        start = idx[1500]  # 1500 pre-campaign rows, then 1500 rows of interleaved on/off
+        schedule = ToggleSchedule(period=pd.Timedelta(minutes=20), start=start)
+        treated = np.asarray(treated_mask(idx, schedule))
+        return _weather_scada(idx, treated=treated, uplift=0.03), schedule
+
+    def test_campaign_only_balances_propensity_and_recovers(self, tmp_path: Path) -> None:
+        scada, schedule = self._toggle_scada()
+        mi = MethodInput(scada_df=scada, test_wtg="T1", upgrade_timing=schedule, turbine_col=_TURBINE)
+        out_on = RLearnerMethod(
+            active_power_col=_POWER, wind_speed_col=_WS, out_dir=tmp_path / "on", n_folds=4, model_params=_SMALL
+        ).estimate(mi)
+        RLearnerMethod(
+            active_power_col=_POWER,
+            wind_speed_col=_WS,
+            out_dir=tmp_path / "off",
+            n_folds=4,
+            model_params=_SMALL,
+            toggle_campaign_only=False,
+        ).estimate(mi)
+        res_on = _read_one(tmp_path / "on", "results").iloc[0]
+        res_off = _read_one(tmp_path / "off", "results").iloc[0]
+        # campaign-only: ~50/50 on/off so propensity centres near 0.5; full-window dilutes it with
+        # 1500 pre-campaign baseline rows, dragging the mean propensity well below 0.5.
+        assert res_on["propensity_mean"] == pytest.approx(0.5, abs=0.12)
+        assert res_on["propensity_mean"] > res_off["propensity_mean"]
+        assert res_on["n_selected"] < res_off["n_selected"]
+        assert out_on.p50_overall == pytest.approx(0.03, abs=0.015)

--- a/tests/benchmarking/harness/test_leaderboard.py
+++ b/tests/benchmarking/harness/test_leaderboard.py
@@ -66,6 +66,22 @@ def test_mean_estimate_and_truth_are_averaged() -> None:
     assert row["mean_truth"] == pytest.approx(0.05)
 
 
+def test_wall_time_is_summed_and_averaged_per_group() -> None:
+    results = _results(
+        [
+            {"campaign_months": 3, "signed_error": 0.0, "wall_time_s": 1.5},
+            {"campaign_months": 3, "signed_error": 0.0, "wall_time_s": 2.5},
+            {"campaign_months": 6, "signed_error": 0.0, "wall_time_s": 4.0},
+        ]
+    )
+    summary = leaderboard(results).set_index("campaign_months")
+    # total compute for the group, and the typical per-run cost
+    assert summary.loc[3, "wall_time_s_sum"] == pytest.approx(4.0)
+    assert summary.loc[3, "wall_time_s_mean"] == pytest.approx(2.0)
+    assert summary.loc[6, "wall_time_s_sum"] == pytest.approx(4.0)
+    assert summary.loc[6, "wall_time_s_mean"] == pytest.approx(4.0)
+
+
 def test_methods_are_compared_side_by_side() -> None:
     results = pd.DataFrame(
         [

--- a/tests/benchmarking/harness/test_scoring.py
+++ b/tests/benchmarking/harness/test_scoring.py
@@ -58,6 +58,14 @@ def test_results_have_one_row_per_method_replicate_and_campaign_length() -> None
     assert set(results.columns) >= expected_columns
 
 
+def test_results_record_wall_time_per_run() -> None:
+    base = _base_scada()
+    results = score_study(base, profile=PROFILE, methods=[OracleMethod(base)], study=_study(n_replicates=1))
+    assert "wall_time_s" in results.columns
+    assert results["wall_time_s"].notna().all()
+    assert (results["wall_time_s"] >= 0).all()
+
+
 def test_results_record_the_window_boundaries_per_replicate() -> None:
     base = _base_scada()
     results = score_study(base, profile=PROFILE, methods=[OracleMethod(base)], study=_study(n_replicates=1))
@@ -168,4 +176,7 @@ def test_on_method_complete_is_optional() -> None:
         base, profile=PROFILE, methods=[OracleMethod(base)], study=_study(), on_method_complete=lambda _n, _d: None
     )
     without_cb = score_study(base, profile=PROFILE, methods=[OracleMethod(base)], study=_study())
-    pd.testing.assert_frame_equal(with_cb, without_cb)
+    # wall_time_s is measured per run, so it differs between two runs; the callback must not change
+    # anything else.
+    drop = ["wall_time_s"]
+    pd.testing.assert_frame_equal(with_cb.drop(columns=drop), without_cb.drop(columns=drop))

--- a/uv.lock
+++ b/uv.lock
@@ -2681,10 +2681,16 @@ examples = [
     { name = "notebook" },
     { name = "requests" },
 ]
+ml = [
+    { name = "lightgbm" },
+    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scikit-learn", version = "1.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
 
 [package.dev-dependencies]
 dev = [
     { name = "coverage" },
+    { name = "lightgbm" },
     { name = "mypy" },
     { name = "openmeteo-requests" },
     { name = "poethepoet" },
@@ -2694,6 +2700,8 @@ dev = [
     { name = "requests-cache" },
     { name = "retry-requests" },
     { name = "ruff" },
+    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scikit-learn", version = "1.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "types-pyyaml" },
     { name = "types-requests" },
     { name = "types-tabulate" },
@@ -2709,6 +2717,7 @@ requires-dist = [
     { name = "geographiclib" },
     { name = "ipywidgets", marker = "extra == 'examples'" },
     { name = "jupyterlab", marker = "extra == 'examples'" },
+    { name = "lightgbm", marker = "extra == 'ml'" },
     { name = "matplotlib" },
     { name = "notebook", marker = "extra == 'examples'" },
     { name = "openmeteo-requests", marker = "extra == 'era5'" },
@@ -2721,6 +2730,7 @@ requires-dist = [
     { name = "requests-cache", marker = "extra == 'era5'" },
     { name = "retry-requests", marker = "extra == 'era5'" },
     { name = "ruptures" },
+    { name = "scikit-learn", marker = "extra == 'ml'" },
     { name = "scipy" },
     { name = "seaborn" },
     { name = "tabulate" },
@@ -2728,11 +2738,12 @@ requires-dist = [
     { name = "tqdm" },
     { name = "utm" },
 ]
-provides-extras = ["era5", "examples"]
+provides-extras = ["era5", "ml", "examples"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "coverage" },
+    { name = "lightgbm" },
     { name = "mypy", specifier = "<1.19" },
     { name = "openmeteo-requests" },
     { name = "poethepoet" },
@@ -2742,6 +2753,7 @@ dev = [
     { name = "requests-cache" },
     { name = "retry-requests" },
     { name = "ruff" },
+    { name = "scikit-learn" },
     { name = "types-pyyaml" },
     { name = "types-requests" },
     { name = "types-tabulate" },


### PR DESCRIPTION

## Issue 5 — First candidate: cross-fit R-learner (P50) (WS2)

**Goal:** implement the design-note R-learner as the first new method and score it against the baselines (naive and v0).
**Scope**
- Cross-fit R-learner producing a P50 uplift, per the design note
  (LightGBM outcome [L2/Huber] + propensity nuisances; effect model on residuals).
- Be sure to provide rich csvs and diagnostic plots; look at Naive for inspiration and grow from there depending on the method details
- There should be no restrictions / limitations on what data is provided (v0 dependency removed from harness in previous PR). To start with just provide the same data columns that v0 gets to prove the method is superior; even more data columns (eg all Min and Max fields) can be provided later
- Provide ERA5 data to the method as well. It will need to be upsampled to 10min timebase. Use a wind speed correlation sweep to sync with the SCADA (see existing wind-up code for inspiration)
- **Treatment-invariant reference-only features** — enforced; include a regression
  test on a deliberately treatment-corrupted nacelle wind speed proving the
  reference-only rule removes the post-treatment bias (design note §8). Reference
  turbines affected by the wakes of upgraded turbines may need to be excluded in
  certain wind directions (very relevant for wake steering).
- Another known feature to avoid is voltage (at the turbine's external connection); if the turbines are wired in series then the voltage drop across the test turbine will be approximately proportional to its active power, so if the method can see the voltage at the two turbines either side of the test turbine then estimating power is trivial and the power estimate is not using information about the weather. The giveaway that this issue is happening is feature importance; make sure feature importance diagnostic plots and log messages are emitted.
- Score on the harness across all synthetic profiles and the short-campaign sweep;
  compare to naive first (fast), then the v0 baseline after naive is beaten.
- Uncertainty/P95 explicitly **out of scope** here (Phase 3 / WS4) but keep it in mind.
- Reporting uplift by condition (eg uplift by wind speed, direction, etc) out of scope for now but keep it in find

**Done when:** the R-learner runs through a prepost and toggle study and its P50 accuracy/precision vs the baseline is recorded in the leaderboard and similar or better than v0.
