### PR TITLE
establish power_model baseline performance

### DIFF
--- a/benchmarking/baselines/inspect_prepost_feature_ablation.py
+++ b/benchmarking/baselines/inspect_prepost_feature_ablation.py
@@ -92,7 +92,7 @@ def inspect_prepost_feature_ablation() -> pd.DataFrame:
         wtg_numbers=DEFAULT_WTG_NUMBERS,
         wtg_names=DEFAULT_TURBINE_SUBSET,
     )
-    _rep, mi, truth = _pin_case(
+    _rep, mi, truth, _window = _pin_case(
         scada_df,
         study=study,
         profile_name=DEFAULT_PROFILE,

--- a/benchmarking/baselines/inspect_prepost_hard_case.py
+++ b/benchmarking/baselines/inspect_prepost_hard_case.py
@@ -48,11 +48,15 @@ from benchmarking.baselines.overnight_profiles import overnight_profiles
 from benchmarking.baselines.power_model import PowerModelMethod
 from benchmarking.baselines.v0_binned import V0BinnedMethod
 from benchmarking.harness import (
+    CONDITION_BINS,
+    CampaignWindow,
     Method,
     MethodInput,
+    MethodOutput,
     StudyConfig,
     build_replicates,
     campaign_windows,
+    plot_conditional_uplift,
     treated_activity_mask,
     window_row_mask,
 )
@@ -106,8 +110,8 @@ def _select_replicate(replicates: list[Replicate], test_wtg: str) -> Replicate:
 
 def _pin_case(
     scada_df: pd.DataFrame, *, study: StudyConfig, profile_name: str, test_wtg: str, campaign_months: int
-) -> tuple[Replicate, MethodInput, float]:
-    """Build the pinned replicate, its shared ``MethodInput`` and the ground-truth uplift."""
+) -> tuple[Replicate, MethodInput, float, CampaignWindow]:
+    """Build the pinned replicate, its shared ``MethodInput``, the ground-truth uplift, and the window."""
     profile = overnight_profiles()[profile_name]
     replicates = build_replicates(scada_df, profile=profile, study=study)
     rep = _select_replicate(replicates, test_wtg)
@@ -145,7 +149,7 @@ def _pin_case(
         window.activity_end,
         100 * truth,
     )
-    return rep, mi, truth
+    return rep, mi, truth, window
 
 
 def _build_methods(out_dir: Path, *, include_v0: bool) -> list[Method]:
@@ -161,6 +165,7 @@ def _build_methods(out_dir: Path, *, include_v0: bool) -> list[Method]:
         PowerModelMethod(
             active_power_col=HOT_COLUMNS.active_power,
             wind_speed_col=HOT_COLUMNS.wind_speed,
+            wind_speed_sd_col=HOT_COLUMNS.wind_speed_sd,
             availability_col=HOT_COLUMNS.availability,
             era5_hourly_df=context.reanalysis_datasets[0].data,
             out_dir=out_dir / "power_model",
@@ -199,6 +204,75 @@ def _run_methods(methods: list[Method], *, mi: MethodInput, truth: float) -> pd.
     return pd.DataFrame(rows)
 
 
+def _plot_conditional_uplift(
+    rep: Replicate, mi: MethodInput, window: CampaignWindow, *, out_dir: Path, profile_name: str
+) -> None:
+    """Re-run the power model on ``mi`` and write per-condition uplift-vs-truth plots."""
+    context = build_hot_v0_context(wtg_names=DEFAULT_TURBINE_SUBSET)
+    power_model = PowerModelMethod(
+        active_power_col=HOT_COLUMNS.active_power,
+        wind_speed_col=HOT_COLUMNS.wind_speed,
+        wind_speed_sd_col=HOT_COLUMNS.wind_speed_sd,
+        availability_col=HOT_COLUMNS.availability,
+        era5_hourly_df=context.reanalysis_datasets[0].data,
+        out_dir=out_dir / "power_model_conditional",
+    )
+    pm_output = power_model.estimate(mi)
+    if pm_output.p50_by_condition is None:
+        logger.warning("power_model returned no p50_by_condition; skipping conditional uplift plots")
+        return
+
+    test_index = rep.synthetic_df.loc[rep.synthetic_df[HOT_COLUMNS.turbine] == rep.test_wtg].index
+    mask = treated_activity_mask(test_index, rep.upgrade_timing, window=window)
+    truth_by_condition = {
+        c: rep.true_uplift(mask=mask, by=c, bins=CONDITION_BINS[c]).by_condition for c in ("ws", "ti")
+    }
+    # Filter out conditions where true_uplift returned None (should not happen when bins given)
+    truth_by_condition_clean: dict[str, pd.DataFrame] = {
+        c: df for c, df in truth_by_condition.items() if df is not None
+    }
+    if not truth_by_condition_clean:
+        logger.warning("No per-condition truth available; skipping conditional uplift plots")
+        return
+
+    frame = conditional_truth_vs_estimate(pm_output, truth_by_condition_clean, method_name=power_model.name)
+    for c in truth_by_condition_clean:
+        plot_conditional_uplift(
+            frame,
+            condition=c,
+            save_path=out_dir / f"conditional_uplift_{c}.png",
+            title=f"Conditional uplift ({c}) — profile={profile_name}, wtg={mi.test_wtg}",
+        )
+    logger.info("Wrote conditional uplift plots to %s", out_dir)
+
+
+def conditional_truth_vs_estimate(
+    output: MethodOutput, truth_by_condition: dict[str, pd.DataFrame], *, method_name: str
+) -> pd.DataFrame:
+    """Shape a method's p50_by_condition + per-condition truth into a plot_conditional_uplift frame."""
+    if output.p50_by_condition is None:
+        msg = "output.p50_by_condition must not be None"
+        raise ValueError(msg)
+    frames = []
+    bc = output.p50_by_condition
+    for condition, truth in truth_by_condition.items():
+        est = bc[bc["condition"] == condition].set_index("condition_bin")["p50_uplift"]
+        t = truth.assign(condition_bin=truth["condition_bin"].astype(str)).set_index("condition_bin")["true_uplift"]
+        bins = est.index.union(t.index)
+        frames.append(
+            pd.DataFrame(
+                {
+                    "method": method_name,
+                    "condition": condition,
+                    "condition_bin": bins,
+                    "mean_estimate": est.reindex(bins).to_numpy(),
+                    "mean_truth": t.reindex(bins).to_numpy(),
+                }
+            )
+        )
+    return pd.concat(frames, ignore_index=True)
+
+
 def inspect_prepost_hard_case(
     *,
     profile_name: str = DEFAULT_PROFILE,
@@ -228,11 +302,13 @@ def inspect_prepost_hard_case(
         wtg_names=DEFAULT_TURBINE_SUBSET,
     )
 
-    _rep, mi, truth = _pin_case(
+    rep, mi, truth, window = _pin_case(
         scada_df, study=study, profile_name=profile_name, test_wtg=test_wtg, campaign_months=campaign_months
     )
     methods = _build_methods(out_dir, include_v0=include_v0)
     summary = _run_methods(methods, mi=mi, truth=truth)
+
+    _plot_conditional_uplift(rep, mi, window, out_dir=out_dir, profile_name=profile_name)
 
     summary_path = out_dir / "comparison_summary.csv"
     summary.to_csv(summary_path, index=False)

--- a/benchmarking/baselines/power_model/diagnostics.py
+++ b/benchmarking/baselines/power_model/diagnostics.py
@@ -401,7 +401,8 @@ def _binned_stats(
 def _power_bin_edges(*arrays: np.ndarray | None, n_bins: int = _RESID_POWER_BINS) -> np.ndarray:
     """Equal-width power-bin edges from 0 to the robust (99th-pct) max across the given arrays."""
     present = [np.asarray(a, dtype=float) for a in arrays if a is not None and len(a)]
-    finite = np.concatenate(present)[np.isfinite(np.concatenate(present))] if present else np.array([])
+    combined = np.concatenate(present) if present else np.array([])
+    finite = combined[np.isfinite(combined)]
     hi = float(np.nanpercentile(finite, 99)) if finite.size else 1.0
     if not np.isfinite(hi) or hi <= 0:
         hi = 1.0

--- a/benchmarking/baselines/power_model/diagnostics.py
+++ b/benchmarking/baselines/power_model/diagnostics.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any
 
 import matplotlib.pyplot as plt
 import numpy as np
+import numpy.typing as npt
 import pandas as pd
 from matplotlib.colors import Normalize
 
@@ -25,6 +26,7 @@ from benchmarking.baselines.power_model.features import QUALIFIER
 from benchmarking.diagnostics import stages
 from benchmarking.diagnostics.density import density_scatter
 from benchmarking.diagnostics.style import apply_grid, save_fig
+from benchmarking.harness.conditions import TI_BINS, WS_BINS
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -66,6 +68,9 @@ class DiagnosticData:
     era5_lag_rows: int | None
     era5_corr: float | None
     era5_sweep: pd.DataFrame | None
+    # test-turbine ws/TI row-aligned to each segment's residuals (None when no wind-speed col)
+    cond_upgraded: pd.DataFrame | None = None
+    cond_baseline_valid: pd.DataFrame | None = None
 
 
 def feature_importance_long(data: DiagnosticData) -> pd.DataFrame:
@@ -206,6 +211,7 @@ def save_plots(plots_dir: Path, data: DiagnosticData, importance: pd.DataFrame) 
     _plot_importance(model_dir, importance, test_wtg=data.test_wtg)
     _plot_predicted_vs_actual(model_dir, data)
     _plot_residual_vs_mean(model_dir, data)
+    _plot_residual_binned(model_dir, data)
 
     results_dir = plots_dir / stages.UPLIFT_RESULTS
     results_dir.mkdir(parents=True, exist_ok=True)
@@ -358,6 +364,170 @@ def _plot_residual_vs_mean(plots_dir: Path, data: DiagnosticData) -> None:
         apply_grid(ax)
     fig.suptitle(f"{data.test_wtg}: power-model residual vs mean power (Bland-Altman)")
     save_fig(fig, plots_dir / "residual_vs_mean.png")
+
+
+_RESID_POWER_BINS = 20
+_MIN_BIN_COUNT = 3  # below this a bin's mean/SD is too noisy to plot
+
+
+def _binned_stats(
+    x: npt.ArrayLike, y: npt.ArrayLike, edges: npt.ArrayLike
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Bin ``y`` by ``x`` over ``edges``; return (bin centres, mean, SD, count), NaN-safe.
+
+    Empty or sparsely populated bins (< :data:`_MIN_BIN_COUNT`) yield NaN mean/SD so a noisy tail
+    does not draw a misleading spike. SD is the sample standard deviation of the residual in the bin.
+    """
+    x = np.asarray(x, dtype=float)
+    y = np.asarray(y, dtype=float)
+    edges = np.asarray(edges, dtype=float)
+    centers = 0.5 * (edges[:-1] + edges[1:])
+    mean = np.full(len(centers), np.nan)
+    sd = np.full(len(centers), np.nan)
+    count = np.zeros(len(centers), dtype=int)
+    finite = np.isfinite(x) & np.isfinite(y)
+    if finite.any():
+        cats = pd.cut(x[finite], bins=edges)
+        grouped = pd.Series(y[finite]).groupby(cats, observed=False)
+        count = grouped.size().to_numpy()
+        mean = grouped.mean().to_numpy()
+        sd = grouped.std().to_numpy()  # ddof=1; NaN for singleton bins
+    thin = count < _MIN_BIN_COUNT
+    mean[thin] = np.nan
+    sd[thin] = np.nan
+    return centers, mean, sd, count
+
+
+def _power_bin_edges(*arrays: np.ndarray | None, n_bins: int = _RESID_POWER_BINS) -> np.ndarray:
+    """Equal-width power-bin edges from 0 to the robust (99th-pct) max across the given arrays."""
+    present = [np.asarray(a, dtype=float) for a in arrays if a is not None and len(a)]
+    finite = np.concatenate(present)[np.isfinite(np.concatenate(present))] if present else np.array([])
+    hi = float(np.nanpercentile(finite, 99)) if finite.size else 1.0
+    if not np.isfinite(hi) or hi <= 0:
+        hi = 1.0
+    return np.linspace(0.0, hi, n_bins + 1)
+
+
+def _axis_values(
+    kind: str, actual: np.ndarray, predicted: np.ndarray, cond: pd.DataFrame | None
+) -> np.ndarray | None:
+    """Binning-axis values for one segment: power axes from actual/predicted, ws/TI from ``cond``."""
+    if kind == "actual":
+        return np.asarray(actual, dtype=float)
+    if kind == "mean":
+        return 0.5 * (np.asarray(actual, dtype=float) + np.asarray(predicted, dtype=float))
+    if cond is not None and kind in cond.columns:
+        return cond[kind].to_numpy(dtype=float)
+    return None
+
+
+def _plot_residual_binned(plots_dir: Path, data: DiagnosticData) -> None:
+    """Mean and SD of the residual (actual - predicted) binned by power, wind speed and TI.
+
+    The shrinkage check: a regularised learner predicts smoother than reality (over-predicts where
+    power is low, under-predicts where it is high), so on the **held-out baseline** — where the true
+    uplift is zero and the residual is pure model error — the mean residual tilts up with power.
+    Because power maps to wind speed, and TI is inversely related to wind speed at fixed power, that
+    single compression re-appears as a negative residual at low wind speed / high TI, which is what
+    masquerades as condition-dependent uplift. The ``upgraded`` segment adds the true uplift on top.
+
+    Binning by *actual* power inflates the trend (the residual contains ``+actual``); the
+    ``mean(actual, predicted)`` (Bland-Altman) axis is the unbiased read. Both are shown so the
+    inflation is visible.
+
+    Two files are written: ``residual_binned.png`` in absolute kW, and ``residual_binned_pct.png``
+    where each bin's mean/SD residual is divided by that same bin's mean actual power (a true
+    percentage of the typical power in the bin, whatever the x-variable); bins with mean power <= 0
+    are dropped.
+    """
+    _residual_binned_figure(plots_dir / "residual_binned.png", data, as_percent=False)
+    _residual_binned_figure(plots_dir / "residual_binned_pct.png", data, as_percent=True)
+
+
+def _residual_binned_figure(save_path: Path, data: DiagnosticData, *, as_percent: bool) -> None:
+    """Render one binned-residual figure (absolute kW or percentage of the mean x-variable)."""
+    segments = [
+        ("baseline (held-out)", data.y_baseline_valid, data.pred_baseline_valid, data.cond_baseline_valid, "C0"),
+        ("upgraded", data.y_upgraded, data.pred_upgraded, data.cond_upgraded, "C1"),
+    ]
+    power_edges = _power_bin_edges(
+        data.y_baseline_valid, data.pred_baseline_valid, data.y_upgraded, data.pred_upgraded
+    )
+    # (axis kind, bin edges, x-axis label); ``_axis_values`` resolves the kind per segment
+    specs: list[tuple[str, np.ndarray, str]] = [
+        ("actual", power_edges, "actual power [kW]"),
+        ("mean", power_edges, "mean(actual, predicted) [kW]"),
+        ("ws", np.asarray(WS_BINS, dtype=float), "wind speed [m/s]"),
+        ("ti", np.asarray(TI_BINS, dtype=float), "TI"),
+    ]
+    # keep an axis only if at least one segment yields values for it (ws/TI need a wind-speed col)
+    specs = [s for s in specs if any(_axis_values(s[0], a, p, c) is not None for _, a, p, c, _ in segments)]
+    if not specs:
+        return
+
+    unit = "%" if as_percent else "kW"
+    fig, axes = plt.subplots(2, len(specs), figsize=(5.0 * len(specs), 8.5), squeeze=False, sharey="row")
+    mean_vals: list[np.ndarray] = []  # every plotted point, to size the shared y-axis from inliers
+    sd_vals: list[np.ndarray] = []
+    for col, (kind, edges, xlabel) in enumerate(specs):
+        mean_ax, sd_ax = axes[0][col], axes[1][col]
+        for label, actual, predicted, cond, color in segments:
+            values = _axis_values(kind, actual, predicted, cond)
+            if values is None:
+                continue
+            actual_arr = np.asarray(actual, dtype=float)
+            resid = actual_arr - np.asarray(predicted, dtype=float)
+            centers, mean, sd, _ = _binned_stats(values, resid, edges)
+            if as_percent:
+                _, mean_power, _, _ = _binned_stats(values, actual_arr, edges)  # per-bin denominator
+                mean = _as_percent_of_power(mean, mean_power)
+                sd = _as_percent_of_power(sd, mean_power)
+            mean_ax.plot(centers, mean, marker="o", ms=3, color=color, label=label)
+            sd_ax.plot(centers, sd, marker="o", ms=3, color=color, label=label)
+            mean_vals.append(mean)
+            sd_vals.append(sd)
+        mean_ax.axhline(0, color="k", lw=1)
+        mean_ax.set_title(xlabel)
+        mean_ax.set_ylabel(f"mean residual [{unit}]")
+        sd_ax.set_ylabel(f"SD of residual [{unit}]")
+        sd_ax.set_xlabel(xlabel)
+        for ax in (mean_ax, sd_ax):
+            ax.legend(loc="best", fontsize=8)
+            apply_grid(ax)
+    if as_percent:
+        # Size the shared y-axis from bins within ±30%; extreme low-power bins still plot but clip.
+        _set_ylim_from_inliers(axes[0][0], mean_vals)
+        _set_ylim_from_inliers(axes[1][0], sd_vals)
+    suffix = " (% of bin mean power)" if as_percent else ""
+    fig.suptitle(f"{data.test_wtg}: residual (actual - predicted) binned — shrinkage check{suffix}")
+    save_fig(fig, save_path)
+
+
+_INLIER_PCT = 30.0  # bins beyond ±this (% of power) don't get to blow up the shared y-axis
+
+
+def _set_ylim_from_inliers(ax: plt.Axes, value_arrays: list[np.ndarray]) -> None:
+    """Set ``ax`` y-limits from points within ±:data:`_INLIER_PCT`, with a small margin.
+
+    Outliers (e.g. tiny-power bins with huge % residuals) are still drawn but fall outside the
+    limits and clip, so the readable bulk is not crushed. No-op if there are no inliers.
+    """
+    if not value_arrays:
+        return
+    pooled = np.concatenate(value_arrays)
+    inliers = pooled[np.isfinite(pooled) & (np.abs(pooled) <= _INLIER_PCT)]
+    if inliers.size == 0:
+        return
+    lo, hi = float(inliers.min()), float(inliers.max())
+    margin = 0.05 * (hi - lo) if hi > lo else max(abs(hi), 1.0) * 0.05
+    ax.set_ylim(lo - margin, hi + margin)
+
+
+def _as_percent_of_power(stat: npt.ArrayLike, mean_power: npt.ArrayLike) -> np.ndarray:
+    """Express a per-bin kW statistic as a percentage of that bin's mean power (NaN where <= 0)."""
+    power = np.asarray(mean_power, dtype=float)
+    denom = np.where(power > 0, power, np.nan)
+    return 100.0 * np.asarray(stat, dtype=float) / denom
 
 
 def _plot_actual_vs_counterfactual_timeseries(plots_dir: Path, data: DiagnosticData) -> None:

--- a/benchmarking/baselines/power_model/features.py
+++ b/benchmarking/baselines/power_model/features.py
@@ -133,6 +133,31 @@ def reference_mean_wind_speed(
     return pd.concat(cols, axis=1).mean(axis=1)
 
 
+def test_condition_signals(
+    scada_df: pd.DataFrame,
+    *,
+    test_wtg: str,
+    turbine_col: str,
+    wind_speed_col: str,
+    wind_speed_sd_col: str | None,
+) -> pd.DataFrame:
+    """Test turbine's MEASURED ws and ti on the unique sorted index (post-treatment, accepted §3).
+
+    ``ti`` is omitted when no SD column is configured.
+    """
+    index = pd.DatetimeIndex(pd.unique(scada_df.index)).sort_values()
+    rows = scada_df[scada_df[turbine_col] == test_wtg]
+    ws = pd.Series(rows[wind_speed_col].to_numpy(dtype=float), index=pd.DatetimeIndex(rows.index))
+    ws = ws[~ws.index.duplicated()].reindex(index)
+    out = pd.DataFrame({"ws": ws})
+    if wind_speed_sd_col is not None and wind_speed_sd_col in scada_df.columns:
+        sd = pd.Series(rows[wind_speed_sd_col].to_numpy(dtype=float), index=pd.DatetimeIndex(rows.index))
+        sd = sd[~sd.index.duplicated()].reindex(index)
+        ws_arr = ws.to_numpy()
+        out["ti"] = np.divide(sd.to_numpy(), ws_arr, out=np.full(len(ws_arr), np.nan), where=ws_arr != 0)
+    return out
+
+
 def check_reference_only(feature_names: list[str], *, test_wtg: str) -> None:
     """Raise if any feature is qualified with the test turbine (violating the §3 rule)."""
     offenders = [f for f in feature_names if f.endswith(f"{QUALIFIER}{test_wtg}")]

--- a/benchmarking/baselines/power_model/method.py
+++ b/benchmarking/baselines/power_model/method.py
@@ -37,9 +37,11 @@ from benchmarking.baselines.power_model.features import (
     era5_feature_frame,
     extract_outcome,
     reference_mean_wind_speed,
+    test_condition_signals,
 )
 from benchmarking.baselines.rlearner.nuisance import make_outcome_model
 from benchmarking.diagnostics import DiagnosticContext, write_common_diagnostics, write_run_config
+from benchmarking.harness.conditions import CONDITION_BINS, energy_ratio_by_bin
 from benchmarking.harness.method import MethodInput, MethodOutput
 from benchmarking.synthetic import HOT_COLUMNS, ToggleSchedule, treated_mask
 
@@ -93,6 +95,7 @@ class PowerModelMethod:
     active_power_col: str
     availability_col: str
     wind_speed_col: str | None = None
+    wind_speed_sd_col: str | None = None
     era5_hourly_df: pd.DataFrame | None = None
     columns: ColumnSchema = HOT_COLUMNS
     name: str = "power_model"
@@ -148,6 +151,17 @@ class PowerModelMethod:
         sum_counter = float(fit["pred_upgraded"].sum())
         uplift = sum_actual / sum_counter - 1.0 if np.isfinite(sum_counter) and sum_counter != 0 else float("nan")
 
+        by_condition: pd.DataFrame | None = None
+        if self.wind_speed_col is not None:
+            conditions = test_condition_signals(
+                scada,
+                test_wtg=mi.test_wtg,
+                turbine_col=mi.turbine_col,
+                wind_speed_col=self.wind_speed_col,
+                wind_speed_sd_col=self.wind_speed_sd_col,
+            )
+            by_condition = self._conditional_uplift(conditions, upgraded_sel=upgraded_sel, fit=fit)
+
         self._write(
             mi,
             index=index,
@@ -164,7 +178,7 @@ class PowerModelMethod:
             n_refs=n_refs,
             era5=era5,
         )
-        return MethodOutput(p50_overall=uplift)
+        return MethodOutput(p50_overall=uplift, p50_by_condition=by_condition)
 
     def _add_era5(
         self,
@@ -233,6 +247,20 @@ class PowerModelMethod:
             "y_baseline_valid": y_valid,
             "pred_baseline_valid": pred_valid,
         }
+
+    def _conditional_uplift(
+        self, conditions: pd.DataFrame, *, upgraded_sel: np.ndarray, fit: dict[str, Any]
+    ) -> pd.DataFrame | None:
+        """Reduce the upgraded actual/counterfactual ledger to per-bin energy-ratio uplift."""
+        cond_up = conditions.iloc[upgraded_sel]
+        actual = fit["y_upgraded"]
+        counterfactual = fit["pred_upgraded"]
+        frames = []
+        for name in [c for c in ("ws", "ti") if c in cond_up.columns]:
+            table = energy_ratio_by_bin(cond_up[name].to_numpy(), actual, counterfactual, bins=CONDITION_BINS[name])
+            table.insert(0, "condition", name)
+            frames.append(table[["condition", "condition_bin", "p50_uplift"]])
+        return pd.concat(frames, ignore_index=True) if frames else None
 
     def _make_model(self) -> Any:  # noqa: ANN401
         """Outcome model with ``seed`` plumbed into LightGBM's ``random_state`` (caller overrides win)."""
@@ -361,6 +389,7 @@ class PowerModelMethod:
             "active_power_col": self.active_power_col,
             "availability_col": self.availability_col,
             "wind_speed_col": self.wind_speed_col,
+            "wind_speed_sd_col": self.wind_speed_sd_col,
             "seed": self.seed,
             "toggle_campaign_only": self.toggle_campaign_only,
             "has_era5": self.era5_hourly_df is not None,

--- a/benchmarking/baselines/power_model/method.py
+++ b/benchmarking/baselines/power_model/method.py
@@ -152,6 +152,8 @@ class PowerModelMethod:
         uplift = sum_actual / sum_counter - 1.0 if np.isfinite(sum_counter) and sum_counter != 0 else float("nan")
 
         by_condition: pd.DataFrame | None = None
+        cond_upgraded: pd.DataFrame | None = None
+        cond_baseline_valid: pd.DataFrame | None = None
         if self.wind_speed_col is not None:
             conditions = test_condition_signals(
                 scada,
@@ -161,6 +163,9 @@ class PowerModelMethod:
                 wind_speed_sd_col=self.wind_speed_sd_col,
             )
             by_condition = self._conditional_uplift(conditions, upgraded_sel=upgraded_sel, fit=fit)
+            # ws/TI for each segment's residuals, row-aligned to the fit arrays for the diagnostics.
+            cond_upgraded = conditions.iloc[upgraded_sel].reset_index(drop=True)
+            cond_baseline_valid = conditions.iloc[fit["baseline_valid_pos"]].reset_index(drop=True)
 
         self._write(
             mi,
@@ -177,6 +182,8 @@ class PowerModelMethod:
             sum_counter=sum_counter,
             n_refs=n_refs,
             era5=era5,
+            cond_upgraded=cond_upgraded,
+            cond_baseline_valid=cond_baseline_valid,
         )
         return MethodOutput(p50_overall=uplift, p50_by_condition=by_condition)
 
@@ -235,7 +242,8 @@ class PowerModelMethod:
         x_up = features.iloc[upgraded_sel]
         y_up = y[upgraded_sel]
 
-        y_valid, pred_valid = self._holdout_fit(x_base, y_base)
+        y_valid, pred_valid, valid_local = self._holdout_fit(x_base, y_base)
+        baseline_valid_pos = np.flatnonzero(baseline_sel)[valid_local]
 
         final = self._make_model()
         final.fit(x_base, y_base)
@@ -246,6 +254,7 @@ class PowerModelMethod:
             "y_upgraded": y_up,
             "y_baseline_valid": y_valid,
             "pred_baseline_valid": pred_valid,
+            "baseline_valid_pos": baseline_valid_pos,  # positions over ``index`` of the held-out rows
         }
 
     def _conditional_uplift(
@@ -266,13 +275,17 @@ class PowerModelMethod:
         """Outcome model with ``seed`` plumbed into LightGBM's ``random_state`` (caller overrides win)."""
         return make_outcome_model(**{"random_state": self.seed, **self.model_params})
 
-    def _holdout_fit(self, x_base: pd.DataFrame, y_base: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
-        """Train on a baseline train split, predict a held-out baseline slice (honest fit quality)."""
+    def _holdout_fit(self, x_base: pd.DataFrame, y_base: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        """Train on a baseline train split, predict a held-out baseline slice (honest fit quality).
+
+        Also returns the held-out rows' positions **within the baseline block** so the caller can
+        line the residuals up with their conditions (ws/TI) for the diagnostics.
+        """
         n = len(y_base)
         if n < _MIN_HOLDOUT_ROWS:
             model = self._make_model()
             model.fit(x_base, y_base)
-            return y_base, np.asarray(model.predict(x_base), dtype=float)
+            return y_base, np.asarray(model.predict(x_base), dtype=float), np.arange(n)
         rng = np.random.default_rng(self.seed)
         order = rng.permutation(n)
         n_valid = n // 5
@@ -281,7 +294,7 @@ class PowerModelMethod:
         model = self._make_model()
         model.fit(x_base.iloc[train_idx], y_base[train_idx])
         pred_valid = np.asarray(model.predict(x_base.iloc[valid_idx]), dtype=float)
-        return y_base[valid_idx], pred_valid
+        return y_base[valid_idx], pred_valid, valid_idx
 
     def _write(
         self,
@@ -300,6 +313,8 @@ class PowerModelMethod:
         sum_counter: float,
         n_refs: int,
         era5: Any,  # noqa: ANN401
+        cond_upgraded: pd.DataFrame | None = None,
+        cond_baseline_valid: pd.DataFrame | None = None,
     ) -> None:
         """Assemble the diagnostic data and write the CSVs (+ plots), logging the top features."""
         upgrade_start = _upgrade_start(mi.upgrade_timing, index)
@@ -334,6 +349,8 @@ class PowerModelMethod:
             era5_lag_rows=era5.best_lag_rows if era5 is not None else None,
             era5_corr=era5.best_corr if era5 is not None else None,
             era5_sweep=era5.sweep if era5 is not None else None,
+            cond_upgraded=cond_upgraded,
+            cond_baseline_valid=cond_baseline_valid,
         )
         importance = diag.write_csvs(run_dir, run_name, ts, data)
         diag.log_top_features(importance)

--- a/benchmarking/baselines/study_power_model_compare.py
+++ b/benchmarking/baselines/study_power_model_compare.py
@@ -69,7 +69,14 @@ from benchmarking.baselines.example_toggle_study import DEFAULT_TOGGLE_PERIOD
 from benchmarking.baselines.hot_context import build_hot_v0_context
 from benchmarking.baselines.overnight_profiles import overnight_profiles
 from benchmarking.baselines.power_model import PowerModelMethod
-from benchmarking.harness import StudyConfig, leaderboard, plot_campaign_curves, score_study
+from benchmarking.harness import (
+    StudyConfig,
+    conditional_leaderboard,
+    leaderboard,
+    plot_campaign_curves,
+    plot_conditional_uplift,
+    score_study,
+)
 from benchmarking.synthetic import HOT_COLUMNS
 from benchmarking.synthetic.sources.hill_of_towie import load_hot_scada
 
@@ -94,7 +101,7 @@ _DEFAULT_OUTPUT_DIR = Path.home() / "temp" / "wind-up-benchmarking" / "power_mod
 # a known-good commit, so future power_model changes are scored against it. Lives next to this script
 # (tracked) — update it deliberately with --update-baseline when an improvement is accepted.
 _BASELINE_PATH = Path(__file__).resolve().parent / "study_power_model_compare_baseline.json"
-_BASELINE_SCHEMA = "power_model_compare_baseline_v1"
+_BASELINE_SCHEMA = "power_model_compare_baseline_v2"
 # Per-cell metrics recorded and diffed. spread/score: lower is better; bias: |bias| nearer 0 is better.
 _METRIC_COLS = ["bias", "spread", "score"]
 # A delta smaller than this (fractional uplift) is floating-point noise, not a real change: an
@@ -152,6 +159,7 @@ def run_power_model(mode: str, out_dir: Path) -> pd.DataFrame:
             active_power_col=HOT_COLUMNS.active_power,
             wind_speed_col=HOT_COLUMNS.wind_speed,
             availability_col=HOT_COLUMNS.availability,
+            wind_speed_sd_col=HOT_COLUMNS.wind_speed_sd,
             era5_hourly_df=context.reanalysis_datasets[0].data,
             out_dir=out_dir / "power_model_runs",
         )
@@ -257,18 +265,23 @@ def _git_commit() -> str:
 
 
 def power_model_leaderboard(fresh: pd.DataFrame) -> pd.DataFrame:
-    """Reduce the fresh ``power_model`` rows to one ``(profile, campaign_months)`` row of bias/spread/score."""
+    """One row per (profile, campaign, condition, bin) of power_model bias/spread/score (overall incl.)."""
     pm = fresh[fresh["method"] == "power_model"]
-    summary = leaderboard(pm)
-    return summary[["profile", "campaign_months", *_METRIC_COLS]].sort_values(["profile", "campaign_months"])
+    overall = leaderboard(pm).assign(condition="overall", condition_bin="overall")
+    conditional = conditional_leaderboard(pm)
+    cols = ["profile", "campaign_months", "condition", "condition_bin", *_METRIC_COLS]
+    stacked = pd.concat([overall[cols], conditional[cols]], ignore_index=True)
+    return stacked.sort_values(["profile", "campaign_months", "condition", "condition_bin"])
 
 
 def record_baseline(lb_by_mode: dict[str, pd.DataFrame], study_by_mode: dict[str, StudyConfig], path: Path) -> None:
     """Write/refresh the committed benchmark for the given modes (other modes in the file are kept)."""
     doc: dict[str, Any] = {"schema": _BASELINE_SCHEMA, "modes": {}}
     if path.exists():
-        doc = json.loads(path.read_text())
-        doc.setdefault("modes", {})
+        loaded = json.loads(path.read_text())
+        if loaded.get("schema") == _BASELINE_SCHEMA:
+            doc = loaded
+            doc.setdefault("modes", {})
     commit = _git_commit()
     now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     for mode, lb in lb_by_mode.items():
@@ -290,7 +303,16 @@ def _load_baseline_cells(mode: str, path: Path) -> tuple[pd.DataFrame, dict[str,
     """Load the recorded benchmark cells (+ provenance) for ``mode``, or ``None`` if not recorded."""
     if not path.exists():
         return None
-    entry = json.loads(path.read_text()).get("modes", {}).get(mode)
+    doc = json.loads(path.read_text())
+    if doc.get("schema") != _BASELINE_SCHEMA:
+        logger.warning(
+            "Baseline %s has schema %r, expected %r — run --update-baseline to regenerate.",
+            path,
+            doc.get("schema"),
+            _BASELINE_SCHEMA,
+        )
+        return None
+    entry = doc.get("modes", {}).get(mode)
     if entry is None:
         return None
     return pd.DataFrame(entry["cells"]), entry
@@ -311,16 +333,17 @@ def compare_to_benchmark(mode: str, lb: pd.DataFrame, baseline_path: Path, compa
         )
         return
     base, prov = loaded
-    merged = lb.merge(base, on=["profile", "campaign_months"], how="outer", suffixes=("", "_base"))
+    merge_keys = ["profile", "campaign_months", "condition", "condition_bin"]
+    merged = lb.merge(base, on=merge_keys, how="outer", suffixes=("", "_base"))
     for col in _METRIC_COLS:
         merged[f"d_{col}"] = merged[col] - merged[f"{col}_base"]
     merged["d_abs_bias"] = merged["bias"].abs() - merged["bias_base"].abs()
-    merged.sort_values(["profile", "campaign_months"]).to_csv(
+    merged.sort_values(["profile", "campaign_months", "condition", "condition_bin"]).to_csv(
         comparison_dir / f"benchmark_comparison_{mode}.csv", index=False
     )
 
     pp = 100.0
-    report = merged.groupby("campaign_months").mean(numeric_only=True)
+    report = merged.groupby(["campaign_months", "condition"]).mean(numeric_only=True)
     overall = merged.mean(numeric_only=True).to_frame().T
     overall.index = ["ALL"]
     table = pd.concat([report, overall])
@@ -387,6 +410,24 @@ def merge_and_plot(mode: str, fresh: pd.DataFrame, reference_mode_dir: Path, out
         mode,
         all_summary[["method", "profile", "campaign_months", "bias", "spread", "score"]].to_string(index=False),
     )
+
+    # Conditional comparison plots for power_model (v0/naive emit no conditional rows — expected).
+    pm_rows = merged[merged["method"] == "power_model"]
+    if not pm_rows.empty and "condition" in pm_rows.columns:
+        cond_lb = conditional_leaderboard(pm_rows)
+        if not cond_lb.empty:
+            for profile in profiles:
+                for condition in cond_lb["condition"].unique():
+                    subset = cond_lb[(cond_lb["profile"] == profile) & (cond_lb["condition"] == condition)]
+                    if subset.empty:
+                        continue
+                    plot_conditional_uplift(
+                        subset,
+                        condition=condition,
+                        save_path=comparison_dir / f"conditional_{profile}_{condition}.png",
+                        title=f"{mode} - {profile} power_model vs {condition}",
+                    )
+
     logger.info("Wrote %s comparison outputs to %s", mode, comparison_dir)
     return merged
 

--- a/benchmarking/baselines/study_power_model_compare.py
+++ b/benchmarking/baselines/study_power_model_compare.py
@@ -1,0 +1,292 @@
+"""Re-run ``power_model`` over the overnight cases and compare it against the existing v0 + naive.
+
+Iterative-development helper. The overnight v0 runs are very slow, so they are computed once
+(:mod:`benchmarking.baselines.study_overnight_prepost` / ``study_overnight_toggle`` with
+``include_v0=True``) and kept on disk. As ``power_model`` is improved you only want to re-run the
+cheap method and re-draw the comparison plots, reusing the frozen v0 (and naive) numbers. That is
+what this script does:
+
+1. **Run** ``power_model`` **only** over the *exact* current overnight prepost + toggle configs —
+   same seven :func:`~benchmarking.baselines.overnight_profiles.overnight_profiles`, same campaign
+   grids, ``n_replicates=4``, ``seed=0`` — so every ``(profile, turbine, treatment-start, campaign)``
+   case matches the frozen overnight run. v0 and naive are *not* recomputed (v0 is very slow and
+   both are already frozen in the reference run).
+2. **Merge** each fresh ``power_model`` result with the ``v0_binned`` and ``naive_ratio`` rows
+   pulled from the reference overnight directory.
+3. **Plot** a three-method campaign-length comparison (``naive_ratio``, ``v0_binned``,
+   ``power_model``) per profile, and write merged per-profile + all-profiles leaderboards.
+
+An alignment guard checks that the method-independent ground ``truth`` of every fresh case equals
+the reference run's truth for the same key; a mismatch means the configs have drifted and the
+merge would be comparing different cases, so it fails loudly rather than plotting nonsense. (The
+``truth`` column the harness attaches to every ``power_model`` row is itself the cross-check, so
+re-running the oracle/naive anchors purely to validate the line-up is unnecessary.)
+
+Run from the repo root::
+
+    uv run python -m benchmarking.baselines.study_power_model_compare \
+        --reference-dir "~/temp/wind-up-benchmarking/badass overnight runs 30 June"
+
+Use ``--skip-run`` to only re-merge/re-plot from a previous ``power_model`` run under
+``--output-dir`` (e.g. to tweak plotting without re-fitting). Use ``--modes prepost`` /
+``--modes toggle`` to restrict to one mode.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from functools import partial
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from benchmarking.baselines.example_prepost_study import (
+    DEFAULT_END_DT_EXCL,
+    DEFAULT_START_DT,
+    DEFAULT_TREATMENT_START_RANGE,
+    DEFAULT_TURBINE_SUBSET,
+    DEFAULT_WTG_NUMBERS,
+    MIN_PRE_MONTHS,
+    save_per_method_curve,
+)
+from benchmarking.baselines.example_toggle_study import DEFAULT_TOGGLE_PERIOD
+from benchmarking.baselines.hot_context import build_hot_v0_context
+from benchmarking.baselines.overnight_profiles import overnight_profiles
+from benchmarking.baselines.power_model import PowerModelMethod
+from benchmarking.harness import StudyConfig, leaderboard, plot_campaign_curves, score_study
+from benchmarking.synthetic import HOT_COLUMNS
+from benchmarking.synthetic.sources.hill_of_towie import load_hot_scada
+
+logger = logging.getLogger(__name__)
+
+# The three methods compared in the merged plots (oracle is dropped: it is only a truth anchor).
+COMPARE_METHODS = ["naive_ratio", "v0_binned", "power_model"]
+REUSED_METHODS = ["naive_ratio", "v0_binned"]  # taken from the reference run, not recomputed
+
+# Match study_overnight_prepost.py / study_overnight_toggle.py exactly.
+PREPOST_CAMPAIGN_MONTHS = [3, 6, 12]
+TOGGLE_CAMPAIGN_MONTHS = [3, 6, 9, 12]
+N_REPLICATES = 4
+SEED = 0
+
+# Keys that identify one scored case independently of the method.
+_CASE_KEYS = ["profile", "test_wtg", "campaign_months", "treatment_start"]
+_DEFAULT_REFERENCE_DIR = Path.home() / "temp" / "wind-up-benchmarking" / "badass overnight runs 30 June"
+_DEFAULT_OUTPUT_DIR = Path.home() / "temp" / "wind-up-benchmarking" / "power_model_compare"
+
+
+def _prepost_study() -> StudyConfig:
+    return StudyConfig(
+        mode="prepost",
+        turbine_subset=DEFAULT_TURBINE_SUBSET,
+        treatment_start_range=DEFAULT_TREATMENT_START_RANGE,
+        min_pre_months=MIN_PRE_MONTHS,
+        campaign_months=PREPOST_CAMPAIGN_MONTHS,
+        n_replicates=N_REPLICATES,
+        seed=SEED,
+    )
+
+
+def _toggle_study() -> StudyConfig:
+    return StudyConfig(
+        mode="toggle",
+        turbine_subset=DEFAULT_TURBINE_SUBSET,
+        treatment_start_range=DEFAULT_TREATMENT_START_RANGE,
+        min_pre_months=MIN_PRE_MONTHS,
+        campaign_months=TOGGLE_CAMPAIGN_MONTHS,
+        toggle_period=DEFAULT_TOGGLE_PERIOD,
+        n_replicates=N_REPLICATES,
+        seed=SEED,
+    )
+
+
+def run_power_model(mode: str, out_dir: Path) -> pd.DataFrame:
+    """Score **only** ``power_model`` over the overnight cases for one mode (no v0/naive/oracle).
+
+    Each fresh row still carries the harness's method-independent ground ``truth`` (so the merge's
+    alignment guard has its cross-check without recomputing any anchor). Writes a per-profile
+    ``results_*.csv`` and per-profile ``power_model`` curve under ``out_dir`` (the latter lets a long
+    run be sanity-checked profile-by-profile), and returns the concatenated tidy results.
+    """
+    out_dir.mkdir(parents=True, exist_ok=True)
+    scada_df, _ = load_hot_scada(
+        start_dt=DEFAULT_START_DT,
+        end_dt_excl=DEFAULT_END_DT_EXCL,
+        wtg_numbers=DEFAULT_WTG_NUMBERS,
+        wtg_names=DEFAULT_TURBINE_SUBSET,
+    )
+    context = build_hot_v0_context(wtg_names=DEFAULT_TURBINE_SUBSET)
+    study = _prepost_study() if mode == "prepost" else _toggle_study()
+
+    all_results = []
+    for profile_name, profile in overnight_profiles().items():
+        method = PowerModelMethod(
+            active_power_col=HOT_COLUMNS.active_power,
+            wind_speed_col=HOT_COLUMNS.wind_speed,
+            availability_col=HOT_COLUMNS.availability,
+            era5_hourly_df=context.reanalysis_datasets[0].data,
+            out_dir=out_dir / "power_model_runs",
+        )
+        logger.info("Scoring %s profile %s with power_model", mode, profile_name)
+        results = score_study(
+            scada_df,
+            profile=profile,
+            methods=[method],
+            study=study,
+            profile_name=profile_name,
+            on_method_complete=partial(save_per_method_curve, out_dir, profile_name),
+        )
+        results.to_csv(out_dir / f"results_{profile_name}.csv", index=False)
+        all_results.append(results)
+    return pd.concat(all_results, ignore_index=True)
+
+
+def _load_fresh_results(mode_out_dir: Path) -> pd.DataFrame:
+    """Concatenate the per-profile ``results_*.csv`` a previous run wrote (for ``--skip-run``)."""
+    files = sorted(mode_out_dir.glob("results_*.csv"))
+    if not files:
+        msg = f"no results_*.csv under {mode_out_dir}; run without --skip-run first."
+        raise FileNotFoundError(msg)
+    return pd.concat([pd.read_csv(f) for f in files], ignore_index=True)
+
+
+def _load_reference_methods(reference_mode_dir: Path, profiles: list[str], methods: list[str]) -> pd.DataFrame:
+    """Load the requested methods' rows for the given profiles from the reference run directory."""
+    frames = []
+    for profile in profiles:
+        path = reference_mode_dir / f"results_{profile}.csv"
+        if not path.exists():
+            msg = f"reference results missing for profile {profile!r}: {path}"
+            raise FileNotFoundError(msg)
+        df = pd.read_csv(path)
+        frames.append(df[df["method"].isin(methods)])
+    return pd.concat(frames, ignore_index=True)
+
+
+def _case_key(df: pd.DataFrame) -> pd.Series:
+    """Build a stable per-case string key (treatment_start normalised so str/Timestamp compare equal)."""
+    ts = pd.to_datetime(df["treatment_start"], utc=True).dt.strftime("%Y-%m-%d %H:%M:%S%z")
+    return (
+        df["profile"].astype(str)
+        + "|"
+        + df["test_wtg"].astype(str)
+        + "|"
+        + df["campaign_months"].astype(int).astype(str)
+        + "|"
+        + ts
+    )
+
+
+def _check_alignment(fresh: pd.DataFrame, reference: pd.DataFrame) -> None:
+    """Fail loudly if the fresh cases do not line up case-for-case with the reference run.
+
+    Ground ``truth`` is method-independent and deterministic in the study config + seed, so equal
+    keys must carry equal truth. Mismatched keys or truths mean the configs drifted.
+    """
+    f_overall = fresh[fresh["condition"] == "overall"].copy()
+    r_overall = reference[reference["condition"] == "overall"].copy()
+    f_truth = f_overall.assign(key=_case_key(f_overall)).groupby("key")["truth"].first()
+    r_truth = r_overall.assign(key=_case_key(r_overall)).groupby("key")["truth"].first()
+
+    missing = sorted(set(f_truth.index) - set(r_truth.index))
+    if missing:
+        msg = f"{len(missing)} fresh case(s) have no reference match, e.g. {missing[:3]}"
+        raise ValueError(msg)
+    common = f_truth.index.intersection(r_truth.index)
+    bad = ~np.isclose(f_truth.loc[common].to_numpy(), r_truth.loc[common].to_numpy(), rtol=1e-6, atol=1e-9)
+    if bad.any():
+        example = common[bad][0]
+        msg = (
+            f"{int(bad.sum())} case(s) disagree on ground truth between the fresh power_model run and the "
+            f"reference run (e.g. {example}: fresh={f_truth[example]:.6g} vs ref={r_truth[example]:.6g}). "
+            f"The overnight config has drifted from the reference run; the merge would compare different cases."
+        )
+        raise ValueError(msg)
+    logger.info("Alignment OK: %d cases match the reference run on ground truth.", len(common))
+
+
+def merge_and_plot(mode: str, fresh: pd.DataFrame, reference_mode_dir: Path, out_dir: Path) -> pd.DataFrame:
+    """Merge fresh power_model with reference v0/naive, write merged tables + per-profile plots."""
+    comparison_dir = out_dir / "comparison"
+    comparison_dir.mkdir(parents=True, exist_ok=True)
+
+    profiles = sorted(fresh["profile"].unique())
+    reference = _load_reference_methods(reference_mode_dir, profiles, REUSED_METHODS)
+    _check_alignment(fresh, reference)
+
+    power_model = fresh[fresh["method"] == "power_model"]
+    merged = pd.concat([reference, power_model], ignore_index=True)
+    merged = merged[merged["method"].isin(COMPARE_METHODS)]
+
+    merged.to_csv(comparison_dir / f"merged_results_{mode}.csv", index=False)
+    for profile in profiles:
+        prof_rows = merged[merged["profile"] == profile]
+        summary = leaderboard(prof_rows)
+        summary.to_csv(comparison_dir / f"leaderboard_{profile}.csv", index=False)
+        plot_campaign_curves(
+            summary,
+            save_path=comparison_dir / f"campaign_curves_{profile}.png",
+            title=f"{mode} - {profile} (naive vs v0 vs power_model)",
+        )
+
+    all_summary = leaderboard(merged)
+    all_summary.to_csv(comparison_dir / f"leaderboard_all_profiles_{mode}.csv", index=False)
+    logger.info(
+        "%s comparison (all profiles):\n%s",
+        mode,
+        all_summary[["method", "profile", "campaign_months", "bias", "spread", "score"]].to_string(index=False),
+    )
+    logger.info("Wrote %s comparison outputs to %s", mode, comparison_dir)
+    return merged
+
+
+def main() -> None:
+    """Run power_model over the overnight cases for each mode, then merge + plot vs v0/naive."""
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--reference-dir",
+        type=Path,
+        default=_DEFAULT_REFERENCE_DIR,
+        help="overnight run dir holding prepost/ and toggle/ with the frozen v0 + naive results",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=_DEFAULT_OUTPUT_DIR,
+        help="where fresh power_model runs and the merged comparison are written",
+    )
+    parser.add_argument(
+        "--modes",
+        nargs="+",
+        choices=["prepost", "toggle"],
+        default=["prepost", "toggle"],
+        help="which mode(s) to run (default: both)",
+    )
+    parser.add_argument(
+        "--skip-run",
+        action="store_true",
+        help="reuse a previous power_model run under --output-dir; only re-merge and re-plot",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s", force=True)
+    reference_dir = args.reference_dir.expanduser()
+    output_dir = args.output_dir.expanduser()
+
+    for mode in args.modes:
+        logger.info("=== %s ===", mode.upper())
+        mode_out_dir = output_dir / mode
+        if args.skip_run:
+            fresh = _load_fresh_results(mode_out_dir)
+            logger.info("Reusing %d fresh rows from %s", len(fresh), mode_out_dir)
+        else:
+            fresh = run_power_model(mode, mode_out_dir)
+        merge_and_plot(mode, fresh, reference_dir / mode, mode_out_dir)
+
+    logger.info("All done. Comparison plots under %s/<mode>/comparison/", output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarking/baselines/study_power_model_compare.py
+++ b/benchmarking/baselines/study_power_model_compare.py
@@ -379,6 +379,21 @@ def compare_to_benchmark(mode: str, lb: pd.DataFrame, baseline_path: Path, compa
     )
 
 
+def _conditional_plot_subset(cond_lb: pd.DataFrame, profile: str, condition: str) -> pd.DataFrame:
+    """Rows for one (profile, condition) at the longest campaign length only.
+
+    ``conditional_leaderboard`` keeps one row per ``(method, profile, campaign_months, condition,
+    condition_bin)``, but :func:`~benchmarking.harness.plots.plot_conditional_uplift` expects a
+    single row per ``condition_bin`` per method. Collapse to the longest campaign (most data, so the
+    cleanest per-bin estimate) rather than mixing campaign lengths into one line.
+    """
+    subset = cond_lb[(cond_lb["profile"] == profile) & (cond_lb["condition"] == condition)]
+    if subset.empty:
+        return subset
+    longest = int(subset["campaign_months"].max())
+    return subset[subset["campaign_months"] == longest]
+
+
 def merge_and_plot(mode: str, fresh: pd.DataFrame, reference_mode_dir: Path, out_dir: Path) -> pd.DataFrame:
     """Merge fresh power_model with reference v0/naive, write merged tables + per-profile plots."""
     comparison_dir = out_dir / "comparison"
@@ -418,14 +433,15 @@ def merge_and_plot(mode: str, fresh: pd.DataFrame, reference_mode_dir: Path, out
         if not cond_lb.empty:
             for profile in profiles:
                 for condition in cond_lb["condition"].unique():
-                    subset = cond_lb[(cond_lb["profile"] == profile) & (cond_lb["condition"] == condition)]
+                    subset = _conditional_plot_subset(cond_lb, profile, condition)
                     if subset.empty:
                         continue
+                    longest = int(subset["campaign_months"].iloc[0])
                     plot_conditional_uplift(
                         subset,
                         condition=condition,
                         save_path=comparison_dir / f"conditional_{profile}_{condition}.png",
-                        title=f"{mode} - {profile} power_model vs {condition}",
+                        title=f"{mode} - {profile} power_model vs {condition} ({longest}mo)",
                     )
 
     logger.info("Wrote %s comparison outputs to %s", mode, comparison_dir)

--- a/benchmarking/baselines/study_power_model_compare.py
+++ b/benchmarking/baselines/study_power_model_compare.py
@@ -22,22 +22,36 @@ merge would be comparing different cases, so it fails loudly rather than plottin
 ``truth`` column the harness attaches to every ``power_model`` row is itself the cross-check, so
 re-running the oracle/naive anchors purely to validate the line-up is unnecessary.)
 
+**Benchmark regression tracking.** ``power_model``'s bias/spread/score per
+``(mode, profile, campaign_months)`` at a known-good commit is frozen in a committed JSON benchmark
+(``study_power_model_compare_baseline.json``, next to this script). Every run diffs the fresh
+``power_model`` against it and logs a mean-over-profiles table of the deltas (spread/score: a
+negative delta is an improvement; bias: a smaller ``|bias|`` is better) plus a per-cell
+``benchmark_comparison_<mode>.csv``, so an attempt to improve ``power_model`` is scored objectively
+against where it stands today. Bump the benchmark **deliberately** with ``--update-baseline`` once an
+improvement is accepted (it rewrites only the modes you ran; commit the new JSON).
+
 Run from the repo root::
 
     uv run python -m benchmarking.baselines.study_power_model_compare \
         --reference-dir "~/temp/wind-up-benchmarking/badass overnight runs 30 June"
 
-Use ``--skip-run`` to only re-merge/re-plot from a previous ``power_model`` run under
-``--output-dir`` (e.g. to tweak plotting without re-fitting). Use ``--modes prepost`` /
-``--modes toggle`` to restrict to one mode.
+Use ``--skip-run`` to only re-merge/re-plot (and re-diff the benchmark) from a previous
+``power_model`` run under ``--output-dir`` (e.g. to tweak plotting without re-fitting). Use
+``--modes prepost`` / ``--modes toggle`` to restrict to one mode. Use ``--update-baseline`` to
+re-record the benchmark from the current run.
 """
 
 from __future__ import annotations
 
 import argparse
+import json
 import logging
+import subprocess
+from datetime import datetime, timezone
 from functools import partial
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -75,6 +89,18 @@ SEED = 0
 _CASE_KEYS = ["profile", "test_wtg", "campaign_months", "treatment_start"]
 _DEFAULT_REFERENCE_DIR = Path.home() / "temp" / "wind-up-benchmarking" / "badass overnight runs 30 June"
 _DEFAULT_OUTPUT_DIR = Path.home() / "temp" / "wind-up-benchmarking" / "power_model_compare"
+
+# The committed power_model benchmark: its bias/spread/score per (mode, profile, campaign) frozen at
+# a known-good commit, so future power_model changes are scored against it. Lives next to this script
+# (tracked) — update it deliberately with --update-baseline when an improvement is accepted.
+_BASELINE_PATH = Path(__file__).resolve().parent / "study_power_model_compare_baseline.json"
+_BASELINE_SCHEMA = "power_model_compare_baseline_v1"
+# Per-cell metrics recorded and diffed. spread/score: lower is better; bias: |bias| nearer 0 is better.
+_METRIC_COLS = ["bias", "spread", "score"]
+# A delta smaller than this (fractional uplift) is floating-point noise, not a real change: an
+# identical (deterministic, seed-fixed) run must read as no change, while any genuine power_model
+# change moves the metrics by >= ~1e-4. 1e-7 fraction = 1e-5 pp, well below the reported resolution.
+_IMPROVE_EPS = 1e-7
 
 
 def _prepost_study() -> StudyConfig:
@@ -207,6 +233,129 @@ def _check_alignment(fresh: pd.DataFrame, reference: pd.DataFrame) -> None:
     logger.info("Alignment OK: %d cases match the reference run on ground truth.", len(common))
 
 
+def _git_commit() -> str:
+    """Return the short HEAD commit (``-dirty`` if the tree is modified), or ``unknown``."""
+    repo = Path(__file__).resolve().parent
+    try:
+        commit = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],  # noqa: S607
+            cwd=repo,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        dirty = subprocess.run(
+            ["git", "status", "--porcelain"],  # noqa: S607
+            cwd=repo,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+    except (subprocess.SubprocessError, OSError):
+        return "unknown"
+    return f"{commit}-dirty" if dirty else commit
+
+
+def power_model_leaderboard(fresh: pd.DataFrame) -> pd.DataFrame:
+    """Reduce the fresh ``power_model`` rows to one ``(profile, campaign_months)`` row of bias/spread/score."""
+    pm = fresh[fresh["method"] == "power_model"]
+    summary = leaderboard(pm)
+    return summary[["profile", "campaign_months", *_METRIC_COLS]].sort_values(["profile", "campaign_months"])
+
+
+def record_baseline(lb_by_mode: dict[str, pd.DataFrame], study_by_mode: dict[str, StudyConfig], path: Path) -> None:
+    """Write/refresh the committed benchmark for the given modes (other modes in the file are kept)."""
+    doc: dict[str, Any] = {"schema": _BASELINE_SCHEMA, "modes": {}}
+    if path.exists():
+        doc = json.loads(path.read_text())
+        doc.setdefault("modes", {})
+    commit = _git_commit()
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    for mode, lb in lb_by_mode.items():
+        study = study_by_mode[mode]
+        doc["modes"][mode] = {
+            "recorded_utc": now,
+            "git_commit": commit,
+            "n_replicates": study.n_replicates,
+            "seed": study.seed,
+            "campaign_months": list(study.campaign_months),
+            "profiles": sorted(lb["profile"].unique()),
+            "cells": lb.round(8).to_dict(orient="records"),
+        }
+    path.write_text(json.dumps(doc, indent=2) + "\n")
+    logger.info("Recorded power_model benchmark for %s at %s (commit %s)", list(lb_by_mode), path, commit)
+
+
+def _load_baseline_cells(mode: str, path: Path) -> tuple[pd.DataFrame, dict[str, Any]] | None:
+    """Load the recorded benchmark cells (+ provenance) for ``mode``, or ``None`` if not recorded."""
+    if not path.exists():
+        return None
+    entry = json.loads(path.read_text()).get("modes", {}).get(mode)
+    if entry is None:
+        return None
+    return pd.DataFrame(entry["cells"]), entry
+
+
+def compare_to_benchmark(mode: str, lb: pd.DataFrame, baseline_path: Path, comparison_dir: Path) -> None:
+    """Diff the fresh power_model bias/spread/score against the committed benchmark and report it.
+
+    Writes a per-cell ``benchmark_comparison_<mode>.csv`` and logs a mean-over-profiles table with the
+    deltas. spread/score: a negative delta is an improvement; bias: a smaller ``|bias|`` is better.
+    """
+    loaded = _load_baseline_cells(mode, baseline_path)
+    if loaded is None:
+        logger.warning(
+            "No power_model benchmark recorded for %s in %s yet — run with --update-baseline to set it.",
+            mode,
+            baseline_path,
+        )
+        return
+    base, prov = loaded
+    merged = lb.merge(base, on=["profile", "campaign_months"], how="outer", suffixes=("", "_base"))
+    for col in _METRIC_COLS:
+        merged[f"d_{col}"] = merged[col] - merged[f"{col}_base"]
+    merged["d_abs_bias"] = merged["bias"].abs() - merged["bias_base"].abs()
+    merged.sort_values(["profile", "campaign_months"]).to_csv(
+        comparison_dir / f"benchmark_comparison_{mode}.csv", index=False
+    )
+
+    pp = 100.0
+    report = merged.groupby("campaign_months").mean(numeric_only=True)
+    overall = merged.mean(numeric_only=True).to_frame().T
+    overall.index = ["ALL"]
+    table = pd.concat([report, overall])
+    show = pd.DataFrame(
+        {
+            "bias": table["bias"] * pp,
+            "Δbias": table["d_bias"] * pp,
+            "spread": table["spread"] * pp,
+            "Δspread": table["d_spread"] * pp,
+            "score": table["score"] * pp,
+            "Δscore": table["d_score"] * pp,
+        }
+    ).round(3)
+    n_cells = int(merged[_METRIC_COLS].notna().all(axis=1).sum())
+
+    def tally(delta: pd.Series) -> str:
+        """Count cells that moved beyond the noise floor: ``better`` (down) vs ``worse`` (up)."""
+        better = int((delta < -_IMPROVE_EPS).sum())
+        worse = int((delta > _IMPROVE_EPS).sum())
+        return f"{better} better / {worse} worse (of {n_cells})"
+
+    logger.info(
+        "%s power_model vs benchmark (recorded %s, commit %s); mean over profiles [pp], "
+        "Δ<0 = better for spread/score:\n%s\n"
+        "cells: spread %s; score %s; |bias| %s",
+        mode,
+        prov.get("recorded_utc", "?"),
+        prov.get("git_commit", "?"),
+        show.to_string(),
+        tally(merged["d_spread"]),
+        tally(merged["d_score"]),
+        tally(merged["d_abs_bias"]),
+    )
+
+
 def merge_and_plot(mode: str, fresh: pd.DataFrame, reference_mode_dir: Path, out_dir: Path) -> pd.DataFrame:
     """Merge fresh power_model with reference v0/naive, write merged tables + per-profile plots."""
     comparison_dir = out_dir / "comparison"
@@ -269,12 +418,27 @@ def main() -> None:
         action="store_true",
         help="reuse a previous power_model run under --output-dir; only re-merge and re-plot",
     )
+    parser.add_argument(
+        "--baseline-path",
+        type=Path,
+        default=_BASELINE_PATH,
+        help="the committed power_model benchmark JSON to diff against (and to --update-baseline)",
+    )
+    parser.add_argument(
+        "--update-baseline",
+        action="store_true",
+        help="overwrite the recorded benchmark for the run modes with this run (do this deliberately, "
+        "only when an improvement is accepted); without it, the run is diffed against the benchmark",
+    )
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s", force=True)
     reference_dir = args.reference_dir.expanduser()
     output_dir = args.output_dir.expanduser()
+    baseline_path = args.baseline_path.expanduser()
 
+    lb_by_mode: dict[str, pd.DataFrame] = {}
+    study_by_mode: dict[str, StudyConfig] = {}
     for mode in args.modes:
         logger.info("=== %s ===", mode.upper())
         mode_out_dir = output_dir / mode
@@ -284,6 +448,13 @@ def main() -> None:
         else:
             fresh = run_power_model(mode, mode_out_dir)
         merge_and_plot(mode, fresh, reference_dir / mode, mode_out_dir)
+        lb_by_mode[mode] = power_model_leaderboard(fresh)
+        study_by_mode[mode] = _prepost_study() if mode == "prepost" else _toggle_study()
+        if not args.update_baseline:
+            compare_to_benchmark(mode, lb_by_mode[mode], baseline_path, mode_out_dir / "comparison")
+
+    if args.update_baseline:
+        record_baseline(lb_by_mode, study_by_mode, baseline_path)
 
     logger.info("All done. Comparison plots under %s/<mode>/comparison/", output_dir)
 

--- a/benchmarking/baselines/study_power_model_compare_baseline.json
+++ b/benchmarking/baselines/study_power_model_compare_baseline.json
@@ -1,0 +1,393 @@
+{
+  "schema": "power_model_compare_baseline_v1",
+  "modes": {
+    "prepost": {
+      "recorded_utc": "2026-06-30T10:04:36Z",
+      "git_commit": "ddd1b63-dirty",
+      "n_replicates": 4,
+      "seed": 0,
+      "campaign_months": [
+        3,
+        6,
+        12
+      ],
+      "profiles": [
+        "cp_0pct",
+        "cp_minus_10pct",
+        "cp_plus_10pct",
+        "cp_plus_3pct",
+        "rated_plus_5pct",
+        "ti_dependent_cp",
+        "ws_dependent_cp"
+      ],
+      "cells": [
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "bias": -0.00660529,
+          "spread": 0.00466565,
+          "score": 0.00808691
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 6,
+          "bias": -0.00216502,
+          "spread": 0.00397077,
+          "score": 0.00452264
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "bias": -0.00260598,
+          "spread": 0.00450127,
+          "score": 0.0052012
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "bias": -0.00608179,
+          "spread": 0.00437577,
+          "score": 0.00749236
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "bias": -0.00192257,
+          "spread": 0.00368846,
+          "score": 0.00415945
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "bias": -0.0023763,
+          "spread": 0.00423041,
+          "score": 0.00485213
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "bias": -0.00712802,
+          "spread": 0.00495523,
+          "score": 0.00868119
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "bias": -0.00240698,
+          "spread": 0.00425268,
+          "score": 0.0048866
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "bias": -0.00283565,
+          "spread": 0.00477221,
+          "score": 0.00555111
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "bias": -0.00676189,
+          "spread": 0.00475233,
+          "score": 0.00826485
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "bias": -0.00223764,
+          "spread": 0.00405543,
+          "score": 0.0046318
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "bias": -0.00267486,
+          "spread": 0.00458252,
+          "score": 0.00530607
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "bias": -0.00670173,
+          "spread": 0.00474853,
+          "score": 0.00821351
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "bias": -0.00218881,
+          "spread": 0.00403347,
+          "score": 0.00458909
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "bias": -0.00264277,
+          "spread": 0.00458772,
+          "score": 0.00529447
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "bias": -0.0069171,
+          "spread": 0.00485054,
+          "score": 0.00844831
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "bias": -0.00231017,
+          "spread": 0.00414554,
+          "score": 0.00474578
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "bias": -0.00274427,
+          "spread": 0.00467084,
+          "score": 0.00541736
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "bias": -0.00683324,
+          "spread": 0.00483019,
+          "score": 0.00836803
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "bias": -0.00225087,
+          "spread": 0.00412935,
+          "score": 0.00470297
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "bias": -0.00267457,
+          "spread": 0.00463682,
+          "score": 0.00535289
+        }
+      ]
+    },
+    "toggle": {
+      "recorded_utc": "2026-06-30T10:04:36Z",
+      "git_commit": "ddd1b63-dirty",
+      "n_replicates": 4,
+      "seed": 0,
+      "campaign_months": [
+        3,
+        6,
+        9,
+        12
+      ],
+      "profiles": [
+        "cp_0pct",
+        "cp_minus_10pct",
+        "cp_plus_10pct",
+        "cp_plus_3pct",
+        "rated_plus_5pct",
+        "ti_dependent_cp",
+        "ws_dependent_cp"
+      ],
+      "cells": [
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "bias": 0.00362415,
+          "spread": 0.00084001,
+          "score": 0.00372022
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 6,
+          "bias": 0.00129828,
+          "spread": 0.00178902,
+          "score": 0.00221046
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 9,
+          "bias": 0.00086062,
+          "spread": 0.00160665,
+          "score": 0.00182263
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "bias": 0.00056382,
+          "spread": 0.00088262,
+          "score": 0.00104734
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "bias": 0.0034594,
+          "spread": 0.00078816,
+          "score": 0.00354805
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "bias": 0.00131574,
+          "spread": 0.00168113,
+          "score": 0.0021348
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "bias": 0.00088486,
+          "spread": 0.0015148,
+          "score": 0.0017543
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "bias": 0.00061016,
+          "spread": 0.00085288,
+          "score": 0.00104867
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "bias": 0.0037889,
+          "spread": 0.00089431,
+          "score": 0.00389301
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "bias": 0.00128082,
+          "spread": 0.00189692,
+          "score": 0.00228884
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "bias": 0.00083644,
+          "spread": 0.00169846,
+          "score": 0.00189325
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "bias": 0.00051748,
+          "spread": 0.00091239,
+          "score": 0.00104892
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "bias": 0.00367357,
+          "spread": 0.00085606,
+          "score": 0.003772
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "bias": 0.00129304,
+          "spread": 0.00182139,
+          "score": 0.0022337
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "bias": 0.00085336,
+          "spread": 0.0016342,
+          "score": 0.00184359
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "bias": 0.00054992,
+          "spread": 0.00089155,
+          "score": 0.00104751
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "bias": 0.00369558,
+          "spread": 0.00086132,
+          "score": 0.00379462
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "bias": 0.00133541,
+          "spread": 0.00181816,
+          "score": 0.00225589
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "bias": 0.00088821,
+          "spread": 0.00163333,
+          "score": 0.00185922
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "bias": 0.00059381,
+          "spread": 0.00090885,
+          "score": 0.00108564
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "bias": 0.00373349,
+          "spread": 0.00087011,
+          "score": 0.00383354
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "bias": 0.00128565,
+          "spread": 0.0018638,
+          "score": 0.00226421
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 9,
+          "bias": 0.0008499,
+          "spread": 0.00167478,
+          "score": 0.00187809
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "bias": 0.00053768,
+          "spread": 0.0009069,
+          "score": 0.00105431
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "bias": 0.00372194,
+          "spread": 0.00088052,
+          "score": 0.00382467
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "bias": 0.00132792,
+          "spread": 0.00184903,
+          "score": 0.00227646
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "bias": 0.00087805,
+          "spread": 0.00165961,
+          "score": 0.00187757
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "bias": 0.00058349,
+          "spread": 0.00092061,
+          "score": 0.00108995
+        }
+      ]
+    }
+  }
+}

--- a/benchmarking/baselines/study_power_model_compare_baseline.json
+++ b/benchmarking/baselines/study_power_model_compare_baseline.json
@@ -1,9 +1,9 @@
 {
-  "schema": "power_model_compare_baseline_v1",
+  "schema": "power_model_compare_baseline_v2",
   "modes": {
     "prepost": {
-      "recorded_utc": "2026-06-30T10:04:36Z",
-      "git_commit": "ddd1b63-dirty",
+      "recorded_utc": "2026-07-01T08:52:23Z",
+      "git_commit": "1ccd745-dirty",
       "n_replicates": 4,
       "seed": 0,
       "campaign_months": [
@@ -24,155 +24,4544 @@
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
-          "bias": -0.00660529,
-          "spread": 0.00466565,
-          "score": 0.00808691
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": -0.00660522,
+          "spread": 0.0046656,
+          "score": 0.00808683
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.60335128,
+          "spread": 0.0,
+          "score": 0.60335128
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.06666825,
+          "spread": 0.03911693,
+          "score": 0.07729676
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.042914,
+          "spread": 0.01035486,
+          "score": 0.04414561
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00786284,
+          "spread": 0.0103869,
+          "score": 0.01302735
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.06965916,
+          "spread": 0.02390404,
+          "score": 0.07364646
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.12072125,
+          "spread": 0.0564512,
+          "score": 0.13326799
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.20188186,
+          "spread": 0.06185548,
+          "score": 0.21114541
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.32438465,
+          "spread": 0.05266856,
+          "score": 0.32863259
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": -1.06510687,
+          "spread": 1.04932843,
+          "score": 1.49517316
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.57710607,
+          "spread": 0.45023269,
+          "score": 0.7319569
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 1.40990333,
+          "spread": 1.49404099,
+          "score": 2.05426042
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.03413508,
+          "spread": 0.0045598,
+          "score": 0.03443829
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.03572933,
+          "spread": 0.00652375,
+          "score": 0.03632002
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.01407931,
+          "spread": 0.00930569,
+          "score": 0.01687669
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00409674,
+          "spread": 0.01097386,
+          "score": 0.01171362
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00101464,
+          "spread": 0.01073525,
+          "score": 0.01078309
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.42260716,
+          "spread": 0.18635483,
+          "score": 0.46187113
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.00096292,
+          "spread": 0.03964622,
+          "score": 0.03965791
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.01218888,
+          "spread": 0.00180133,
+          "score": 0.01232127
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": -0.01094652,
+          "spread": 0.0,
+          "score": 0.01094652
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.13207522,
+          "spread": 0.03849023,
+          "score": 0.13756948
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.04675598,
+          "spread": 0.01413337,
+          "score": 0.04884541
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 3.724e-05,
+          "spread": 0.0104083,
+          "score": 0.01040837
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
-          "bias": -0.00216502,
-          "spread": 0.00397077,
-          "score": 0.00452264
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": -0.00216497,
+          "spread": 0.00397076,
+          "score": 0.00452262
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.17086914,
+          "spread": 0.38168262,
+          "score": 0.41818403
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.07556052,
+          "spread": 0.02063257,
+          "score": 0.07832685
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.0433495,
+          "spread": 0.00526447,
+          "score": 0.043668
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00485191,
+          "spread": 0.00953015,
+          "score": 0.01069415
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.06653272,
+          "spread": 0.02280311,
+          "score": 0.07033196
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.11390629,
+          "spread": 0.03147063,
+          "score": 0.11817378
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.1808946,
+          "spread": 0.03322087,
+          "score": 0.18391977
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.30797606,
+          "spread": 0.04011755,
+          "score": 0.31057796
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": -0.52709624,
+          "spread": 0.16459852,
+          "score": 0.55219844
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.75989824,
+          "spread": 0.74590112,
+          "score": 1.06480694
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.8512039,
+          "spread": 1.13449077,
+          "score": 1.41831498
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.03618916,
+          "spread": 0.00328763,
+          "score": 0.03633819
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.03568157,
+          "spread": 0.00454008,
+          "score": 0.03596924
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.01691756,
+          "spread": 0.00714257,
+          "score": 0.01836355
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00469014,
+          "spread": 0.00924097,
+          "score": 0.01036305
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00302445,
+          "spread": 0.00384508,
+          "score": 0.00489203
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.44459916,
+          "spread": 0.12145097,
+          "score": 0.46088909
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": -0.00900666,
+          "spread": 0.02003737,
+          "score": 0.02196853
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.05410844,
+          "spread": 0.064496,
+          "score": 0.08418704
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": -0.01094652,
+          "spread": 0.0,
+          "score": 0.01094652
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.11687254,
+          "spread": 0.03340899,
+          "score": 0.1215539
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.04044854,
+          "spread": 0.01114972,
+          "score": 0.04195713
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00420083,
+          "spread": 0.0112338,
+          "score": 0.01199355
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
-          "bias": -0.00260598,
-          "spread": 0.00450127,
-          "score": 0.0052012
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": -0.00260595,
+          "spread": 0.00450124,
+          "score": 0.00520117
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.16555192,
+          "spread": 0.38699984,
+          "score": 0.42092317
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.0657515,
+          "spread": 0.02265017,
+          "score": 0.06954344
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.03605937,
+          "spread": 0.01083232,
+          "score": 0.03765126
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00520769,
+          "spread": 0.00850712,
+          "score": 0.00997452
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.06249583,
+          "spread": 0.02138951,
+          "score": 0.06605482
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.10554275,
+          "spread": 0.02221696,
+          "score": 0.10785576
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.1752726,
+          "spread": 0.0267202,
+          "score": 0.17729764
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.25495364,
+          "spread": 0.03246988,
+          "score": 0.25701294
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": -0.43439172,
+          "spread": 0.04642704,
+          "score": 0.43686569
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.76339821,
+          "spread": 0.3480648,
+          "score": 0.83900294
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.23783049,
+          "spread": 0.0694984,
+          "score": 0.24777685
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.02756654,
+          "spread": 0.00552269,
+          "score": 0.02811431
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.03096734,
+          "spread": 0.00269057,
+          "score": 0.031084
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.01535895,
+          "spread": 0.00264913,
+          "score": 0.01558574
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00508092,
+          "spread": 0.00199297,
+          "score": 0.00545781
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00403679,
+          "spread": 0.00426815,
+          "score": 0.00587476
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.45357804,
+          "spread": 0.11884614,
+          "score": 0.46888959
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.02153599,
+          "spread": 0.02846229,
+          "score": 0.03569175
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.08435554,
+          "spread": 0.097448,
+          "score": 0.12888743
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": -0.05327625,
+          "spread": 0.01649998,
+          "score": 0.05577283
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.11839379,
+          "spread": 0.02632634,
+          "score": 0.12128547
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.04521209,
+          "spread": 0.01064231,
+          "score": 0.04644773
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": -0.00064319,
+          "spread": 0.01035553,
+          "score": 0.01037548
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
-          "bias": -0.00608179,
-          "spread": 0.00437577,
-          "score": 0.00749236
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": -0.00608197,
+          "spread": 0.0043759,
+          "score": 0.00749259
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.54334957,
+          "spread": 0.0,
+          "score": 0.54334957
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.06287137,
+          "spread": 0.03657997,
+          "score": 0.0727386
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.04071664,
+          "spread": 0.00990277,
+          "score": 0.04190358
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00721323,
+          "spread": 0.00964775,
+          "score": 0.01204615
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.06334955,
+          "spread": 0.02161907,
+          "score": 0.06693691
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.10846306,
+          "spread": 0.05046225,
+          "score": 0.11962723
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.17956048,
+          "spread": 0.05377246,
+          "score": 0.18743918
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.281721,
+          "spread": 0.04792138,
+          "score": 0.28576771
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": -1.20967792,
+          "spread": 1.43060094,
+          "score": 1.87348331
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.56326186,
+          "spread": 0.63288847,
+          "score": 0.84723771
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 1.40993225,
+          "spread": 1.49402763,
+          "score": 2.05427056
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.03167518,
+          "spread": 0.00394706,
+          "score": 0.03192016
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.03535638,
+          "spread": 0.00631377,
+          "score": 0.03591569
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.01408116,
+          "spread": 0.00928939,
+          "score": 0.01686926
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00454791,
+          "spread": 0.01036669,
+          "score": 0.01132041
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00302093,
+          "spread": 0.00921781,
+          "score": 0.00970021
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.34435865,
+          "spread": 0.1355168,
+          "score": 0.37006443
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.01036502,
+          "spread": 0.04681163,
+          "score": 0.04794541
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.00737204,
+          "spread": 0.00661817,
+          "score": 0.00990692
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": -0.01094652,
+          "spread": 0.0,
+          "score": 0.01094652
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.11877339,
+          "spread": 0.03469661,
+          "score": 0.12373752
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.04204839,
+          "spread": 0.0127403,
+          "score": 0.04393612
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 7.566e-05,
+          "spread": 0.00939748,
+          "score": 0.00939779
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
-          "bias": -0.00192257,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": -0.00192252,
           "spread": 0.00368846,
-          "score": 0.00415945
+          "score": 0.00415942
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.15452521,
+          "spread": 0.34303125,
+          "score": 0.37622929
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.07054648,
+          "spread": 0.01924206,
+          "score": 0.07312362
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.04119499,
+          "spread": 0.00529545,
+          "score": 0.04153395
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00444117,
+          "spread": 0.00888623,
+          "score": 0.00993423
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.06060786,
+          "spread": 0.02073967,
+          "score": 0.06405816
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.10248917,
+          "spread": 0.02823384,
+          "score": 0.106307
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.16064338,
+          "spread": 0.02901732,
+          "score": 0.16324307
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.26560721,
+          "spread": 0.03646912,
+          "score": 0.26809921
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": -0.64653465,
+          "spread": 0.49188022,
+          "score": 0.81237504
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.91051546,
+          "spread": 0.89856099,
+          "score": 1.27923815
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.85120815,
+          "spread": 1.13448838,
+          "score": 1.41831562
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.03357879,
+          "spread": 0.00319923,
+          "score": 0.03373085
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.03527814,
+          "spread": 0.0043211,
+          "score": 0.0355418
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.0169201,
+          "spread": 0.00712877,
+          "score": 0.01836053
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00512235,
+          "spread": 0.00869095,
+          "score": 0.01008817
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00468139,
+          "spread": 0.00547917,
+          "score": 0.00720671
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.35211852,
+          "spread": 0.07442509,
+          "score": 0.35989797
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": -0.00305029,
+          "spread": 0.01792852,
+          "score": 0.01818615
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.06676451,
+          "spread": 0.06126627,
+          "score": 0.09061487
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": -0.01094652,
+          "spread": 0.0,
+          "score": 0.01094652
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.10505968,
+          "spread": 0.03011464,
+          "score": 0.10929056
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.03636523,
+          "spread": 0.01003751,
+          "score": 0.03772508
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00381828,
+          "spread": 0.01013013,
+          "score": 0.01082584
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
-          "bias": -0.0023763,
-          "spread": 0.00423041,
-          "score": 0.00485213
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": -0.00237632,
+          "spread": 0.00423042,
+          "score": 0.00485214
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.15015188,
+          "spread": 0.34785865,
+          "score": 0.37888154
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.0614477,
+          "spread": 0.02099323,
+          "score": 0.06493486
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.03444591,
+          "spread": 0.01040129,
+          "score": 0.03598204
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00482748,
+          "spread": 0.00801255,
+          "score": 0.00935444
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.05725657,
+          "spread": 0.01951979,
+          "score": 0.06049246
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.09549147,
+          "spread": 0.02014445,
+          "score": 0.09759314
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.1565126,
+          "spread": 0.02414366,
+          "score": 0.15836385
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.22404734,
+          "spread": 0.02856193,
+          "score": 0.22586056
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": -0.36341803,
+          "spread": 0.0392083,
+          "score": 0.36552695
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -1.05039062,
+          "spread": 0.85267794,
+          "score": 1.35291542
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.23790427,
+          "spread": 0.069587,
+          "score": 0.24787253
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.02556934,
+          "spread": 0.00523725,
+          "score": 0.02610019
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.03065048,
+          "spread": 0.00268275,
+          "score": 0.03076766
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.01537713,
+          "spread": 0.00266395,
+          "score": 0.01560617
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00530771,
+          "spread": 0.00192587,
+          "score": 0.00564631
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00578283,
+          "spread": 0.0054731,
+          "score": 0.00796216
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.36534291,
+          "spread": 0.07083089,
+          "score": 0.37214574
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.02630905,
+          "spread": 0.03078416,
+          "score": 0.04049482
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.09181322,
+          "spread": 0.09882895,
+          "score": 0.13489562
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": -0.05283479,
+          "spread": 0.01605852,
+          "score": 0.0552213
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.10642011,
+          "spread": 0.02369615,
+          "score": 0.10902637
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.0406545,
+          "spread": 0.00957591,
+          "score": 0.04176705
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": -0.00055607,
+          "spread": 0.00933605,
+          "score": 0.0093526
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
-          "bias": -0.00712802,
-          "spread": 0.00495523,
-          "score": 0.00868119
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": -0.00712816,
+          "spread": 0.00495535,
+          "score": 0.00868137
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.663353,
+          "spread": 0.0,
+          "score": 0.663353
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.07046482,
+          "spread": 0.04165577,
+          "score": 0.08185654
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.04511136,
+          "spread": 0.01080788,
+          "score": 0.04638798
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00851225,
+          "spread": 0.01112801,
+          "score": 0.01401039
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.07596814,
+          "spread": 0.02619258,
+          "score": 0.08035676
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.13297755,
+          "spread": 0.06244652,
+          "score": 0.14691016
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.22420323,
+          "spread": 0.06997554,
+          "score": 0.23486947
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.36704829,
+          "spread": 0.0576019,
+          "score": 0.37154061
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": -0.92053582,
+          "spread": 0.67495422,
+          "score": 1.14146809
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.59095029,
+          "spread": 0.51165357,
+          "score": 0.78167232
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 1.4098744,
+          "spread": 1.49405434,
+          "score": 2.05425028
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.03659548,
+          "spread": 0.00518461,
+          "score": 0.03696091
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.03610263,
+          "spread": 0.00673427,
+          "score": 0.03672534
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.01407888,
+          "spread": 0.00932287,
+          "score": 0.01688582
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00364556,
+          "spread": 0.01158261,
+          "score": 0.01214277
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": -0.00099165,
+          "spread": 0.01255178,
+          "score": 0.01259089
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.50085602,
+          "spread": 0.23926808,
+          "score": 0.55507294
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": -0.00843917,
+          "spread": 0.03320235,
+          "score": 0.03425807
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.01700572,
+          "spread": 0.00301551,
+          "score": 0.01727101
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": -0.01094652,
+          "spread": 0.0,
+          "score": 0.01094652
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.14537726,
+          "spread": 0.04228381,
+          "score": 0.15140168
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.05146357,
+          "spread": 0.01552646,
+          "score": 0.05375472
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": -7.7e-07,
+          "spread": 0.011419,
+          "score": 0.011419
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
-          "bias": -0.00240698,
-          "spread": 0.00425268,
-          "score": 0.0048866
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": -0.00240721,
+          "spread": 0.00425299,
+          "score": 0.00488698
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.18721307,
+          "spread": 0.42033399,
+          "score": 0.46014063
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.08057456,
+          "spread": 0.0220606,
+          "score": 0.08353999
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.04550406,
+          "spread": 0.00523398,
+          "score": 0.04580408
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00526252,
+          "spread": 0.01017536,
+          "score": 0.01145565
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.07245722,
+          "spread": 0.0248712,
+          "score": 0.07660695
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.12532242,
+          "spread": 0.03471736,
+          "score": 0.13004232
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.20114581,
+          "spread": 0.03748994,
+          "score": 0.20460971
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.35034491,
+          "spread": 0.0444956,
+          "score": 0.35315919
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": -0.40765783,
+          "spread": 0.23833224,
+          "score": 0.47221517
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.60928102,
+          "spread": 0.62728778,
+          "score": 0.87447888
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.85119965,
+          "spread": 1.13449316,
+          "score": 1.41831434
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.03879984,
+          "spread": 0.0033947,
+          "score": 0.03894806
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.03608522,
+          "spread": 0.0047603,
+          "score": 0.03639785
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.01691586,
+          "spread": 0.00715692,
+          "score": 0.01836757
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00425793,
+          "spread": 0.00979289,
+          "score": 0.01067851
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00136751,
+          "spread": 0.00255017,
+          "score": 0.00289369
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.53707981,
+          "spread": 0.17711175,
+          "score": 0.56552921
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": -0.01496304,
+          "spread": 0.02314112,
+          "score": 0.02755729
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.04145237,
+          "spread": 0.06772573,
+          "score": 0.07940449
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": -0.01094652,
+          "spread": 0.0,
+          "score": 0.01094652
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.1286854,
+          "spread": 0.03670352,
+          "score": 0.13381734
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.04453171,
+          "spread": 0.01226189,
+          "score": 0.04618903
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.0045836,
+          "spread": 0.01233741,
+          "score": 0.01316135
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
-          "bias": -0.00283565,
-          "spread": 0.00477221,
-          "score": 0.00555111
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": -0.00283554,
+          "spread": 0.00477233,
+          "score": 0.00555116
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.18095196,
+          "spread": 0.42614103,
+          "score": 0.46296846
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.0700553,
+          "spread": 0.02431994,
+          "score": 0.07415663
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.03767292,
+          "spread": 0.01126372,
+          "score": 0.03932074
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00558782,
+          "spread": 0.00900178,
+          "score": 0.01059508
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.06773505,
+          "spread": 0.02326033,
+          "score": 0.0716176
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.11559398,
+          "spread": 0.02429252,
+          "score": 0.11811898
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.19403544,
+          "spread": 0.029304,
+          "score": 0.19623577
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.28587109,
+          "spread": 0.03640149,
+          "score": 0.28817937
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": -0.50535165,
+          "spread": 0.05368063,
+          "score": 0.50819475
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.47645009,
+          "spread": 0.66756009,
+          "score": 0.82014703
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.23789808,
+          "spread": 0.06958938,
+          "score": 0.24786726
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.02956374,
+          "spread": 0.0058094,
+          "score": 0.03012912
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.03128419,
+          "spread": 0.00270335,
+          "score": 0.03140078
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.01534078,
+          "spread": 0.00263443,
+          "score": 0.01556534
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00485412,
+          "spread": 0.0020733,
+          "score": 0.00527836
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00229076,
+          "spread": 0.00310424,
+          "score": 0.00385796
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.54181157,
+          "spread": 0.17013814,
+          "score": 0.56789679
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.01676294,
+          "spread": 0.02628107,
+          "score": 0.03117195
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.07689787,
+          "spread": 0.09627198,
+          "score": 0.12321354
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": -0.05371771,
+          "spread": 0.01694144,
+          "score": 0.05632588
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.13036655,
+          "spread": 0.02895781,
+          "score": 0.13354397
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.04976965,
+          "spread": 0.0117087,
+          "score": 0.05112839
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": -0.0007303,
+          "spread": 0.011375,
+          "score": 0.01139842
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
-          "bias": -0.00676189,
-          "spread": 0.00475233,
-          "score": 0.00826485
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": -0.00676183,
+          "spread": 0.00475228,
+          "score": 0.00826478
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.6213518,
+          "spread": 0.0,
+          "score": 0.6213518
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.06780722,
+          "spread": 0.03987841,
+          "score": 0.07866452
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.04357324,
+          "spread": 0.01049073,
+          "score": 0.04481833
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00805748,
+          "spread": 0.01060918,
+          "score": 0.01332208
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.07155131,
+          "spread": 0.02459027,
+          "score": 0.07565892
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.12439693,
+          "spread": 0.05824906,
+          "score": 0.1373592
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.20857827,
+          "spread": 0.06428824,
+          "score": 0.21826102
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.33718374,
+          "spread": 0.05413129,
+          "score": 0.3415012
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": -1.02173555,
+          "spread": 0.93591231,
+          "score": 1.38559568
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.58125934,
+          "spread": 0.43983751,
+          "score": 0.72891663
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 1.40989465,
+          "spread": 1.49404499,
+          "score": 2.05425738
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.03487352,
+          "spread": 0.00474593,
+          "score": 0.03519498
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.03584156,
+          "spread": 0.00658668,
+          "score": 0.03644176
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.01408017,
+          "spread": 0.00931146,
+          "score": 0.0168806
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00396138,
+          "spread": 0.01115633,
+          "score": 0.01183876
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00041275,
+          "spread": 0.01125493,
+          "score": 0.0112625
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.44607821,
+          "spread": 0.20208141,
+          "score": 0.48971692
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": -0.0018577,
+          "spread": 0.03761962,
+          "score": 0.03766546
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.01363393,
+          "spread": 0.00035627,
+          "score": 0.01363859
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": -0.01094652,
+          "spread": 0.0,
+          "score": 0.01094652
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.13606572,
+          "spread": 0.03962814,
+          "score": 0.14171898
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.04816826,
+          "spread": 0.0145513,
+          "score": 0.0503182
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 2.61e-05,
+          "spread": 0.01071137,
+          "score": 0.0107114
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
+          "condition": "overall",
+          "condition_bin": "overall",
           "bias": -0.00223764,
           "spread": 0.00405543,
           "score": 0.0046318
         },
         {
           "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.17577232,
+          "spread": 0.39327803,
+          "score": 0.43077084
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.07706473,
+          "spread": 0.02105738,
+          "score": 0.07988984
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.04399593,
+          "spread": 0.0052552,
+          "score": 0.04430868
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00497503,
+          "spread": 0.00972353,
+          "score": 0.01092236
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.06831011,
+          "spread": 0.02342315,
+          "score": 0.07221437
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.11733133,
+          "spread": 0.03244374,
+          "score": 0.12173429
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.18697233,
+          "spread": 0.03449637,
+          "score": 0.19012798
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.32069758,
+          "spread": 0.04137616,
+          "score": 0.32335573
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": -0.49126472,
+          "spread": 0.10161902,
+          "score": 0.50166468
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.71475499,
+          "spread": 0.70585472,
+          "score": 1.00454248
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.85280785,
+          "spread": 1.13726999,
+          "score": 1.42150071
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.03697236,
+          "spread": 0.00331788,
+          "score": 0.03712094
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.03580266,
+          "spread": 0.00460602,
+          "score": 0.03609773
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.01691705,
+          "spread": 0.00714686,
+          "score": 0.01836475
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00456047,
+          "spread": 0.00940636,
+          "score": 0.01045359
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00252737,
+          "spread": 0.00340146,
+          "score": 0.00423763
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.47234494,
+          "spread": 0.13768888,
+          "score": 0.49200403
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": -0.01079358,
+          "spread": 0.02088147,
+          "score": 0.02350611
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.05031162,
+          "spread": 0.06546492,
+          "score": 0.08256461
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": -0.01094652,
+          "spread": 0.0,
+          "score": 0.01094652
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.1204164,
+          "spread": 0.03439734,
+          "score": 0.12523293
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.04167321,
+          "spread": 0.01148318,
+          "score": 0.04322637
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00431566,
+          "spread": 0.01156488,
+          "score": 0.01234388
+        },
+        {
+          "profile": "cp_plus_3pct",
           "campaign_months": 12,
-          "bias": -0.00267486,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": -0.00267489,
           "spread": 0.00458252,
-          "score": 0.00530607
+          "score": 0.00530608
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.17017193,
+          "spread": 0.3987422,
+          "score": 0.43353642
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.06704264,
+          "spread": 0.02314988,
+          "score": 0.07092695
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.03654336,
+          "spread": 0.01096174,
+          "score": 0.03815202
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00532178,
+          "spread": 0.00865552,
+          "score": 0.01016068
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.06406758,
+          "spread": 0.02195069,
+          "score": 0.06772361
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.10855828,
+          "spread": 0.0228393,
+          "score": 0.11093482
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.18090245,
+          "spread": 0.02749638,
+          "score": 0.18298018
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.26423278,
+          "spread": 0.03365098,
+          "score": 0.26636694
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": -0.45568382,
+          "spread": 0.04859791,
+          "score": 0.45826794
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.67732927,
+          "spread": 0.34753896,
+          "score": 0.76128725
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.23790025,
+          "spread": 0.06958855,
+          "score": 0.2478691
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.0281657,
+          "spread": 0.00560858,
+          "score": 0.02871868
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.03106239,
+          "spread": 0.00269388,
+          "score": 0.03117899
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.0153535,
+          "spread": 0.00264471,
+          "score": 0.01557962
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00501288,
+          "spread": 0.00201575,
+          "score": 0.00540298
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00351298,
+          "spread": 0.00391297,
+          "score": 0.00525856
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.48004932,
+          "spread": 0.13405596,
+          "score": 0.49841584
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.02010407,
+          "spread": 0.02779161,
+          "score": 0.03430083
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.08211824,
+          "spread": 0.09707331,
+          "score": 0.12714807
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": -0.05340869,
+          "spread": 0.01663242,
+          "score": 0.05593859
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.12198612,
+          "spread": 0.02711546,
+          "score": 0.12496344
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.0465795,
+          "spread": 0.01096241,
+          "score": 0.0478521
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": -0.00066932,
+          "spread": 0.01066137,
+          "score": 0.01068236
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
-          "bias": -0.00670173,
-          "spread": 0.00474853,
-          "score": 0.00821351
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": -0.00670211,
+          "spread": 0.00474883,
+          "score": 0.00821399
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.60351799,
+          "spread": 0.0,
+          "score": 0.60351799
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.06806593,
+          "spread": 0.03981541,
+          "score": 0.0788558
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.04395128,
+          "spread": 0.01064743,
+          "score": 0.04522259
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00795563,
+          "spread": 0.01051691,
+          "score": 0.01318702
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.07003207,
+          "spread": 0.02395084,
+          "score": 0.07401442
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.1208942,
+          "spread": 0.05646921,
+          "score": 0.1334323
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.20200994,
+          "spread": 0.06189479,
+          "score": 0.21127939
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.3244143,
+          "spread": 0.05271003,
+          "score": 0.32866851
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": -1.06510877,
+          "spread": 1.04932713,
+          "score": 1.4951736
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.57716028,
+          "spread": 0.45021982,
+          "score": 0.73199172
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 1.4132972,
+          "spread": 1.49986345,
+          "score": 2.06082491
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.03459405,
+          "spread": 0.00449486,
+          "score": 0.03488484
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.03731573,
+          "spread": 0.00675733,
+          "score": 0.03792262
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.01476429,
+          "spread": 0.00976017,
+          "score": 0.01769874
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00451312,
+          "spread": 0.01121757,
+          "score": 0.0120914
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00205473,
+          "spread": 0.01047018,
+          "score": 0.01066989
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.42260628,
+          "spread": 0.18635419,
+          "score": 0.46187006
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.00555696,
+          "spread": 0.04513769,
+          "score": 0.04547847
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.01044117,
+          "spread": 0.00424209,
+          "score": 0.01127002
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": -0.01148907,
+          "spread": 0.0,
+          "score": 0.01148907
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.13207513,
+          "spread": 0.03849007,
+          "score": 0.13756935
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.04675612,
+          "spread": 0.01413338,
+          "score": 0.04884554
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 3.855e-05,
+          "spread": 0.01041252,
+          "score": 0.01041259
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
-          "bias": -0.00218881,
-          "spread": 0.00403347,
-          "score": 0.00458909
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": -0.00218897,
+          "spread": 0.00403319,
+          "score": 0.00458892
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.17093409,
+          "spread": 0.3817476,
+          "score": 0.41826988
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.07680596,
+          "spread": 0.02096361,
+          "score": 0.0796155
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.04442331,
+          "spread": 0.00554765,
+          "score": 0.04476837
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00491456,
+          "spread": 0.00967434,
+          "score": 0.01085107
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.06695866,
+          "spread": 0.02291728,
+          "score": 0.07077192
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.11417168,
+          "spread": 0.03151402,
+          "score": 0.11844114
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.18104354,
+          "spread": 0.03326715,
+          "score": 0.18407463
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.30799577,
+          "spread": 0.04012906,
+          "score": 0.310599
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": -0.52710026,
+          "spread": 0.16459305,
+          "score": 0.55220065
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.75990082,
+          "spread": 0.74589991,
+          "score": 1.06480794
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.85120392,
+          "spread": 1.13449079,
+          "score": 1.41831501
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.03668051,
+          "spread": 0.00340497,
+          "score": 0.03683821
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.0372543,
+          "spread": 0.00466475,
+          "score": 0.0375452
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.01775063,
+          "spread": 0.00749292,
+          "score": 0.0192673
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00513028,
+          "spread": 0.00942742,
+          "score": 0.01073294
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00398935,
+          "spread": 0.00482155,
+          "score": 0.00625797
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.4445974,
+          "spread": 0.12144983,
+          "score": 0.46088709
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": -0.00656848,
+          "spread": 0.01985854,
+          "score": 0.02091666
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.06299882,
+          "spread": 0.06609339,
+          "score": 0.0913082
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": -0.01148907,
+          "spread": 0.0,
+          "score": 0.01148907
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.11687347,
+          "spread": 0.03340778,
+          "score": 0.12155446
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.04044866,
+          "spread": 0.01114955,
+          "score": 0.0419572
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00420326,
+          "spread": 0.01123792,
+          "score": 0.01199826
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
-          "bias": -0.00264277,
-          "spread": 0.00458772,
-          "score": 0.00529447
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": -0.00264285,
+          "spread": 0.00458759,
+          "score": 0.0052944
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.16561634,
+          "spread": 0.38706428,
+          "score": 0.42100776
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.06687022,
+          "spread": 0.02295225,
+          "score": 0.07069959
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.03704379,
+          "spread": 0.01115836,
+          "score": 0.03868787
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00529252,
+          "spread": 0.00868104,
+          "score": 0.01016716
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.06304121,
+          "spread": 0.0215217,
+          "score": 0.06661365
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.10596408,
+          "spread": 0.02230383,
+          "score": 0.10828595
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.17546183,
+          "spread": 0.0268024,
+          "score": 0.1774971
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.25502704,
+          "spread": 0.03251504,
+          "score": 0.25709146
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": -0.43439824,
+          "spread": 0.04642239,
+          "score": 0.43687168
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.76343543,
+          "spread": 0.3480127,
+          "score": 0.83901519
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.23790118,
+          "spread": 0.06958819,
+          "score": 0.2478699
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.02793837,
+          "spread": 0.00565243,
+          "score": 0.02850443
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.03235154,
+          "spread": 0.00282217,
+          "score": 0.0324744
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.01612813,
+          "spread": 0.00279197,
+          "score": 0.01636801
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.0054432,
+          "spread": 0.00205861,
+          "score": 0.00581948
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.0050954,
+          "spread": 0.00506988,
+          "score": 0.00718796
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.45357779,
+          "spread": 0.11884607,
+          "score": 0.46888932
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.02493297,
+          "spread": 0.03101367,
+          "score": 0.03979322
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.09216353,
+          "spread": 0.10294529,
+          "score": 0.13817326
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": -0.05602043,
+          "spread": 0.01680316,
+          "score": 0.05848619
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.11839352,
+          "spread": 0.02632635,
+          "score": 0.12128521
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.04521216,
+          "spread": 0.01064231,
+          "score": 0.0464478
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": -0.0006427,
+          "spread": 0.01035862,
+          "score": 0.01037854
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
-          "bias": -0.0069171,
-          "spread": 0.00485054,
-          "score": 0.00844831
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": -0.00691731,
+          "spread": 0.00485141,
+          "score": 0.00844899
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.663353,
+          "spread": 0.0,
+          "score": 0.663353
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.07046482,
+          "spread": 0.04165577,
+          "score": 0.08185654
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.04476874,
+          "spread": 0.01073821,
+          "score": 0.04603856
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00827623,
+          "spread": 0.01085824,
+          "score": 0.01365274
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.07219813,
+          "spread": 0.02484749,
+          "score": 0.07635423
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.12271685,
+          "spread": 0.05745397,
+          "score": 0.1355005
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.20188652,
+          "spread": 0.0618571,
+          "score": 0.21115035
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.32441044,
+          "spread": 0.05270889,
+          "score": 0.32866451
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": -1.06509064,
+          "spread": 1.0493362,
+          "score": 1.49516706
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.57715586,
+          "spread": 0.45022103,
+          "score": 0.73198898
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 1.41329717,
+          "spread": 1.49986342,
+          "score": 2.06082488
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.03571678,
+          "spread": 0.00494465,
+          "score": 0.03605743
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.03598972,
+          "spread": 0.00667666,
+          "score": 0.0366038
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.01407744,
+          "spread": 0.0093184,
+          "score": 0.01688215
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00384265,
+          "spread": 0.01131652,
+          "score": 0.01195114
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00015227,
+          "spread": 0.01152152,
+          "score": 0.01152252
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.4551848,
+          "spread": 0.21268021,
+          "score": 0.50242021
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": -0.00518249,
+          "spread": 0.03371312,
+          "score": 0.03410913
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.01602633,
+          "spread": 0.00203612,
+          "score": 0.01615516
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": -0.01094652,
+          "spread": 0.0,
+          "score": 0.01094652
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.1397569,
+          "spread": 0.04114538,
+          "score": 0.14568779
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.04962953,
+          "spread": 0.01503582,
+          "score": 0.05185717
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": -2.89e-06,
+          "spread": 0.01104039,
+          "score": 0.01104039
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
-          "bias": -0.00231017,
-          "spread": 0.00414554,
-          "score": 0.00474578
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": -0.00231062,
+          "spread": 0.00414486,
+          "score": 0.0047454
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.18721307,
+          "spread": 0.42033399,
+          "score": 0.46014063
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.08057456,
+          "spread": 0.0220606,
+          "score": 0.08353999
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.04516853,
+          "spread": 0.00523896,
+          "score": 0.04547134
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00511692,
+          "spread": 0.00994081,
+          "score": 0.01118045
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.0689189,
+          "spread": 0.02365192,
+          "score": 0.07286445
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.1157304,
+          "spread": 0.03199829,
+          "score": 0.12007255
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.18089689,
+          "spread": 0.03322146,
+          "score": 0.18392213
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.30798658,
+          "spread": 0.04012966,
+          "score": 0.31058996
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": -0.52709899,
+          "spread": 0.16459736,
+          "score": 0.55220072
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.75993836,
+          "spread": 0.74588682,
+          "score": 1.06482555
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.85280912,
+          "spread": 1.13726928,
+          "score": 1.4215009
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.03787307,
+          "spread": 0.00329693,
+          "score": 0.0380163
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.03595658,
+          "spread": 0.00471173,
+          "score": 0.03626397
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.01691182,
+          "spread": 0.00715418,
+          "score": 0.01836278
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00444385,
+          "spread": 0.00953026,
+          "score": 0.0105154
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00229454,
+          "spread": 0.00348085,
+          "score": 0.00416908
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.48399469,
+          "spread": 0.1484146,
+          "score": 0.50623883
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": -0.01300642,
+          "spread": 0.02148917,
+          "score": 0.02511875
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.04346204,
+          "spread": 0.06716468,
+          "score": 0.08000027
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": -0.01094652,
+          "spread": 0.0,
+          "score": 0.01094652
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.12407502,
+          "spread": 0.03563684,
+          "score": 0.12909142
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.04297548,
+          "spread": 0.0119208,
+          "score": 0.04459818
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00442041,
+          "spread": 0.01190049,
+          "score": 0.01269495
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
-          "bias": -0.00274427,
-          "spread": 0.00467084,
-          "score": 0.00541736
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": -0.00274432,
+          "spread": 0.00467085,
+          "score": 0.00541739
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.18095196,
+          "spread": 0.42614103,
+          "score": 0.46296846
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.0700553,
+          "spread": 0.02431994,
+          "score": 0.07415663
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.03742572,
+          "spread": 0.01119443,
+          "score": 0.03906405
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00544903,
+          "spread": 0.00882064,
+          "score": 0.01036801
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.06460251,
+          "spread": 0.02214587,
+          "score": 0.06829293
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.10716245,
+          "spread": 0.02256746,
+          "score": 0.10951293
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.17527402,
+          "spread": 0.02672213,
+          "score": 0.17729934
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.25495921,
+          "spread": 0.03247412,
+          "score": 0.25701901
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": -0.43439172,
+          "spread": 0.04642704,
+          "score": 0.43686569
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.76342035,
+          "spread": 0.34803291,
+          "score": 0.83900986
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.23790117,
+          "spread": 0.06958819,
+          "score": 0.2478699
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.02884084,
+          "spread": 0.005671,
+          "score": 0.0293931
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.0311771,
+          "spread": 0.00270242,
+          "score": 0.031294
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.01534527,
+          "spread": 0.00263165,
+          "score": 0.01556929
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.0049456,
+          "spread": 0.00201824,
+          "score": 0.00534156
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00300117,
+          "spread": 0.00364428,
+          "score": 0.004721
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.49149519,
+          "spread": 0.14212235,
+          "score": 0.511631
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.01810253,
+          "spread": 0.02701234,
+          "score": 0.03251719
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.07833403,
+          "spread": 0.09645527,
+          "score": 0.12425715
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": -0.05360083,
+          "spread": 0.01682456,
+          "score": 0.05617931
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.12573337,
+          "spread": 0.02799561,
+          "score": 0.1288124
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.04805173,
+          "spread": 0.01139505,
+          "score": 0.04938437
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": -0.00069967,
+          "spread": 0.01099477,
+          "score": 0.01101701
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
-          "bias": -0.00683324,
-          "spread": 0.00483019,
-          "score": 0.00836803
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": -0.00683299,
+          "spread": 0.0048307,
+          "score": 0.00836812
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.61595635,
+          "spread": 0.0,
+          "score": 0.61595635
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.06893056,
+          "spread": 0.04069549,
+          "score": 0.08004714
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.0439288,
+          "spread": 0.01058455,
+          "score": 0.04518597
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00812912,
+          "spread": 0.01070707,
+          "score": 0.01344336
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.07278519,
+          "spread": 0.02508014,
+          "score": 0.07698504
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.1279691,
+          "spread": 0.06016463,
+          "score": 0.14140677
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.21719673,
+          "spread": 0.06716477,
+          "score": 0.22734451
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.35926234,
+          "spread": 0.05613581,
+          "score": 0.36362159
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": -0.91403967,
+          "spread": 0.67946424,
+          "score": 1.13892062
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.58363962,
+          "spread": 0.50706237,
+          "score": 0.77314129
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 1.41326824,
+          "spread": 1.49987679,
+          "score": 2.06081477
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.03456217,
+          "spread": 0.0046474,
+          "score": 0.03487323
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.03572933,
+          "spread": 0.00652375,
+          "score": 0.03632002
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.01407931,
+          "spread": 0.00930569,
+          "score": 0.01687669
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00409674,
+          "spread": 0.01097386,
+          "score": 0.01171362
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00101464,
+          "spread": 0.01073525,
+          "score": 0.01078309
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.50084889,
+          "spread": 0.23927779,
+          "score": 0.55507069
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.00096292,
+          "spread": 0.03964622,
+          "score": 0.03965791
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.01218888,
+          "spread": 0.00180133,
+          "score": 0.01232127
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": -0.01094652,
+          "spread": 0.0,
+          "score": 0.01094652
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.14464283,
+          "spread": 0.04210922,
+          "score": 0.15064772
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.05003719,
+          "spread": 0.01509711,
+          "score": 0.05226512
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 2.323e-05,
+          "spread": 0.01084255,
+          "score": 0.01084257
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
-          "bias": -0.00225087,
-          "spread": 0.00412935,
-          "score": 0.00470297
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": -0.00225093,
+          "spread": 0.00412934,
+          "score": 0.00470299
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.17029099,
+          "spread": 0.39876511,
+          "score": 0.43360424
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.07873988,
+          "spread": 0.02141806,
+          "score": 0.08160087
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.0443911,
+          "spread": 0.00532122,
+          "score": 0.0447089
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00498772,
+          "spread": 0.00980549,
+          "score": 0.01100113
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.06946134,
+          "spread": 0.02378712,
+          "score": 0.07342142
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.12031917,
+          "spread": 0.03312592,
+          "score": 0.12479595
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.19379166,
+          "spread": 0.03483285,
+          "score": 0.19689727
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.34156406,
+          "spread": 0.04282988,
+          "score": 0.34423888
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": -0.41427212,
+          "spread": 0.21188134,
+          "score": 0.46531182
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.60887344,
+          "spread": 0.62985284,
+          "score": 0.87603737
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.85119965,
+          "spread": 1.13449316,
+          "score": 1.41831434
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.03663733,
+          "spread": 0.00330914,
+          "score": 0.03678647
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.0356818,
+          "spread": 0.00454002,
+          "score": 0.03596946
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.0169184,
+          "spread": 0.00714302,
+          "score": 0.0183645
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00469014,
+          "spread": 0.00924097,
+          "score": 0.01036305
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00302445,
+          "spread": 0.00384508,
+          "score": 0.00489203
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.53707981,
+          "spread": 0.17711175,
+          "score": 0.56552921
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": -0.00900666,
+          "spread": 0.02003737,
+          "score": 0.02196853
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.05410844,
+          "spread": 0.064496,
+          "score": 0.08418704
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": -0.01094652,
+          "spread": 0.0,
+          "score": 0.01094652
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.1280475,
+          "spread": 0.03651235,
+          "score": 0.13315147
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.04330615,
+          "spread": 0.01192084,
+          "score": 0.04491692
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00436956,
+          "spread": 0.01170654,
+          "score": 0.01249544
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
-          "bias": -0.00267457,
-          "spread": 0.00463682,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": -0.00267455,
+          "spread": 0.00463684,
           "score": 0.00535289
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.16433811,
+          "spread": 0.40458172,
+          "score": 0.43668453
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.06817389,
+          "spread": 0.02355293,
+          "score": 0.0721278
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.03684483,
+          "spread": 0.0110663,
+          "score": 0.03847083
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00532638,
+          "spread": 0.00873906,
+          "score": 0.01023433
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.06492339,
+          "spread": 0.02226652,
+          "score": 0.06863559
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.11080294,
+          "spread": 0.02310404,
+          "score": 0.11318608
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.18657365,
+          "spread": 0.02801131,
+          "score": 0.18866468
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.27721664,
+          "spread": 0.03621307,
+          "score": 0.27957191
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": -0.49248413,
+          "spread": 0.05490073,
+          "score": 0.49553477
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.51484072,
+          "spread": 0.57399518,
+          "score": 0.77105865
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.23789808,
+          "spread": 0.06958938,
+          "score": 0.24786726
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.02790073,
+          "spread": 0.00558061,
+          "score": 0.02845336
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.03096728,
+          "spread": 0.00269062,
+          "score": 0.03108395
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.01535891,
+          "spread": 0.00264916,
+          "score": 0.0155857
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00508092,
+          "spread": 0.00199297,
+          "score": 0.00545781
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00403679,
+          "spread": 0.00426815,
+          "score": 0.00587476
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.54181263,
+          "spread": 0.17013617,
+          "score": 0.56789721
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.02153599,
+          "spread": 0.02846229,
+          "score": 0.03569175
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.08435554,
+          "spread": 0.097448,
+          "score": 0.12888743
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": -0.05327625,
+          "spread": 0.01649998,
+          "score": 0.05577283
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.12970753,
+          "spread": 0.02880359,
+          "score": 0.13286719
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.04839087,
+          "spread": 0.01138002,
+          "score": 0.04971097
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": -0.0006787,
+          "spread": 0.01079108,
+          "score": 0.0108124
         }
       ]
     },
     "toggle": {
-      "recorded_utc": "2026-06-30T10:04:36Z",
-      "git_commit": "ddd1b63-dirty",
+      "recorded_utc": "2026-07-01T08:52:23Z",
+      "git_commit": "1ccd745-dirty",
       "n_replicates": 4,
       "seed": 0,
       "campaign_months": [
@@ -194,198 +4583,6050 @@
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
+          "condition": "overall",
+          "condition_bin": "overall",
           "bias": 0.00362415,
           "spread": 0.00084001,
           "score": 0.00372022
         },
         {
           "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.0725688,
+          "spread": 0.04296709,
+          "score": 0.08433505
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.04137978,
+          "spread": 0.01248489,
+          "score": 0.0432222
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00390505,
+          "spread": 0.00713679,
+          "score": 0.0081353
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.05080816,
+          "spread": 0.02188556,
+          "score": 0.0553213
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.09955908,
+          "spread": 0.05191607,
+          "score": 0.11228219
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.19283457,
+          "spread": 0.07378147,
+          "score": 0.20646762
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.30695144,
+          "spread": 0.06108829,
+          "score": 0.31297119
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": -0.05030028,
+          "spread": 0.79275906,
+          "score": 0.79435322
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.60850882,
+          "spread": 0.72776091,
+          "score": 0.94864057
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.42643752,
+          "spread": 0.16995806,
+          "score": 0.45905849
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.03481803,
+          "spread": 0.00553015,
+          "score": 0.03525447
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.0377612,
+          "spread": 0.00860171,
+          "score": 0.03872851
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.01528605,
+          "spread": 0.0086295,
+          "score": 0.01755367
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00880417,
+          "spread": 0.00955974,
+          "score": 0.01299623
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.02044985,
+          "spread": 0.0284785,
+          "score": 0.03506026
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.33902348,
+          "spread": 0.15490214,
+          "score": 0.37273529
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.10917218,
+          "spread": 0.14966031,
+          "score": 0.18524787
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.03146924,
+          "spread": 0.03598574,
+          "score": 0.04780467
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.09961219,
+          "spread": 0.02727846,
+          "score": 0.10327973
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.02699246,
+          "spread": 0.0111982,
+          "score": 0.02922316
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00734324,
+          "spread": 0.00803343,
+          "score": 0.0108839
+        },
+        {
+          "profile": "cp_0pct",
           "campaign_months": 6,
+          "condition": "overall",
+          "condition_bin": "overall",
           "bias": 0.00129828,
           "spread": 0.00178902,
           "score": 0.00221046
         },
         {
           "profile": "cp_0pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.07172624,
+          "spread": 0.18758343,
+          "score": 0.20082878
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.06084225,
+          "spread": 0.01500185,
+          "score": 0.06266446
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.03587791,
+          "spread": 0.00409578,
+          "score": 0.03611093
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00130209,
+          "spread": 0.00928846,
+          "score": 0.00937928
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.0531264,
+          "spread": 0.02039189,
+          "score": 0.05690557
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.09442732,
+          "spread": 0.02407035,
+          "score": 0.09744691
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.16322269,
+          "spread": 0.02562153,
+          "score": 0.16522139
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.31748293,
+          "spread": 0.04716023,
+          "score": 0.32096651
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": -0.12954566,
+          "spread": 0.46638117,
+          "score": 0.48403871
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -1.08266035,
+          "spread": 1.94437884,
+          "score": 2.22548029
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.26948173,
+          "spread": 0.14456417,
+          "score": 0.30580909
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.03085874,
+          "spread": 0.00692359,
+          "score": 0.03162591
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.03094049,
+          "spread": 0.00448862,
+          "score": 0.03126438
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.01405346,
+          "spread": 0.00520259,
+          "score": 0.01498555
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00519709,
+          "spread": 0.00700346,
+          "score": 0.00872113
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.0229594,
+          "spread": 0.03635384,
+          "score": 0.04299693
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.35777593,
+          "spread": 0.1114151,
+          "score": 0.37472249
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.00638983,
+          "spread": 0.00782921,
+          "score": 0.01010577
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.11643556,
+          "spread": 0.12278728,
+          "score": 0.16921571
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.09537696,
+          "spread": 0.02180894,
+          "score": 0.09783861
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.02942573,
+          "spread": 0.0125112,
+          "score": 0.03197505
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00684728,
+          "spread": 0.00924592,
+          "score": 0.01150531
+        },
+        {
+          "profile": "cp_0pct",
           "campaign_months": 9,
-          "bias": 0.00086062,
-          "spread": 0.00160665,
-          "score": 0.00182263
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00086065,
+          "spread": 0.00160661,
+          "score": 0.00182261
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.08607062,
+          "spread": 0.23385038,
+          "score": 0.24918698
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.05634065,
+          "spread": 0.01742052,
+          "score": 0.0589724
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.03336178,
+          "spread": 0.00484679,
+          "score": 0.03371201
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 9.996e-05,
+          "spread": 0.00876898,
+          "score": 0.00876955
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.05135417,
+          "spread": 0.01866066,
+          "score": 0.05463946
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.09062971,
+          "spread": 0.0192712,
+          "score": 0.09265594
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.17182902,
+          "spread": 0.03302273,
+          "score": 0.17497346
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.21555439,
+          "spread": 0.05592531,
+          "score": 0.22269112
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": -0.39135721,
+          "spread": 0.17362477,
+          "score": 0.42814253
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.64365086,
+          "spread": 0.52287243,
+          "score": 0.82926595
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.07270515,
+          "spread": 0.05177916,
+          "score": 0.08925873
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.02674066,
+          "spread": 0.00582959,
+          "score": 0.02736873
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.02962513,
+          "spread": 0.00272976,
+          "score": 0.02975063
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.01333601,
+          "spread": 0.00405941,
+          "score": 0.01394015
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00321629,
+          "spread": 0.00317021,
+          "score": 0.00451605
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.01626209,
+          "spread": 0.03025559,
+          "score": 0.03434903
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.37638841,
+          "spread": 0.10557553,
+          "score": 0.39091486
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.01197757,
+          "spread": 0.01791138,
+          "score": 0.02154715
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.06497681,
+          "spread": 0.10901263,
+          "score": 0.12690838
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": -0.05352162,
+          "spread": 0.0,
+          "score": 0.05352162
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.09473215,
+          "spread": 0.02357955,
+          "score": 0.09762262
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.03317491,
+          "spread": 0.01063821,
+          "score": 0.03483886
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00366757,
+          "spread": 0.0077561,
+          "score": 0.00857952
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
+          "condition": "overall",
+          "condition_bin": "overall",
           "bias": 0.00056382,
           "spread": 0.00088262,
           "score": 0.00104734
         },
         {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.05072946,
+          "spread": 0.2079989,
+          "score": 0.21409582
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.05304106,
+          "spread": 0.01934364,
+          "score": 0.05645822
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.03035949,
+          "spread": 0.00745886,
+          "score": 0.03126233
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00052224,
+          "spread": 0.00628376,
+          "score": 0.00630543
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.04864369,
+          "spread": 0.01659399,
+          "score": 0.0513962
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.08480506,
+          "spread": 0.01214415,
+          "score": 0.08567017
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.15673588,
+          "spread": 0.04476985,
+          "score": 0.16300453
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.22170784,
+          "spread": 0.07376056,
+          "score": 0.2336557
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": -0.3845603,
+          "spread": 0.11345253,
+          "score": 0.40094651
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.81986538,
+          "spread": 0.41598445,
+          "score": 0.91935973
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.03996867,
+          "spread": 0.06396209,
+          "score": 0.07542309
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.02451635,
+          "spread": 0.00737081,
+          "score": 0.02560039
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.02835509,
+          "spread": 0.00357923,
+          "score": 0.0285801
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.01187041,
+          "spread": 0.00326057,
+          "score": 0.01231007
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00259627,
+          "spread": 0.00158386,
+          "score": 0.00304125
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00242023,
+          "spread": 0.00299091,
+          "score": 0.00384748
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.38758069,
+          "spread": 0.0941431,
+          "score": 0.39885049
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.01919412,
+          "spread": 0.02558017,
+          "score": 0.0319806
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.10574487,
+          "spread": 0.10966452,
+          "score": 0.15234265
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": -0.02575415,
+          "spread": 0.0,
+          "score": 0.02575415
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.09090171,
+          "spread": 0.02228511,
+          "score": 0.09359352
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.03262346,
+          "spread": 0.00911619,
+          "score": 0.03387322
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00127804,
+          "spread": 0.00726706,
+          "score": 0.00737858
+        },
+        {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
+          "condition": "overall",
+          "condition_bin": "overall",
           "bias": 0.0034594,
           "spread": 0.00078816,
           "score": 0.00354805
         },
         {
           "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.06830113,
+          "spread": 0.04011243,
+          "score": 0.07920891
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.03927348,
+          "spread": 0.01189949,
+          "score": 0.04103662
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00372192,
+          "spread": 0.00667132,
+          "score": 0.00763932
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.04611883,
+          "spread": 0.01976071,
+          "score": 0.05017402
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.0894371,
+          "spread": 0.04633941,
+          "score": 0.10072902
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.17150558,
+          "spread": 0.0651374,
+          "score": 0.18345856
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.26309396,
+          "spread": 0.05668092,
+          "score": 0.26913038
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.36335274,
+          "spread": 0.6133078,
+          "score": 0.71286161
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.93532584,
+          "spread": 1.03945132,
+          "score": 1.39831809
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.42646322,
+          "spread": 0.16998224,
+          "score": 0.45909132
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.03230966,
+          "spread": 0.00494386,
+          "score": 0.03268572
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.03735159,
+          "spread": 0.00837916,
+          "score": 0.03827991
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.01530115,
+          "spread": 0.00860361,
+          "score": 0.01755413
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00916504,
+          "spread": 0.00911348,
+          "score": 0.01292492
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.02230959,
+          "spread": 0.03034727,
+          "score": 0.03766529
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.27644876,
+          "spread": 0.11300094,
+          "score": 0.29865219
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.11609461,
+          "spread": 0.15944115,
+          "score": 0.19722941
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.03901948,
+          "spread": 0.02843549,
+          "score": 0.04828144
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.08955983,
+          "spread": 0.0246033,
+          "score": 0.0928778
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.02426282,
+          "spread": 0.01010333,
+          "score": 0.02628235
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00665658,
+          "spread": 0.00724874,
+          "score": 0.00984146
+        },
+        {
+          "profile": "cp_minus_10pct",
           "campaign_months": 6,
+          "condition": "overall",
+          "condition_bin": "overall",
           "bias": 0.00131574,
           "spread": 0.00168113,
           "score": 0.0021348
         },
         {
           "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.065484,
+          "spread": 0.16789477,
+          "score": 0.18021323
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.05674516,
+          "spread": 0.01416225,
+          "score": 0.05848574
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.03410116,
+          "spread": 0.0040361,
+          "score": 0.03433918
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00131213,
+          "spread": 0.00864584,
+          "score": 0.00874485
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.04837116,
+          "spread": 0.01851807,
+          "score": 0.05179468
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.08489255,
+          "spread": 0.02145188,
+          "score": 0.087561
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.14498629,
+          "spread": 0.02335235,
+          "score": 0.14685488
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.27131227,
+          "spread": 0.04541822,
+          "score": 0.27508756
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": -0.46970009,
+          "spread": 0.40029833,
+          "score": 0.61713607
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -1.18305647,
+          "spread": 2.04104371,
+          "score": 2.35912739
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.26948521,
+          "spread": 0.14456183,
+          "score": 0.30581105
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.02865613,
+          "spread": 0.00658847,
+          "score": 0.02940377
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.03058934,
+          "spread": 0.00431655,
+          "score": 0.0308924
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.01405546,
+          "spread": 0.00518321,
+          "score": 0.0149807
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.0055654,
+          "spread": 0.00666553,
+          "score": 0.00868349
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.02466864,
+          "spread": 0.03793078,
+          "score": 0.04524694
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.27946043,
+          "spread": 0.06418473,
+          "score": 0.28673648
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.01175941,
+          "spread": 0.01244059,
+          "score": 0.01711876
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.13126831,
+          "spread": 0.12251955,
+          "score": 0.17956172
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.08571026,
+          "spread": 0.01968201,
+          "score": 0.08794106
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.02644728,
+          "spread": 0.01127155,
+          "score": 0.02874902
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00620359,
+          "spread": 0.00834578,
+          "score": 0.01039887
+        },
+        {
+          "profile": "cp_minus_10pct",
           "campaign_months": 9,
-          "bias": 0.00088486,
-          "spread": 0.0015148,
-          "score": 0.0017543
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00088483,
+          "spread": 0.00151483,
+          "score": 0.00175432
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.07865029,
+          "spread": 0.20927868,
+          "score": 0.22356975
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.05259933,
+          "spread": 0.01620704,
+          "score": 0.0550396
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.03173971,
+          "spread": 0.00482514,
+          "score": 0.03210438
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.0001665,
+          "spread": 0.0081893,
+          "score": 0.00819099
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.04688867,
+          "spread": 0.01701167,
+          "score": 0.04987929
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.08169365,
+          "spread": 0.01735838,
+          "score": 0.08351746
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.15289739,
+          "spread": 0.02973037,
+          "score": 0.15576106
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.18746992,
+          "spread": 0.05034272,
+          "score": 0.19411172
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": -0.30944468,
+          "spread": 0.12802803,
+          "score": 0.33488384
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.86699902,
+          "spread": 0.7588673,
+          "score": 1.15220089
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.07270747,
+          "spread": 0.05177987,
+          "score": 0.08926103
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.02480047,
+          "spread": 0.00553782,
+          "score": 0.02541123
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.02929655,
+          "spread": 0.00264111,
+          "score": 0.02941535
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.01334982,
+          "spread": 0.00404478,
+          "score": 0.01394912
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00349255,
+          "spread": 0.00290655,
+          "score": 0.00454378
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.01832636,
+          "spread": 0.03147424,
+          "score": 0.03642092
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.299286,
+          "spread": 0.06812276,
+          "score": 0.30694107
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.01648911,
+          "spread": 0.01678491,
+          "score": 0.02352921
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.07392362,
+          "spread": 0.11384066,
+          "score": 0.1357365
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": -0.05331816,
+          "spread": 0.0,
+          "score": 0.05331816
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.0851346,
+          "spread": 0.02127153,
+          "score": 0.0877518
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.02982309,
+          "spread": 0.0095818,
+          "score": 0.03132455
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00333275,
+          "spread": 0.00700168,
+          "score": 0.0077544
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
+          "condition": "overall",
+          "condition_bin": "overall",
           "bias": 0.00061016,
           "spread": 0.00085288,
           "score": 0.00104867
         },
         {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.04691945,
+          "spread": 0.18593614,
+          "score": 0.19176465
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.04956847,
+          "spread": 0.01797251,
+          "score": 0.05272613
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.02901131,
+          "spread": 0.00717992,
+          "score": 0.02988657
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00041614,
+          "spread": 0.00592162,
+          "score": 0.00593623
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.04454466,
+          "spread": 0.0151243,
+          "score": 0.04704222
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.07664329,
+          "spread": 0.0109777,
+          "score": 0.07742547
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.13965784,
+          "spread": 0.04008129,
+          "score": 0.14529564
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.19486338,
+          "spread": 0.06566118,
+          "score": 0.20562862
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": -0.32488822,
+          "spread": 0.09755935,
+          "score": 0.33921996
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -1.41887071,
+          "spread": 0.8068144,
+          "score": 1.63222044
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.03997096,
+          "spread": 0.06396431,
+          "score": 0.0754262
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.02274784,
+          "spread": 0.00691767,
+          "score": 0.02377643
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.02807011,
+          "spread": 0.0035443,
+          "score": 0.02829299
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.01189229,
+          "spread": 0.00327084,
+          "score": 0.01233389
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00276225,
+          "spread": 0.00149892,
+          "score": 0.00314273
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00440546,
+          "spread": 0.00438329,
+          "score": 0.0062146
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.31203118,
+          "spread": 0.05648844,
+          "score": 0.31710314
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.02359286,
+          "spread": 0.02755067,
+          "score": 0.03627206
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.11342261,
+          "spread": 0.11031958,
+          "score": 0.15822484
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": -0.02553399,
+          "spread": 0.0,
+          "score": 0.02553399
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.08167612,
+          "spread": 0.02005299,
+          "score": 0.08410179
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.0293257,
+          "spread": 0.00820321,
+          "score": 0.03045143
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00117546,
+          "spread": 0.00655059,
+          "score": 0.00665522
+        },
+        {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
+          "condition": "overall",
+          "condition_bin": "overall",
           "bias": 0.0037889,
           "spread": 0.00089431,
           "score": 0.00389301
         },
         {
           "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.07683646,
+          "spread": 0.04582382,
+          "score": 0.0894632
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.04348607,
+          "spread": 0.01307167,
+          "score": 0.04540823
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00408818,
+          "spread": 0.0076025,
+          "score": 0.00863199
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.05549748,
+          "spread": 0.02401245,
+          "score": 0.06046957
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.10968107,
+          "spread": 0.05749581,
+          "score": 0.12383741
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.21416357,
+          "spread": 0.08249915,
+          "score": 0.22950413
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.35080893,
+          "spread": 0.06588346,
+          "score": 0.35694192
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": -0.46395331,
+          "spread": 1.30043329,
+          "score": 1.380717
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.2816918,
+          "spread": 0.6704476,
+          "score": 0.72722092
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.42641182,
+          "spread": 0.16993388,
+          "score": 0.45902567
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.0373264,
+          "spread": 0.0061346,
+          "score": 0.03782715
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.03817081,
+          "spread": 0.0088255,
+          "score": 0.0391778
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.01527095,
+          "spread": 0.00865543,
+          "score": 0.0175533
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.0084433,
+          "spread": 0.01001063,
+          "score": 0.01309588
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.01859012,
+          "spread": 0.02668429,
+          "score": 0.03252143
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.4015982,
+          "spread": 0.19782684,
+          "score": 0.4476791
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.10224975,
+          "spread": 0.13988137,
+          "score": 0.17326803
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.023919,
+          "spread": 0.04353598,
+          "score": 0.04967394
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.10966456,
+          "spread": 0.02995364,
+          "score": 0.11368173
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.0297221,
+          "spread": 0.01229308,
+          "score": 0.032164
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00802989,
+          "spread": 0.00881833,
+          "score": 0.01192653
+        },
+        {
+          "profile": "cp_plus_10pct",
           "campaign_months": 6,
+          "condition": "overall",
+          "condition_bin": "overall",
           "bias": 0.00128082,
           "spread": 0.00189692,
           "score": 0.00228884
         },
         {
           "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.07796849,
+          "spread": 0.2072721,
+          "score": 0.2214516
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.06493934,
+          "spread": 0.01586976,
+          "score": 0.06685033
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.03765465,
+          "spread": 0.00416561,
+          "score": 0.03788437
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00129205,
+          "spread": 0.00993139,
+          "score": 0.01001508
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.05788164,
+          "spread": 0.02226977,
+          "score": 0.06201796
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.10396208,
+          "spread": 0.02669662,
+          "score": 0.1073351
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.18145908,
+          "spread": 0.0279348,
+          "score": 0.18359671
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.3636536,
+          "spread": 0.05025797,
+          "score": 0.36711007
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.21060878,
+          "spread": 1.2852939,
+          "score": 1.30243482
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.98226423,
+          "spread": 1.85128552,
+          "score": 2.09573402
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.26947824,
+          "spread": 0.14456652,
+          "score": 0.30580713
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.03306135,
+          "spread": 0.00726097,
+          "score": 0.03384929
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.03129164,
+          "spread": 0.00466271,
+          "score": 0.03163712
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.01405147,
+          "spread": 0.005222,
+          "score": 0.01499043
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00482878,
+          "spread": 0.00735996,
+          "score": 0.00880262
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.02125016,
+          "spread": 0.03480804,
+          "score": 0.04078197
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.43609144,
+          "spread": 0.16489568,
+          "score": 0.46622562
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.00102025,
+          "spread": 0.00646639,
+          "score": 0.00654639
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.10160281,
+          "spread": 0.12305502,
+          "score": 0.15957966
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.10504366,
+          "spread": 0.02393608,
+          "score": 0.10773628
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.03240418,
+          "spread": 0.01375088,
+          "score": 0.03520111
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00749097,
+          "spread": 0.01014609,
+          "score": 0.01261181
+        },
+        {
+          "profile": "cp_plus_10pct",
           "campaign_months": 9,
+          "condition": "overall",
+          "condition_bin": "overall",
           "bias": 0.00083644,
           "spread": 0.00169846,
           "score": 0.00189325
         },
         {
           "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.09349095,
+          "spread": 0.25842208,
+          "score": 0.27481363
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.06008197,
+          "spread": 0.0186549,
+          "score": 0.06291143
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.03498378,
+          "spread": 0.00487204,
+          "score": 0.0353214
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 3.343e-05,
+          "spread": 0.00934884,
+          "score": 0.0093489
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.05581967,
+          "spread": 0.02031322,
+          "score": 0.05940086
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.09956576,
+          "spread": 0.02119307,
+          "score": 0.1017963
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.19076065,
+          "spread": 0.03633711,
+          "score": 0.19419066
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.24363886,
+          "spread": 0.06169165,
+          "score": 0.25132798
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": -0.47326974,
+          "spread": 0.21980146,
+          "score": 0.52182078
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.4203027,
+          "spread": 0.29441591,
+          "score": 0.51316185
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.07270283,
+          "spread": 0.05177846,
+          "score": 0.08925643
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.02868085,
+          "spread": 0.00612139,
+          "score": 0.02932683
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.02995371,
+          "spread": 0.00282211,
+          "score": 0.03008636
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.0133222,
+          "spread": 0.00407435,
+          "score": 0.01393131
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00294003,
+          "spread": 0.00345616,
+          "score": 0.00453749
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.01419781,
+          "spread": 0.02906267,
+          "score": 0.03234527
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.45349083,
+          "spread": 0.14922846,
+          "score": 0.47741289
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.00746603,
+          "spread": 0.01982846,
+          "score": 0.02118748
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.05603,
+          "spread": 0.10433599,
+          "score": 0.11842871
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": -0.05372509,
+          "spread": 0.0,
+          "score": 0.05372509
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.10433014,
+          "spread": 0.02588756,
+          "score": 0.10749393
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.03652674,
+          "spread": 0.01169462,
+          "score": 0.03835319
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.0040024,
+          "spread": 0.00851055,
+          "score": 0.00940471
+        },
+        {
+          "profile": "cp_plus_10pct",
           "campaign_months": 12,
+          "condition": "overall",
+          "condition_bin": "overall",
           "bias": 0.00051748,
           "spread": 0.00091239,
           "score": 0.00104892
         },
         {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.05453948,
+          "spread": 0.23006166,
+          "score": 0.23643799
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.05651364,
+          "spread": 0.02072609,
+          "score": 0.06019437
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.03170767,
+          "spread": 0.007738,
+          "score": 0.03263821
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00062835,
+          "spread": 0.0066459,
+          "score": 0.00667554
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.05274273,
+          "spread": 0.01806415,
+          "score": 0.05575042
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.09296683,
+          "spread": 0.01331529,
+          "score": 0.09391554
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.17381393,
+          "spread": 0.04945887,
+          "score": 0.18071376
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.24855231,
+          "spread": 0.08189668,
+          "score": 0.26169699
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": -0.44423238,
+          "spread": 0.1296197,
+          "score": 0.4627566
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.22086005,
+          "spread": 0.65560259,
+          "score": 0.69180483
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.03996637,
+          "spread": 0.06395986,
+          "score": 0.07541999
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.02628485,
+          "spread": 0.00782425,
+          "score": 0.02742467
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.02864007,
+          "spread": 0.00361789,
+          "score": 0.02886768
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.01184853,
+          "spread": 0.00325059,
+          "score": 0.01228633
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00243029,
+          "spread": 0.0016882,
+          "score": 0.00295911
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.000435,
+          "spread": 0.00176687,
+          "score": 0.00181963
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.46313019,
+          "spread": 0.1356434,
+          "score": 0.48258544
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.01479538,
+          "spread": 0.02376339,
+          "score": 0.02799289
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.09806712,
+          "spread": 0.10955485,
+          "score": 0.14703546
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": -0.02597432,
+          "spread": 0.0,
+          "score": 0.02597432
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.1001273,
+          "spread": 0.02451737,
+          "score": 0.10308529
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.03592121,
+          "spread": 0.01002916,
+          "score": 0.03729501
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00138061,
+          "spread": 0.00798354,
+          "score": 0.00810204
+        },
+        {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
+          "condition": "overall",
+          "condition_bin": "overall",
           "bias": 0.00367357,
           "spread": 0.00085606,
           "score": 0.003772
         },
         {
           "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.0738491,
+          "spread": 0.04382391,
+          "score": 0.0858733
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.04201167,
+          "spread": 0.01266079,
+          "score": 0.04387796
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00395999,
+          "spread": 0.00727648,
+          "score": 0.00828424
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.05221495,
+          "spread": 0.02252344,
+          "score": 0.05686569
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.10259568,
+          "spread": 0.05358971,
+          "score": 0.11574857
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.19923327,
+          "spread": 0.07639019,
+          "score": 0.21337609
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.32010869,
+          "spread": 0.06249005,
+          "score": 0.32615116
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": -0.17439619,
+          "spread": 0.92853607,
+          "score": 0.94477154
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.51046372,
+          "spread": 0.67540581,
+          "score": 0.84660865
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.42642981,
+          "spread": 0.1699508,
+          "score": 0.45904865
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.03557054,
+          "spread": 0.00570984,
+          "score": 0.0360259
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.03788408,
+          "spread": 0.00866872,
+          "score": 0.03886322
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.01528152,
+          "spread": 0.00863727,
+          "score": 0.01755355
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00869591,
+          "spread": 0.00969455,
+          "score": 0.01302318
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.01989193,
+          "spread": 0.02793174,
+          "score": 0.03429098
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.3577959,
+          "spread": 0.16770748,
+          "score": 0.39515023
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.10709545,
+          "spread": 0.14672641,
+          "score": 0.18165373
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.02920417,
+          "spread": 0.03825081,
+          "score": 0.04812492
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.1026279,
+          "spread": 0.02808101,
+          "score": 0.10640032
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.02781136,
+          "spread": 0.01152667,
+          "score": 0.03010541
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00754923,
+          "spread": 0.00826888,
+          "score": 0.01119667
+        },
+        {
+          "profile": "cp_plus_3pct",
           "campaign_months": 6,
+          "condition": "overall",
+          "condition_bin": "overall",
           "bias": 0.00129304,
           "spread": 0.00182139,
           "score": 0.0022337
         },
         {
           "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.07359892,
+          "spread": 0.19349003,
+          "score": 0.20701496
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.06207138,
+          "spread": 0.01525947,
+          "score": 0.06391953
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.03641093,
+          "spread": 0.00411568,
+          "score": 0.0366428
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00129908,
+          "spread": 0.00948131,
+          "score": 0.00956989
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.05455297,
+          "spread": 0.02095488,
+          "score": 0.05843915
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.09728775,
+          "spread": 0.02485753,
+          "score": 0.10041316
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.16869361,
+          "spread": 0.02631141,
+          "score": 0.17073319
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.33133413,
+          "spread": 0.04795693,
+          "score": 0.33478676
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": -0.02749933,
+          "spread": 0.70939868,
+          "score": 0.70993147
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -1.05254151,
+          "spread": 1.91605176,
+          "score": 2.18611481
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.26948068,
+          "spread": 0.14456488,
+          "score": 0.3058085
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.03151952,
+          "spread": 0.00702458,
+          "score": 0.0322928
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.03104583,
+          "spread": 0.00454064,
+          "score": 0.03137612
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.01405287,
+          "spread": 0.00520841,
+          "score": 0.01498701
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00508659,
+          "spread": 0.00710858,
+          "score": 0.00874102
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.02244663,
+          "spread": 0.03588664,
+          "score": 0.04232851
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.38127059,
+          "spread": 0.1271445,
+          "score": 0.40191166
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.00477895,
+          "spread": 0.00690529,
+          "score": 0.0083977
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.11198573,
+          "spread": 0.1228676,
+          "score": 0.16624456
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.09827697,
+          "spread": 0.02244707,
+          "score": 0.1008079
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.03031927,
+          "spread": 0.0128831,
+          "score": 0.03294286
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00704039,
+          "spread": 0.00951597,
+          "score": 0.01183726
+        },
+        {
+          "profile": "cp_plus_3pct",
           "campaign_months": 9,
+          "condition": "overall",
+          "condition_bin": "overall",
           "bias": 0.00085336,
           "spread": 0.0016342,
           "score": 0.00184359
         },
         {
           "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.08829672,
+          "spread": 0.24122189,
+          "score": 0.25687411
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.05746305,
+          "spread": 0.01778883,
+          "score": 0.06015351
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.03384831,
+          "spread": 0.00485406,
+          "score": 0.03419459
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 8e-05,
+          "spread": 0.00894292,
+          "score": 0.00894328
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.05269382,
+          "spread": 0.0191561,
+          "score": 0.05606777
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.09331053,
+          "spread": 0.01984693,
+          "score": 0.09539788
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.17750851,
+          "spread": 0.03401503,
+          "score": 0.18073819
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.22397973,
+          "spread": 0.05763839,
+          "score": 0.23127712
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": -0.41593097,
+          "spread": 0.18743628,
+          "score": 0.45621369
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.57664641,
+          "spread": 0.45301806,
+          "score": 0.73331197
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.07270445,
+          "spread": 0.05177895,
+          "score": 0.08925804
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.02732272,
+          "spread": 0.00591713,
+          "score": 0.0279561
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.0297237,
+          "spread": 0.00275709,
+          "score": 0.0298513
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.01333186,
+          "spread": 0.00406386,
+          "score": 0.01393749
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00313341,
+          "spread": 0.00325391,
+          "score": 0.00451732
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.0156428,
+          "spread": 0.02989487,
+          "score": 0.03374019
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.39951914,
+          "spread": 0.11831416,
+          "score": 0.41666987
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.01062411,
+          "spread": 0.01841276,
+          "score": 0.02125797
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.06229276,
+          "spread": 0.10759283,
+          "score": 0.12432459
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": -0.05358266,
+          "spread": 0.0,
+          "score": 0.05358266
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.09761205,
+          "spread": 0.02427184,
+          "score": 0.10058446
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.03418046,
+          "spread": 0.01095513,
+          "score": 0.03589316
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00376802,
+          "spread": 0.00798244,
+          "score": 0.00882708
+        },
+        {
+          "profile": "cp_plus_3pct",
           "campaign_months": 12,
+          "condition": "overall",
+          "condition_bin": "overall",
           "bias": 0.00054992,
           "spread": 0.00089155,
           "score": 0.00104751
         },
         {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.05187247,
+          "spread": 0.21461773,
+          "score": 0.22079747
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.05408283,
+          "spread": 0.0197573,
+          "score": 0.05757867
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.03076394,
+          "spread": 0.00754258,
+          "score": 0.03167508
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00055407,
+          "spread": 0.0063924,
+          "score": 0.00641637
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.04987341,
+          "spread": 0.017035,
+          "score": 0.05270245
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.08725359,
+          "spread": 0.01249506,
+          "score": 0.08814372
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.1618593,
+          "spread": 0.04617652,
+          "score": 0.16831727
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.22976118,
+          "spread": 0.07619807,
+          "score": 0.24206682
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": -0.40246192,
+          "spread": 0.11827899,
+          "score": 0.41948244
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.64016378,
+          "spread": 0.41585258,
+          "score": 0.76337608
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.03996798,
+          "spread": 0.06396142,
+          "score": 0.07542216
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.0250469,
+          "spread": 0.00750682,
+          "score": 0.02614765
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.02844058,
+          "spread": 0.00359045,
+          "score": 0.02866632
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.01186384,
+          "spread": 0.00325755,
+          "score": 0.01230294
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00254648,
+          "spread": 0.00161328,
+          "score": 0.0030145
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00182466,
+          "spread": 0.00259458,
+          "score": 0.00317194
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.41024554,
+          "spread": 0.10638629,
+          "score": 0.42381534
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.01787449,
+          "spread": 0.02501741,
+          "score": 0.03074685
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.10344154,
+          "spread": 0.10957412,
+          "score": 0.15068723
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": -0.0258202,
+          "spread": 0.0,
+          "score": 0.0258202
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.09366939,
+          "spread": 0.02295478,
+          "score": 0.09644105
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.03361278,
+          "spread": 0.00939008,
+          "score": 0.03489975
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00130881,
+          "spread": 0.007482,
+          "score": 0.00759561
+        },
+        {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
+          "condition": "overall",
+          "condition_bin": "overall",
           "bias": 0.00369558,
           "spread": 0.00086132,
           "score": 0.00379462
         },
         {
           "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.07402148,
+          "spread": 0.04370924,
+          "score": 0.08596323
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.04238616,
+          "spread": 0.01281889,
+          "score": 0.04428217
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00398519,
+          "spread": 0.00724196,
+          "score": 0.00826606
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.0510471,
+          "spread": 0.0219102,
+          "score": 0.05555055
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.09971409,
+          "spread": 0.05192829,
+          "score": 0.11242529
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.19322108,
+          "spread": 0.07411641,
+          "score": 0.20694837
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.3069526,
+          "spread": 0.0610878,
+          "score": 0.31297223
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": -0.05030349,
+          "spread": 0.79276099,
+          "score": 0.79435536
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.60850858,
+          "spread": 0.72776066,
+          "score": 0.94864022
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.42643753,
+          "spread": 0.16995806,
+          "score": 0.4590585
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.03528775,
+          "spread": 0.00552122,
+          "score": 0.03571707
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.03943026,
+          "spread": 0.00893357,
+          "score": 0.04042961
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.01603737,
+          "spread": 0.00905389,
+          "score": 0.01841657
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00941009,
+          "spread": 0.00981587,
+          "score": 0.01359783
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.02238471,
+          "spread": 0.03080654,
+          "score": 0.03808042
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.3390235,
+          "spread": 0.15490214,
+          "score": 0.3727353
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.1179857,
+          "spread": 0.16197409,
+          "score": 0.2003902
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.03671396,
+          "spread": 0.03408258,
+          "score": 0.05009528
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.0996122,
+          "spread": 0.02727846,
+          "score": 0.10327974
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.02699254,
+          "spread": 0.01119822,
+          "score": 0.02922323
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00734653,
+          "spread": 0.00803603,
+          "score": 0.01088803
+        },
+        {
+          "profile": "rated_plus_5pct",
           "campaign_months": 6,
+          "condition": "overall",
+          "condition_bin": "overall",
           "bias": 0.00133541,
           "spread": 0.00181816,
           "score": 0.00225589
         },
         {
           "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.07172625,
+          "spread": 0.18758345,
+          "score": 0.2008288
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.06180799,
+          "spread": 0.01533414,
+          "score": 0.06368174
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.03676772,
+          "spread": 0.00427115,
+          "score": 0.03701497
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00134706,
+          "spread": 0.00942316,
+          "score": 0.00951896
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.05346406,
+          "spread": 0.02048112,
+          "score": 0.05725279
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.09463454,
+          "spread": 0.02407795,
+          "score": 0.09764959
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.16336004,
+          "spread": 0.02574579,
+          "score": 0.16537638
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.3175112,
+          "spread": 0.04719448,
+          "score": 0.3209995
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": -0.129548,
+          "spread": 0.46638681,
+          "score": 0.48404477
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -1.08266066,
+          "spread": 1.94437866,
+          "score": 2.22548028
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.26948173,
+          "spread": 0.14456418,
+          "score": 0.3058091
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.03128787,
+          "spread": 0.00709518,
+          "score": 0.03208227
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.03230224,
+          "spread": 0.00463572,
+          "score": 0.03263318
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.01474379,
+          "spread": 0.00545588,
+          "score": 0.01572087
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00563112,
+          "spread": 0.00718388,
+          "score": 0.00912785
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.02494073,
+          "spread": 0.03893665,
+          "score": 0.04623962
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.35777595,
+          "spread": 0.11141511,
+          "score": 0.37472251
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.00934026,
+          "spread": 0.01029753,
+          "score": 0.0139025
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.12950115,
+          "spread": 0.12879597,
+          "score": 0.18264433
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.09537697,
+          "spread": 0.02180895,
+          "score": 0.09783863
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.02942581,
+          "spread": 0.01251122,
+          "score": 0.03197513
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00685058,
+          "spread": 0.00924922,
+          "score": 0.01150993
+        },
+        {
+          "profile": "rated_plus_5pct",
           "campaign_months": 9,
-          "bias": 0.00088821,
-          "spread": 0.00163333,
-          "score": 0.00185922
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00088824,
+          "spread": 0.0016333,
+          "score": 0.0018592
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.08607064,
+          "spread": 0.2338504,
+          "score": 0.24918701
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.05726665,
+          "spread": 0.01768366,
+          "score": 0.0599348
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.03420672,
+          "spread": 0.0050806,
+          "score": 0.03458197
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00011984,
+          "spread": 0.0089117,
+          "score": 0.00891251
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.0517372,
+          "spread": 0.01876539,
+          "score": 0.05503524
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.09089705,
+          "spread": 0.01930069,
+          "score": 0.09292357
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.17193712,
+          "spread": 0.03311256,
+          "score": 0.17509658
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.21564668,
+          "spread": 0.05598973,
+          "score": 0.22279664
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": -0.39136256,
+          "spread": 0.17362157,
+          "score": 0.42814613
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.64365058,
+          "spread": 0.52286843,
+          "score": 0.82926321
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.07270515,
+          "spread": 0.05177917,
+          "score": 0.08925873
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.0270973,
+          "spread": 0.00596849,
+          "score": 0.02774683
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.03093386,
+          "spread": 0.00282969,
+          "score": 0.03106301
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.01399901,
+          "spread": 0.00426076,
+          "score": 0.01463306
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00350747,
+          "spread": 0.00319837,
+          "score": 0.00474678
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.01808721,
+          "spread": 0.03235439,
+          "score": 0.03706688
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.37638843,
+          "spread": 0.10557553,
+          "score": 0.39091488
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.01478334,
+          "spread": 0.01810953,
+          "score": 0.02337738
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.07259765,
+          "spread": 0.11679895,
+          "score": 0.13752241
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": -0.05609597,
+          "spread": 0.0,
+          "score": 0.05609597
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.09473216,
+          "spread": 0.02357955,
+          "score": 0.09762263
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.033175,
+          "spread": 0.01063822,
+          "score": 0.03483895
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00366945,
+          "spread": 0.00775822,
+          "score": 0.00858224
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
+          "condition": "overall",
+          "condition_bin": "overall",
           "bias": 0.00059381,
           "spread": 0.00090885,
           "score": 0.00108564
         },
         {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.05072947,
+          "spread": 0.20799892,
+          "score": 0.21409584
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.05394004,
+          "spread": 0.01962349,
+          "score": 0.05739868
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.031192,
+          "spread": 0.00769244,
+          "score": 0.03212654
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00050989,
+          "spread": 0.00641347,
+          "score": 0.00643371
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.04906492,
+          "spread": 0.01668848,
+          "score": 0.0518254
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.08511731,
+          "spread": 0.0121802,
+          "score": 0.08598438
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.15688233,
+          "spread": 0.04484533,
+          "score": 0.16316608
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.22180711,
+          "spread": 0.0738236,
+          "score": 0.2337698
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": -0.38456599,
+          "spread": 0.11344886,
+          "score": 0.40095093
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.81986492,
+          "spread": 0.41597888,
+          "score": 0.91935679
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.03996867,
+          "spread": 0.06396209,
+          "score": 0.07542309
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.02485025,
+          "spread": 0.00750974,
+          "score": 0.02596018
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.0296247,
+          "spread": 0.00374368,
+          "score": 0.02986031
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.01246782,
+          "spread": 0.00343182,
+          "score": 0.01293151
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00280502,
+          "spread": 0.00161981,
+          "score": 0.00323912
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00351876,
+          "spread": 0.00381735,
+          "score": 0.00519171
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.3875807,
+          "spread": 0.09414311,
+          "score": 0.39885051
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.02229585,
+          "spread": 0.02781703,
+          "score": 0.03564957
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.11473362,
+          "spread": 0.11537708,
+          "score": 0.16271347
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": -0.02693178,
+          "spread": 0.0,
+          "score": 0.02693178
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.09090172,
+          "spread": 0.02228512,
+          "score": 0.09359353
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.03262354,
+          "spread": 0.00911619,
+          "score": 0.0338733
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00127913,
+          "spread": 0.00726855,
+          "score": 0.00738024
+        },
+        {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
+          "condition": "overall",
+          "condition_bin": "overall",
           "bias": 0.00373349,
           "spread": 0.00087011,
           "score": 0.00383354
         },
         {
           "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.07683646,
+          "spread": 0.04582382,
+          "score": 0.0894632
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.04316041,
+          "spread": 0.01298745,
+          "score": 0.04507211
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.0040198,
+          "spread": 0.00742961,
+          "score": 0.00844736
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.05269563,
+          "spread": 0.02276669,
+          "score": 0.05740341
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.10121746,
+          "spread": 0.05288648,
+          "score": 0.11420138
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.19283457,
+          "spread": 0.07378147,
+          "score": 0.20646762
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.30695144,
+          "spread": 0.06108829,
+          "score": 0.31297119
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": -0.05030028,
+          "spread": 0.79275906,
+          "score": 0.79435322
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.60850882,
+          "spread": 0.72776091,
+          "score": 0.94864057
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.42643752,
+          "spread": 0.16995806,
+          "score": 0.45905849
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.03643209,
+          "spread": 0.00589339,
+          "score": 0.03690568
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.03804761,
+          "spread": 0.00875874,
+          "score": 0.03904275
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.01527426,
+          "spread": 0.00865087,
+          "score": 0.01755393
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00865583,
+          "spread": 0.0097394,
+          "score": 0.01302994
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.01968968,
+          "spread": 0.02794934,
+          "score": 0.03418844
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.36534456,
+          "spread": 0.17644882,
+          "score": 0.40572261
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.10370197,
+          "spread": 0.14193283,
+          "score": 0.17578119
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.02545416,
+          "spread": 0.04200082,
+          "score": 0.04911194
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.10539941,
+          "spread": 0.02921057,
+          "score": 0.10937227
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.02869308,
+          "spread": 0.01191552,
+          "score": 0.03106884
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00774164,
+          "spread": 0.00852627,
+          "score": 0.01151652
+        },
+        {
+          "profile": "ti_dependent_cp",
           "campaign_months": 6,
+          "condition": "overall",
+          "condition_bin": "overall",
           "bias": 0.00128565,
           "spread": 0.0018638,
           "score": 0.00226421
         },
         {
           "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.07796849,
+          "spread": 0.2072721,
+          "score": 0.2214516
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.06493934,
+          "spread": 0.01586976,
+          "score": 0.06685033
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.03737911,
+          "spread": 0.00415213,
+          "score": 0.03760902
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00129244,
+          "spread": 0.00969717,
+          "score": 0.00978292
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.05504353,
+          "spread": 0.02116977,
+          "score": 0.05897414
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.09592772,
+          "spread": 0.02449447,
+          "score": 0.09900559
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.16322269,
+          "spread": 0.02562153,
+          "score": 0.16522139
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.31748293,
+          "spread": 0.04716023,
+          "score": 0.32096651
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": -0.12954566,
+          "spread": 0.46638117,
+          "score": 0.48403871
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -1.08266035,
+          "spread": 1.94437884,
+          "score": 2.22548029
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.26948173,
+          "spread": 0.14456417,
+          "score": 0.30580909
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.03227209,
+          "spread": 0.00708959,
+          "score": 0.03304164
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.03117958,
+          "spread": 0.00462195,
+          "score": 0.03152029
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.0140521,
+          "spread": 0.00521785,
+          "score": 0.01498958
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00501882,
+          "spread": 0.00716829,
+          "score": 0.0087506
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.0222198,
+          "spread": 0.03592134,
+          "score": 0.04223816
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.39115508,
+          "spread": 0.13713388,
+          "score": 0.41449729
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.00243557,
+          "spread": 0.00611648,
+          "score": 0.00658356
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.10426054,
+          "spread": 0.12264242,
+          "score": 0.16097026
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.10125568,
+          "spread": 0.02328627,
+          "score": 0.10389881
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.03130064,
+          "spread": 0.01335866,
+          "score": 0.0340321
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00722152,
+          "spread": 0.00979911,
+          "score": 0.01217263
+        },
+        {
+          "profile": "ti_dependent_cp",
           "campaign_months": 9,
+          "condition": "overall",
+          "condition_bin": "overall",
           "bias": 0.0008499,
           "spread": 0.00167478,
           "score": 0.00187809
         },
         {
           "profile": "ti_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.09349095,
+          "spread": 0.25842208,
+          "score": 0.27481363
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.06008197,
+          "spread": 0.0186549,
+          "score": 0.06291143
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.03473442,
+          "spread": 0.00486575,
+          "score": 0.03507357
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 5.442e-05,
+          "spread": 0.00913672,
+          "score": 0.00913689
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.0531529,
+          "spread": 0.01933951,
+          "score": 0.05656189
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.09202761,
+          "spread": 0.01956878,
+          "score": 0.09408517
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.17182902,
+          "spread": 0.03302273,
+          "score": 0.17497346
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.21555439,
+          "spread": 0.05592531,
+          "score": 0.22269112
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": -0.39135721,
+          "spread": 0.17362477,
+          "score": 0.42814253
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.64365086,
+          "spread": 0.52287243,
+          "score": 0.82926595
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.07270515,
+          "spread": 0.05177916,
+          "score": 0.08925873
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.02797683,
+          "spread": 0.00597412,
+          "score": 0.02860757
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.02984919,
+          "spread": 0.00281129,
+          "score": 0.02998129
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.01332143,
+          "spread": 0.00407175,
+          "score": 0.01392981
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00308332,
+          "spread": 0.0032961,
+          "score": 0.00451344
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.01529064,
+          "spread": 0.02999562,
+          "score": 0.0336681
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.40946733,
+          "spread": 0.12604141,
+          "score": 0.42842728
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.00866803,
+          "spread": 0.01927572,
+          "score": 0.02113499
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.05763209,
+          "spread": 0.1049502,
+          "score": 0.11973305
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": -0.05368554,
+          "spread": 0.0,
+          "score": 0.05368554
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.10059318,
+          "spread": 0.02503021,
+          "score": 0.1036605
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.03528121,
+          "spread": 0.01138974,
+          "score": 0.03707411
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00387029,
+          "spread": 0.00824513,
+          "score": 0.00910831
+        },
+        {
+          "profile": "ti_dependent_cp",
           "campaign_months": 12,
+          "condition": "overall",
+          "condition_bin": "overall",
           "bias": 0.00053768,
           "spread": 0.0009069,
           "score": 0.00105431
         },
         {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.05453948,
+          "spread": 0.23006166,
+          "score": 0.23643799
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.05651364,
+          "spread": 0.02072609,
+          "score": 0.06019437
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.03150209,
+          "spread": 0.00769245,
+          "score": 0.0324277
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00059137,
+          "spread": 0.00651181,
+          "score": 0.00653861
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.05029459,
+          "spread": 0.01719175,
+          "score": 0.05315169
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.08610414,
+          "spread": 0.01234822,
+          "score": 0.08698506
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.15673588,
+          "spread": 0.04476985,
+          "score": 0.16300453
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.22170784,
+          "spread": 0.07376056,
+          "score": 0.2336557
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": -0.3845603,
+          "spread": 0.11345253,
+          "score": 0.40094651
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.81986538,
+          "spread": 0.41598445,
+          "score": 0.91935973
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.03996867,
+          "spread": 0.06396209,
+          "score": 0.07542309
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.02563881,
+          "spread": 0.00763126,
+          "score": 0.02675041
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.02854867,
+          "spread": 0.00360701,
+          "score": 0.02877563
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.01184951,
+          "spread": 0.00325219,
+          "score": 0.0122877
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00251021,
+          "spread": 0.0016276,
+          "score": 0.0029917
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00128371,
+          "spread": 0.00232707,
+          "score": 0.00265766
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.41983586,
+          "spread": 0.11300368,
+          "score": 0.43477809
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.0159588,
+          "spread": 0.02433852,
+          "score": 0.02910407
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.0995998,
+          "spread": 0.10922663,
+          "score": 0.1478194
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": -0.02593563,
+          "spread": 0.0,
+          "score": 0.02593563
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.09655926,
+          "spread": 0.02369739,
+          "score": 0.09942463
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.03468905,
+          "spread": 0.00977248,
+          "score": 0.0360393
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00134042,
+          "spread": 0.00774356,
+          "score": 0.00785872
+        },
+        {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
+          "condition": "overall",
+          "condition_bin": "overall",
           "bias": 0.00372194,
           "spread": 0.00088052,
           "score": 0.00382467
         },
         {
           "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.07503288,
+          "spread": 0.04468192,
+          "score": 0.0873293
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.04235793,
+          "spread": 0.01277511,
+          "score": 0.04424248
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00400197,
+          "spread": 0.00734604,
+          "score": 0.0083654
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.05307928,
+          "spread": 0.02296613,
+          "score": 0.05783471
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.10556095,
+          "spread": 0.05536494,
+          "score": 0.11919895
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.20790749,
+          "spread": 0.07946282,
+          "score": 0.22257553
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.34629797,
+          "spread": 0.06578039,
+          "score": 0.35249021
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": -0.45996837,
+          "spread": 1.29990976,
+          "score": 1.37888952
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.28942344,
+          "spread": 0.66576145,
+          "score": 0.72595057
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.42641182,
+          "spread": 0.16993388,
+          "score": 0.45902567
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.03525431,
+          "spread": 0.00561533,
+          "score": 0.03569871
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.0377612,
+          "spread": 0.00860171,
+          "score": 0.03872851
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.01528605,
+          "spread": 0.0086295,
+          "score": 0.01755367
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00880417,
+          "spread": 0.00955974,
+          "score": 0.01299623
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.02044985,
+          "spread": 0.0284785,
+          "score": 0.03506026
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.4015982,
+          "spread": 0.19782684,
+          "score": 0.4476791
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.10917218,
+          "spread": 0.14966031,
+          "score": 0.18524787
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.03146924,
+          "spread": 0.03598574,
+          "score": 0.04780467
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.1091042,
+          "spread": 0.02982877,
+          "score": 0.11310827
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.02889962,
+          "spread": 0.01195818,
+          "score": 0.03127596
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00763822,
+          "spread": 0.00837144,
+          "score": 0.0113324
+        },
+        {
+          "profile": "ws_dependent_cp",
           "campaign_months": 6,
+          "condition": "overall",
+          "condition_bin": "overall",
           "bias": 0.00132792,
           "spread": 0.00184903,
           "score": 0.00227646
         },
         {
           "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.0755245,
+          "spread": 0.20482812,
+          "score": 0.21830829
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.06339547,
+          "spread": 0.01534305,
+          "score": 0.06522572
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.03674769,
+          "spread": 0.00421303,
+          "score": 0.0369884
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00134623,
+          "spread": 0.00957186,
+          "score": 0.00966607
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.05543921,
+          "spread": 0.02125509,
+          "score": 0.05937411
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.09980063,
+          "spread": 0.02527671,
+          "score": 0.10295182
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.17487626,
+          "spread": 0.02617565,
+          "score": 0.17682441
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.35765333,
+          "spread": 0.04848815,
+          "score": 0.36092521
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.1421895,
+          "spread": 1.14383718,
+          "score": 1.15264104
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.98289831,
+          "spread": 1.85161125,
+          "score": 2.09631899
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.26947824,
+          "spread": 0.14456652,
+          "score": 0.30580713
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.03124292,
+          "spread": 0.00699144,
+          "score": 0.03201562
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.03094049,
+          "spread": 0.00448862,
+          "score": 0.03126438
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.01405346,
+          "spread": 0.00520259,
+          "score": 0.01498555
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00519709,
+          "spread": 0.00700346,
+          "score": 0.00872113
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.0229594,
+          "spread": 0.03635384,
+          "score": 0.04299693
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.43609144,
+          "spread": 0.16489568,
+          "score": 0.46622562
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.00638983,
+          "spread": 0.00782921,
+          "score": 0.01010577
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.11643556,
+          "spread": 0.12278728,
+          "score": 0.16921571
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.10451404,
+          "spread": 0.02380861,
+          "score": 0.10719158
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.0315086,
+          "spread": 0.01336963,
+          "score": 0.03422775
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.0071259,
+          "spread": 0.0096324,
+          "score": 0.01198172
+        },
+        {
+          "profile": "ws_dependent_cp",
           "campaign_months": 9,
-          "bias": 0.00087805,
-          "spread": 0.00165961,
-          "score": 0.00187757
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00087807,
+          "spread": 0.00165957,
+          "score": 0.00187755
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.09047571,
+          "spread": 0.25540684,
+          "score": 0.2709585
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.05852265,
+          "spread": 0.01809503,
+          "score": 0.06125627
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.03412978,
+          "spread": 0.00490437,
+          "score": 0.03448035
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00011144,
+          "spread": 0.00902798,
+          "score": 0.00902866
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.05343545,
+          "spread": 0.01940066,
+          "score": 0.05684833
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.09546469,
+          "spread": 0.02010553,
+          "score": 0.09755891
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.18337677,
+          "spread": 0.0341425,
+          "score": 0.18652815
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.23773323,
+          "spread": 0.06075968,
+          "score": 0.24537487
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": -0.46091876,
+          "spread": 0.21565011,
+          "score": 0.50887236
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.43363478,
+          "spread": 0.31721053,
+          "score": 0.53727241
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.07270283,
+          "spread": 0.05177846,
+          "score": 0.08925643
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.02707026,
+          "spread": 0.00588838,
+          "score": 0.02770328
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.02962513,
+          "spread": 0.00272976,
+          "score": 0.02975063
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.01333601,
+          "spread": 0.00405941,
+          "score": 0.01394015
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00321629,
+          "spread": 0.00317021,
+          "score": 0.00451605
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.01626209,
+          "spread": 0.03025559,
+          "score": 0.03434903
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.45349083,
+          "spread": 0.14922846,
+          "score": 0.47741289
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.01197757,
+          "spread": 0.01791138,
+          "score": 0.02154715
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.06497681,
+          "spread": 0.10901263,
+          "score": 0.12690838
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": -0.05352162,
+          "spread": 0.0,
+          "score": 0.05352162
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.1037965,
+          "spread": 0.02574445,
+          "score": 0.10694152
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.03551226,
+          "spread": 0.0113692,
+          "score": 0.03728779
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00381103,
+          "spread": 0.00807802,
+          "score": 0.00893188
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
+          "condition": "overall",
+          "condition_bin": "overall",
           "bias": 0.00058349,
           "spread": 0.00092061,
           "score": 0.00108995
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.05210098,
+          "spread": 0.22762316,
+          "score": 0.23350977
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.0549858,
+          "spread": 0.02008191,
+          "score": 0.0585382
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.03102112,
+          "spread": 0.00763406,
+          "score": 0.03194665
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00051455,
+          "spread": 0.00646027,
+          "score": 0.00648073
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.05053386,
+          "spread": 0.01726959,
+          "score": 0.05340328
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.08912906,
+          "spread": 0.01257233,
+          "score": 0.09001141
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.16715775,
+          "spread": 0.04770747,
+          "score": 0.17383244
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.24140096,
+          "spread": 0.07965814,
+          "score": 0.25420433
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": -0.43295635,
+          "spread": 0.12804426,
+          "score": 0.45149367
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.26485386,
+          "spread": 0.61675114,
+          "score": 0.67121497
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.03996637,
+          "spread": 0.06395986,
+          "score": 0.07541999
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.02481665,
+          "spread": 0.00745364,
+          "score": 0.02591183
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.02835509,
+          "spread": 0.00357923,
+          "score": 0.0285801
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.01187041,
+          "spread": 0.00326057,
+          "score": 0.01231007
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00259627,
+          "spread": 0.00158386,
+          "score": 0.00304125
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00242023,
+          "spread": 0.00299091,
+          "score": 0.00384748
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.46313019,
+          "spread": 0.1356434,
+          "score": 0.48258544
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.01919412,
+          "spread": 0.02558017,
+          "score": 0.0319806
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.10574487,
+          "spread": 0.10966452,
+          "score": 0.15234265
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": -0.02575415,
+          "spread": 0.0,
+          "score": 0.02575415
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.09961715,
+          "spread": 0.0243894,
+          "score": 0.10255935
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.03492303,
+          "spread": 0.00974475,
+          "score": 0.03625712
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00132258,
+          "spread": 0.00757177,
+          "score": 0.00768641
         }
       ]
     }

--- a/benchmarking/harness/__init__.py
+++ b/benchmarking/harness/__init__.py
@@ -12,14 +12,25 @@ from benchmarking.harness.campaign import (
     treated_activity_mask,
     window_row_mask,
 )
-from benchmarking.harness.leaderboard import leaderboard
+from benchmarking.harness.conditions import (
+    CONDITION_BINS,
+    CONDITIONS,
+    TI_BINS,
+    WS_BINS,
+    energy_ratio_by_bin,
+)
+from benchmarking.harness.leaderboard import conditional_leaderboard, leaderboard
 from benchmarking.harness.method import Method, MethodInput, MethodOutput
 from benchmarking.harness.metrics import ErrorSummary, summarize_errors
-from benchmarking.harness.plots import plot_campaign_curves
+from benchmarking.harness.plots import plot_campaign_curves, plot_conditional_uplift
 from benchmarking.harness.replicates import Replicate, StudyConfig, build_replicates
 from benchmarking.harness.scoring import score_study
 
 __all__ = [
+    "CONDITIONS",
+    "CONDITION_BINS",
+    "TI_BINS",
+    "WS_BINS",
     "CampaignWindow",
     "ErrorSummary",
     "Method",
@@ -29,8 +40,11 @@ __all__ = [
     "StudyConfig",
     "build_replicates",
     "campaign_windows",
+    "conditional_leaderboard",
+    "energy_ratio_by_bin",
     "leaderboard",
     "plot_campaign_curves",
+    "plot_conditional_uplift",
     "score_study",
     "summarize_errors",
     "treated_activity_mask",

--- a/benchmarking/harness/conditions.py
+++ b/benchmarking/harness/conditions.py
@@ -1,0 +1,49 @@
+"""Shared condition bins and the binned energy-ratio reducer.
+
+One source of truth for the wind-speed / TI bin edges, imported by both the method (to bin its
+counterfactual ledger) and the harness truth path, so the two bin identically. The reducer is the
+same energy ratio as the overall number, taken within each bin: ``Σactual / Σcounterfactual - 1``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import numpy.typing as npt
+import pandas as pd
+
+WS_BINS: list[float] = [float(x) for x in np.arange(0.0, 28.0, 2.0)]  # 0,2,…,26
+TI_BINS: list[float] = [round(float(x), 2) for x in np.arange(0.0, 0.55, 0.05)]  # 0,0.05,…,0.50
+CONDITIONS: tuple[str, ...] = ("ws", "ti")
+CONDITION_BINS: dict[str, list[float]] = {"ws": WS_BINS, "ti": TI_BINS}
+
+
+def energy_ratio_by_bin(
+    condition_values: npt.ArrayLike,
+    actual: npt.ArrayLike,
+    counterfactual: npt.ArrayLike,
+    *,
+    bins: list[float],
+) -> pd.DataFrame:
+    """Energy-ratio uplift within bins of a condition signal (NaN-safe; every bin represented)."""
+    cond = np.asarray(condition_values, dtype=float)
+    act = np.asarray(actual, dtype=float)
+    cf = np.asarray(counterfactual, dtype=float)
+    finite = np.isfinite(cond) & np.isfinite(act) & np.isfinite(cf)
+    frame = pd.DataFrame(
+        {
+            "condition_bin": pd.cut(cond[finite], bins=bins).astype(str),
+            "actual": act[finite],
+            "counterfactual": cf[finite],
+        }
+    )
+    all_bins = pd.cut([], bins=bins).categories.astype(str)
+    grouped = frame.groupby("condition_bin", observed=False)
+    table = grouped[["actual", "counterfactual"]].sum()
+    table["n_records"] = grouped.size()
+    table = table.reindex(all_bins)
+    table["n_records"] = table["n_records"].fillna(0).astype(int)
+    denom = table["counterfactual"].to_numpy()
+    table["p50_uplift"] = (
+        np.divide(table["actual"].to_numpy(), denom, out=np.full(len(table), np.nan), where=denom != 0) - 1.0
+    )
+    return table.reset_index(names="condition_bin")[["condition_bin", "p50_uplift", "n_records"]]

--- a/benchmarking/harness/leaderboard.py
+++ b/benchmarking/harness/leaderboard.py
@@ -12,6 +12,7 @@ import pandas as pd
 from benchmarking.harness.metrics import summarize_errors
 
 _GROUP_KEYS = ["method", "profile", "campaign_months"]
+_CONDITION_GROUP_KEYS = ["method", "profile", "campaign_months", "condition", "condition_bin"]
 
 
 def leaderboard(results_df: pd.DataFrame) -> pd.DataFrame:
@@ -55,4 +56,33 @@ def leaderboard(results_df: pd.DataFrame) -> pd.DataFrame:
         "wall_time_s_sum",
         "wall_time_s_mean",
     ]
+    return pd.DataFrame(records, columns=columns)
+
+
+def conditional_leaderboard(results_df: pd.DataFrame) -> pd.DataFrame:
+    """Per-(method, profile, campaign, condition, bin) bias/spread/score over the conditional rows.
+
+    Only per-condition rows (``condition`` in ["ws", "ti"]) are summarised; overall rows
+    (``condition == "overall"``) are excluded. Returns one row per group with ``bias``,
+    ``spread``, ``score``, the mean recovered and true uplift (``mean_estimate`` /
+    ``mean_truth``, when those columns are present in the input), and ``n_replicates``,
+    sorted by method, profile, campaign length, condition, then condition_bin.
+    """
+    cond = results_df[results_df["condition"].isin(["ws", "ti"])] if "condition" in results_df else results_df.iloc[:0]
+
+    records = []
+    for keys, group in cond.groupby(_CONDITION_GROUP_KEYS, sort=True):
+        summary = summarize_errors(group["signed_error"].to_numpy())
+        records.append(
+            {
+                **dict(zip(_CONDITION_GROUP_KEYS, keys, strict=True)),
+                "bias": summary.bias,
+                "spread": summary.spread,
+                "score": summary.score,
+                "mean_estimate": float(group["estimate"].mean()) if "estimate" in group else float("nan"),
+                "mean_truth": float(group["truth"].mean()) if "truth" in group else float("nan"),
+                "n_replicates": summary.n,
+            }
+        )
+    columns = [*_CONDITION_GROUP_KEYS, "bias", "spread", "score", "mean_estimate", "mean_truth", "n_replicates"]
     return pd.DataFrame(records, columns=columns)

--- a/benchmarking/harness/method.py
+++ b/benchmarking/harness/method.py
@@ -44,8 +44,9 @@ class MethodOutput:
     """A method's P50 uplift estimate.
 
     :param p50_overall: overall P50 uplift (energy-ratio fraction)
-    :param p50_by_condition: optional per-condition estimates (columns ``condition_bin``,
-        ``p50_uplift``); ``None`` when the method produces only an overall number
+    :param p50_by_condition: optional per-condition estimates (columns ``condition``,
+        ``condition_bin``, ``p50_uplift``); ``condition`` ∈ {"ws","ti"}; ``None`` when the
+        method produces only an overall number
     """
 
     p50_overall: float

--- a/benchmarking/harness/plots.py
+++ b/benchmarking/harness/plots.py
@@ -105,3 +105,41 @@ def _set_score_ylim(ax: plt.Axes, scores_pp: np.ndarray) -> None:
     span = hi - lo
     margin = 0.05 * span if span > 0 else max(abs(hi), 1.0) * 0.05
     ax.set_ylim(bottom=min(0.0, lo) - margin)
+
+
+def plot_conditional_uplift(
+    summary_df: pd.DataFrame,
+    *,
+    condition: str,
+    save_path: str | Path | None = None,
+    title: str | None = None,
+) -> Figure:
+    """Plot mean recovered vs true uplift across bins of one condition, with a bias±spread band."""
+    df = summary_df[summary_df["condition"] == condition].copy()
+    df["_left"] = df["condition_bin"].str.extract(r"\(([-0-9.]+),").astype(float)
+    df = df.sort_values("_left")
+    order = df.drop_duplicates("condition_bin")["condition_bin"].tolist()
+    x = np.arange(len(order))
+
+    fig, ax = plt.subplots(figsize=(9, 5))
+    truth = df.drop_duplicates("condition_bin").set_index("condition_bin").reindex(order)["mean_truth"]
+    ax.plot(x, truth.to_numpy() * _FRACTION_TO_PP, "--", marker="s", color="k", label="true uplift")
+    for i, method in enumerate(sorted(df["method"].unique())):
+        m = df[df["method"] == method].set_index("condition_bin").reindex(order)
+        est = m["mean_estimate"].to_numpy() * _FRACTION_TO_PP
+        ax.plot(x, est, marker="o", color=f"C{i}", label=method)
+        if "spread" in m:
+            sp = m["spread"].to_numpy() * _FRACTION_TO_PP
+            ax.fill_between(x, est - sp, est + sp, color=f"C{i}", alpha=0.2)
+    ax.set_xticks(x)
+    ax.set_xticklabels(order, rotation=45, ha="right")
+    ax.set_xlabel(condition)
+    ax.set_ylabel("uplift [pp]")
+    ax.axhline(0.0, color="grey", lw=0.8)
+    ax.legend()
+    if title:
+        ax.set_title(title)
+    fig.tight_layout()
+    if save_path is not None:
+        fig.savefig(save_path, dpi=120)
+    return fig

--- a/benchmarking/harness/scoring.py
+++ b/benchmarking/harness/scoring.py
@@ -23,12 +23,16 @@ from typing import TYPE_CHECKING
 import pandas as pd
 
 from benchmarking.harness.campaign import campaign_windows, treated_activity_mask, window_row_mask
+from benchmarking.harness.conditions import CONDITION_BINS
 from benchmarking.harness.method import MethodInput
 from benchmarking.harness.replicates import build_replicates
 from benchmarking.synthetic import HOT_COLUMNS
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+
+    import numpy as np
+    import numpy.typing as npt
 
     from benchmarking.harness.campaign import CampaignWindow
     from benchmarking.harness.method import Method
@@ -66,33 +70,40 @@ def score_study(
     instances = _materialise_instances(replicates, study, data_start=data_start, data_end=data_end)
     # Truth depends only on ``(replicate, window)``, so compute it once here rather than once
     # per method (it would otherwise carry an avoidable ``len(methods)`` multiplier).
-    truths = [_truth_overall(replicate, window) for replicate, window in instances]
+    truth_masks = [_truth_mask(r, w) for r, w in instances]
+    truths = [r.true_uplift(mask=m).overall for (r, _), m in zip(instances, truth_masks, strict=True)]
 
     rows = []
     for method in methods:
-        method_rows = []
-        for (replicate, window), truth in zip(instances, truths, strict=True):
+        method_rows: list[dict[str, object]] = []
+        for (replicate, window), truth, mask in zip(instances, truths, truth_masks, strict=True):
             method_input = _method_input(replicate, window)
             start = time.perf_counter()
             output = method.estimate(method_input)
             wall_time_s = time.perf_counter() - start
+            base_fields: dict[str, object] = {
+                "method": method.name,
+                "profile": profile_name,
+                "replicate": replicate.replicate_id,
+                "test_wtg": replicate.test_wtg,
+                "campaign_months": window.months,
+                "treatment_start": window.treatment_start,
+                "baseline_start": window.baseline_start,
+                "activity_end": window.activity_end,
+            }
             method_rows.append(
                 {
-                    "method": method.name,
-                    "profile": profile_name,
-                    "replicate": replicate.replicate_id,
-                    "test_wtg": replicate.test_wtg,
-                    "campaign_months": window.months,
-                    "treatment_start": window.treatment_start,
-                    "baseline_start": window.baseline_start,
-                    "activity_end": window.activity_end,
+                    **base_fields,
                     "condition": "overall",
+                    "condition_bin": "overall",
                     "estimate": output.p50_overall,
                     "truth": truth,
                     "signed_error": output.p50_overall - truth,
                     "wall_time_s": wall_time_s,
                 }
             )
+            if output.p50_by_condition is not None:
+                method_rows.extend(_conditional_rows(output.p50_by_condition, replicate, window, mask, base_fields))
         if on_method_complete is not None:
             on_method_complete(method.name, pd.DataFrame(method_rows))
         rows.extend(method_rows)
@@ -132,9 +143,42 @@ def _method_input(replicate: Replicate, window: CampaignWindow) -> MethodInput:
     )
 
 
-def _truth_overall(replicate: Replicate, window: CampaignWindow) -> float:
-    """Ground-truth uplift over the test turbine's treated rows within the activity window."""
+def _truth_mask(replicate: Replicate, window: CampaignWindow) -> npt.NDArray[np.bool_]:
+    """Return the treated-activity mask over the test turbine's rows for this window."""
     synthetic = replicate.synthetic_df
     test_index = synthetic.loc[synthetic[replicate.dataset.columns.turbine] == replicate.test_wtg].index
-    mask = treated_activity_mask(test_index, replicate.upgrade_timing, window=window)
-    return replicate.true_uplift(mask=mask).overall
+    return treated_activity_mask(test_index, replicate.upgrade_timing, window=window)
+
+
+def _conditional_rows(
+    by_condition: pd.DataFrame,
+    replicate: Replicate,
+    window: CampaignWindow,  # noqa: ARG001 (kept for symmetry / future use)
+    mask: npt.NDArray[np.bool_],
+    base_fields: dict[str, object],
+) -> list[dict[str, object]]:
+    """Join each method per-bin estimate to per-bin truth for every condition present."""
+    rows: list[dict[str, object]] = []
+    for condition, est in by_condition.groupby("condition"):
+        truth_df = replicate.true_uplift(mask=mask, by=condition, bins=CONDITION_BINS[str(condition)]).by_condition
+        if truth_df is None:  # always set when by= is passed; guard for type narrowing
+            continue  # pragma: no cover
+        truth_series = truth_df.assign(condition_bin=truth_df["condition_bin"].astype(str)).set_index("condition_bin")[
+            "true_uplift"
+        ]
+        for _, r in est.iterrows():
+            bin_label = str(r["condition_bin"])
+            t = float(truth_series.get(bin_label, float("nan")))
+            e = float(r["p50_uplift"])
+            rows.append(
+                {
+                    **base_fields,
+                    "condition": condition,
+                    "condition_bin": bin_label,
+                    "estimate": e,
+                    "truth": t,
+                    "signed_error": e - t,
+                    "wall_time_s": float("nan"),
+                }
+            )
+    return rows

--- a/docs/v1/findings.md
+++ b/docs/v1/findings.md
@@ -7,6 +7,94 @@ from, not just conclusions.
 
 ---
 
+## F4 — power_model beats v0 in prepost and at longer-toggle; v0's edge is only short-toggle, and v0 alone breaks on rated-power uprates
+
+*2026-06-30 — the three-way comparison F3 flagged as the open question (power_model vs v0 in
+*both* modes). Source: `benchmarking/baselines/study_power_model_compare.py`, which re-runs
+**only** `power_model` over the current overnight cases and merges it with the frozen `v0_binned`
++ `naive_ratio` rows from the overnight run (`study_overnight_{prepost,toggle}.py`,
+`include_v0=True`). Seven `overnight_profiles` (`cp_minus_10pct`, `cp_0pct`, `cp_plus_3pct`,
+`cp_plus_10pct`, `ws_dependent_cp`, `ti_dependent_cp`, `rated_plus_5pct`), `n_replicates=4`,
+seed 0; prepost campaigns 3/6/12 mo (84 cases/method), toggle 3/6/9/12 mo (112 cases/method). The
+script's alignment guard confirmed all 84 + 112 fresh cases match the reference run's
+method-independent ground truth exactly, so the merge compares identical cases.*
+
+All numbers below are percentage points of fractional uplift (a 0.01 fraction = 1 pp). Bias = mean
+signed error, spread = std of signed error, RMSE pooled over all cases for that mode/method.
+
+### Observation — pooled over all profiles and campaign lengths
+
+| mode | method | bias | spread | MAE | RMSE | within ±1pp | per-case win |
+|---|---|---|---|---|---|---|---|
+| prepost | naive_ratio | −1.11 | 4.62 | 3.83 | 4.73 | 17% | 0% |
+| prepost | **power_model** | **−0.39** | **0.49** | **0.53** | **0.62** | **86%** | **73%** |
+| prepost | v0_binned | −0.73 | 0.72 | 0.84 | 1.03 | 62% | 27% |
+| toggle | naive_ratio | +0.15 | 0.16 | 0.19 | 0.22 | 100% | 39% |
+| toggle | power_model | +0.16 | 0.19 | 0.20 | 0.24 | 100% | 22% |
+| toggle | v0_binned | −0.01 | 0.33 | 0.23 | 0.32 | 98% | 38% |
+
+("per-case win" = share of the N cases where that method has the smallest |error|.) In prepost,
+**power_model's |error| is smaller than v0's in 73% of cases and smaller than naive's in 100%**.
+
+### Observation — RMSE by campaign length (the short-data story, serves G2)
+
+| mode | method | 3mo | 6mo | 9mo | 12mo |
+|---|---|---|---|---|---|
+| prepost | naive_ratio | 7.32 | 3.19 | — | 1.84 |
+| prepost | **power_model** | **0.82** | **0.46** | — | **0.53** |
+| prepost | v0_binned | 1.22 | 0.94 | — | 0.89 |
+| toggle | naive_ratio | **0.30** | 0.23 | 0.17 | 0.14 |
+| toggle | power_model | 0.38 | **0.22** | **0.18** | **0.11** |
+| toggle | v0_binned | 0.32 | 0.31 | 0.33 | 0.32 |
+
+The two structural facts: **(a)** in prepost power_model leads at every length, its biggest margin
+at 3 months (0.82 vs v0 1.22 vs naive 7.32); **(b)** in toggle, power_model and naive both tighten
+with more data (power_model 0.38 → 0.11), but **v0 does not improve with campaign length** — it
+sits at ~0.32 RMSE from 3 to 12 months. So v0 only wins the shortest toggle campaign; from 6
+months on, power_model is best in toggle too.
+
+### Observation — profile spotlight (pooled over campaigns)
+
+| profile | method | bias | RMSE | max |error| |
+|---|---|---|---|---|
+| prepost `rated_plus_5pct` | **power_model** | **−0.38** | **0.62** | **1.05** |
+| prepost `rated_plus_5pct` | v0_binned | −1.24 | 1.42 | 2.23 |
+| toggle `rated_plus_5pct` | **power_model** | +0.16 | **0.25** | **0.49** |
+| toggle `rated_plus_5pct` | v0_binned | −0.63 | 0.68 | 1.10 |
+
+power_model is **flat across all seven profiles** (prepost RMSE 0.61–0.63, bias ≈ −0.38 on every
+one), whereas **v0 has a specific weak spot on the rated-power uprate** — its worst profile in both
+modes (the only profile where v0's toggle RMSE, 0.68, is more than ~2× its others). A rated-power
+change shifts power at high wind speeds where v0's binned power-curve has sparse, noisy bins;
+power_model's continuous reference-conditioned fit has no such blind spot. On the placebo
+(`cp_0pct`) all three are well-behaved (toggle v0 even edges power_model, 0.18 vs 0.24 RMSE).
+
+### Interpretation
+- **Prepost: power_model is the better method, decisively.** Lower bias (−0.39 vs −0.73 pp), lower
+  spread (0.49 vs 0.72), ~40% lower RMSE than v0, and it wins the majority of cases head-to-head —
+  the F1 contrast lever (expected power through the references) cancelling the common-mode drift
+  that v0 corrects only through its detrend step. naive is not in contention (covariate shift).
+- **Toggle: a near-tie that tips to power_model with data.** Naive and power_model are
+  near-identical and both beat v0 overall on RMSE; v0's larger spread and its failure to improve
+  with longer toggling are the cost of its binning. v0's only advantage is the 3-month toggle
+  campaign, where power_model carries slightly more bias (+0.37) before its variance collapses.
+- **v0's rated-power weakness is the clearest single result.** It is the one regime where v0 is
+  both biased and high-variance in *both* modes, and where power_model's flatness is most valuable.
+
+### Implications
+1. **Answers F3's open question: power_model ≥ v0 in both modes for P50** — strictly better in
+   prepost and at toggle ≥ 6 months, with v0 ahead only at the shortest toggle campaign. It is now
+   the baseline to beat (G-level), not just vs naive.
+2. **Short-toggle bias is power_model's one soft spot** — the +0.37 pp at 3-month toggle is the
+   thing to chip at next (mirrors the residual prepost bias noted in F3 #3); candidates are the
+   baseline-horizon / recency weighting already on the list.
+3. **Add a rated-power-uprate case to any v0 regression framing** — it is v0's worst regime and a
+   natural demonstrator for power_model's advantage; worth a dedicated diagnostic.
+4. Reproduce/extend with `study_power_model_compare.py` (`--skip-run` to re-merge, `--modes` to
+   restrict); it reuses the frozen slow v0 so each power_model iteration is cheap.
+
+---
+
 ## F3 — A simple counterfactual power model halves prepost bias and spread vs naive; toggle is a wash
 
 *2026-06-29 — new method `power_model` (the simplest-possible ML method: a single LightGBM

--- a/docs/v1/findings.md
+++ b/docs/v1/findings.md
@@ -7,6 +7,86 @@ from, not just conclusions.
 
 ---
 
+## F5 — power_model's condition-dependent uplift error is the counterfactual model's own conditional bias (shrinkage), not a §3 post-treatment-conditioning artefact
+
+*2026-07-01 — first result off the conditional-uplift instrument (per-(ws, TI)-bin scoring; see
+`benchmarking/harness/conditions.py`, `scoring.py`, `PowerModelMethod._conditional_uplift`).
+Diagnosed with a new per-segment residual diagnostic
+`benchmarking/baselines/power_model/diagnostics.py::_plot_residual_binned` (writes
+`residual_binned.png` and `residual_binned_pct.png` under `5_uplift_modelling/`), regenerated via
+`benchmarking/baselines/inspect_prepost_hard_case.py`. The pinned case is the `cp_0pct` placebo on
+`T07`, 6-month prepost, true uplift 0% — so in both the held-out baseline and the "upgraded" window
+the residual is pure model error, an unusually clean read on model bias.*
+
+### Observation
+`power_model`'s overall P50 is excellent (F3/F4), but its **per-bin** uplift decomposition is badly
+distorted at the condition extremes. On `ti_dependent_cp` the recovered uplift slopes to ≈ −75 pp in
+the highest TI bin where the truth is roughly flat; on `ws_dependent_cp` the (2,4] m/s bin reads
+≈ −30 pp against a +17 pp truth. The overall estimate is unaffected because these errors integrate
+to ≈ 0.
+
+### Evidence — three facts that localise the cause
+1. **Not a §3 / binning-axis problem.** The synthetic upgrades for `ti_dependent_cp` and
+   `ws_dependent_cp` use `ws_delta = 0` (`ws_factor = 1.0`) and never modify `wind_speed_sd`
+   (`generator.py` `modified_columns = active_power, gen_rpm, wind_speed`). So the test turbine's
+   **measured** ws/TI under treatment equals its **original untreated** ws/TI exactly — the method
+   already bins on the same treatment-invariant axis the ground truth uses. (Binning the estimate on
+   a reference-derived ws/TI instead would therefore change nothing; confirmed by reasoning, not
+   pursued. Ground-truth binning was left unchanged.)
+2. **Not confounding.** Toggle (concurrent reference, ≈ no temporal confounding) shows the *same*
+   per-bin distortion shape as prepost.
+3. **It is model shrinkage / conditional bias.** On the placebo, `residual_binned.png` shows the mean
+   residual (actual − predicted) tilting from ≈ −25 kW at low power to ≈ +80 kW at high power — the
+   tilt survives the Bland-Altman `mean(actual, predicted)` axis, so it is a real conditional bias,
+   not just the errors-in-variables inflation from binning by actual. Across TI the same residual runs
+   ≈ +30 kW → −38 kW (zero-crossing at TI ≈ 0.17), exactly the shape of the fake TI-uplift. The
+   baseline and upgraded residual curves overlay (as they must at truth 0).
+
+### Root cause
+A regularised learner minimises squared error, so its prediction is pulled toward the conditional
+mean: with imperfect features it **predicts smoother than reality** — over-predicts where power is low,
+under-predicts where it is high (predicted-vs-actual slope < 1). The §3 rule forbids the test
+turbine's own ws/TI as features, so the counterfactual model carries no direct turbulence
+information; its residuals are therefore correlated with TI. Because power maps monotonically to wind
+speed, and TI is inversely related to wind speed at fixed power, this single compression re-appears as
+a negative residual at low ws / high TI and positive at high ws / low TI. The compression averages to
+≈ 0 over the whole window (so the headline uplift is clean), but slicing the energy ratio
+`Σactual / Σcounterfactual` **by condition** re-exposes the conditional bias as a spurious
+condition-dependent uplift.
+
+A **second, separate** failure mode inflates the visible excursions at the extremes: the low-ws /
+high-TI bins hold very little energy, so a small kW residual over a tiny `Σcounterfactual` becomes a
+huge *percentage*. The `residual_binned_pct.png` view (each bin's residual as a % of that bin's mean
+power) makes this explicit — the well-populated bins sit within ±5–15% while the tiny-power bins blow
+out to −160% (ws 5 m/s) / −330% (TI 0.35). So the extremes combine real conditional bias with ratio
+instability.
+
+### Interpretation
+The per-bin instrument is faithfully measuring **model bias**, not a defect in the harness or the
+conditioning axis. The overall-P50 verdict of F3/F4 stands; what F5 adds is that *conditional* P50 is
+only trustworthy where (a) the counterfactual model's conditional bias is small and (b) the bin holds
+enough energy for a stable ratio.
+
+### Implications / candidate directions (not yet actioned)
+1. **Reduce the counterfactual model's conditional bias** — the core lever. Leading candidate:
+   **baseline-residual calibration** — estimate the model's per-condition mean residual `b(cond)` on
+   untreated data (prepost baseline / toggle off-blocks, where the true uplift is 0) and subtract it
+   from the upgraded per-bin ratio. On the placebo the baseline residual curve *is* an estimate of
+   that bias and overlays the upgraded curve, so this should flatten the conditional-uplift curves
+   toward truth. To be designed before coding.
+2. **Give the model a treatment-invariant turbulence proxy** (each reference's own sd/ws, or ERA5
+   gust/spread) so the counterfactual can learn the TI–power relation without touching the treated
+   signal (§3-legal). Partial: only as good as the proxy's correlation with local TI.
+3. **Guard the fragile tails** — suppress or flag bins below an energy/count floor; orthogonal to
+   1–2 and fixes only the ratio-instability half.
+4. **Reporting/tooling shipped this cycle:** the two `residual_binned*` diagnostics (shared y per row;
+   percentage version normalised by each bin's own mean power, with the shared y-axis sized from bins
+   within ±30% so tiny-power outliers clip rather than crush the scale). Widening TI bins 5%→10% was
+   tried to tame the plot and **reverted** — it did not address the underlying bias and the y-axis
+   sizing is the better fix.
+
+---
+
 ## F4 — power_model beats v0 in prepost and at longer-toggle; v0's edge is only short-toggle, and v0 alone breaks on rated-power uprates
 
 *2026-06-30 — the three-way comparison F3 flagged as the open question (power_model vs v0 in

--- a/docs/v1/issues.md
+++ b/docs/v1/issues.md
@@ -133,6 +133,87 @@ its accuracy/precision appears in the leaderboard.
 
 ---
 
+## Issue 6 — Clip power_model predicted power to a sane range (power_model)
+
+**Goal:** stop the boosted counterfactual over/under-shooting the physically plausible
+range at the extremes — a small precision gain, especially in the fragile tail bins. Do
+this first: it is low-risk and serves as the simple test case for Issue 7.
+
+**Scope**
+- In `PowerModelMethod._fit_predict` (`benchmarking/baselines/power_model/method.py`),
+  clip every model prediction (the upgraded counterfactual *and* the baseline-holdout
+  prediction) to `[lower, upper]` with `lower = min(0, min(y_train))` and
+  `upper = max(rated_power_kw, max(y_train))`, where `y_train` is the fitted-on baseline
+  outcome. (Tree boosting sums trees, so predictions can slightly exceed the training
+  `y` range; the clip binds only at the extremes — expect a small effect.)
+- Add an optional `rated_power_kw: float | None = None` config field; when `None` the
+  upper bound is just `max(y_train)`. HoT rated = 2300 kW.
+- Keep it a pure post-prediction transform so overall and conditional both use clipped
+  predictions consistently.
+
+**Done when:** predictions are bounded; existing recovery/placebo tests still pass; a
+unit test on the clip helper confirms out-of-range predictions are pulled to the bounds
+and in-range ones are untouched.
+
+---
+
+## Issue 7 — Confirm the improvement-evaluation workflow surfaces what's needed (power_model)
+
+**Goal:** before the larger bias-correction work, prove that
+`study_power_model_compare.py` gives the information needed to judge a power_model change
+— using the Issue 6 clip as the first, simple test case.
+
+**Scope**
+- Run `benchmarking/baselines/study_power_model_compare.py` (power_model vs frozen
+  v0/naive, 3-method plots) on the clipped power_model.
+- Confirm it reports, side-by-side and legibly, both **overall** P50 error and the
+  **per-condition** (ws & TI) recovered-vs-truth curves for the `ti_dependent_cp` /
+  `ws_dependent_cp` hard cases — enough to see whether a change helped, hurt, or was
+  neutral, overall and per bin.
+- If a needed view is missing (e.g. a corrected-vs-current conditional overlay against
+  truth, or a per-bin error table), add the minimal reporting to the study/inspect
+  scripts so Issue 8 can be evaluated the same way.
+
+**Done when:** a single command produces the overall + per-condition comparison for the
+clip change, and the improvement is readable from it without ad-hoc digging.
+
+---
+
+## Issue 8 — Cross-prediction bias-cancellation for shrinkage-driven conditional bias (power_model)
+
+**Goal:** remove the counterfactual model's conditional (shrinkage) bias — the F5 root
+cause — by cancelling it between two symmetric train/predict directions on weather-matched
+data. Applies to both the overall and per-condition estimates.
+
+**Scope**
+- **Matching-variable analysis (one-off, do first).** On Hill of Towie, run a feature-
+  importance analysis to choose which ERA5 variables to match on (likely wind speed +
+  direction, possibly more). Record the chosen set + rationale in `docs/v1/findings.md`
+  and hard-code it as the default matching set. ERA5 is preferred for its full coverage
+  and temporal stability; the set may later be tuned per wind farm.
+- **ERA5 coarsened-exact matching (CEM).** New utility: bin baseline vs upgraded rows on
+  the chosen (synced) ERA5 variables; within each cell subsample the larger side to the
+  smaller side's count (seeded); drop one-sided cells. Yields equal-count, weather-matched
+  baseline/upgraded sets. The matching axis (ERA5) is distinct from the reporting/binning
+  axis (test-turbine ws/TI, kept as today so bins match ground truth).
+- **Two directions + geometric combine.** Forward: train on matched baseline, predict
+  matched upgraded → `r_fwd` (overall and per bin via `energy_ratio_by_bin`). Reverse:
+  train on matched upgraded, predict matched baseline → `r_rev`. Combine
+  `uplift = sqrt((1+r_fwd)/(1+r_rev)) − 1` (exact under a common per-bin multiplicative
+  shrinkage); also emit implied bias `1/sqrt((1+r_fwd)(1+r_rev))` as a diagnostic. Guard
+  non-positive `(1+r)` and empty/sparse bins.
+- **Opt-in flag** (e.g. `bias_correct: bool = False`) so the corrected overall +
+  conditional can be A/B'd against current behaviour before any default flips.
+- Reuse the existing outcome model factory (`make_outcome_model`) and `CONDITION_BINS`;
+  extend diagnostics to overlay corrected vs current conditional curves against truth.
+
+**Done when:** with the flag on, `study_power_model_compare.py` (Issue 7) shows the
+`ti_dependent_cp` / `ws_dependent_cp` conditional curves materially flatter toward truth
+and the overall P50 no worse than today; a regression test recovers a known condition-
+dependent uplift more accurately with correction on than off; findings.md updated.
+
+---
+
 ## Not in the first wave (tracked for later phases)
 
 - Uncertainty / P95 model: block bootstrap, conformal OOD, density-ratio long-term

--- a/tests/benchmarking/baselines/test_inspect_prepost_hard_case.py
+++ b/tests/benchmarking/baselines/test_inspect_prepost_hard_case.py
@@ -1,0 +1,23 @@
+"""The hard-case inspector's conditional-uplift plotting helper."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from benchmarking.baselines.inspect_prepost_hard_case import conditional_truth_vs_estimate
+from benchmarking.harness.method import MethodOutput
+
+
+def test_conditional_truth_vs_estimate_merges_estimate_and_truth() -> None:
+    out = MethodOutput(
+        p50_overall=0.05,
+        p50_by_condition=pd.DataFrame(
+            {"condition": ["ws", "ws"], "condition_bin": ["(6.0, 8.0]", "(8.0, 10.0]"], "p50_uplift": [0.06, 0.04]}
+        ),
+    )
+    truth = pd.DataFrame({"condition_bin": ["(6.0, 8.0]", "(8.0, 10.0]"], "true_uplift": [0.05, 0.05]})
+    merged = conditional_truth_vs_estimate(out, {"ws": truth}, method_name="power_model")
+    row = merged[merged["condition_bin"] == "(6.0, 8.0]"].iloc[0]
+    assert row["mean_estimate"] == 0.06
+    assert row["mean_truth"] == 0.05
+    assert row["method"] == "power_model"

--- a/tests/benchmarking/baselines/test_power_model_diagnostics.py
+++ b/tests/benchmarking/baselines/test_power_model_diagnostics.py
@@ -1,0 +1,130 @@
+"""Tests for the power-model residual diagnostics (the shrinkage-check plot)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+from benchmarking.baselines.power_model.diagnostics import (
+    DiagnosticData,
+    _as_percent_of_power,
+    _binned_stats,
+    _plot_residual_binned,
+    _set_ylim_from_inliers,
+)
+from benchmarking.diagnostics import stages
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_binned_stats_mean_sd_and_count() -> None:
+    x = np.array([0.5, 1.5, 1.6, 1.7, 10.0])  # last value falls outside the edges
+    y = np.array([1.0, 10.0, 12.0, 14.0, 999.0])
+    edges = np.array([0.0, 1.0, 2.0])
+    centers, mean, sd, count = _binned_stats(x, y, edges)
+    assert list(centers) == [0.5, 1.5]
+    # bin [0,1): a single point -> below _MIN_BIN_COUNT, so NaN mean/SD but count recorded
+    assert count[0] == 1
+    assert np.isnan(mean[0])
+    assert np.isnan(sd[0])
+    # bin [1,2): three points {10,12,14} -> mean 12, sample SD 2
+    assert count[1] == 3
+    assert mean[1] == 12.0
+    assert sd[1] == 2.0
+
+
+def test_binned_stats_all_nan_input_is_safe() -> None:
+    edges = np.array([0.0, 1.0, 2.0])
+    centers, mean, sd, count = _binned_stats(np.full(3, np.nan), np.arange(3.0), edges)
+    assert len(centers) == 2
+    assert np.isnan(mean).all()
+    assert np.isnan(sd).all()
+    assert (count == 0).all()
+
+
+def _diag_data(*, with_conditions: bool) -> DiagnosticData:
+    """A minimal DiagnosticData carrying only what the residual-binned plot reads."""
+    rng = np.random.default_rng(0)
+    n = 400
+    y_base = rng.uniform(0, 2000, n)
+    pred_base = 0.7 * y_base + 300  # deliberate shrinkage: slope < 1
+    y_up = rng.uniform(0, 2000, n)
+    pred_up = 0.7 * y_up + 300
+    cond_up = cond_base = None
+    if with_conditions:
+        cond_base = pd.DataFrame({"ws": rng.uniform(0, 25, n), "ti": rng.uniform(0, 0.4, n)})
+        cond_up = pd.DataFrame({"ws": rng.uniform(0, 25, n), "ti": rng.uniform(0, 0.4, n)})
+    return DiagnosticData(
+        test_wtg="T07",
+        mode="prepost",
+        index=pd.DatetimeIndex([]),
+        treated_all=np.array([]),
+        selected_all=np.array([]),
+        y_all=np.array([]),
+        timebase=pd.Timedelta(minutes=10),
+        upgraded_ts=pd.DatetimeIndex([]),
+        y_upgraded=y_up,
+        pred_upgraded=pred_up,
+        y_baseline_valid=y_base,
+        pred_baseline_valid=pred_base,
+        feature_names=[],
+        feature_values=pd.DataFrame(),
+        y_selected=np.array([]),
+        outcome_model=None,
+        overall_uplift=0.0,
+        sum_actual_kw=0.0,
+        sum_counterfactual_kw=0.0,
+        n_refs=3,
+        era5_lag_rows=None,
+        era5_corr=None,
+        era5_sweep=None,
+        cond_upgraded=cond_up,
+        cond_baseline_valid=cond_base,
+    )
+
+
+def test_as_percent_of_power_divides_per_bin_and_drops_nonpositive() -> None:
+    out = _as_percent_of_power(np.array([10.0, 5.0, -3.0]), np.array([100.0, 0.0, 60.0]))
+    assert out[0] == 10.0  # 10 kW of 100 kW
+    assert np.isnan(out[1])  # mean power 0 -> dropped
+    assert out[2] == -5.0  # -3 kW of 60 kW
+
+
+def test_set_ylim_from_inliers_ignores_out_of_range_points() -> None:
+    _, ax = plt.subplots()
+    # inliers within +/-30 are {-10, 20}; the -330 outlier must not stretch the limits
+    _set_ylim_from_inliers(ax, [np.array([-10.0, 20.0, -330.0, np.nan])])
+    lo, hi = ax.get_ylim()
+    assert lo < -10.0  # a small margin below the min inlier
+    assert lo > -20.0  # but nowhere near the -330 outlier
+    assert 20.0 < hi < 30.0
+    plt.close()
+
+
+def test_set_ylim_from_inliers_noop_when_no_inliers() -> None:
+    _, ax = plt.subplots()
+    before = ax.get_ylim()
+    _set_ylim_from_inliers(ax, [np.array([100.0, -330.0])])  # all outside +/-30
+    assert ax.get_ylim() == before
+    plt.close()
+
+
+def test_plot_residual_binned_writes_both_png_with_conditions(tmp_path: Path) -> None:
+    model_dir = tmp_path / stages.UPLIFT_MODELLING
+    model_dir.mkdir()
+    _plot_residual_binned(model_dir, _diag_data(with_conditions=True))
+    assert (model_dir / "residual_binned.png").exists()
+    assert (model_dir / "residual_binned_pct.png").exists()
+
+
+def test_plot_residual_binned_writes_png_without_conditions(tmp_path: Path) -> None:
+    # No ws/TI columns configured: the plot still renders the power-axis panels.
+    model_dir = tmp_path / stages.UPLIFT_MODELLING
+    model_dir.mkdir()
+    _plot_residual_binned(model_dir, _diag_data(with_conditions=False))
+    assert (model_dir / "residual_binned.png").exists()
+    assert (model_dir / "residual_binned_pct.png").exists()

--- a/tests/benchmarking/baselines/test_power_model_method.py
+++ b/tests/benchmarking/baselines/test_power_model_method.py
@@ -20,6 +20,7 @@ _TURBINE = "TurbineName"
 _POWER = "wtc_ActPower_mean"
 _AVAIL = "wtc_ScReToOp_timeon"
 _WS = "wtc_AcWindSp_mean"
+_WS_SD = "wtc_AcWindSp_stddev"
 
 # Small/fast LightGBM so the toy data (a few thousand rows) is fit well.
 _FAST_PARAMS = {"n_estimators": 120, "learning_rate": 0.1, "num_leaves": 31, "min_child_samples": 20}
@@ -45,7 +46,9 @@ def _toy_scada(n: int, *, uplift: float, treated: np.ndarray, seed: int = 0) -> 
         "R3": r3,
     }
     parts = [
-        pd.DataFrame({_TURBINE: name, _POWER: power, _AVAIL: 600.0, _WS: power / 100.0}, index=idx)
+        pd.DataFrame(
+            {_TURBINE: name, _POWER: power, _AVAIL: 600.0, _WS: power / 100.0, _WS_SD: power / 1000.0}, index=idx
+        )
         for name, power in frames.items()
     ]
     return pd.concat(parts)
@@ -131,3 +134,37 @@ class TestReferenceOnly:
         with_leak = method.estimate(mi_leak).p50_overall
         # the reference-only builder ignores test-turbine columns, so the estimate is unchanged
         assert with_leak == pytest.approx(baseline, abs=1e-9)
+
+
+class TestConditionalUplift:
+    def test_emits_conditional_uplift_by_ws_and_ti(self) -> None:
+        n = 4000
+        idx = pd.date_range("2019-01-01", periods=n, freq="10min", tz="UTC")
+        changeover = idx[n // 2]
+        treated = np.asarray(idx >= changeover)
+        scada = _toy_scada(n, uplift=0.05, treated=treated)  # now includes _WS_SD
+        method = PowerModelMethod(
+            active_power_col=_POWER,
+            availability_col=_AVAIL,
+            wind_speed_col=_WS,
+            wind_speed_sd_col=_WS_SD,
+            model_params=_FAST_PARAMS,
+        )
+        mi = MethodInput(scada_df=scada, test_wtg="T1", upgrade_timing=pd.Timestamp(changeover), turbine_col=_TURBINE)
+        out = method.estimate(mi)
+        bc = out.p50_by_condition
+        assert list(bc.columns) == ["condition", "condition_bin", "p50_uplift"]
+        assert set(bc["condition"]) == {"ws", "ti"}
+
+    def test_ws_only_when_no_sd_column_configured(self) -> None:
+        n = 4000
+        idx = pd.date_range("2019-01-01", periods=n, freq="10min", tz="UTC")
+        changeover = idx[n // 2]
+        treated = np.asarray(idx >= changeover)
+        scada = _toy_scada(n, uplift=0.05, treated=treated)
+        method = PowerModelMethod(
+            active_power_col=_POWER, availability_col=_AVAIL, wind_speed_col=_WS, model_params=_FAST_PARAMS
+        )
+        mi = MethodInput(scada_df=scada, test_wtg="T1", upgrade_timing=pd.Timestamp(changeover), turbine_col=_TURBINE)
+        out = method.estimate(mi)
+        assert set(out.p50_by_condition["condition"]) == {"ws"}

--- a/tests/benchmarking/baselines/test_study_power_model_compare.py
+++ b/tests/benchmarking/baselines/test_study_power_model_compare.py
@@ -1,0 +1,193 @@
+"""Benchmark reshaping in study_power_model_compare."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pandas as pd
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from benchmarking.baselines.study_power_model_compare import (
+    _BASELINE_SCHEMA,
+    _load_baseline_cells,
+    power_model_leaderboard,
+    record_baseline,
+)
+from benchmarking.harness import StudyConfig
+
+
+def test_power_model_leaderboard_includes_overall_and_conditional_cells() -> None:
+    fresh = pd.DataFrame(
+        {
+            "method": "power_model",
+            "profile": "ws_dependent_cp",
+            "campaign_months": 6,
+            "replicate": [0, 1, 0, 1],
+            "condition": ["overall", "overall", "ws", "ws"],
+            "condition_bin": ["overall", "overall", "(6.0, 8.0]", "(6.0, 8.0]"],
+            "estimate": [0.05, 0.05, 0.08, 0.06],
+            "truth": [0.05, 0.05, 0.07, 0.07],
+            "signed_error": [0.0, 0.0, 0.01, -0.01],
+        }
+    )
+    lb = power_model_leaderboard(fresh)
+    keys = set(zip(lb["condition"], lb["condition_bin"], strict=True))
+    assert ("overall", "overall") in keys
+    assert ("ws", "(6.0, 8.0]") in keys
+    assert {"profile", "campaign_months", "condition", "condition_bin", "bias", "spread", "score"} <= set(lb.columns)
+
+
+def _minimal_study() -> StudyConfig:
+    return StudyConfig(
+        mode="prepost",
+        turbine_subset=["WT01"],
+        treatment_start_range=(pd.Timestamp("2020-01-01", tz="UTC"), pd.Timestamp("2020-06-01", tz="UTC")),
+        min_pre_months=6,
+        campaign_months=[6],
+        n_replicates=1,
+        seed=0,
+    )
+
+
+def _minimal_leaderboard() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "profile": ["test_profile"],
+            "campaign_months": [6],
+            "condition": ["overall"],
+            "condition_bin": ["overall"],
+            "bias": [0.01],
+            "spread": [0.02],
+            "score": [0.03],
+        }
+    )
+
+
+def test_load_baseline_cells_returns_none_for_wrong_schema(tmp_path: Path) -> None:
+    """_load_baseline_cells must return None (not crash) when the file has an old/mismatched schema."""
+    path = tmp_path / "baseline.json"
+    doc = {
+        "schema": "power_model_compare_baseline_v1",
+        "modes": {
+            "prepost": {
+                "recorded_utc": "2025-01-01T00:00:00Z",
+                "git_commit": "abc1234",
+                "n_replicates": 1,
+                "seed": 0,
+                "campaign_months": [6],
+                "profiles": ["test_profile"],
+                "cells": [{"profile": "test_profile", "campaign_months": 6, "bias": 0.01}],
+            }
+        },
+    }
+    path.write_text(json.dumps(doc))
+
+    result = _load_baseline_cells("prepost", path)
+
+    assert result is None
+
+
+def test_record_baseline_drops_stale_modes_on_schema_bump(tmp_path: Path) -> None:
+    """When on-disk schema != _BASELINE_SCHEMA, old-schema mode cells must be dropped (not inherited)."""
+    path = tmp_path / "baseline.json"
+    # Simulate a v1 file that has a toggle entry with v1-shaped cells (no condition/condition_bin).
+    old_doc = {
+        "schema": "power_model_compare_baseline_v1",
+        "modes": {
+            "toggle": {
+                "recorded_utc": "2025-01-01T00:00:00Z",
+                "git_commit": "abc1234",
+                "n_replicates": 1,
+                "seed": 0,
+                "campaign_months": [6],
+                "profiles": ["test_profile"],
+                "cells": [
+                    {"profile": "test_profile", "campaign_months": 6, "bias": 0.01, "spread": 0.02, "score": 0.03}
+                ],
+            }
+        },
+    }
+    path.write_text(json.dumps(old_doc))
+
+    lb = _minimal_leaderboard()
+    study = _minimal_study()
+    record_baseline({"prepost": lb}, {"prepost": study}, path)
+
+    written = json.loads(path.read_text())
+    assert written["schema"] == _BASELINE_SCHEMA
+    # The stale v1 toggle entry must be gone — a later toggle compare must not KeyError on missing columns.
+    assert "toggle" not in written.get("modes", {}), "stale v1 toggle cells must be dropped after schema bump"
+    # Equivalently, _load_baseline_cells for toggle returns None.
+    assert _load_baseline_cells("toggle", path) is None
+
+
+def test_record_baseline_preserves_sibling_modes_when_schemas_match(tmp_path: Path) -> None:
+    """When on-disk schema matches _BASELINE_SCHEMA, sibling modes must be preserved (incremental update)."""
+    path = tmp_path / "baseline.json"
+    # Write a v2 file that already has a toggle entry.
+    existing_toggle_cells = [
+        {
+            "profile": "test_profile",
+            "campaign_months": 6,
+            "condition": "overall",
+            "condition_bin": "overall",
+            "bias": 0.05,
+            "spread": 0.06,
+            "score": 0.07,
+        }
+    ]
+    existing_doc = {
+        "schema": _BASELINE_SCHEMA,
+        "modes": {
+            "toggle": {
+                "recorded_utc": "2025-01-01T00:00:00Z",
+                "git_commit": "abc1234",
+                "n_replicates": 1,
+                "seed": 0,
+                "campaign_months": [6],
+                "profiles": ["test_profile"],
+                "cells": existing_toggle_cells,
+            }
+        },
+    }
+    path.write_text(json.dumps(existing_doc))
+
+    lb = _minimal_leaderboard()
+    study = _minimal_study()
+    record_baseline({"prepost": lb}, {"prepost": study}, path)
+
+    written = json.loads(path.read_text())
+    assert written["schema"] == _BASELINE_SCHEMA
+    # The sibling toggle mode must still be present (incremental update must not drop it).
+    assert "toggle" in written.get("modes", {}), "matching-schema sibling mode must be preserved"
+    assert "prepost" in written.get("modes", {}), "newly recorded prepost mode must be present"
+    toggle_result = _load_baseline_cells("toggle", path)
+    assert toggle_result is not None
+
+
+def test_record_baseline_stamps_current_schema_over_old_file(tmp_path: Path) -> None:
+    """record_baseline must overwrite 'schema' with _BASELINE_SCHEMA even when an old-schema file exists."""
+    path = tmp_path / "baseline.json"
+    # Write a v1 stub to simulate the on-disk old file.
+    old_doc = {
+        "schema": "power_model_compare_baseline_v1",
+        "modes": {},
+    }
+    path.write_text(json.dumps(old_doc))
+
+    lb = _minimal_leaderboard()
+    study = _minimal_study()
+    record_baseline({"prepost": lb}, {"prepost": study}, path)
+
+    written = json.loads(path.read_text())
+    assert written["schema"] == _BASELINE_SCHEMA
+
+    # The round-trip via _load_baseline_cells must now succeed (not return None).
+    loaded = _load_baseline_cells("prepost", path)
+    assert loaded is not None
+    cells_df, prov = loaded
+    assert isinstance(cells_df, pd.DataFrame)
+    assert prov["n_replicates"] == 1

--- a/tests/benchmarking/baselines/test_study_power_model_compare.py
+++ b/tests/benchmarking/baselines/test_study_power_model_compare.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
 
 from benchmarking.baselines.study_power_model_compare import (
     _BASELINE_SCHEMA,
+    _conditional_plot_subset,
     _load_baseline_cells,
     power_model_leaderboard,
     record_baseline,
@@ -38,6 +39,40 @@ def test_power_model_leaderboard_includes_overall_and_conditional_cells() -> Non
     assert ("overall", "overall") in keys
     assert ("ws", "(6.0, 8.0]") in keys
     assert {"profile", "campaign_months", "condition", "condition_bin", "bias", "spread", "score"} <= set(lb.columns)
+
+
+def test_conditional_plot_subset_collapses_to_longest_campaign() -> None:
+    # conditional_leaderboard keeps one row per (campaign_months, condition_bin); the plot needs a
+    # single row per bin, so mixing campaign lengths must be collapsed (regression: a multi-campaign
+    # subset raised "cannot reindex on an axis with duplicate labels" in plot_conditional_uplift).
+    cond_lb = pd.DataFrame(
+        {
+            "method": "power_model",
+            "profile": "ws_dependent_cp",
+            "campaign_months": [3, 3, 12, 12],
+            "condition": "ws",
+            "condition_bin": ["(4.0, 6.0]", "(6.0, 8.0]", "(4.0, 6.0]", "(6.0, 8.0]"],
+            "mean_estimate": [0.09, 0.05, 0.10, 0.05],
+            "mean_truth": [0.10, 0.05, 0.10, 0.05],
+            "bias": [-0.01, 0.0, 0.0, 0.0],
+            "spread": [0.01, 0.005, 0.008, 0.004],
+        }
+    )
+    subset = _conditional_plot_subset(cond_lb, "ws_dependent_cp", "ws")
+    assert list(subset["campaign_months"].unique()) == [12]
+    assert not subset["condition_bin"].duplicated().any()
+
+
+def test_conditional_plot_subset_empty_for_absent_profile() -> None:
+    cond_lb = pd.DataFrame(
+        {
+            "profile": ["ws_dependent_cp"],
+            "condition": ["ws"],
+            "campaign_months": [6],
+            "condition_bin": ["(6.0, 8.0]"],
+        }
+    )
+    assert _conditional_plot_subset(cond_lb, "other_profile", "ws").empty
 
 
 def _minimal_study() -> StudyConfig:

--- a/tests/benchmarking/harness/stubs.py
+++ b/tests/benchmarking/harness/stubs.py
@@ -8,15 +8,12 @@ bias/precision metrics; Recording captures inputs for the fairness test.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import numpy as np
+import pandas as pd
 
+from benchmarking.harness.conditions import CONDITION_BINS, energy_ratio_by_bin
 from benchmarking.harness.method import MethodInput, MethodOutput
 from benchmarking.synthetic import HOT_COLUMNS, treated_mask
-
-if TYPE_CHECKING:
-    import pandas as pd
 
 
 def oracle_overall_uplift(mi: MethodInput, original_df: pd.DataFrame) -> float:
@@ -88,3 +85,37 @@ class RecordingMethod:
         )
         self.seen.append(captured)
         return MethodOutput(p50_overall=0.0)
+
+
+def conditional_oracle_by_condition(mi: MethodInput, original_df: pd.DataFrame) -> pd.DataFrame:
+    """Per-bin oracle uplift over treated rows, binned on the test turbine's measured ws/ti."""
+    syn = mi.scada_df
+    test_rows = syn[syn[mi.turbine_col] == mi.test_wtg]
+    treated = treated_mask(test_rows.index, mi.upgrade_timing)
+    treated_rows = test_rows[treated]
+    orig_test = original_df[original_df[mi.turbine_col] == mi.test_wtg]
+    actual = treated_rows[HOT_COLUMNS.active_power].to_numpy(dtype=float)
+    counterfactual = orig_test.loc[treated_rows.index, HOT_COLUMNS.active_power].to_numpy(dtype=float)
+    ws = treated_rows[HOT_COLUMNS.wind_speed].to_numpy(dtype=float)
+    sd = treated_rows[HOT_COLUMNS.wind_speed_sd].to_numpy(dtype=float)
+    ti = np.divide(sd, ws, out=np.full_like(sd, np.nan), where=ws != 0)
+    frames = []
+    for name, values in (("ws", ws), ("ti", ti)):
+        table = energy_ratio_by_bin(values, actual, counterfactual, bins=CONDITION_BINS[name])
+        table.insert(0, "condition", name)
+        frames.append(table[["condition", "condition_bin", "p50_uplift"]])
+    return pd.concat(frames, ignore_index=True)
+
+
+class ConditionalOracleMethod:
+    """Oracle that also emits per-bin oracle uplift; conditional signed error should be ~0."""
+
+    def __init__(self, original_df: pd.DataFrame, name: str = "cond_oracle") -> None:
+        self._original = original_df
+        self.name = name
+
+    def estimate(self, mi: MethodInput) -> MethodOutput:
+        return MethodOutput(
+            p50_overall=oracle_overall_uplift(mi, self._original),
+            p50_by_condition=conditional_oracle_by_condition(mi, self._original),
+        )

--- a/tests/benchmarking/harness/test_conditions.py
+++ b/tests/benchmarking/harness/test_conditions.py
@@ -1,0 +1,47 @@
+"""Tests for the shared condition bins and the binned energy-ratio reducer."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from benchmarking.harness.conditions import (
+    CONDITION_BINS,
+    CONDITIONS,
+    TI_BINS,
+    WS_BINS,
+    energy_ratio_by_bin,
+)
+
+
+def test_bin_edges_have_expected_width() -> None:
+    assert WS_BINS[0] == 0.0
+    assert WS_BINS[-1] == 26.0
+    assert np.allclose(np.diff(WS_BINS), 2.0)
+    assert TI_BINS[0] == 0.0
+    assert TI_BINS[-1] == 0.5
+    assert np.allclose(np.diff(TI_BINS), 0.05)
+    assert CONDITIONS == ("ws", "ti")
+    assert CONDITION_BINS == {"ws": WS_BINS, "ti": TI_BINS}
+
+
+def test_energy_ratio_by_bin_computes_per_bin_ratio() -> None:
+    # two rows in (4,6], two in (6,8]; counterfactual constant so uplift = mean(actual)/cf - 1
+    cond = np.array([5.0, 5.0, 7.0, 7.0])
+    actual = np.array([110.0, 90.0, 150.0, 150.0])
+    counterfactual = np.array([100.0, 100.0, 100.0, 100.0])
+    out = energy_ratio_by_bin(cond, actual, counterfactual, bins=WS_BINS)
+    by = out.set_index("condition_bin")
+    assert by.loc["(4.0, 6.0]", "p50_uplift"] == 0.0  # (110+90)/200 - 1
+    assert by.loc["(6.0, 8.0]", "p50_uplift"] == 0.5  # 300/200 - 1
+    assert by.loc["(4.0, 6.0]", "n_records"] == 2
+
+
+def test_energy_ratio_by_bin_is_nan_safe_and_covers_all_bins() -> None:
+    cond = np.array([5.0, np.nan, 7.0])
+    actual = np.array([100.0, 50.0, np.nan])
+    counterfactual = np.array([100.0, 50.0, 100.0])
+    out = energy_ratio_by_bin(cond, actual, counterfactual, bins=WS_BINS)
+    # one row per bin edge interval, no warnings, empty bins -> NaN uplift
+    assert len(out) == len(WS_BINS) - 1
+    assert out["condition_bin"].is_unique
+    assert out.loc[out["condition_bin"] == "(6.0, 8.0]", "p50_uplift"].isna().all()

--- a/tests/benchmarking/harness/test_leaderboard.py
+++ b/tests/benchmarking/harness/test_leaderboard.py
@@ -7,7 +7,7 @@ import math
 import pandas as pd
 import pytest
 
-from benchmarking.harness.leaderboard import leaderboard
+from benchmarking.harness.leaderboard import conditional_leaderboard, leaderboard
 
 
 def _results(rows: list[dict]) -> pd.DataFrame:
@@ -94,3 +94,48 @@ def test_methods_are_compared_side_by_side() -> None:
     by_method = summary.set_index("method")
     assert by_method.loc["a", "score"] == pytest.approx(0.0)
     assert by_method.loc["b", "score"] == pytest.approx(0.1)
+
+
+def test_conditional_leaderboard_groups_by_condition_bin() -> None:
+    df = pd.DataFrame(
+        {
+            "method": "m",
+            "profile": "p",
+            "campaign_months": 6,
+            "condition": ["ws", "ws", "ws", "ws"],
+            "condition_bin": ["(6.0, 8.0]", "(6.0, 8.0]", "(8.0, 10.0]", "(8.0, 10.0]"],
+            "estimate": [0.11, 0.09, 0.05, 0.05],
+            "truth": [0.10, 0.10, 0.05, 0.05],
+            "signed_error": [0.01, -0.01, 0.0, 0.0],
+        }
+    )
+    lb = conditional_leaderboard(df)
+    assert set(lb.columns) >= {
+        "method",
+        "profile",
+        "campaign_months",
+        "condition",
+        "condition_bin",
+        "bias",
+        "spread",
+        "score",
+    }
+    row = lb[lb["condition_bin"] == "(6.0, 8.0]"].iloc[0]
+    assert row["bias"] == 0.0
+    assert row["spread"] == pytest.approx(0.01)
+
+
+def test_conditional_leaderboard_ignores_overall_rows() -> None:
+    df = pd.DataFrame(
+        {
+            "method": "m",
+            "profile": "p",
+            "campaign_months": 6,
+            "condition": ["overall"],
+            "condition_bin": ["overall"],
+            "estimate": [0.1],
+            "truth": [0.1],
+            "signed_error": [0.0],
+        }
+    )
+    assert conditional_leaderboard(df).empty

--- a/tests/benchmarking/harness/test_plots.py
+++ b/tests/benchmarking/harness/test_plots.py
@@ -8,9 +8,10 @@ import matplotlib as mpl
 
 mpl.use("Agg")  # headless: no display needed for tests
 
+import matplotlib.pyplot as plt
 import pandas as pd
 
-from benchmarking.harness.plots import plot_campaign_curves
+from benchmarking.harness.plots import plot_campaign_curves, plot_conditional_uplift
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -91,3 +92,21 @@ def test_saves_file(tmp_path: Path) -> None:
     plot_campaign_curves(_summary(), save_path=save_path)
     assert save_path.exists()
     assert save_path.stat().st_size > 0
+
+
+def test_plot_conditional_uplift_writes_png(tmp_path: Path) -> None:
+    summary = pd.DataFrame(
+        {
+            "method": ["power_model", "power_model"],
+            "condition": ["ws", "ws"],
+            "condition_bin": ["(4.0, 6.0]", "(6.0, 8.0]"],
+            "mean_estimate": [0.09, 0.05],
+            "mean_truth": [0.10, 0.05],
+            "bias": [-0.01, 0.0],
+            "spread": [0.01, 0.005],
+        }
+    )
+    out = tmp_path / "cond.png"
+    fig = plot_conditional_uplift(summary, condition="ws", save_path=out, title="ws_dependent_cp 6mo")
+    assert out.exists()
+    plt.close(fig)

--- a/tests/benchmarking/harness/test_scoring.py
+++ b/tests/benchmarking/harness/test_scoring.py
@@ -10,7 +10,7 @@ from benchmarking.harness.scoring import score_study
 from benchmarking.synthetic import HOT_COLUMNS, ConstantCpChange
 from wind_up.constants import TIMESTAMP_COL
 
-from .stubs import BiasedMethod, OracleMethod, RecordingMethod
+from .stubs import BiasedMethod, ConditionalOracleMethod, OracleMethod, RecordingMethod
 
 PROFILE = [ConstantCpChange(delta=0.05)]
 
@@ -180,3 +180,23 @@ def test_on_method_complete_is_optional() -> None:
     # anything else.
     drop = ["wall_time_s"]
     pd.testing.assert_frame_equal(with_cb.drop(columns=drop), without_cb.drop(columns=drop))
+
+
+def test_conditional_rows_are_emitted_with_truth_and_near_zero_error() -> None:
+    base = _base_scada()
+    results = score_study(base, profile=PROFILE, methods=[ConditionalOracleMethod(base)], study=_study(n_replicates=1))
+    assert "condition_bin" in results.columns
+    overall = results[results["condition"] == "overall"]
+    assert (overall["condition_bin"] == "overall").all()
+    cond = results[results["condition"].isin(["ws", "ti"])]
+    assert set(cond["condition"]) == {"ws", "ti"}
+    # populated bins: a per-bin oracle must match per-bin truth
+    populated = cond[cond["truth"].notna() & cond["estimate"].notna()]
+    assert len(populated) > 0
+    assert np.allclose(populated["signed_error"].to_numpy(), 0.0, atol=1e-9)
+
+
+def test_overall_only_method_emits_no_conditional_rows() -> None:
+    base = _base_scada()
+    results = score_study(base, profile=PROFILE, methods=[OracleMethod(base)], study=_study(n_replicates=1))
+    assert set(results["condition"]) == {"overall"}


### PR DESCRIPTION
The main contribution of this PR is `study_power_model_compare.py` and associated json file which can be used to judge how well the power_model is performing compared to before. This will allow improvement ideas to power_model to be tested objectively.