### PR TITLE
V1 issue9-11

### DIFF
--- a/benchmarking/baselines/era5_derived.py
+++ b/benchmarking/baselines/era5_derived.py
@@ -1,0 +1,174 @@
+"""Derive physically meaningful quantities from raw (synced) ERA5 columns (shared, Issue 9).
+
+The methods consume ERA5 as raw Open-Meteo columns; this module turns those into the derived,
+treatment-invariant quantities that actually drive turbine power and its scatter, so every method
+*and* the CEM matching step share one implementation:
+
+* ``shear_exponent`` — the power-law exponent ``alpha = ln(ws_100m/ws_10m)/ln(100/10)``; folds the
+  collinear 10 m / 100 m speeds into one physical vertical-shear (stability) signal.
+* ``wind_speed_hub`` — hub-height wind speed by the shear power law,
+  ``ws_hh = ws_100m * (hub_height_m/100)^alpha`` (needs the site's hub height).
+* ``gust_ratio`` — ``wind_gusts_10m / wind_speed_10m``, a unitless TI-like turbulence proxy
+  (NaN below a calm-wind floor where the ratio degenerates).
+* ``veer`` — vertical direction veer ``wind_direction_100m - wind_direction_10m`` wrapped to
+  ±180°.
+* ``air_density`` — moist-air density from 2 m temperature, surface pressure and relative
+  humidity (partial pressures of dry air and vapour, Magnus saturation formula).
+
+All functions are NaN-tolerant (LightGBM handles NaN natively) and operate on the *aligned* ERA5
+frame the lag sync produces (original Open-Meteo column names).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pandas as pd
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+# The derivation vocabulary: each name is both the config token and the output column name.
+ERA5_DERIVATIONS: tuple[str, ...] = (
+    "shear_exponent",
+    "wind_speed_hub",
+    "gust_ratio",
+    "gust_margin",
+    "veer",
+    "air_density",
+)
+
+# The two ERA5 wind-speed levels the shear exponent is fit between.
+_SHEAR_LO_M = 10.0
+_SHEAR_HI_M = 100.0
+# Below this 10 m wind speed the gust ratio degenerates (tiny denominator) and TI is meaningless.
+_GUST_RATIO_MIN_WS = 1.0
+# Specific gas constants [J/(kg K)] for dry air and water vapour.
+_R_DRY = 287.05
+_R_VAPOUR = 461.5
+_KELVIN_OFFSET = 273.15
+# Magnus saturation-vapour-pressure constants (over water), e_s in Pa for t in degC.
+_MAGNUS_A = 611.2
+_MAGNUS_B = 17.62
+_MAGNUS_C = 243.12
+
+
+def shear_exponent(ws_lo: pd.Series, ws_hi: pd.Series) -> pd.Series:
+    """Power-law shear exponent ``alpha = ln(ws_hi/ws_lo)/ln(hi/lo)``; NaN where either speed <= 0."""
+    lo = ws_lo.to_numpy(dtype=float)
+    hi = ws_hi.to_numpy(dtype=float)
+    positive = (lo > 0) & (hi > 0)
+    alpha = np.full(len(lo), np.nan)
+    alpha[positive] = np.log(hi[positive] / lo[positive]) / np.log(_SHEAR_HI_M / _SHEAR_LO_M)
+    return pd.Series(alpha, index=ws_hi.index, name="shear_exponent")
+
+
+def hub_height_wind_speed(ws_hi: pd.Series, alpha: pd.Series, *, hub_height_m: float) -> pd.Series:
+    """Interpolate to hub height with the shear power law: ``ws_hh = ws_hi * (hh/hi)^alpha``."""
+    hi = ws_hi.to_numpy(dtype=float)
+    a = alpha.to_numpy(dtype=float)
+    with np.errstate(invalid="ignore"):
+        ws_hh = hi * (hub_height_m / _SHEAR_HI_M) ** a
+    return pd.Series(ws_hh, index=ws_hi.index, name="wind_speed_hub")
+
+
+def gust_ratio(gusts: pd.Series, ws: pd.Series, *, min_ws: float = _GUST_RATIO_MIN_WS) -> pd.Series:
+    """TI-like gust ratio ``gusts/ws``; NaN where ``ws < min_ws`` (calm-wind degenerate denominator)."""
+    g = gusts.to_numpy(dtype=float)
+    w = ws.to_numpy(dtype=float)
+    valid = w >= min_ws
+    ratio = np.divide(g, w, out=np.full(len(w), np.nan), where=valid)
+    return pd.Series(ratio, index=ws.index, name="gust_ratio")
+
+
+def gust_margin(gusts: pd.Series, ws: pd.Series) -> pd.Series:
+    """Gust margin ``gusts - ws`` [m/s] — an absolute gustiness signal.
+
+    On Hill of Towie this correlates with measured nacelle TI better than the ratio form
+    (the calm-wind denominator makes ``gust_ratio`` nearly uncorrelated with TI at 10 min).
+    """
+    margin = gusts.to_numpy(dtype=float) - ws.to_numpy(dtype=float)
+    return pd.Series(margin, index=ws.index, name="gust_margin")
+
+
+def vertical_veer(wd_hi: pd.Series, wd_lo: pd.Series) -> pd.Series:
+    """Vertical direction veer ``wd_hi - wd_lo`` wrapped to (-180, 180] degrees."""
+    diff = wd_hi.to_numpy(dtype=float) - wd_lo.to_numpy(dtype=float)
+    wrapped = -((180.0 - diff) % 360.0 - 180.0)
+    return pd.Series(wrapped, index=wd_hi.index, name="veer")
+
+
+def air_density(temperature_c: pd.Series, pressure_hpa: pd.Series, relative_humidity_pct: pd.Series) -> pd.Series:
+    """Moist-air density [kg/m3] from 2 m temperature [degC], surface pressure [hPa] and RH [%].
+
+    Partial-pressure form: ``rho = p_dry/(R_dry T) + p_vapour/(R_vapour T)`` with the vapour
+    pressure from the Magnus saturation formula scaled by relative humidity.
+    """
+    t_c = temperature_c.to_numpy(dtype=float)
+    t_k = t_c + _KELVIN_OFFSET
+    p_pa = pressure_hpa.to_numpy(dtype=float) * 100.0
+    saturation_pa = _MAGNUS_A * np.exp(_MAGNUS_B * t_c / (_MAGNUS_C + t_c))
+    p_vapour = np.clip(relative_humidity_pct.to_numpy(dtype=float), 0.0, 100.0) / 100.0 * saturation_pa
+    p_dry = p_pa - p_vapour
+    rho = p_dry / (_R_DRY * t_k) + p_vapour / (_R_VAPOUR * t_k)
+    return pd.Series(rho, index=temperature_c.index, name="air_density")
+
+
+# Raw Open-Meteo columns each derivation needs (validated before deriving so a missing input is a
+# clear configuration error, not a KeyError deep in numpy).
+_REQUIRED_RAW: dict[str, tuple[str, ...]] = {
+    "shear_exponent": ("wind_speed_10m", "wind_speed_100m"),
+    "wind_speed_hub": ("wind_speed_10m", "wind_speed_100m"),
+    "gust_ratio": ("wind_gusts_10m", "wind_speed_10m"),
+    "gust_margin": ("wind_gusts_10m", "wind_speed_100m"),
+    "veer": ("wind_direction_100m", "wind_direction_10m"),
+    "air_density": ("temperature_2m", "surface_pressure", "relative_humidity_2m"),
+}
+
+
+def era5_derived_frame(
+    aligned_era5: pd.DataFrame,
+    *,
+    derivations: Sequence[str],
+    hub_height_m: float | None = None,
+) -> pd.DataFrame:
+    """Build the requested derived columns from an aligned ERA5 frame (one column per derivation).
+
+    :param aligned_era5: ERA5 aligned to the analysis grid (original Open-Meteo column names)
+    :param derivations: which of :data:`ERA5_DERIVATIONS` to compute (also the output column names)
+    :param hub_height_m: turbine hub height; required by the ``wind_speed_hub`` derivation
+    """
+    unknown = [d for d in derivations if d not in ERA5_DERIVATIONS]
+    if unknown:
+        msg = f"unknown ERA5 derivation(s) {unknown}; available: {list(ERA5_DERIVATIONS)}"
+        raise ValueError(msg)
+    if "wind_speed_hub" in derivations and hub_height_m is None:
+        msg = "the wind_speed_hub derivation requires hub_height_m (the site's turbine hub height)."
+        raise ValueError(msg)
+    missing = sorted({c for d in derivations for c in _REQUIRED_RAW[d]} - set(aligned_era5.columns))
+    if missing:
+        msg = f"aligned ERA5 is missing columns {missing} required by derivations {list(derivations)}"
+        raise ValueError(msg)
+
+    out = pd.DataFrame(index=aligned_era5.index)
+    for name in derivations:
+        if name == "shear_exponent":
+            out[name] = shear_exponent(aligned_era5["wind_speed_10m"], aligned_era5["wind_speed_100m"])
+        elif name == "wind_speed_hub":
+            alpha = shear_exponent(aligned_era5["wind_speed_10m"], aligned_era5["wind_speed_100m"])
+            assert hub_height_m is not None  # noqa: S101 - narrowed above; mypy needs the hint
+            out[name] = hub_height_wind_speed(aligned_era5["wind_speed_100m"], alpha, hub_height_m=hub_height_m)
+        elif name == "gust_ratio":
+            out[name] = gust_ratio(aligned_era5["wind_gusts_10m"], aligned_era5["wind_speed_10m"])
+        elif name == "gust_margin":
+            out[name] = gust_margin(aligned_era5["wind_gusts_10m"], aligned_era5["wind_speed_100m"])
+        elif name == "veer":
+            out[name] = vertical_veer(aligned_era5["wind_direction_100m"], aligned_era5["wind_direction_10m"])
+        elif name == "air_density":
+            out[name] = air_density(
+                aligned_era5["temperature_2m"],
+                aligned_era5["surface_pressure"],
+                aligned_era5["relative_humidity_2m"],
+            )
+    return out

--- a/benchmarking/baselines/era5_derived.py
+++ b/benchmarking/baselines/era5_derived.py
@@ -151,12 +151,17 @@ def era5_derived_frame(
         msg = f"aligned ERA5 is missing columns {missing} required by derivations {list(derivations)}"
         raise ValueError(msg)
 
+    # alpha feeds both shear_exponent and wind_speed_hub; compute it at most once.
+    alpha: pd.Series | None = None
+    if {"shear_exponent", "wind_speed_hub"} & set(derivations):
+        alpha = shear_exponent(aligned_era5["wind_speed_10m"], aligned_era5["wind_speed_100m"])
     out = pd.DataFrame(index=aligned_era5.index)
     for name in derivations:
         if name == "shear_exponent":
-            out[name] = shear_exponent(aligned_era5["wind_speed_10m"], aligned_era5["wind_speed_100m"])
+            assert alpha is not None  # noqa: S101 - set above whenever this branch is reachable
+            out[name] = alpha
         elif name == "wind_speed_hub":
-            alpha = shear_exponent(aligned_era5["wind_speed_10m"], aligned_era5["wind_speed_100m"])
+            assert alpha is not None  # noqa: S101 - set above whenever this branch is reachable
             assert hub_height_m is not None  # noqa: S101 - narrowed above; mypy needs the hint
             out[name] = hub_height_wind_speed(aligned_era5["wind_speed_100m"], alpha, hub_height_m=hub_height_m)
         elif name == "gust_ratio":

--- a/benchmarking/baselines/example_prepost_study.py
+++ b/benchmarking/baselines/example_prepost_study.py
@@ -37,7 +37,7 @@ import pandas as pd
 
 from benchmarking.baselines.hot_context import build_hot_v0_context
 from benchmarking.baselines.naive_ratio import NaiveRatioMethod
-from benchmarking.baselines.power_model import PowerModelMethod
+from benchmarking.baselines.power_model import CURATED_ERA5_EXCLUDE, PowerModelMethod
 from benchmarking.baselines.v0_binned import V0BinnedMethod
 from benchmarking.harness import Method, StudyConfig, leaderboard, plot_campaign_curves, score_study
 from benchmarking.harness.example_hot_study import OracleMethod
@@ -147,6 +147,9 @@ def run_prepost_study(
                 era5_hourly_df=context.reanalysis_datasets[0].data,
                 # Issue 11 accepted default (findings F12): reference active-power minimum feature.
                 reference_stat_cols=("wtc_ActPower_min",),
+                # Removal-ablation accepted defaults (findings F13).
+                availability_feature=False,
+                era5_exclude=CURATED_ERA5_EXCLUDE,
                 out_dir=out_dir / "power_model_runs",
             )
         )

--- a/benchmarking/baselines/example_prepost_study.py
+++ b/benchmarking/baselines/example_prepost_study.py
@@ -145,6 +145,8 @@ def run_prepost_study(
                 availability_col=HOT_COLUMNS.availability,
                 baseline_rated_power_kw=HOT_RATED_POWER_KW,
                 era5_hourly_df=context.reanalysis_datasets[0].data,
+                # Issue 11 accepted default (findings F12): reference active-power minimum feature.
+                reference_stat_cols=("wtc_ActPower_min",),
                 out_dir=out_dir / "power_model_runs",
             )
         )

--- a/benchmarking/baselines/example_toggle_study.py
+++ b/benchmarking/baselines/example_toggle_study.py
@@ -38,7 +38,7 @@ from benchmarking.baselines.example_prepost_study import (
 )
 from benchmarking.baselines.hot_context import build_hot_v0_context
 from benchmarking.baselines.naive_ratio import NaiveRatioMethod
-from benchmarking.baselines.power_model import PowerModelMethod
+from benchmarking.baselines.power_model import CURATED_ERA5_EXCLUDE, PowerModelMethod
 from benchmarking.baselines.v0_binned import V0BinnedMethod
 from benchmarking.harness import Method, StudyConfig, leaderboard, plot_campaign_curves, score_study
 from benchmarking.harness.example_hot_study import OracleMethod
@@ -115,6 +115,9 @@ def run_toggle_study(
                 era5_hourly_df=context.reanalysis_datasets[0].data,
                 # Issue 11 accepted default (findings F12): reference active-power minimum feature.
                 reference_stat_cols=("wtc_ActPower_min",),
+                # Removal-ablation accepted defaults (findings F13).
+                availability_feature=False,
+                era5_exclude=CURATED_ERA5_EXCLUDE,
                 out_dir=out_dir / "power_model_runs",
             )
         )

--- a/benchmarking/baselines/example_toggle_study.py
+++ b/benchmarking/baselines/example_toggle_study.py
@@ -113,6 +113,8 @@ def run_toggle_study(
                 availability_col=HOT_COLUMNS.availability,
                 baseline_rated_power_kw=HOT_RATED_POWER_KW,
                 era5_hourly_df=context.reanalysis_datasets[0].data,
+                # Issue 11 accepted default (findings F12): reference active-power minimum feature.
+                reference_stat_cols=("wtc_ActPower_min",),
                 out_dir=out_dir / "power_model_runs",
             )
         )

--- a/benchmarking/baselines/inspect_era5_matching_importance.py
+++ b/benchmarking/baselines/inspect_era5_matching_importance.py
@@ -45,6 +45,7 @@ import numpy as np
 import pandas as pd
 from sklearn.inspection import permutation_importance
 
+from benchmarking.baselines.era5_derived import shear_exponent
 from benchmarking.baselines.era5_sync import sync_era5
 from benchmarking.baselines.example_prepost_study import (
     DEFAULT_END_DT_EXCL,
@@ -81,26 +82,18 @@ def _infer_timebase(index: pd.DatetimeIndex) -> pd.Timedelta:
     return pd.Timedelta(np.median(np.diff(unique.to_numpy())))
 
 
-_SHEAR_HEIGHTS_M = (10.0, 100.0)  # the two ERA5 wind-speed levels the shear exponent is fit between
-
-
 def add_shear_exponent(features: pd.DataFrame) -> pd.DataFrame:
     """Fold the collinear 10m/100m wind speeds into one physical vertical-shear exponent.
 
     The two ERA5 wind speeds are strongly correlated, so gain splits credit between them while
     permutation discounts whichever is redundant — neither view then cleanly reflects the *shear* they
-    jointly encode. The power-law exponent ``alpha = ln(ws_100m / ws_10m) / ln(100/10)`` captures that
-    shear in a single column (a stability / turbulence proxy that directly attacks the F5 cause), so we
-    keep ``wind_speed_100m`` as the magnitude and drop the now-redundant ``wind_speed_10m``. ``alpha`` is
-    NaN where either speed is non-positive (calm); LightGBM handles that natively.
+    jointly encode. The power-law exponent (see
+    :func:`benchmarking.baselines.era5_derived.shear_exponent`, the shared Issue 9 utility) captures
+    that shear in a single column (a stability / turbulence proxy that directly attacks the F5 cause),
+    so we keep ``wind_speed_100m`` as the magnitude and drop the now-redundant ``wind_speed_10m``.
     """
-    lo_m, hi_m = _SHEAR_HEIGHTS_M
-    ws_hi = features["wind_speed_100m"].to_numpy(dtype=float)
-    ws_lo = features["wind_speed_10m"].to_numpy(dtype=float)
-    positive = (ws_hi > 0) & (ws_lo > 0)
-    alpha = np.full(len(features), np.nan)
-    alpha[positive] = np.log(ws_hi[positive] / ws_lo[positive]) / np.log(hi_m / lo_m)
-    return features.assign(wind_shear_exponent=alpha).drop(columns=["wind_speed_10m"])
+    alpha = shear_exponent(features["wind_speed_10m"], features["wind_speed_100m"])
+    return features.assign(wind_shear_exponent=alpha.to_numpy()).drop(columns=["wind_speed_10m"])
 
 
 def build_era5_and_outcome(scada_df: pd.DataFrame, *, test_wtg: str) -> tuple[pd.DataFrame, pd.Series]:

--- a/benchmarking/baselines/inspect_prepost_hard_case.py
+++ b/benchmarking/baselines/inspect_prepost_hard_case.py
@@ -161,6 +161,8 @@ def _power_model(out_dir: Path, era5_hourly_df: pd.DataFrame, *, save_plots: boo
         availability_col=HOT_COLUMNS.availability,
         baseline_rated_power_kw=HOT_RATED_POWER_KW,
         era5_hourly_df=era5_hourly_df,
+        # Issue 11 accepted default (findings F12): reference active-power minimum feature.
+        reference_stat_cols=("wtc_ActPower_min",),
         out_dir=out_dir,
         save_plots=save_plots,
     )

--- a/benchmarking/baselines/inspect_prepost_hard_case.py
+++ b/benchmarking/baselines/inspect_prepost_hard_case.py
@@ -45,7 +45,7 @@ from benchmarking.baselines.hot_context import build_hot_v0_context
 from benchmarking.baselines.naive_ratio import NaiveRatioMethod
 from benchmarking.baselines.overnight_common import start_overnight_run
 from benchmarking.baselines.overnight_profiles import overnight_profiles
-from benchmarking.baselines.power_model import PowerModelMethod
+from benchmarking.baselines.power_model import CURATED_ERA5_EXCLUDE, PowerModelMethod
 from benchmarking.baselines.v0_binned import V0BinnedMethod
 from benchmarking.harness import (
     CONDITION_BINS,
@@ -163,6 +163,9 @@ def _power_model(out_dir: Path, era5_hourly_df: pd.DataFrame, *, save_plots: boo
         era5_hourly_df=era5_hourly_df,
         # Issue 11 accepted default (findings F12): reference active-power minimum feature.
         reference_stat_cols=("wtc_ActPower_min",),
+        # Removal-ablation accepted defaults (findings F13).
+        availability_feature=False,
+        era5_exclude=CURATED_ERA5_EXCLUDE,
         out_dir=out_dir,
         save_plots=save_plots,
     )

--- a/benchmarking/baselines/power_model/__init__.py
+++ b/benchmarking/baselines/power_model/__init__.py
@@ -7,6 +7,6 @@ baseline, predict the counterfactual over the upgraded window, and take the ener
 
 from __future__ import annotations
 
-from benchmarking.baselines.power_model.method import PowerModelMethod
+from benchmarking.baselines.power_model.method import CURATED_ERA5_EXCLUDE, PowerModelMethod
 
-__all__ = ["PowerModelMethod"]
+__all__ = ["CURATED_ERA5_EXCLUDE", "PowerModelMethod"]

--- a/benchmarking/baselines/power_model/features.py
+++ b/benchmarking/baselines/power_model/features.py
@@ -20,10 +20,15 @@ test-turbine-qualified column (the §3 guard).
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 import pandas as pd
 
 from benchmarking.baselines.era5_sync import ERA5_WD, ERA5_WS
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 # Separator between a source-native tag and the turbine it came from in a feature name.
 QUALIFIER = " @ "
@@ -48,6 +53,7 @@ def build_reference_features(
     turbine_col: str,
     active_power_col: str,
     availability_col: str,
+    extra_cols: Sequence[str] = (),
 ) -> pd.DataFrame:
     """Wide, curated reference features: each reference turbine's active power + availability.
 
@@ -55,9 +61,12 @@ def build_reference_features(
     contributes nothing (its power is the outcome, extracted separately). NaNs are preserved (no
     complete-case dropping) — LightGBM handles them natively. Raises if no reference turbine is
     present, or (defensively) if any test-turbine column would leak in.
+
+    :param extra_cols: additional per-reference value columns to carry as features (Issue 11's
+        active-power max/min/SD statistics); must be present in ``scada_df`` like the primary two
     """
     refs = _references(scada_df, test_wtg=test_wtg, turbine_col=turbine_col)
-    value_cols = [active_power_col, availability_col]
+    value_cols = [active_power_col, availability_col, *extra_cols]
     missing = [c for c in value_cols if c not in scada_df.columns]
     if missing:
         msg = f"scada_df is missing required reference-feature columns {missing}; have {list(scada_df.columns)}"

--- a/benchmarking/baselines/power_model/features.py
+++ b/benchmarking/baselines/power_model/features.py
@@ -54,6 +54,7 @@ def build_reference_features(
     active_power_col: str,
     availability_col: str,
     extra_cols: Sequence[str] = (),
+    include_availability: bool = True,
 ) -> pd.DataFrame:
     """Wide, curated reference features: each reference turbine's active power + availability.
 
@@ -64,9 +65,11 @@ def build_reference_features(
 
     :param extra_cols: additional per-reference value columns to carry as features (Issue 11's
         active-power max/min/SD statistics); must be present in ``scada_df`` like the primary two
+    :param include_availability: when ``False``, drop the per-reference availability *feature*
+        (removal-ablation knob); the column must still exist (the downtime filter needs it)
     """
     refs = _references(scada_df, test_wtg=test_wtg, turbine_col=turbine_col)
-    value_cols = [active_power_col, availability_col, *extra_cols]
+    value_cols = [active_power_col, *([availability_col] if include_availability else []), *extra_cols]
     missing = [c for c in value_cols if c not in scada_df.columns]
     if missing:
         msg = f"scada_df is missing required reference-feature columns {missing}; have {list(scada_df.columns)}"

--- a/benchmarking/baselines/power_model/features.py
+++ b/benchmarking/baselines/power_model/features.py
@@ -56,8 +56,10 @@ def build_reference_features(
     extra_cols: Sequence[str] = (),
     include_availability: bool = True,
 ) -> pd.DataFrame:
-    """Wide, curated reference features: each reference turbine's active power + availability.
+    """Wide, curated reference features: each reference turbine's active power (+ optional extras).
 
+    By default each reference contributes its active power and availability; ``extra_cols`` adds
+    more per-reference channels and ``include_availability=False`` drops the availability feature.
     Columns are ``"<tag>{QUALIFIER}<turbine>"`` keeping the original tag name. The test turbine
     contributes nothing (its power is the outcome, extracted separately). NaNs are preserved (no
     complete-case dropping) — LightGBM handles them natively. Raises if no reference turbine is
@@ -66,11 +68,14 @@ def build_reference_features(
     :param extra_cols: additional per-reference value columns to carry as features (Issue 11's
         active-power max/min/SD statistics); must be present in ``scada_df`` like the primary two
     :param include_availability: when ``False``, drop the per-reference availability *feature*
-        (removal-ablation knob); the column must still exist (the downtime filter needs it)
+        (removal-ablation knob); ``availability_col`` must still exist in ``scada_df`` (the
+        downtime filter needs it), so its presence is validated either way
     """
     refs = _references(scada_df, test_wtg=test_wtg, turbine_col=turbine_col)
     value_cols = [active_power_col, *([availability_col] if include_availability else []), *extra_cols]
-    missing = [c for c in value_cols if c not in scada_df.columns]
+    # availability_col stays validated even when not featured: it is a required input and the
+    # docstring contract is that it exists for the downstream downtime filter.
+    missing = sorted(c for c in {*value_cols, availability_col} if c not in scada_df.columns)
     if missing:
         msg = f"scada_df is missing required reference-feature columns {missing}; have {list(scada_df.columns)}"
         raise ValueError(msg)

--- a/benchmarking/baselines/power_model/method.py
+++ b/benchmarking/baselines/power_model/method.py
@@ -193,6 +193,11 @@ class PowerModelMethod:
     :param longitude: site longitude in degrees (east positive), required by the ``solar`` time feature
     :param reference_stat_cols: extra per-reference value columns to carry as features (Issue 11's
         active-power max/min/SD companion statistics)
+    :param era5_exclude: raw ERA5 columns to drop from the model features (removal-ablation knob;
+        a dropped direction column also loses its sin/cos companions). Columns used as
+        ``matching_vars`` cannot be excluded while ``conditional_uplift`` is on.
+    :param availability_feature: when ``False``, drop the per-reference availability *feature*
+        (removal-ablation knob); ``availability_col`` itself stays required for the downtime filter
     """
 
     active_power_col: str
@@ -218,6 +223,8 @@ class PowerModelMethod:
     latitude: float | None = None
     longitude: float | None = None
     reference_stat_cols: tuple[str, ...] = ()
+    era5_exclude: tuple[str, ...] = ()
+    availability_feature: bool = True
 
     def estimate(self, mi: MethodInput) -> MethodOutput:
         """Estimate the test turbine's P50 uplift for one campaign and write diagnostics."""
@@ -243,6 +250,7 @@ class PowerModelMethod:
             active_power_col=self.active_power_col,
             availability_col=self.availability_col,
             extra_cols=self.reference_stat_cols,
+            include_availability=self.availability_feature,
         )
         features, era5 = self._add_era5(scada, features, mi=mi, index=index, timebase=timebase)
         if self.time_features:
@@ -553,7 +561,27 @@ class PowerModelMethod:
             scada, test_wtg=mi.test_wtg, turbine_col=mi.turbine_col, wind_speed_col=self.wind_speed_col
         )
         result = sync_era5(self.era5_hourly_df, target_index=index, reference_ws=reference_ws, timebase=timebase)
-        frames = [features, era5_feature_frame(result.aligned)]
+        era5_features = era5_feature_frame(result.aligned)
+        if self.era5_exclude:
+            missing = sorted(set(self.era5_exclude) - set(era5_features.columns))
+            if missing:
+                msg = f"era5_exclude names columns not in the ERA5 features: {missing}"
+                raise ValueError(msg)
+            blocked = sorted(set(self.era5_exclude) & set(self.matching_vars))
+            if blocked and self.conditional_uplift:
+                msg = (
+                    f"era5_exclude {blocked} are conditional-uplift matching_vars; excluding them as model "
+                    f"features would break the CEM matching step. Turn conditional_uplift off or re-pick "
+                    f"matching_vars first."
+                )
+                raise ValueError(msg)
+            drop = [
+                c
+                for c in era5_features.columns
+                if c in self.era5_exclude or any(c == f"{raw}_{t}" for raw in self.era5_exclude for t in ("sin", "cos"))
+            ]
+            era5_features = era5_features.drop(columns=drop)
+        frames = [features, era5_features]
         if self.era5_derivations:
             frames.append(
                 era5_derived_frame(result.aligned, derivations=self.era5_derivations, hub_height_m=self.hub_height_m)
@@ -793,5 +821,7 @@ class PowerModelMethod:
             "latitude": self.latitude,
             "longitude": self.longitude,
             "reference_stat_cols": list(self.reference_stat_cols),
+            "era5_exclude": list(self.era5_exclude),
+            "availability_feature": self.availability_feature,
             "model_params": self.model_params,
         }

--- a/benchmarking/baselines/power_model/method.py
+++ b/benchmarking/baselines/power_model/method.py
@@ -61,6 +61,19 @@ logger = logging.getLogger(__name__)
 _MIN_BASELINE_ROWS = 10
 _MIN_HOLDOUT_ROWS = 20  # below this, report the in-sample fit (no point splitting off a tiny valid set)
 
+# The removal-ablation verdict (findings F13): raw Open-Meteo columns the curated feature set does
+# better without — redundant thermodynamic derivatives of temperature/humidity and the precipitation
+# trio. HoT drivers pass this (with availability_feature=False) as the accepted default; kept here,
+# not baked into ``era5_exclude``'s dataclass default, so a non-Open-Meteo ERA5 frame is not broken
+# by exclusions it never had.
+CURATED_ERA5_EXCLUDE: tuple[str, ...] = (
+    "apparent_temperature",
+    "dew_point_2m",
+    "precipitation",
+    "rain",
+    "snowfall",
+)
+
 # F6 matching set + bin widths for the bias-cancellation correction, verified on real HoT by the CEM
 # coverage sweep (docs/v1/findings.md F6). wind_speed_100m (dominant) is binned finest, wind_gusts_10m
 # coarser, and wind_direction_100m in 20° sectors (a reanalysis direction — finer is finer than the

--- a/benchmarking/baselines/power_model/method.py
+++ b/benchmarking/baselines/power_model/method.py
@@ -27,6 +27,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 import pandas as pd
 
+from benchmarking.baselines.era5_derived import era5_derived_frame
 from benchmarking.baselines.era5_sync import sync_era5
 from benchmarking.baselines.filtering import NormalOperationFilter
 from benchmarking.baselines.naive_ratio import restrict_to_campaign
@@ -41,6 +42,12 @@ from benchmarking.baselines.power_model.features import (
 )
 from benchmarking.baselines.power_model.matching import coarsened_exact_match
 from benchmarking.baselines.rlearner.nuisance import make_outcome_model
+from benchmarking.baselines.time_features import (
+    TIME_FEATURE_NAMES,
+    days_since_campaign_start,
+    season_sin_cos,
+    solar_altitude_azimuth,
+)
 from benchmarking.diagnostics import DiagnosticContext, stages, write_common_diagnostics, write_run_config
 from benchmarking.harness.conditions import CONDITION_BINS, energy_ratio_by_bin
 from benchmarking.harness.method import MethodInput, MethodOutput
@@ -177,6 +184,15 @@ class PowerModelMethod:
         cross-prediction — the expensive part — and return only the overall P50.
     :param matching_vars: ERA5 columns matched on for the conditional step (default: the F6 set)
     :param matching_bin_edges: per-variable CEM bin edges; the F6 defaults are used when ``None``
+    :param era5_derivations: derived ERA5 feature columns to add (Issue 9; see
+        :data:`~benchmarking.baselines.era5_derived.ERA5_DERIVATIONS`); requires ``era5_hourly_df``
+    :param hub_height_m: turbine hub height, required by the ``wind_speed_hub`` derivation
+    :param time_features: explicit time features to add (Issue 10; see
+        :data:`~benchmarking.baselines.time_features.TIME_FEATURE_NAMES`)
+    :param latitude: site latitude in degrees, required by the ``solar`` time feature
+    :param longitude: site longitude in degrees (east positive), required by the ``solar`` time feature
+    :param reference_stat_cols: extra per-reference value columns to carry as features (Issue 11's
+        active-power max/min/SD companion statistics)
     """
 
     active_power_col: str
@@ -196,6 +212,12 @@ class PowerModelMethod:
     conditional_uplift: bool = True
     matching_vars: tuple[str, ...] = _DEFAULT_MATCHING_VARS
     matching_bin_edges: dict[str, list[float]] | None = None
+    era5_derivations: tuple[str, ...] = ()
+    hub_height_m: float | None = None
+    time_features: tuple[str, ...] = ()
+    latitude: float | None = None
+    longitude: float | None = None
+    reference_stat_cols: tuple[str, ...] = ()
 
     def estimate(self, mi: MethodInput) -> MethodOutput:
         """Estimate the test turbine's P50 uplift for one campaign and write diagnostics."""
@@ -220,8 +242,12 @@ class PowerModelMethod:
             turbine_col=mi.turbine_col,
             active_power_col=self.active_power_col,
             availability_col=self.availability_col,
+            extra_cols=self.reference_stat_cols,
         )
         features, era5 = self._add_era5(scada, features, mi=mi, index=index, timebase=timebase)
+        if self.time_features:
+            time_frame = self._time_feature_frame(index, campaign_start=_upgrade_start(mi.upgrade_timing, index))
+            features = pd.concat([features, time_frame], axis=1)
         check_reference_only(features.columns.tolist(), test_wtg=mi.test_wtg)
 
         t = np.asarray(treated_mask(index, mi.upgrade_timing)).astype(bool)
@@ -507,8 +533,11 @@ class PowerModelMethod:
         index: pd.DatetimeIndex,
         timebase: pd.Timedelta,
     ) -> tuple[pd.DataFrame, Any]:
-        """Sync ERA5 (if supplied) and append its features; return the (features, sync-result)."""
+        """Sync ERA5 (if supplied) and append its features (+ requested derived quantities)."""
         if self.era5_hourly_df is None:
+            if self.era5_derivations:
+                msg = "era5_derivations requested but no era5_hourly_df supplied; the derivations need ERA5."
+                raise ValueError(msg)
             return features, None
         if self.wind_speed_col is None:
             msg = "wind_speed_col is required to sync ERA5 (it provides the reference wind speed)."
@@ -524,7 +553,36 @@ class PowerModelMethod:
             scada, test_wtg=mi.test_wtg, turbine_col=mi.turbine_col, wind_speed_col=self.wind_speed_col
         )
         result = sync_era5(self.era5_hourly_df, target_index=index, reference_ws=reference_ws, timebase=timebase)
-        return pd.concat([features, era5_feature_frame(result.aligned)], axis=1), result
+        frames = [features, era5_feature_frame(result.aligned)]
+        if self.era5_derivations:
+            frames.append(
+                era5_derived_frame(result.aligned, derivations=self.era5_derivations, hub_height_m=self.hub_height_m)
+            )
+        return pd.concat(frames, axis=1), result
+
+    def _time_feature_frame(self, index: pd.DatetimeIndex, *, campaign_start: pd.Timestamp) -> pd.DataFrame:
+        """Build the configured explicit time features (Issue 10) on the analysis index.
+
+        ``days_since_campaign_start`` is anchored to the upgrade start (prepost changeover / toggle
+        origin) so the model can absorb slow reference drift relative to the campaign; ``season``
+        adds the June-21-anchored sin/cos pair; ``solar`` adds solar altitude + azimuth sin/cos
+        (requires ``latitude`` / ``longitude``).
+        """
+        unknown = [f for f in self.time_features if f not in TIME_FEATURE_NAMES]
+        if unknown:
+            msg = f"unknown time feature(s) {unknown}; available: {list(TIME_FEATURE_NAMES)}"
+            raise ValueError(msg)
+        frames: list[pd.DataFrame] = []
+        if "days_since_campaign_start" in self.time_features:
+            frames.append(days_since_campaign_start(index, campaign_start=campaign_start).to_frame())
+        if "season" in self.time_features:
+            frames.append(season_sin_cos(index))
+        if "solar" in self.time_features:
+            if self.latitude is None or self.longitude is None:
+                msg = "the solar time feature requires latitude and longitude."
+                raise ValueError(msg)
+            frames.append(solar_altitude_azimuth(index, latitude=self.latitude, longitude=self.longitude))
+        return pd.concat(frames, axis=1)
 
     def _select_rows(
         self, scada: pd.DataFrame, *, mi: MethodInput, index: pd.DatetimeIndex, y: pd.Series, timebase: pd.Timedelta
@@ -729,5 +787,11 @@ class PowerModelMethod:
             "seed": self.seed,
             "toggle_campaign_only": self.toggle_campaign_only,
             "has_era5": self.era5_hourly_df is not None,
+            "era5_derivations": list(self.era5_derivations),
+            "hub_height_m": self.hub_height_m,
+            "time_features": list(self.time_features),
+            "latitude": self.latitude,
+            "longitude": self.longitude,
+            "reference_stat_cols": list(self.reference_stat_cols),
             "model_params": self.model_params,
         }

--- a/benchmarking/baselines/study_power_model_compare.py
+++ b/benchmarking/baselines/study_power_model_compare.py
@@ -63,6 +63,7 @@ to promote the candidate a previous full sweep already wrote (no re-run).
 from __future__ import annotations
 
 import argparse
+import dataclasses
 import json
 import logging
 import subprocess
@@ -177,20 +178,44 @@ def _select_profiles(requested: list[str] | None) -> dict[str, list]:
     return {name: all_profiles[name] for name in requested}
 
 
-def _make_power_model(out_dir: Path, *, era5_hourly_df: pd.DataFrame) -> PowerModelMethod:
-    """Construct the HoT-configured ``power_model`` method (its default: conditional uplift on)."""
-    return PowerModelMethod(
-        active_power_col=HOT_COLUMNS.active_power,
-        wind_speed_col=HOT_COLUMNS.wind_speed,
-        availability_col=HOT_COLUMNS.availability,
-        wind_speed_sd_col=HOT_COLUMNS.wind_speed_sd,
-        baseline_rated_power_kw=HOT_RATED_POWER_KW,
-        era5_hourly_df=era5_hourly_df,
-        out_dir=out_dir / "power_model_runs",
-    )
+def _make_power_model(
+    out_dir: Path, *, era5_hourly_df: pd.DataFrame, overrides: dict[str, Any] | None = None
+) -> PowerModelMethod:
+    """Construct the HoT-configured ``power_model`` method (its default: conditional uplift on).
+
+    ``overrides`` are ``PowerModelMethod`` field overrides for candidate A/B runs (the Issue 9/10/11
+    protocol), e.g. ``{"era5_derivations": ["gust_ratio"]}``; unknown field names fail loudly and
+    JSON lists are coerced to the tuples the dataclass fields expect.
+    """
+    kwargs: dict[str, Any] = {
+        "active_power_col": HOT_COLUMNS.active_power,
+        "wind_speed_col": HOT_COLUMNS.wind_speed,
+        "availability_col": HOT_COLUMNS.availability,
+        "wind_speed_sd_col": HOT_COLUMNS.wind_speed_sd,
+        "baseline_rated_power_kw": HOT_RATED_POWER_KW,
+        "era5_hourly_df": era5_hourly_df,
+        # Issue 11 accepted default (findings F12): each reference's within-period active-power
+        # minimum. Better on every benchmark gate in both modes; max/SD were rejected.
+        "reference_stat_cols": ("wtc_ActPower_min",),
+        "out_dir": out_dir / "power_model_runs",
+    }
+    if overrides:
+        known = {f.name for f in dataclasses.fields(PowerModelMethod)}
+        unknown = sorted(set(overrides) - known)
+        if unknown:
+            msg = f"unknown PowerModelMethod field(s) in --method-overrides: {unknown}"
+            raise ValueError(msg)
+        kwargs.update({k: tuple(v) if isinstance(v, list) else v for k, v in overrides.items()})
+    return PowerModelMethod(**kwargs)
 
 
-def run_power_model(mode: str, out_dir: Path, *, profiles: list[str] | None = None) -> pd.DataFrame:
+def run_power_model(
+    mode: str,
+    out_dir: Path,
+    *,
+    profiles: list[str] | None = None,
+    method_overrides: dict[str, Any] | None = None,
+) -> pd.DataFrame:
     """Score **only** ``power_model`` over the overnight cases for one mode (no v0/naive/oracle).
 
     ``profiles`` restricts to a subset of :func:`overnight_profiles` (default: all) for fast feedback on
@@ -214,7 +239,11 @@ def run_power_model(mode: str, out_dir: Path, *, profiles: list[str] | None = No
     for profile_name, profile in _select_profiles(profiles).items():
         # Per-profile subfolder: the method's run dir is power_model_<wtg>_<start>_<end> (no profile), so
         # profiles sharing a (wtg, window) would otherwise overwrite each other's non-timestamped diagnostics.
-        method = _make_power_model(out_dir / profile_name, era5_hourly_df=context.reanalysis_datasets[0].data)
+        method = _make_power_model(
+            out_dir / profile_name,
+            era5_hourly_df=context.reanalysis_datasets[0].data,
+            overrides=method_overrides,
+        )
         logger.info("Scoring %s profile %s with power_model", mode, profile_name)
         results = score_study(
             scada_df,
@@ -718,6 +747,14 @@ def main() -> None:
         "e.g. --profiles cp_0pct runs just the placebo. Cannot be combined with --update-baseline.",
     )
     parser.add_argument(
+        "--method-overrides",
+        type=str,
+        default=None,
+        help="JSON dict of PowerModelMethod field overrides for a candidate A/B run, e.g. "
+        '\'{"era5_derivations": ["gust_ratio"]}\'. The run is diffed against the benchmark as usual '
+        "but no candidate baseline is written (the overridden config is not the committed default).",
+    )
+    parser.add_argument(
         "--skip-run",
         action="store_true",
         help="reuse a previous power_model run under --output-dir; only re-merge and re-plot",
@@ -745,6 +782,10 @@ def main() -> None:
         # record_baseline rewrites a mode's cells wholesale, so a subset run would drop the other
         # profiles from the committed benchmark. Refuse rather than silently corrupt it.
         parser.error("--update-baseline needs the full profile set; do not combine it with --profiles")
+    method_overrides: dict[str, Any] | None = json.loads(args.method_overrides) if args.method_overrides else None
+    if method_overrides is not None and args.update_baseline:
+        # the benchmark freezes the *committed default* config; an overridden run must not be recorded as it
+        parser.error("--update-baseline records the default config; do not combine it with --method-overrides")
 
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s", force=True)
     reference_dir = args.reference_dir.expanduser()
@@ -766,7 +807,9 @@ def main() -> None:
                 fresh = fresh[fresh["profile"].isin(args.profiles)]
             logger.info("Reusing %d fresh rows from %s", len(fresh), mode_out_dir)
         else:
-            fresh = run_power_model(mode, mode_out_dir, profiles=args.profiles)
+            fresh = run_power_model(mode, mode_out_dir, profiles=args.profiles, method_overrides=method_overrides)
+            if method_overrides is not None:  # provenance: which A/B candidate this run was
+                (mode_out_dir / "method_overrides.json").write_text(json.dumps(method_overrides, indent=2) + "\n")
         merge_and_plot(mode, fresh, reference_dir / mode, mode_out_dir)
         lb_by_mode[mode] = power_model_leaderboard(fresh)
         study_by_mode[mode] = _prepost_study() if mode == "prepost" else _toggle_study()
@@ -776,6 +819,8 @@ def main() -> None:
 
     if args.update_baseline:
         record_baseline(lb_by_mode, study_by_mode, baseline_path)
+    elif method_overrides is not None:
+        logger.info("Overridden run (--method-overrides) — no candidate baseline written (not the default config).")
     elif args.profiles is None:
         # A full sweep: drop a candidate baseline (seeded from committed) so an accepted improvement is a
         # near-instant `--accept-candidate` away, with no second sweep. Subset runs are incomplete -> skip.

--- a/benchmarking/baselines/study_power_model_compare.py
+++ b/benchmarking/baselines/study_power_model_compare.py
@@ -87,7 +87,7 @@ from benchmarking.baselines.example_prepost_study import (
 from benchmarking.baselines.example_toggle_study import DEFAULT_TOGGLE_PERIOD
 from benchmarking.baselines.hot_context import build_hot_v0_context
 from benchmarking.baselines.overnight_profiles import overnight_profiles
-from benchmarking.baselines.power_model import PowerModelMethod
+from benchmarking.baselines.power_model import CURATED_ERA5_EXCLUDE, PowerModelMethod
 from benchmarking.harness import (
     StudyConfig,
     conditional_leaderboard,
@@ -197,6 +197,10 @@ def _make_power_model(
         # Issue 11 accepted default (findings F12): each reference's within-period active-power
         # minimum. Better on every benchmark gate in both modes; max/SD were rejected.
         "reference_stat_cols": ("wtc_ActPower_min",),
+        # Removal-ablation accepted defaults (findings F13): drop the availability feature and the
+        # redundant thermodynamic/precipitation ERA5 columns.
+        "availability_feature": False,
+        "era5_exclude": CURATED_ERA5_EXCLUDE,
         "out_dir": out_dir / "power_model_runs",
     }
     if overrides:

--- a/benchmarking/baselines/study_power_model_compare_baseline.json
+++ b/benchmarking/baselines/study_power_model_compare_baseline.json
@@ -2,8 +2,8 @@
   "schema": "power_model_compare_baseline_v2",
   "modes": {
     "prepost": {
-      "recorded_utc": "2026-07-04T02:48:54Z",
-      "git_commit": "789bc1e-dirty",
+      "recorded_utc": "2026-07-04T11:35:03Z",
+      "git_commit": "1a478df-dirty",
       "n_replicates": 4,
       "seed": 0,
       "campaign_months": [
@@ -26,171 +26,171 @@
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00590994,
-          "spread": 0.00524659,
-          "score": 0.00790279
+          "bias": -0.00120936,
+          "spread": 0.00294773,
+          "score": 0.00318617
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.15151524,
+          "bias": 0.12207163,
           "spread": 0.0,
-          "score": 0.15151524
+          "score": 0.12207163
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.01913765,
-          "spread": 0.01280035,
-          "score": 0.02302387
+          "bias": -0.01237234,
+          "spread": 0.01481883,
+          "score": 0.01930473
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00339564,
-          "spread": 0.00503552,
-          "score": 0.00607345
+          "bias": 0.00208864,
+          "spread": 0.00451881,
+          "score": 0.00497816
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00799482,
-          "spread": 0.00392708,
-          "score": 0.00890725
+          "bias": -0.0037385,
+          "spread": 0.0020399,
+          "score": 0.00425882
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00721038,
-          "spread": 0.01384436,
-          "score": 0.01560948
+          "bias": -0.00332704,
+          "spread": 0.01074896,
+          "score": 0.01125208
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": -0.00642325,
-          "spread": 0.03074172,
-          "score": 0.03140559
+          "bias": -0.00202179,
+          "spread": 0.02336512,
+          "score": 0.02345243
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.04530385,
-          "spread": 0.06566345,
-          "score": 0.07977548
+          "bias": -0.03297508,
+          "spread": 0.05049263,
+          "score": 0.0603064
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.01764975,
-          "spread": 0.06086104,
-          "score": 0.06336861
+          "bias": 0.06357861,
+          "spread": 0.09302898,
+          "score": 0.11267933
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.1752514,
-          "spread": 0.36285118,
-          "score": 0.40295661
+          "bias": 0.23462464,
+          "spread": 0.40448196,
+          "score": 0.46760494
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.18739279,
-          "spread": 0.71607179,
-          "score": 0.7401857
+          "bias": 0.18683716,
+          "spread": 0.79660277,
+          "score": 0.81822008
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.24094315,
-          "spread": 0.0,
-          "score": 0.24094315
+          "bias": -0.11040057,
+          "spread": 0.31772178,
+          "score": 0.33635608
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00455755,
-          "spread": 0.0051241,
-          "score": 0.00685768
+          "bias": -0.00041073,
+          "spread": 0.0075197,
+          "score": 0.00753091
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00025908,
-          "spread": 0.00580198,
-          "score": 0.00580777
+          "bias": 0.00547481,
+          "spread": 0.0075027,
+          "score": 0.00928784
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00647064,
-          "spread": 0.00870879,
-          "score": 0.01084953
+          "bias": 0.01136434,
+          "spread": 0.00847252,
+          "score": 0.01417504
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00255331,
-          "spread": 0.00743421,
-          "score": 0.00786046
+          "bias": 0.00140254,
+          "spread": 0.00850077,
+          "score": 0.0086157
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00806805,
-          "spread": 0.0156248,
-          "score": 0.01758487
+          "bias": 0.01358,
+          "spread": 0.01588256,
+          "score": 0.0208967
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.14952226,
-          "spread": 0.13338856,
-          "score": 0.20037319
+          "bias": -0.12110035,
+          "spread": 0.10670492,
+          "score": 0.16140395
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00797576,
-          "spread": 0.03767835,
-          "score": 0.03851326
+          "bias": 0.0150516,
+          "spread": 0.04275081,
+          "score": 0.04532309
         },
         {
           "profile": "cp_0pct",
@@ -215,36 +215,36 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.01361579,
-          "spread": 0.02609218,
-          "score": 0.02943114
+          "bias": -0.00998837,
+          "spread": 0.01933413,
+          "score": 0.02176181
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.01143414,
-          "spread": 0.01512843,
-          "score": 0.01896336
+          "bias": -0.00794316,
+          "spread": 0.01078858,
+          "score": 0.01339728
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00931376,
-          "spread": 0.00996479,
-          "score": 0.01363977
+          "bias": -0.00587845,
+          "spread": 0.00721646,
+          "score": 0.00930771
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00172752,
-          "spread": 0.00436217,
-          "score": 0.00469179
+          "bias": 0.00300067,
+          "spread": 0.00226196,
+          "score": 0.00375772
         },
         {
           "profile": "cp_0pct",
@@ -260,162 +260,162 @@
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00718893,
-          "spread": 0.00544853,
-          "score": 0.00902038
+          "bias": -0.00167303,
+          "spread": 0.00663827,
+          "score": 0.00684585
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00102697,
-          "spread": 0.00394892,
-          "score": 0.00408027
+          "bias": 0.00362049,
+          "spread": 0.00243486,
+          "score": 0.00436308
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00350857,
-          "spread": 0.00405937,
-          "score": 0.0053655
+          "bias": 0.00055699,
+          "spread": 0.00233296,
+          "score": 0.00239853
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00040712,
-          "spread": 0.00810419,
-          "score": 0.00811441
+          "bias": 0.00510153,
+          "spread": 0.00712748,
+          "score": 0.00876508
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00018809,
-          "spread": 0.01244876,
-          "score": 0.01245019
+          "bias": 0.00827919,
+          "spread": 0.00903417,
+          "score": 0.01225403
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00264637,
-          "spread": 0.01703156,
-          "score": 0.01723593
+          "bias": 0.0109377,
+          "spread": 0.01704072,
+          "score": 0.02024893
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.03314424,
-          "spread": 0.06883026,
-          "score": 0.07639467
+          "bias": 0.07473308,
+          "spread": 0.06851502,
+          "score": 0.10138709
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.15397332,
-          "spread": 0.10463201,
-          "score": 0.18616026
+          "bias": 0.22495603,
+          "spread": 0.06418127,
+          "score": 0.23393258
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.07982816,
-          "spread": 0.3021172,
-          "score": 0.31248574
+          "bias": -0.0633299,
+          "spread": 0.57549817,
+          "score": 0.57897221
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.1513414,
-          "spread": 0.05802769,
-          "score": 0.16208465
+          "bias": 0.02334352,
+          "spread": 0.2631843,
+          "score": 0.26421752
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00306613,
-          "spread": 0.00112059,
-          "score": 0.00326449
+          "bias": 0.0008957,
+          "spread": 0.00304593,
+          "score": 0.0031749
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.0004719,
-          "spread": 0.00244379,
-          "score": 0.00248893
+          "bias": 0.00548623,
+          "spread": 0.00562033,
+          "score": 0.00785409
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00329019,
-          "spread": 0.0029934,
-          "score": 0.00444812
+          "bias": 0.00835267,
+          "spread": 0.00611441,
+          "score": 0.01035148
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00118638,
-          "spread": 0.00301301,
-          "score": 0.00323817
+          "bias": 0.00482663,
+          "spread": 0.00523108,
+          "score": 0.00711762
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.02778016,
-          "spread": 0.04525142,
-          "score": 0.05309829
+          "bias": 0.03109943,
+          "spread": 0.04755708,
+          "score": 0.05682298
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.15166403,
-          "spread": 0.0696654,
-          "score": 0.16689891
+          "bias": -0.11291816,
+          "spread": 0.06809725,
+          "score": 0.1318626
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.0102531,
-          "spread": 0.04831375,
-          "score": 0.04938972
+          "bias": 0.01166266,
+          "spread": 0.05043091,
+          "score": 0.0517619
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.19296999,
+          "bias": 0.1944361,
           "spread": 0.0,
-          "score": 0.19296999
+          "score": 0.1944361
         },
         {
           "profile": "cp_0pct",
@@ -431,207 +431,207 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00388494,
-          "spread": 0.00486661,
-          "score": 0.00622709
+          "bias": 0.00294472,
+          "spread": 0.00270175,
+          "score": 0.00399636
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00507975,
-          "spread": 0.01013057,
-          "score": 0.0113328
+          "bias": -0.00094195,
+          "spread": 0.00677045,
+          "score": 0.00683566
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00109698,
-          "spread": 0.01071347,
-          "score": 0.01076949
+          "bias": 0.00189932,
+          "spread": 0.00784102,
+          "score": 0.00806778
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00213816,
-          "spread": 0.00422496,
-          "score": 0.00473519
+          "bias": 4.315e-05,
+          "spread": 0.00338294,
+          "score": 0.00338321
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.16926857,
+          "bias": 0.14352619,
           "spread": 0.0,
-          "score": 0.16926857
+          "score": 0.14352619
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.0053057,
-          "spread": 0.00378346,
-          "score": 0.00651652
+          "bias": -0.0031906,
+          "spread": 0.00246498,
+          "score": 0.00403188
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00300595,
-          "spread": 0.00376066,
-          "score": 0.00481438
+          "bias": -0.00108787,
+          "spread": 0.00233406,
+          "score": 0.00257513
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00309526,
-          "spread": 0.00464519,
-          "score": 0.00558197
+          "bias": -0.00094637,
+          "spread": 0.00429957,
+          "score": 0.00440248
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00022897,
-          "spread": 0.0050147,
-          "score": 0.00501992
+          "bias": 0.00299573,
+          "spread": 0.00438947,
+          "score": 0.00531431
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00647905,
-          "spread": 0.00843785,
-          "score": 0.01063839
+          "bias": 0.01001108,
+          "spread": 0.00490168,
+          "score": 0.01114667
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00076792,
-          "spread": 0.01522482,
-          "score": 0.01524417
+          "bias": 0.00180225,
+          "spread": 0.01174672,
+          "score": 0.01188417
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.04883774,
-          "spread": 0.05878311,
-          "score": 0.07642368
+          "bias": 0.05311871,
+          "spread": 0.052568,
+          "score": 0.07473281
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.37397117,
-          "spread": 0.39433677,
-          "score": 0.54346658
+          "bias": 0.35855897,
+          "spread": 0.38891391,
+          "score": 0.5289788
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.84233406,
-          "spread": 0.75840245,
-          "score": 1.13344649
+          "bias": 0.82103771,
+          "spread": 0.71963603,
+          "score": 1.09177787
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.04722723,
-          "spread": 0.13985304,
-          "score": 0.14761194
+          "bias": -0.09832414,
+          "spread": 0.10476674,
+          "score": 0.14367917
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00148592,
-          "spread": 0.00308955,
-          "score": 0.00342831
+          "bias": 0.00046073,
+          "spread": 0.00251403,
+          "score": 0.0025559
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00106802,
-          "spread": 0.00176468,
-          "score": 0.00206271
+          "bias": 0.00098379,
+          "spread": 0.00336072,
+          "score": 0.00350176
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00053192,
-          "spread": 0.00160692,
-          "score": 0.00169268
+          "bias": 0.00124188,
+          "spread": 0.00316563,
+          "score": 0.00340051
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00179264,
-          "spread": 0.0011507,
-          "score": 0.00213018
+          "bias": -0.00036853,
+          "spread": 0.00134806,
+          "score": 0.00139753
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": -0.00036222,
-          "spread": 0.00272319,
-          "score": 0.00274717
+          "bias": 0.00169876,
+          "spread": 0.00434743,
+          "score": 0.00466754
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.13121348,
-          "spread": 0.07071799,
-          "score": 0.14905707
+          "bias": -0.12648349,
+          "spread": 0.07016081,
+          "score": 0.1446396
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.01069174,
-          "spread": 0.02166034,
-          "score": 0.02415541
+          "bias": 0.01467869,
+          "spread": 0.02679489,
+          "score": 0.03055209
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.05462794,
-          "spread": 0.03948652,
-          "score": 0.06740472
+          "bias": 0.07044116,
+          "spread": 0.05057416,
+          "score": 0.08671622
         },
         {
           "profile": "cp_0pct",
@@ -647,198 +647,198 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00404436,
-          "spread": 0.00916264,
-          "score": 0.01001553
+          "bias": -0.00125573,
+          "spread": 0.0081073,
+          "score": 0.00820397
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00451811,
-          "spread": 0.00902315,
-          "score": 0.01009111
+          "bias": -0.0016511,
+          "spread": 0.00823808,
+          "score": 0.00840191
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00225867,
-          "spread": 0.00882238,
-          "score": 0.00910692
+          "bias": -0.00033879,
+          "spread": 0.00781086,
+          "score": 0.0078182
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00543049,
-          "spread": 0.00491109,
-          "score": 0.00732181
+          "bias": -0.00105103,
+          "spread": 0.00276975,
+          "score": 0.00296247
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.10716488,
+          "bias": 0.0896622,
           "spread": 0.0,
-          "score": 0.10716488
+          "score": 0.0896622
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.01964753,
-          "spread": 0.0123913,
-          "score": 0.02322864
+          "bias": -0.01436947,
+          "spread": 0.01495131,
+          "score": 0.02073701
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00632667,
-          "spread": 0.00388087,
-          "score": 0.00742212
+          "bias": -0.0016897,
+          "spread": 0.00353612,
+          "score": 0.00391908
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00648528,
-          "spread": 0.00425204,
-          "score": 0.00775492
+          "bias": -0.00249134,
+          "spread": 0.00256771,
+          "score": 0.0035777
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00370975,
-          "spread": 0.0119557,
-          "score": 0.01251803
+          "bias": 0.00057387,
+          "spread": 0.00914196,
+          "score": 0.00915996
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": -0.00219034,
-          "spread": 0.02591076,
-          "score": 0.02600318
+          "bias": 0.00385933,
+          "spread": 0.01963781,
+          "score": 0.02001345
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.0376318,
-          "spread": 0.06006972,
-          "score": 0.07088388
+          "bias": -0.02410608,
+          "spread": 0.0449148,
+          "score": 0.05097492
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.02304361,
-          "spread": 0.04010619,
-          "score": 0.04625489
+          "bias": 0.06574782,
+          "spread": 0.07235291,
+          "score": 0.09776359
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.20650505,
-          "spread": 0.34529411,
-          "score": 0.40233364
+          "bias": 0.23169778,
+          "spread": 0.34400191,
+          "score": 0.41475435
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.38354955,
-          "spread": 0.59710361,
-          "score": 0.70967808
+          "bias": 0.33964473,
+          "spread": 0.62648756,
+          "score": 0.71263259
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.30527846,
-          "spread": 0.0,
-          "score": 0.30527846
+          "bias": -0.00906542,
+          "spread": 0.43589907,
+          "score": 0.43599332
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00077907,
-          "spread": 0.00784927,
-          "score": 0.00788783
+          "bias": 0.00268673,
+          "spread": 0.01074182,
+          "score": 0.01107273
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00585762,
-          "spread": 0.00553902,
-          "score": 0.00806179
+          "bias": -0.00081509,
+          "spread": 0.00785107,
+          "score": 0.00789326
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00373225,
-          "spread": 0.00710513,
-          "score": 0.00802575
+          "bias": 0.0091186,
+          "spread": 0.0074532,
+          "score": 0.01177705
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00386273,
-          "spread": 0.00869354,
-          "score": 0.00951306
+          "bias": 0.00065549,
+          "spread": 0.00856267,
+          "score": 0.00858772
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00804665,
-          "spread": 0.01257199,
-          "score": 0.01492661
+          "bias": 0.01293886,
+          "spread": 0.01368609,
+          "score": 0.01883409
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.1012951,
-          "spread": 0.09302521,
-          "score": 0.13752959
+          "bias": -0.07153959,
+          "spread": 0.07251678,
+          "score": 0.10186558
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.01678409,
-          "spread": 0.04436623,
-          "score": 0.04743488
+          "bias": 0.02177502,
+          "spread": 0.04975775,
+          "score": 0.05431377
         },
         {
           "profile": "cp_minus_10pct",
@@ -863,36 +863,36 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.01244095,
-          "spread": 0.02339032,
-          "score": 0.0264931
+          "bias": -0.00956992,
+          "spread": 0.01859106,
+          "score": 0.02090959
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.01121409,
-          "spread": 0.01449027,
-          "score": 0.01832276
+          "bias": -0.00755503,
+          "spread": 0.01095808,
+          "score": 0.01331007
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00644423,
-          "spread": 0.0098129,
-          "score": 0.01173972
+          "bias": -0.00371407,
+          "spread": 0.0073934,
+          "score": 0.00827386
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00151197,
-          "spread": 0.00405403,
-          "score": 0.0043268
+          "bias": 0.002895,
+          "spread": 0.00211412,
+          "score": 0.00358477
         },
         {
           "profile": "cp_minus_10pct",
@@ -908,162 +908,162 @@
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00475925,
-          "spread": 0.00243352,
-          "score": 0.00534532
+          "bias": -0.00032589,
+          "spread": 0.00501012,
+          "score": 0.00502071
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00294416,
-          "spread": 0.00411748,
-          "score": 0.00506179
+          "bias": 0.00146461,
+          "spread": 0.00163766,
+          "score": 0.00219705
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00340567,
-          "spread": 0.00424723,
-          "score": 0.00544403
+          "bias": 0.00048363,
+          "spread": 0.00232793,
+          "score": 0.00237764
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.0036575,
-          "spread": 0.00716437,
-          "score": 0.00804397
+          "bias": 0.00778453,
+          "spread": 0.00679812,
+          "score": 0.01033506
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00423248,
-          "spread": 0.00950951,
-          "score": 0.01040888
+          "bias": 0.01137612,
+          "spread": 0.00714018,
+          "score": 0.01343124
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00097594,
-          "spread": 0.01538858,
-          "score": 0.01541949
+          "bias": 0.01294851,
+          "spread": 0.01753136,
+          "score": 0.02179478
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.03996947,
-          "spread": 0.06194079,
-          "score": 0.07371716
+          "bias": 0.07596016,
+          "spread": 0.05941033,
+          "score": 0.09643409
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.16354799,
-          "spread": 0.07351758,
-          "score": 0.17931196
+          "bias": 0.22150259,
+          "spread": 0.03855219,
+          "score": 0.22483254
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.05986372,
-          "spread": 0.30631757,
-          "score": 0.31211235
+          "bias": 0.01223292,
+          "spread": 0.46203135,
+          "score": 0.46219326
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.16904946,
-          "spread": 0.09550484,
-          "score": 0.19416203
+          "bias": 0.08798484,
+          "spread": 0.33872168,
+          "score": 0.34996244
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -5.88e-06,
-          "spread": 0.00346445,
-          "score": 0.00346446
+          "bias": 0.00410837,
+          "spread": 0.00430802,
+          "score": 0.00595296
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.0043293,
-          "spread": 0.00379862,
-          "score": 0.00575954
+          "bias": 0.00057008,
+          "spread": 0.00671374,
+          "score": 0.0067379
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00109969,
-          "spread": 0.00412492,
-          "score": 0.00426899
+          "bias": 0.0062025,
+          "spread": 0.00618177,
+          "score": 0.00875702
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00043083,
-          "spread": 0.00389933,
-          "score": 0.00392306
+          "bias": 0.00380554,
+          "spread": 0.00513381,
+          "score": 0.00639047
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.02733881,
-          "spread": 0.04566316,
-          "score": 0.05322156
+          "bias": 0.03083117,
+          "spread": 0.04655298,
+          "score": 0.05583674
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.08882161,
-          "spread": 0.02777189,
-          "score": 0.09306211
+          "bias": -0.05457938,
+          "spread": 0.03409597,
+          "score": 0.06435405
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.01400158,
-          "spread": 0.05084332,
-          "score": 0.05273601
+          "bias": 0.01641501,
+          "spread": 0.05150549,
+          "score": 0.054058
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.19921411,
+          "bias": 0.19937795,
           "spread": 0.0,
-          "score": 0.19921411
+          "score": 0.19937795
         },
         {
           "profile": "cp_minus_10pct",
@@ -1079,207 +1079,207 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00450805,
-          "spread": 0.00529426,
-          "score": 0.00695354
+          "bias": 0.00170127,
+          "spread": 0.00292315,
+          "score": 0.00338218
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00466344,
-          "spread": 0.01004373,
-          "score": 0.01107358
+          "bias": -0.0015643,
+          "spread": 0.00740839,
+          "score": 0.00757174
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00055212,
-          "spread": 0.01009823,
-          "score": 0.01011331
+          "bias": 0.00340741,
+          "spread": 0.00759675,
+          "score": 0.00832593
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00193682,
-          "spread": 0.00397211,
-          "score": 0.00441916
+          "bias": 0.00011388,
+          "spread": 0.0031849,
+          "score": 0.00318694
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.11909327,
+          "bias": 0.11176534,
           "spread": 0.0,
-          "score": 0.11909327
+          "score": 0.11176534
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00160698,
-          "spread": 0.00536962,
-          "score": 0.00560493
+          "bias": 0.00055797,
+          "spread": 0.00517479,
+          "score": 0.00520479
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00364148,
-          "spread": 0.00355886,
-          "score": 0.00509175
+          "bias": -0.00173388,
+          "spread": 0.00204159,
+          "score": 0.00267851
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00347636,
-          "spread": 0.00456382,
-          "score": 0.00573703
+          "bias": -0.0014788,
+          "spread": 0.00413664,
+          "score": 0.00439302
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00260735,
-          "spread": 0.00435385,
-          "score": 0.00507487
+          "bias": 0.00497604,
+          "spread": 0.00387083,
+          "score": 0.00630431
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00912005,
-          "spread": 0.00740204,
-          "score": 0.01174587
+          "bias": 0.01265144,
+          "spread": 0.00474559,
+          "score": 0.0135122
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00513717,
-          "spread": 0.0126081,
-          "score": 0.0136145
+          "bias": 0.00778036,
+          "spread": 0.01060958,
+          "score": 0.01315664
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.04828167,
-          "spread": 0.04632518,
-          "score": 0.06691145
+          "bias": 0.05572183,
+          "spread": 0.04468634,
+          "score": 0.07142683
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.33240454,
-          "spread": 0.31917032,
-          "score": 0.46082803
+          "bias": 0.32524506,
+          "spread": 0.31614789,
+          "score": 0.45357892
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.947253,
-          "spread": 0.48955273,
-          "score": 1.06627863
+          "bias": 0.92902579,
+          "spread": 0.4400985,
+          "score": 1.02799592
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.02065236,
-          "spread": 0.13157975,
-          "score": 0.13319065
+          "bias": -0.07710702,
+          "spread": 0.08771317,
+          "score": 0.11678652
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00262049,
-          "spread": 0.00260176,
-          "score": 0.00369272
+          "bias": 0.00438048,
+          "spread": 0.00235169,
+          "score": 0.00497183
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00554926,
-          "spread": 0.00207403,
-          "score": 0.00592418
+          "bias": -0.00328147,
+          "spread": 0.00356203,
+          "score": 0.00484315
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.0027192,
-          "spread": 0.00174865,
-          "score": 0.00323292
+          "bias": -0.00071283,
+          "spread": 0.00309188,
+          "score": 0.00317299
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00314228,
-          "spread": 0.00142096,
-          "score": 0.00344862
+          "bias": -0.0016607,
+          "spread": 0.00149006,
+          "score": 0.00223119
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": -1.41e-06,
-          "spread": 0.00477634,
-          "score": 0.00477634
+          "bias": 0.00184109,
+          "spread": 0.00556922,
+          "score": 0.00586564
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.07674344,
-          "spread": 0.02977752,
-          "score": 0.08231802
+          "bias": -0.07174064,
+          "spread": 0.02877381,
+          "score": 0.07729587
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.01434616,
-          "spread": 0.02426836,
-          "score": 0.02819158
+          "bias": 0.01791244,
+          "spread": 0.02842609,
+          "score": 0.03359908
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.0591561,
-          "spread": 0.04212885,
-          "score": 0.07262426
+          "bias": 0.07573681,
+          "spread": 0.05392207,
+          "score": 0.09297125
         },
         {
           "profile": "cp_minus_10pct",
@@ -1295,198 +1295,198 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00411574,
-          "spread": 0.00890646,
-          "score": 0.00981144
+          "bias": -0.00166719,
+          "spread": 0.00845548,
+          "score": 0.00861827
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00448543,
-          "spread": 0.00868571,
-          "score": 0.00977551
+          "bias": -0.00228441,
+          "spread": 0.00795346,
+          "score": 0.00827503
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.0005272,
-          "spread": 0.00835944,
-          "score": 0.00837604
+          "bias": 0.00118884,
+          "spread": 0.00715897,
+          "score": 0.00725701
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00638937,
-          "spread": 0.00558237,
-          "score": 0.00848452
+          "bias": -0.00136789,
+          "spread": 0.0031261,
+          "score": 0.00341227
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.09906586,
+          "bias": 0.11096596,
           "spread": 0.0,
-          "score": 0.09906586
+          "score": 0.11096596
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.01737151,
-          "spread": 0.01343781,
-          "score": 0.02196234
+          "bias": -0.00989294,
+          "spread": 0.01505647,
+          "score": 0.01801576
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00040861,
-          "spread": 0.00696666,
-          "score": 0.00697864
+          "bias": 0.00584204,
+          "spread": 0.00602875,
+          "score": 0.00839495
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00953532,
-          "spread": 0.00455394,
-          "score": 0.01056697
+          "bias": -0.00499397,
+          "spread": 0.00275839,
+          "score": 0.00570512
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.01206618,
-          "spread": 0.01577833,
-          "score": 0.01986324
+          "bias": -0.00759901,
+          "spread": 0.01271372,
+          "score": 0.0148116
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": -0.01362128,
-          "spread": 0.03490692,
-          "score": 0.03747042
+          "bias": -0.00730622,
+          "spread": 0.02857989,
+          "score": 0.029499
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.0559482,
-          "spread": 0.0754887,
-          "score": 0.09396141
+          "bias": -0.03881224,
+          "spread": 0.05607113,
+          "score": 0.06819356
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.00744879,
-          "spread": 0.06401613,
-          "score": 0.06444804
+          "bias": 0.06541148,
+          "spread": 0.11243163,
+          "score": 0.13007511
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.17212235,
-          "spread": 0.41528174,
-          "score": 0.44953869
+          "bias": 0.23631361,
+          "spread": 0.43039482,
+          "score": 0.49100287
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.11131473,
-          "spread": 0.87843364,
-          "score": 0.88545843
+          "bias": 0.43478116,
+          "spread": 0.96900339,
+          "score": 1.06207449
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.27313382,
-          "spread": 0.0,
-          "score": 0.27313382
+          "bias": -0.17898855,
+          "spread": 0.44414426,
+          "score": 0.47885387
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00764268,
-          "spread": 0.00396769,
-          "score": 0.00861122
+          "bias": -0.00500561,
+          "spread": 0.0073971,
+          "score": 0.00893158
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00711507,
-          "spread": 0.00531616,
-          "score": 0.00888177
+          "bias": 0.01062112,
+          "spread": 0.00958686,
+          "score": 0.01430791
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00947511,
-          "spread": 0.00926498,
-          "score": 0.01325208
+          "bias": 0.01257617,
+          "spread": 0.01207841,
+          "score": 0.01743697
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00083005,
-          "spread": 0.00766574,
-          "score": 0.00771055
+          "bias": 0.00145035,
+          "spread": 0.00807065,
+          "score": 0.00819993
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00846943,
-          "spread": 0.01744688,
-          "score": 0.01939394
+          "bias": 0.01191047,
+          "spread": 0.01940325,
+          "score": 0.0227672
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.20550607,
-          "spread": 0.17866447,
-          "score": 0.27231184
+          "bias": -0.16010848,
+          "spread": 0.15607239,
+          "score": 0.22359185
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00314289,
-          "spread": 0.03059247,
-          "score": 0.03075348
+          "bias": 0.00720921,
+          "spread": 0.03805637,
+          "score": 0.03873319
         },
         {
           "profile": "cp_plus_10pct",
@@ -1511,36 +1511,36 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.0157341,
-          "spread": 0.02649037,
-          "score": 0.03081074
+          "bias": -0.01212325,
+          "spread": 0.0185166,
+          "score": 0.02213227
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.01294889,
-          "spread": 0.01429287,
-          "score": 0.01928626
+          "bias": -0.01008861,
+          "spread": 0.0082152,
+          "score": 0.01301036
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.01273846,
-          "spread": 0.00985306,
-          "score": 0.01610438
+          "bias": -0.0103711,
+          "spread": 0.0051581,
+          "score": 0.01158299
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00194305,
-          "spread": 0.00467044,
-          "score": 0.00505851
+          "bias": 0.00310628,
+          "spread": 0.00240997,
+          "score": 0.00393152
         },
         {
           "profile": "cp_plus_10pct",
@@ -1556,162 +1556,162 @@
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00905329,
-          "spread": 0.00892997,
-          "score": 0.01271638
+          "bias": -0.00293031,
+          "spread": 0.01037535,
+          "score": 0.01078122
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00088251,
-          "spread": 0.0040521,
-          "score": 0.00414709
+          "bias": 0.00581487,
+          "spread": 0.00367607,
+          "score": 0.0068794
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00379284,
-          "spread": 0.00402469,
-          "score": 0.00553026
+          "bias": 0.00067641,
+          "spread": 0.00250599,
+          "score": 0.00259567
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00255423,
-          "spread": 0.00944072,
-          "score": 0.00978015
+          "bias": 0.00212108,
+          "spread": 0.00796022,
+          "score": 0.00823797
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": -0.00393702,
-          "spread": 0.01579345,
-          "score": 0.01627677
+          "bias": 0.00509415,
+          "spread": 0.01105336,
+          "score": 0.01217075
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00841339,
-          "spread": 0.01809178,
-          "score": 0.01995239
+          "bias": 0.00749775,
+          "spread": 0.01684971,
+          "score": 0.01844259
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.02596617,
-          "spread": 0.08005191,
-          "score": 0.08415789
+          "bias": 0.07182245,
+          "spread": 0.08055147,
+          "score": 0.10792129
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.06663101,
-          "spread": 0.17781478,
-          "score": 0.18988888
+          "bias": 0.16595985,
+          "spread": 0.13529327,
+          "score": 0.21411899
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.05478595,
-          "spread": 0.35559766,
-          "score": 0.35979327
+          "bias": 0.24825245,
+          "spread": 0.33889456,
+          "score": 0.4200938
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.12476769,
-          "spread": 0.04116928,
-          "score": 0.1313845
+          "bias": -0.06289311,
+          "spread": 0.16250907,
+          "score": 0.17425482
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00689883,
-          "spread": 0.00277254,
-          "score": 0.00743511
+          "bias": -0.00274311,
+          "spread": 0.00388476,
+          "score": 0.00475563
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00509547,
-          "spread": 0.00156989,
-          "score": 0.00533182
+          "bias": 0.01003943,
+          "spread": 0.0051134,
+          "score": 0.01126663
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00498275,
-          "spread": 0.00299976,
-          "score": 0.00581605
+          "bias": 0.01004412,
+          "spread": 0.00655419,
+          "score": 0.0119934
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00198623,
-          "spread": 0.00310676,
-          "score": 0.00368742
+          "bias": 0.00541597,
+          "spread": 0.00575199,
+          "score": 0.00790051
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.02742224,
-          "spread": 0.04512326,
-          "score": 0.05280235
+          "bias": 0.0307486,
+          "spread": 0.04756738,
+          "score": 0.05664038
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.21615064,
-          "spread": 0.11866451,
-          "score": 0.24658135
+          "bias": -0.17145688,
+          "spread": 0.11314132,
+          "score": 0.20542254
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00603129,
-          "spread": 0.04715843,
-          "score": 0.04754255
+          "bias": 0.00712128,
+          "spread": 0.048952,
+          "score": 0.04946727
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.1837499,
+          "bias": 0.18471019,
           "spread": 0.0,
-          "score": 0.1837499
+          "score": 0.18471019
         },
         {
           "profile": "cp_plus_10pct",
@@ -1727,207 +1727,207 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00373582,
-          "spread": 0.00452025,
-          "score": 0.00586421
+          "bias": 0.00406034,
+          "spread": 0.00316616,
+          "score": 0.00514888
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00471259,
-          "spread": 0.01062217,
-          "score": 0.01162063
+          "bias": -0.00048829,
+          "spread": 0.00661821,
+          "score": 0.0066362
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00271963,
-          "spread": 0.01180431,
-          "score": 0.01211355
+          "bias": 0.00066056,
+          "spread": 0.00846233,
+          "score": 0.00848807
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00233955,
-          "spread": 0.00447799,
-          "score": 0.00505231
+          "bias": -2.698e-05,
+          "spread": 0.00358059,
+          "score": 0.00358069
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.19119051,
+          "bias": 0.15931245,
           "spread": 0.0,
-          "score": 0.19119051
+          "score": 0.15931245
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00869362,
-          "spread": 0.00269628,
-          "score": 0.00910214
+          "bias": -0.00636788,
+          "spread": 0.00115051,
+          "score": 0.00647098
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00242943,
-          "spread": 0.00401634,
-          "score": 0.00469395
+          "bias": -0.00029661,
+          "spread": 0.00255771,
+          "score": 0.00257485
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00277351,
-          "spread": 0.00484707,
-          "score": 0.00558448
+          "bias": -0.00047277,
+          "spread": 0.00444058,
+          "score": 0.00446567
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.0020399,
-          "spread": 0.00576907,
-          "score": 0.00611909
+          "bias": 0.00061055,
+          "spread": 0.00511016,
+          "score": 0.0051465
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00394154,
-          "spread": 0.0086802,
-          "score": 0.00953319
+          "bias": 0.00776301,
+          "spread": 0.00567657,
+          "score": 0.00961706
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00645203,
-          "spread": 0.01718426,
-          "score": 0.01835559
+          "bias": -0.00399632,
+          "spread": 0.01338765,
+          "score": 0.01397139
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.04319279,
-          "spread": 0.06415913,
-          "score": 0.07734346
+          "bias": 0.05123575,
+          "spread": 0.05810948,
+          "score": 0.07747138
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.39986542,
-          "spread": 0.45903281,
-          "score": 0.6087721
+          "bias": 0.3769808,
+          "spread": 0.44148628,
+          "score": 0.58053825
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.73095534,
-          "spread": 1.06878378,
-          "score": 1.29483377
+          "bias": 0.71322948,
+          "spread": 1.00110909,
+          "score": 1.22919311
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.0519094,
-          "spread": 0.15034686,
-          "score": 0.15905585
+          "bias": -0.103947,
+          "spread": 0.12002327,
+          "score": 0.15877834
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00582611,
-          "spread": 0.00443833,
-          "score": 0.00732409
+          "bias": -0.00365048,
+          "spread": 0.00383766,
+          "score": 0.00529657
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00301402,
-          "spread": 0.00155237,
-          "score": 0.0033903
+          "bias": 0.00518674,
+          "spread": 0.00292542,
+          "score": 0.00595486
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.0012918,
-          "spread": 0.00174282,
-          "score": 0.00216937
+          "bias": 0.003146,
+          "spread": 0.00330017,
+          "score": 0.00455943
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00066704,
-          "spread": 0.00140359,
-          "score": 0.00155403
+          "bias": 0.00089968,
+          "spread": 0.00176542,
+          "score": 0.00198145
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": -0.00069728,
-          "spread": 0.00154199,
-          "score": 0.00169232
+          "bias": 0.00116337,
+          "spread": 0.00318498,
+          "score": 0.0033908
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.18763492,
-          "spread": 0.1123894,
-          "score": 0.21871955
+          "bias": -0.18240299,
+          "spread": 0.11408167,
+          "score": 0.2151406
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00711075,
-          "spread": 0.02014192,
-          "score": 0.02136024
+          "bias": 0.0104994,
+          "spread": 0.02441153,
+          "score": 0.02657367
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.0475991,
-          "spread": 0.03614243,
-          "score": 0.05976579
+          "bias": 0.06514802,
+          "spread": 0.04833989,
+          "score": 0.08112343
         },
         {
           "profile": "cp_plus_10pct",
@@ -1943,198 +1943,198 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00452471,
-          "spread": 0.00937182,
-          "score": 0.01040692
+          "bias": -0.00149291,
+          "spread": 0.00826294,
+          "score": 0.00839673
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00413357,
-          "spread": 0.00930446,
-          "score": 0.01018132
+          "bias": -0.0012721,
+          "spread": 0.0084853,
+          "score": 0.00858012
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00387377,
-          "spread": 0.00940981,
-          "score": 0.01017598
+          "bias": -0.00183301,
+          "spread": 0.00838032,
+          "score": 0.00857845
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00605378,
-          "spread": 0.0053473,
-          "score": 0.00807724
+          "bias": -0.00125686,
+          "spread": 0.00300119,
+          "score": 0.00325374
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.13716425,
+          "bias": 0.13228286,
           "spread": 0.0,
-          "score": 0.13716425
+          "score": 0.13228286
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.01782395,
-          "spread": 0.01244126,
-          "score": 0.02173656
+          "bias": -0.01101027,
+          "spread": 0.01420275,
+          "score": 0.01797064
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00232203,
-          "spread": 0.00554423,
-          "score": 0.00601085
+          "bias": 0.00340302,
+          "spread": 0.00496217,
+          "score": 0.00601695
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00844908,
-          "spread": 0.00399905,
-          "score": 0.0093477
+          "bias": -0.0042432,
+          "spread": 0.00227674,
+          "score": 0.00481542
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00857501,
-          "spread": 0.01422067,
-          "score": 0.01660597
+          "bias": -0.00457703,
+          "spread": 0.01132569,
+          "score": 0.01221558
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": -0.00853518,
-          "spread": 0.03160858,
-          "score": 0.03274068
+          "bias": -0.00475973,
+          "spread": 0.02485465,
+          "score": 0.0253063
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.04770317,
-          "spread": 0.06869257,
-          "score": 0.0836317
+          "bias": -0.03475382,
+          "spread": 0.05284287,
+          "score": 0.06324711
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.01454282,
-          "spread": 0.05285219,
-          "score": 0.0548165
+          "bias": 0.05758191,
+          "spread": 0.09380948,
+          "score": 0.11007223
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.20012048,
-          "spread": 0.40726139,
-          "score": 0.45377312
+          "bias": 0.23340785,
+          "spread": 0.41164971,
+          "score": 0.4732174
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.23829923,
-          "spread": 0.82133852,
-          "score": 0.85520962
+          "bias": 0.12038303,
+          "spread": 0.82868243,
+          "score": 0.83738083
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.27167519,
-          "spread": 0.0,
-          "score": 0.27167519
+          "bias": -0.11489509,
+          "spread": 0.40066239,
+          "score": 0.41681079
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00552432,
-          "spread": 0.00458512,
-          "score": 0.00717924
+          "bias": -0.0021266,
+          "spread": 0.00725091,
+          "score": 0.00755633
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00245861,
-          "spread": 0.00553067,
-          "score": 0.00605252
+          "bias": 0.00705676,
+          "spread": 0.00808803,
+          "score": 0.01073378
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00742785,
-          "spread": 0.00891748,
-          "score": 0.01160579
+          "bias": 0.01189711,
+          "spread": 0.00967099,
+          "score": 0.01533197
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00204021,
-          "spread": 0.00758238,
-          "score": 0.00785206
+          "bias": 0.00196659,
+          "spread": 0.00828448,
+          "score": 0.0085147
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00774343,
-          "spread": 0.01595403,
-          "score": 0.01773391
+          "bias": 0.01287465,
+          "spread": 0.01721664,
+          "score": 0.02149812
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.16288504,
-          "spread": 0.14893739,
-          "score": 0.22071221
+          "bias": -0.13573569,
+          "spread": 0.1260509,
+          "score": 0.1852377
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00615668,
-          "spread": 0.03708775,
-          "score": 0.03759529
+          "bias": 0.01407683,
+          "spread": 0.04258955,
+          "score": 0.04485563
         },
         {
           "profile": "cp_plus_3pct",
@@ -2159,36 +2159,36 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.01361826,
-          "spread": 0.02531926,
-          "score": 0.0287493
+          "bias": -0.01107492,
+          "spread": 0.01973593,
+          "score": 0.02263097
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.01171689,
-          "spread": 0.01497256,
-          "score": 0.01901218
+          "bias": -0.00825879,
+          "spread": 0.00975538,
+          "score": 0.01278182
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.01073336,
-          "spread": 0.01013803,
-          "score": 0.0147643
+          "bias": -0.00688084,
+          "spread": 0.00678243,
+          "score": 0.00966164
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00179211,
-          "spread": 0.00445474,
-          "score": 0.00480171
+          "bias": 0.00303237,
+          "spread": 0.00230633,
+          "score": 0.00380978
         },
         {
           "profile": "cp_plus_3pct",
@@ -2204,162 +2204,162 @@
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00749822,
-          "spread": 0.00630722,
-          "score": 0.00979818
+          "bias": -0.00230323,
+          "spread": 0.00720768,
+          "score": 0.00756674
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.0004381,
-          "spread": 0.00388045,
-          "score": 0.0039051
+          "bias": 0.00425242,
+          "spread": 0.00285373,
+          "score": 0.00512122
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00359816,
-          "spread": 0.00404779,
-          "score": 0.00541584
+          "bias": 0.00057975,
+          "spread": 0.00230871,
+          "score": 0.00238039
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00040652,
-          "spread": 0.00860153,
-          "score": 0.00861113
+          "bias": 0.00430031,
+          "spread": 0.00748373,
+          "score": 0.00863127
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": -0.00129986,
-          "spread": 0.013571,
-          "score": 0.01363311
+          "bias": 0.00751779,
+          "spread": 0.00962649,
+          "score": 0.01221419
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00471997,
-          "spread": 0.01668002,
-          "score": 0.01733496
+          "bias": 0.01005615,
+          "spread": 0.01810125,
+          "score": 0.02070703
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.03118128,
-          "spread": 0.07041279,
-          "score": 0.077008
+          "bias": 0.07439086,
+          "spread": 0.0691234,
+          "score": 0.10154824
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.15212227,
-          "spread": 0.11731031,
-          "score": 0.19210126
+          "bias": 0.22670622,
+          "spread": 0.06590753,
+          "score": 0.23609217
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.03440847,
-          "spread": 0.37793326,
-          "score": 0.37949637
+          "bias": -0.04191098,
+          "spread": 0.56928782,
+          "score": 0.57082848
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.13571475,
-          "spread": 0.04887355,
-          "score": 0.14424672
+          "bias": 0.00428396,
+          "spread": 0.24577445,
+          "score": 0.24581178
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00421598,
-          "spread": 0.00105083,
-          "score": 0.00434496
+          "bias": -0.00022237,
+          "spread": 0.00305873,
+          "score": 0.00306681
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00189769,
-          "spread": 0.00220235,
-          "score": 0.00290716
+          "bias": 0.00675298,
+          "spread": 0.00553345,
+          "score": 0.00873051
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00374085,
-          "spread": 0.0031195,
-          "score": 0.00487086
+          "bias": 0.008815,
+          "spread": 0.0064671,
+          "score": 0.01093287
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00143854,
-          "spread": 0.00332508,
-          "score": 0.00362292
+          "bias": 0.00480252,
+          "spread": 0.00574728,
+          "score": 0.00748969
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.02811117,
-          "spread": 0.0458412,
-          "score": 0.0537741
+          "bias": 0.030689,
+          "spread": 0.04762843,
+          "score": 0.05665935
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.16987999,
-          "spread": 0.08346613,
-          "score": 0.18927706
+          "bias": -0.13076366,
+          "spread": 0.08265837,
+          "score": 0.15469822
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.0103334,
-          "spread": 0.04824895,
-          "score": 0.04934309
+          "bias": 0.00976593,
+          "spread": 0.05027403,
+          "score": 0.05121378
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.18998443,
+          "bias": 0.19162498,
           "spread": 0.0,
-          "score": 0.18998443
+          "score": 0.19162498
         },
         {
           "profile": "cp_plus_3pct",
@@ -2375,207 +2375,207 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00373503,
-          "spread": 0.00485385,
-          "score": 0.00612457
+          "bias": 0.00353357,
+          "spread": 0.00305055,
+          "score": 0.00466819
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00491036,
-          "spread": 0.01064772,
-          "score": 0.01172542
+          "bias": -0.00080072,
+          "spread": 0.00669792,
+          "score": 0.00674561
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00173268,
-          "spread": 0.01104535,
-          "score": 0.01118043
+          "bias": 0.00166697,
+          "spread": 0.00793054,
+          "score": 0.00810384
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00219861,
-          "spread": 0.00430089,
-          "score": 0.00483027
+          "bias": 2.259e-05,
+          "spread": 0.00344174,
+          "score": 0.00344181
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.16099914,
+          "bias": 0.14317606,
           "spread": 0.0,
-          "score": 0.16099914
+          "score": 0.14317606
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00599863,
-          "spread": 0.003535,
-          "score": 0.00696274
+          "bias": -0.00431547,
+          "spread": 0.00199352,
+          "score": 0.00475367
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00284192,
-          "spread": 0.00384387,
-          "score": 0.00478036
+          "bias": -0.00083575,
+          "spread": 0.00232912,
+          "score": 0.00247453
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00298031,
-          "spread": 0.00472572,
-          "score": 0.00558701
+          "bias": -0.00074873,
+          "spread": 0.00435013,
+          "score": 0.00441409
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00041672,
-          "spread": 0.00517067,
-          "score": 0.00518743
+          "bias": 0.00212804,
+          "spread": 0.00474555,
+          "score": 0.00520085
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00543353,
-          "spread": 0.00817642,
-          "score": 0.00981718
+          "bias": 0.00904328,
+          "spread": 0.00529117,
+          "score": 0.01047747
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00249965,
-          "spread": 0.01580582,
-          "score": 0.01600225
+          "bias": -7.776e-05,
+          "spread": 0.01213057,
+          "score": 0.01213082
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.04636341,
-          "spread": 0.05888745,
-          "score": 0.07494863
+          "bias": 0.05066861,
+          "spread": 0.0531005,
+          "score": 0.07339599
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.38428703,
-          "spread": 0.41739884,
-          "score": 0.56736083
+          "bias": 0.36132503,
+          "spread": 0.39581441,
+          "score": 0.5359336
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.81215698,
-          "spread": 0.83680325,
-          "score": 1.1661212
+          "bias": 0.7897756,
+          "spread": 0.79934043,
+          "score": 1.12369508
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.0483725,
-          "spread": 0.13207454,
-          "score": 0.14065412
+          "bias": -0.10643653,
+          "spread": 0.09189321,
+          "score": 0.14061685
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00267759,
-          "spread": 0.00341006,
-          "score": 0.00433567
+          "bias": -0.0006366,
+          "spread": 0.0027475,
+          "score": 0.00282029
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 9.256e-05,
-          "spread": 0.00166987,
-          "score": 0.00167243
+          "bias": 0.00231312,
+          "spread": 0.00308162,
+          "score": 0.00385317
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -2.885e-05,
-          "spread": 0.00172513,
-          "score": 0.00172537
+          "bias": 0.00184655,
+          "spread": 0.0030839,
+          "score": 0.00359446
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00138436,
-          "spread": 0.00129322,
-          "score": 0.00189443
+          "bias": -1.667e-05,
+          "spread": 0.00135643,
+          "score": 0.00135653
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": -0.00025164,
-          "spread": 0.0022529,
-          "score": 0.00226691
+          "bias": 0.00158715,
+          "spread": 0.00353353,
+          "score": 0.00387361
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.14816369,
-          "spread": 0.08153045,
-          "score": 0.16911444
+          "bias": -0.14211312,
+          "spread": 0.08191143,
+          "score": 0.16402933
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00985364,
-          "spread": 0.02066589,
-          "score": 0.02289483
+          "bias": 0.01360771,
+          "spread": 0.02567411,
+          "score": 0.02905735
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.05303001,
-          "spread": 0.03885584,
-          "score": 0.06574161
+          "bias": 0.06791827,
+          "spread": 0.05026685,
+          "score": 0.08449644
         },
         {
           "profile": "cp_plus_3pct",
@@ -2591,198 +2591,198 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00439363,
-          "spread": 0.00984105,
-          "score": 0.0107773
+          "bias": -0.00146805,
+          "spread": 0.00852011,
+          "score": 0.00864566
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00433283,
-          "spread": 0.00916701,
-          "score": 0.01013941
+          "bias": -0.00185979,
+          "spread": 0.00823651,
+          "score": 0.00844387
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00272765,
-          "spread": 0.00894423,
-          "score": 0.0093509
+          "bias": -0.00073719,
+          "spread": 0.00789142,
+          "score": 0.00792578
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.0059939,
-          "spread": 0.00533646,
-          "score": 0.00802525
+          "bias": -0.00121873,
+          "spread": 0.00300114,
+          "score": 0.00323916
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.1302007,
+          "bias": 0.14940647,
           "spread": 0.0,
-          "score": 0.1302007
+          "score": 0.14940647
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.02034771,
-          "spread": 0.0124143,
-          "score": 0.02383577
+          "bias": -0.01458256,
+          "spread": 0.01547577,
+          "score": 0.02126383
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00507315,
-          "spread": 0.00495404,
-          "score": 0.0070908
+          "bias": 0.00011134,
+          "spread": 0.00421872,
+          "score": 0.00422019
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00765446,
-          "spread": 0.00405491,
-          "score": 0.00866216
+          "bias": -0.00320506,
+          "spread": 0.0022304,
+          "score": 0.00390475
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00566708,
-          "spread": 0.01341087,
-          "score": 0.0145591
+          "bias": -0.00131211,
+          "spread": 0.01012895,
+          "score": 0.01021358
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": -0.00470613,
-          "spread": 0.029848,
-          "score": 0.03021674
+          "bias": 0.0006459,
+          "spread": 0.02264664,
+          "score": 0.02265585
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.0425895,
-          "spread": 0.0656197,
-          "score": 0.07822922
+          "bias": -0.03134492,
+          "spread": 0.05190288,
+          "score": 0.06063343
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.02410242,
-          "spread": 0.05498974,
-          "score": 0.06003997
+          "bias": 0.06836422,
+          "spread": 0.09264566,
+          "score": 0.11513854
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.211291,
-          "spread": 0.40506347,
-          "score": 0.45685917
+          "bias": 0.2318546,
+          "spread": 0.39200014,
+          "score": 0.45543459
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.25070584,
-          "spread": 0.76305456,
-          "score": 0.80318471
+          "bias": 0.22196797,
+          "spread": 0.76269559,
+          "score": 0.79433893
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.22232073,
-          "spread": 0.0,
-          "score": 0.22232073
+          "bias": 0.07555541,
+          "spread": 0.09257135,
+          "score": 0.1194909
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00281805,
-          "spread": 0.00669332,
-          "score": 0.00726237
+          "bias": 0.00198359,
+          "spread": 0.00867807,
+          "score": 0.00890188
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00233869,
-          "spread": 0.00556151,
-          "score": 0.00603323
+          "bias": 0.00317234,
+          "spread": 0.00755752,
+          "score": 0.00819633
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00561591,
-          "spread": 0.008323,
-          "score": 0.01004045
+          "bias": 0.01095038,
+          "spread": 0.00799457,
+          "score": 0.01355817
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00312217,
-          "spread": 0.00874087,
-          "score": 0.00928174
+          "bias": 0.0014848,
+          "spread": 0.0099788,
+          "score": 0.01008866
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.0083281,
-          "spread": 0.01486228,
-          "score": 0.01703657
+          "bias": 0.01371012,
+          "spread": 0.01559799,
+          "score": 0.02076691
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.14793379,
-          "spread": 0.13222629,
-          "score": 0.19841421
+          "bias": -0.11775178,
+          "spread": 0.11544516,
+          "score": 0.1649032
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.01229032,
-          "spread": 0.04297022,
-          "score": 0.04469331
+          "bias": 0.01803757,
+          "spread": 0.04976682,
+          "score": 0.05293477
         },
         {
           "profile": "rated_plus_5pct",
@@ -2807,36 +2807,36 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.0135268,
-          "spread": 0.02436741,
-          "score": 0.02787015
+          "bias": -0.01134585,
+          "spread": 0.01998614,
+          "score": 0.02298203
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.01220965,
-          "spread": 0.01592506,
-          "score": 0.02006697
+          "bias": -0.0078409,
+          "spread": 0.01261426,
+          "score": 0.01485259
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00839309,
-          "spread": 0.0101254,
-          "score": 0.01315172
+          "bias": -0.00409777,
+          "spread": 0.00887524,
+          "score": 0.00977556
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00174293,
-          "spread": 0.00443283,
-          "score": 0.00476317
+          "bias": 0.00306163,
+          "spread": 0.00229078,
+          "score": 0.00382378
         },
         {
           "profile": "rated_plus_5pct",
@@ -2852,162 +2852,162 @@
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00613392,
-          "spread": 0.00372552,
-          "score": 0.00717666
+          "bias": -0.00147872,
+          "spread": 0.00581659,
+          "score": 0.00600161
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00200767,
-          "spread": 0.0042103,
-          "score": 0.00466448
+          "bias": 0.00284794,
+          "spread": 0.0022112,
+          "score": 0.00360558
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00371197,
-          "spread": 0.00431128,
-          "score": 0.0056891
+          "bias": 0.00059154,
+          "spread": 0.0023575,
+          "score": 0.00243058
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.0022488,
-          "spread": 0.00818687,
-          "score": 0.00849011
+          "bias": 0.00670399,
+          "spread": 0.00726206,
+          "score": 0.00988337
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00173316,
-          "spread": 0.01189571,
-          "score": 0.0120213
+          "bias": 0.00946876,
+          "spread": 0.00845388,
+          "score": 0.01269352
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00178517,
-          "spread": 0.01762742,
-          "score": 0.01771758
+          "bias": 0.0116771,
+          "spread": 0.01878252,
+          "score": 0.02211646
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.03770001,
-          "spread": 0.07190917,
-          "score": 0.08119248
+          "bias": 0.07561952,
+          "spread": 0.0658453,
+          "score": 0.10026921
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.15474408,
-          "spread": 0.11122613,
-          "score": 0.19057015
+          "bias": 0.22347679,
+          "spread": 0.06379974,
+          "score": 0.23240542
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.05745015,
-          "spread": 0.35693762,
-          "score": 0.36153144
+          "bias": 0.00597907,
+          "spread": 0.52786327,
+          "score": 0.52789714
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.15445527,
-          "spread": 0.06800451,
-          "score": 0.16876328
+          "bias": 0.00206266,
+          "spread": 0.22927929,
+          "score": 0.22928857
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00156576,
-          "spread": 0.00188793,
-          "score": 0.00245274
+          "bias": 0.00264873,
+          "spread": 0.00351274,
+          "score": 0.00439944
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00193445,
-          "spread": 0.00329127,
-          "score": 0.00381766
+          "bias": 0.00342692,
+          "spread": 0.00643193,
+          "score": 0.00728791
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00231377,
-          "spread": 0.00390918,
-          "score": 0.0045426
+          "bias": 0.00781417,
+          "spread": 0.0066256,
+          "score": 0.01024499
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00063074,
-          "spread": 0.00398661,
-          "score": 0.0040362
+          "bias": 0.00438045,
+          "spread": 0.005715,
+          "score": 0.00720066
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.02880744,
-          "spread": 0.04822818,
-          "score": 0.05617674
+          "bias": 0.03238718,
+          "spread": 0.04982474,
+          "score": 0.05942587
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.15030774,
-          "spread": 0.06851497,
-          "score": 0.16518692
+          "bias": -0.11349,
+          "spread": 0.06847812,
+          "score": 0.13254899
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.01269361,
-          "spread": 0.0522636,
-          "score": 0.053783
+          "bias": 0.01394611,
+          "spread": 0.05378306,
+          "score": 0.05556178
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.20219071,
+          "bias": 0.20318569,
           "spread": 0.0,
-          "score": 0.20219071
+          "score": 0.20318569
         },
         {
           "profile": "rated_plus_5pct",
@@ -3023,207 +3023,207 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.0041039,
-          "spread": 0.00588599,
-          "score": 0.00717544
+          "bias": 0.00248097,
+          "spread": 0.00378367,
+          "score": 0.00452453
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00505717,
-          "spread": 0.01075532,
-          "score": 0.01188494
+          "bias": -0.00112259,
+          "spread": 0.00764851,
+          "score": 0.00773045
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00026044,
-          "spread": 0.01085579,
-          "score": 0.01085892
+          "bias": 0.00246932,
+          "spread": 0.00798579,
+          "score": 0.00835885
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00216586,
-          "spread": 0.00430639,
-          "score": 0.00482037
+          "bias": 5.963e-05,
+          "spread": 0.00344792,
+          "score": 0.00344844
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.15122466,
+          "bias": 0.12113829,
           "spread": 0.0,
-          "score": 0.15122466
+          "score": 0.12113829
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00367241,
-          "spread": 0.00534181,
-          "score": 0.0064824
+          "bias": -0.00161726,
+          "spread": 0.00411674,
+          "score": 0.00442301
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00347039,
-          "spread": 0.00395069,
-          "score": 0.00525848
+          "bias": -0.0014817,
+          "spread": 0.00235305,
+          "score": 0.0027807
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00340766,
-          "spread": 0.00485472,
-          "score": 0.00593131
+          "bias": -0.00116007,
+          "spread": 0.0044049,
+          "score": 0.0045551
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00137041,
-          "spread": 0.00477746,
-          "score": 0.00497012
+          "bias": 0.00402215,
+          "spread": 0.0042814,
+          "score": 0.00587436
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00781048,
-          "spread": 0.0077448,
-          "score": 0.01099934
+          "bias": 0.01140189,
+          "spread": 0.00525365,
+          "score": 0.01255404
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00199987,
-          "spread": 0.01464657,
-          "score": 0.01478247
+          "bias": 0.0040978,
+          "spread": 0.01156215,
+          "score": 0.01226684
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.05069216,
-          "spread": 0.05585186,
-          "score": 0.07542629
+          "bias": 0.05625165,
+          "spread": 0.05157257,
+          "score": 0.076315
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.37435994,
-          "spread": 0.39478979,
-          "score": 0.54406281
+          "bias": 0.35868519,
+          "spread": 0.37910046,
+          "score": 0.52189292
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.8551451,
-          "spread": 0.7691382,
-          "score": 1.15015073
+          "bias": 0.84046661,
+          "spread": 0.71169434,
+          "score": 1.1013142
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.04102452,
-          "spread": 0.1272645,
-          "score": 0.13371336
+          "bias": -0.09854897,
+          "spread": 0.09744882,
+          "score": 0.13859355
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00042188,
-          "spread": 0.00287325,
-          "score": 0.00290405
+          "bias": 0.00248376,
+          "spread": 0.00256693,
+          "score": 0.00357186
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00325101,
-          "spread": 0.00195812,
-          "score": 0.00379517
+          "bias": -0.00100764,
+          "spread": 0.00374987,
+          "score": 0.00388289
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00155395,
-          "spread": 0.00157709,
-          "score": 0.00221404
+          "bias": 0.00026649,
+          "spread": 0.00329633,
+          "score": 0.00330708
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00249774,
-          "spread": 0.0012349,
-          "score": 0.00278634
+          "bias": -0.00117245,
+          "spread": 0.00138115,
+          "score": 0.00181169
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": -0.00025157,
-          "spread": 0.00369332,
-          "score": 0.00370188
+          "bias": 0.00170008,
+          "spread": 0.00513741,
+          "score": 0.00541141
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.13136713,
-          "spread": 0.06907233,
-          "score": 0.14841937
+          "bias": -0.12568026,
+          "spread": 0.06999126,
+          "score": 0.14385515
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.01278827,
-          "spread": 0.02368681,
-          "score": 0.02691849
+          "bias": 0.01639208,
+          "spread": 0.02874957,
+          "score": 0.03309438
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.05980249,
-          "spread": 0.04268276,
-          "score": 0.07347215
+          "bias": 0.07599822,
+          "spread": 0.05473316,
+          "score": 0.093656
         },
         {
           "profile": "rated_plus_5pct",
@@ -3239,198 +3239,198 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00433595,
-          "spread": 0.00951912,
-          "score": 0.01046011
+          "bias": -0.00134962,
+          "spread": 0.00895912,
+          "score": 0.00906021
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00455204,
-          "spread": 0.0093149,
-          "score": 0.01036766
+          "bias": -0.00204644,
+          "spread": 0.0086806,
+          "score": 0.00891856
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00154645,
-          "spread": 0.00905058,
-          "score": 0.00918174
+          "bias": 0.00050435,
+          "spread": 0.00754118,
+          "score": 0.00755803
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00619852,
-          "spread": 0.00546557,
-          "score": 0.00826403
+          "bias": -0.00129766,
+          "spread": 0.0030679,
+          "score": 0.00333106
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.12401385,
+          "bias": 0.12056824,
           "spread": 0.0,
-          "score": 0.12401385
+          "score": 0.12056824
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.02221745,
-          "spread": 0.01342857,
-          "score": 0.02596039
+          "bias": -0.01484544,
+          "spread": 0.01504515,
+          "score": 0.02113631
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.0041166,
-          "spread": 0.00675305,
-          "score": 0.00790885
+          "bias": 0.00158726,
+          "spread": 0.00628073,
+          "score": 0.00647819
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.0096964,
-          "spread": 0.0040356,
-          "score": 0.01050268
+          "bias": -0.00535787,
+          "spread": 0.00197553,
+          "score": 0.00571047
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00430282,
-          "spread": 0.01369787,
-          "score": 0.01435778
+          "bias": -0.00040532,
+          "spread": 0.01059349,
+          "score": 0.01060124
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.0037,
-          "spread": 0.03138539,
-          "score": 0.03160273
+          "bias": 0.01004271,
+          "spread": 0.0247902,
+          "score": 0.02674715
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.02867755,
-          "spread": 0.06655487,
-          "score": 0.07247036
+          "bias": -0.01280818,
+          "spread": 0.05047022,
+          "score": 0.05207007
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.03248782,
-          "spread": 0.0600332,
-          "score": 0.06826012
+          "bias": 0.08871442,
+          "spread": 0.10478226,
+          "score": 0.13729374
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.20315646,
-          "spread": 0.3744173,
-          "score": 0.42598223
+          "bias": 0.25653665,
+          "spread": 0.39774766,
+          "score": 0.47330144
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.23195809,
-          "spread": 0.73711614,
-          "score": 0.77275142
+          "bias": 0.19128321,
+          "spread": 0.79617622,
+          "score": 0.818832
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.28497296,
-          "spread": 0.0,
-          "score": 0.28497296
+          "bias": 0.09218963,
+          "spread": 0.1997149,
+          "score": 0.21996583
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00737744,
-          "spread": 0.00412198,
-          "score": 0.00845088
+          "bias": -0.00260674,
+          "spread": 0.00554241,
+          "score": 0.00612482
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00363554,
-          "spread": 0.00521766,
-          "score": 0.00635934
+          "bias": 0.00912387,
+          "spread": 0.0065386,
+          "score": 0.0112249
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00737927,
-          "spread": 0.00902433,
-          "score": 0.01165728
+          "bias": 0.01286825,
+          "spread": 0.00886872,
+          "score": 0.01562838
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00214078,
-          "spread": 0.00797963,
-          "score": 0.00826181
+          "bias": 0.00225205,
+          "spread": 0.00938533,
+          "score": 0.00965174
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00807565,
-          "spread": 0.01628869,
-          "score": 0.01818069
+          "bias": 0.01359505,
+          "spread": 0.01687871,
+          "score": 0.02167294
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.1709518,
-          "spread": 0.15424475,
-          "score": 0.23025194
+          "bias": -0.12853745,
+          "spread": 0.13436776,
+          "score": 0.18594777
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00313781,
-          "spread": 0.03515065,
-          "score": 0.03529042
+          "bias": 0.01158102,
+          "spread": 0.0381975,
+          "score": 0.03991452
         },
         {
           "profile": "ti_dependent_cp",
@@ -3455,36 +3455,36 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.01473681,
-          "spread": 0.02540682,
-          "score": 0.02937141
+          "bias": -0.00820348,
+          "spread": 0.02259789,
+          "score": 0.02404083
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.01124457,
-          "spread": 0.01449731,
-          "score": 0.018347
+          "bias": -0.00712926,
+          "spread": 0.01010693,
+          "score": 0.01236836
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.01070469,
-          "spread": 0.00991104,
-          "score": 0.01458832
+          "bias": -0.00685052,
+          "spread": 0.00788478,
+          "score": 0.01044507
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00185913,
-          "spread": 0.00455507,
-          "score": 0.00491986
+          "bias": 0.00306575,
+          "spread": 0.0023589,
+          "score": 0.00386823
         },
         {
           "profile": "ti_dependent_cp",
@@ -3500,162 +3500,162 @@
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.01331717,
-          "spread": 0.0101256,
-          "score": 0.01672946
+          "bias": -0.00805838,
+          "spread": 0.0104324,
+          "score": 0.01318228
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00262529,
-          "spread": 0.00389239,
-          "score": 0.00469498
+          "bias": 0.00242133,
+          "spread": 0.00318991,
+          "score": 0.00400479
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00435533,
-          "spread": 0.00420609,
-          "score": 0.00605476
+          "bias": 4.761e-05,
+          "spread": 0.0019866,
+          "score": 0.00198717
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00379036,
-          "spread": 0.00839436,
-          "score": 0.00921044
+          "bias": 0.00815621,
+          "spread": 0.00638179,
+          "score": 0.01035621
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01232525,
-          "spread": 0.01271277,
-          "score": 0.01770667
+          "bias": 0.02031797,
+          "spread": 0.00873573,
+          "score": 0.02211635
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.01814274,
-          "spread": 0.01348804,
-          "score": 0.02260721
+          "bias": 0.02986307,
+          "spread": 0.01533687,
+          "score": 0.03357116
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.05546259,
-          "spread": 0.07295015,
-          "score": 0.09163964
+          "bias": 0.09434108,
+          "spread": 0.073079,
+          "score": 0.11933473
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.18054482,
-          "spread": 0.11047442,
-          "score": 0.21166254
+          "bias": 0.24542985,
+          "spread": 0.06453822,
+          "score": 0.25377351
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.01836268,
-          "spread": 0.43138972,
-          "score": 0.43178036
+          "bias": -0.03509813,
+          "spread": 0.58125646,
+          "score": 0.58231516
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.10941547,
-          "spread": 0.04231747,
-          "score": 0.11731374
+          "bias": 0.00257336,
+          "spread": 0.24307318,
+          "score": 0.2430868
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00622243,
-          "spread": 0.00171274,
-          "score": 0.00645384
+          "bias": -0.00187539,
+          "spread": 0.0032767,
+          "score": 0.00377543
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00233061,
-          "spread": 0.00185603,
-          "score": 0.00297936
+          "bias": 0.00766536,
+          "spread": 0.00500635,
+          "score": 0.0091554
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00363276,
-          "spread": 0.00297712,
-          "score": 0.00469683
+          "bias": 0.00899708,
+          "spread": 0.00622212,
+          "score": 0.01093902
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00104014,
-          "spread": 0.00299026,
-          "score": 0.003166
+          "bias": 0.00448457,
+          "spread": 0.00541157,
+          "score": 0.00702826
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.02702385,
-          "spread": 0.04520804,
-          "score": 0.0526693
+          "bias": 0.0303588,
+          "spread": 0.04678408,
+          "score": 0.05577102
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.17215455,
-          "spread": 0.09031532,
-          "score": 0.19440691
+          "bias": -0.13451692,
+          "spread": 0.08929981,
+          "score": 0.16145977
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00563555,
-          "spread": 0.04654105,
-          "score": 0.046881
+          "bias": 0.00689573,
+          "spread": 0.04867168,
+          "score": 0.04915775
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.18222609,
+          "bias": 0.18407063,
           "spread": 0.0,
-          "score": 0.18222609
+          "score": 0.18407063
         },
         {
           "profile": "ti_dependent_cp",
@@ -3671,207 +3671,207 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00288579,
-          "spread": 0.00487239,
-          "score": 0.00566286
+          "bias": 0.00426554,
+          "spread": 0.00325237,
+          "score": 0.00536402
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00375256,
-          "spread": 0.01066295,
-          "score": 0.01130399
+          "bias": 5.33e-06,
+          "spread": 0.00683027,
+          "score": 0.00683027
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.0017236,
-          "spread": 0.01118891,
-          "score": 0.01132089
+          "bias": 0.00161179,
+          "spread": 0.00789641,
+          "score": 0.00805923
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00225941,
-          "spread": 0.00438412,
-          "score": 0.00493208
+          "bias": 3.08e-06,
+          "spread": 0.00350969,
+          "score": 0.00350969
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.19344302,
+          "bias": 0.17991698,
           "spread": 0.0,
-          "score": 0.19344302
+          "score": 0.17991698
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.01214838,
-          "spread": 0.00335081,
-          "score": 0.01260203
+          "bias": -0.009635,
+          "spread": 0.00146293,
+          "score": 0.00974542
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00491707,
-          "spread": 0.00411801,
-          "score": 0.00641371
+          "bias": -0.00276718,
+          "spread": 0.00247729,
+          "score": 0.00371406
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00342812,
-          "spread": 0.00486511,
-          "score": 0.00595158
+          "bias": -0.00124699,
+          "spread": 0.0044152,
+          "score": 0.00458791
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00329466,
-          "spread": 0.00477649,
-          "score": 0.00580256
+          "bias": 0.00599607,
+          "spread": 0.00394881,
+          "score": 0.00717955
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.0178468,
-          "spread": 0.00848423,
-          "score": 0.01976083
+          "bias": 0.02171046,
+          "spread": 0.00542486,
+          "score": 0.02237796
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.01745707,
-          "spread": 0.01588766,
-          "score": 0.02360438
+          "bias": 0.02013145,
+          "spread": 0.01336257,
+          "score": 0.02416265
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.06652675,
-          "spread": 0.05874806,
-          "score": 0.08875327
+          "bias": 0.07219902,
+          "spread": 0.05384097,
+          "score": 0.09006413
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.39804185,
-          "spread": 0.40313184,
-          "score": 0.56652678
+          "bias": 0.39652115,
+          "spread": 0.40897845,
+          "score": 0.56964234
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.88693294,
-          "spread": 0.79673823,
-          "score": 1.19224236
+          "bias": 0.86507966,
+          "spread": 0.74696168,
+          "score": 1.1429412
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.05900242,
-          "spread": 0.15183898,
-          "score": 0.16289985
+          "bias": -0.1088266,
+          "spread": 0.10522304,
+          "score": 0.1513774
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00448266,
-          "spread": 0.00389579,
-          "score": 0.00593897
+          "bias": -0.00245347,
+          "spread": 0.0035019,
+          "score": 0.00427584
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00104671,
-          "spread": 0.00146263,
-          "score": 0.00179858
+          "bias": 0.00313565,
+          "spread": 0.00303652,
+          "score": 0.00436495
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00013945,
-          "spread": 0.00152372,
-          "score": 0.00153009
+          "bias": 0.00210807,
+          "spread": 0.00309069,
+          "score": 0.00374116
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00133532,
-          "spread": 0.00122245,
-          "score": 0.00181038
+          "bias": 5.258e-05,
+          "spread": 0.00144984,
+          "score": 0.00145079
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": -0.00068486,
-          "spread": 0.00186728,
-          "score": 0.00198891
+          "bias": 0.00112696,
+          "spread": 0.00327063,
+          "score": 0.00345934
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.14918609,
-          "spread": 0.08805759,
-          "score": 0.17323576
+          "bias": -0.1435506,
+          "spread": 0.08791612,
+          "score": 0.16833305
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00745576,
-          "spread": 0.02034892,
-          "score": 0.0216718
+          "bias": 0.01100978,
+          "spread": 0.02492745,
+          "score": 0.02725056
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.04755519,
-          "spread": 0.0363992,
-          "score": 0.05988654
+          "bias": 0.06344936,
+          "spread": 0.04768338,
+          "score": 0.07936955
         },
         {
           "profile": "ti_dependent_cp",
@@ -3887,198 +3887,198 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00347535,
-          "spread": 0.00882782,
-          "score": 0.00948728
+          "bias": -0.00036152,
+          "spread": 0.00811569,
+          "score": 0.00812374
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00354229,
-          "spread": 0.00927576,
-          "score": 0.00992913
+          "bias": -0.00066411,
+          "spread": 0.00861912,
+          "score": 0.00864467
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00304986,
-          "spread": 0.00905295,
-          "score": 0.00955289
+          "bias": -0.00100225,
+          "spread": 0.00805782,
+          "score": 0.00811991
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00611557,
-          "spread": 0.00543753,
-          "score": 0.00818334
+          "bias": -0.00126301,
+          "spread": 0.0030625,
+          "score": 0.00331271
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.162932,
+          "bias": 0.14033036,
           "spread": 0.0,
-          "score": 0.162932
+          "score": 0.14033036
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.01856236,
-          "spread": 0.01147791,
-          "score": 0.02182438
+          "bias": -0.01184419,
+          "spread": 0.01364275,
+          "score": 0.01806681
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00160866,
-          "spread": 0.00631268,
-          "score": 0.00651442
+          "bias": 0.00395937,
+          "spread": 0.00567434,
+          "score": 0.00691916
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00855711,
-          "spread": 0.00380189,
-          "score": 0.00936368
+          "bias": -0.00425899,
+          "spread": 0.00213262,
+          "score": 0.00476309
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.0093185,
-          "spread": 0.01507683,
-          "score": 0.01772414
+          "bias": -0.00503126,
+          "spread": 0.0117479,
+          "score": 0.01277993
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": -0.0101933,
-          "spread": 0.0346538,
-          "score": 0.03612186
+          "bias": -0.0053997,
+          "spread": 0.02725628,
+          "score": 0.027786
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.05347693,
-          "spread": 0.07111013,
-          "score": 0.08897433
+          "bias": -0.03771078,
+          "spread": 0.05313258,
+          "score": 0.065155
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.00551058,
-          "spread": 0.05217365,
-          "score": 0.05246386
+          "bias": 0.05324166,
+          "spread": 0.10062625,
+          "score": 0.11384339
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.17287545,
-          "spread": 0.42040453,
-          "score": 0.45456121
+          "bias": 0.22392445,
+          "spread": 0.43889931,
+          "score": 0.49272179
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.15658092,
-          "spread": 0.87333648,
-          "score": 0.88726218
+          "bias": 0.07832105,
+          "spread": 0.89108057,
+          "score": 0.89451594
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.28147777,
-          "spread": 0.0,
-          "score": 0.28147777
+          "bias": -0.1355912,
+          "spread": 0.40996391,
+          "score": 0.4318048
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00275191,
-          "spread": 0.00467228,
-          "score": 0.00542247
+          "bias": 0.00111977,
+          "spread": 0.0079876,
+          "score": 0.00806571
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00257437,
-          "spread": 0.00649773,
-          "score": 0.00698913
+          "bias": 0.00742972,
+          "spread": 0.00908658,
+          "score": 0.01173741
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00783916,
-          "spread": 0.00947347,
-          "score": 0.0122963
+          "bias": 0.01230292,
+          "spread": 0.01033308,
+          "score": 0.01606657
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00093671,
-          "spread": 0.00704753,
-          "score": 0.00710951
+          "bias": 0.00213778,
+          "spread": 0.00832559,
+          "score": 0.00859567
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.009694,
-          "spread": 0.01559592,
-          "score": 0.01836318
+          "bias": 0.01385991,
+          "spread": 0.017404,
+          "score": 0.02224851
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.20471669,
-          "spread": 0.18083483,
-          "score": 0.2731486
+          "bias": -0.17028898,
+          "spread": 0.15659725,
+          "score": 0.23134614
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00907782,
-          "spread": 0.03982059,
-          "score": 0.04084221
+          "bias": 0.01650616,
+          "spread": 0.04397117,
+          "score": 0.04696719
         },
         {
           "profile": "ws_dependent_cp",
@@ -4103,36 +4103,36 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.01886602,
-          "spread": 0.02677444,
-          "score": 0.03275358
+          "bias": -0.01546282,
+          "spread": 0.01935687,
+          "score": 0.02477473
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.01429213,
-          "spread": 0.01649931,
-          "score": 0.02182871
+          "bias": -0.01213074,
+          "spread": 0.00965578,
+          "score": 0.01550449
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.01103663,
-          "spread": 0.01074639,
-          "score": 0.01540429
+          "bias": -0.00806681,
+          "spread": 0.00674079,
+          "score": 0.01051245
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00179816,
-          "spread": 0.00453889,
-          "score": 0.0048821
+          "bias": 0.00308915,
+          "spread": 0.00234129,
+          "score": 0.00387615
         },
         {
           "profile": "ws_dependent_cp",
@@ -4148,162 +4148,162 @@
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00995095,
-          "spread": 0.00970485,
-          "score": 0.01389984
+          "bias": -0.00410972,
+          "spread": 0.01053816,
+          "score": 0.01131117
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -9.06e-06,
-          "spread": 0.00398877,
-          "score": 0.00398878
+          "bias": 0.00476844,
+          "spread": 0.00325215,
+          "score": 0.00577187
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00348624,
-          "spread": 0.0038651,
-          "score": 0.00520508
+          "bias": 0.00068133,
+          "spread": 0.00245985,
+          "score": 0.00255246
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00108206,
-          "spread": 0.00940458,
-          "score": 0.00946662
+          "bias": 0.00349093,
+          "spread": 0.00776182,
+          "score": 0.00851073
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": -0.00102495,
-          "spread": 0.01480184,
-          "score": 0.01483728
+          "bias": 0.0081003,
+          "spread": 0.00916346,
+          "score": 0.01223045
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00305897,
-          "spread": 0.01612437,
-          "score": 0.01641197
+          "bias": 0.011943,
+          "spread": 0.01699373,
+          "score": 0.0207707
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.02699251,
-          "spread": 0.07735994,
-          "score": 0.08193385
+          "bias": 0.07202508,
+          "spread": 0.07506215,
+          "score": 0.10402855
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.03198228,
-          "spread": 0.22405948,
-          "score": 0.22633054
+          "bias": 0.12249703,
+          "spread": 0.19668757,
+          "score": 0.23171431
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.04959803,
-          "spread": 0.34027327,
-          "score": 0.34386896
+          "bias": -0.13082906,
+          "spread": 0.57679566,
+          "score": 0.59144693
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.14575092,
-          "spread": 0.04554098,
-          "score": 0.15270007
+          "bias": -0.05507076,
+          "spread": 0.16599528,
+          "score": 0.17489203
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00143202,
-          "spread": 0.00110699,
-          "score": 0.00181
+          "bias": 0.00292878,
+          "spread": 0.00329682,
+          "score": 0.00440986
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00237242,
-          "spread": 0.00286178,
-          "score": 0.00371728
+          "bias": 0.0074039,
+          "spread": 0.00605124,
+          "score": 0.00956218
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00433418,
-          "spread": 0.00369241,
-          "score": 0.00569377
+          "bias": 0.00945546,
+          "spread": 0.00655528,
+          "score": 0.01150554
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00225359,
-          "spread": 0.00380344,
-          "score": 0.00442095
+          "bias": 0.00561303,
+          "spread": 0.00592773,
+          "score": 0.00816358
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.02869758,
-          "spread": 0.04557696,
-          "score": 0.05385917
+          "bias": 0.03175349,
+          "spread": 0.04804918,
+          "score": 0.05759347
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.21688074,
-          "spread": 0.11708208,
-          "score": 0.24646596
+          "bias": -0.17378702,
+          "spread": 0.1139387,
+          "score": 0.2078075
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.01209983,
-          "spread": 0.04923724,
-          "score": 0.05070218
+          "bias": 0.0125808,
+          "spread": 0.05041758,
+          "score": 0.05196354
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.19181805,
+          "bias": 0.19460533,
           "spread": 0.0,
-          "score": 0.19181805
+          "score": 0.19460533
         },
         {
           "profile": "ws_dependent_cp",
@@ -4319,207 +4319,207 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00766966,
-          "spread": 0.00486662,
-          "score": 0.00908338
+          "bias": -0.00013107,
+          "spread": 0.00264825,
+          "score": 0.00265149
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.0071678,
-          "spread": 0.01160475,
-          "score": 0.01363993
+          "bias": -0.00338209,
+          "spread": 0.00752725,
+          "score": 0.00825215
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00234086,
-          "spread": 0.01144322,
-          "score": 0.0116802
+          "bias": 0.00077982,
+          "spread": 0.00855301,
+          "score": 0.00858849
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.0021932,
-          "spread": 0.00435369,
-          "score": 0.00487491
+          "bias": 4.993e-05,
+          "spread": 0.00348735,
+          "score": 0.0034877
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.20605606,
+          "bias": 0.19471163,
           "spread": 0.0,
-          "score": 0.20605606
+          "score": 0.19471163
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00620552,
-          "spread": 0.00283145,
-          "score": 0.00682097
+          "bias": -0.00390888,
+          "spread": 0.00135011,
+          "score": 0.00413548
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00299307,
-          "spread": 0.00400128,
-          "score": 0.00499687
+          "bias": -0.00094495,
+          "spread": 0.00244856,
+          "score": 0.00262457
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.0029679,
-          "spread": 0.00468792,
-          "score": 0.00554842
+          "bias": -0.00076758,
+          "spread": 0.00439319,
+          "score": 0.00445974
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.0002458,
-          "spread": 0.00568732,
-          "score": 0.00569263
+          "bias": 0.0024109,
+          "spread": 0.00519439,
+          "score": 0.00572662
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00679622,
-          "spread": 0.00886034,
-          "score": 0.01116665
+          "bias": 0.01066365,
+          "spread": 0.00550608,
+          "score": 0.01200126
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00063001,
-          "spread": 0.01591712,
-          "score": 0.01592958
+          "bias": 0.00185423,
+          "spread": 0.01287714,
+          "score": 0.01300996
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.05047697,
-          "spread": 0.06216465,
-          "score": 0.08007726
+          "bias": 0.05543473,
+          "spread": 0.05409508,
+          "score": 0.07745507
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.40068333,
-          "spread": 0.44896738,
-          "score": 0.60176311
+          "bias": 0.37454174,
+          "spread": 0.42088753,
+          "score": 0.56340734
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.74317653,
-          "spread": 0.99659105,
-          "score": 1.24318345
+          "bias": 0.72276906,
+          "spread": 0.94902298,
+          "score": 1.19291229
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.06506684,
-          "spread": 0.14527571,
-          "score": 0.15918143
+          "bias": -0.09978606,
+          "spread": 0.11453335,
+          "score": 0.15190505
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00023702,
-          "spread": 0.00314436,
-          "score": 0.00315328
+          "bias": 0.00184394,
+          "spread": 0.00250061,
+          "score": 0.00310696
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00042391,
-          "spread": 0.00191777,
-          "score": 0.00196406
+          "bias": 0.00255261,
+          "spread": 0.00329835,
+          "score": 0.00417073
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00025909,
-          "spread": 0.001912,
-          "score": 0.00192947
+          "bias": 0.0022068,
+          "spread": 0.00339982,
+          "score": 0.00405324
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00102969,
-          "spread": 0.00127996,
-          "score": 0.00164273
+          "bias": 0.00059934,
+          "spread": 0.00146572,
+          "score": 0.00158352
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00047775,
-          "spread": 0.00269558,
-          "score": 0.00273759
+          "bias": 0.00264927,
+          "spread": 0.00382884,
+          "score": 0.00465603
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.186608,
-          "spread": 0.11152137,
-          "score": 0.21739265
+          "bias": -0.18212567,
+          "spread": 0.11447043,
+          "score": 0.21511216
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.01149964,
-          "spread": 0.02150511,
-          "score": 0.0243867
+          "bias": 0.01540069,
+          "spread": 0.02569357,
+          "score": 0.02995565
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.05617746,
-          "spread": 0.03957729,
-          "score": 0.06871877
+          "bias": 0.07263917,
+          "spread": 0.05186623,
+          "score": 0.08925556
         },
         {
           "profile": "ws_dependent_cp",
@@ -4535,33 +4535,33 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00790112,
-          "spread": 0.01047095,
-          "score": 0.01311749
+          "bias": -0.00406282,
+          "spread": 0.00946504,
+          "score": 0.01030017
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00656539,
-          "spread": 0.00993222,
-          "score": 0.01190602
+          "bias": -0.00392771,
+          "spread": 0.00898242,
+          "score": 0.00980361
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00361782,
-          "spread": 0.00944471,
-          "score": 0.01011391
+          "bias": -0.00181579,
+          "spread": 0.00819261,
+          "score": 0.00839142
         }
       ]
     },
     "toggle": {
-      "recorded_utc": "2026-07-04T02:48:54Z",
-      "git_commit": "789bc1e-dirty",
+      "recorded_utc": "2026-07-04T11:35:03Z",
+      "git_commit": "1a478df-dirty",
       "n_replicates": 4,
       "seed": 0,
       "campaign_months": [
@@ -4585,9 +4585,9 @@
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00382878,
-          "spread": 0.00071257,
-          "score": 0.00389452
+          "bias": 0.0038551,
+          "spread": 0.0007212,
+          "score": 0.00392198
         },
         {
           "profile": "cp_0pct",
@@ -4603,162 +4603,162 @@
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00912415,
-          "spread": 0.00978747,
-          "score": 0.01338075
+          "bias": 0.00815341,
+          "spread": 0.00914232,
+          "score": 0.0122499
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00139116,
-          "spread": 0.0024915,
-          "score": 0.00285357
+          "bias": 0.00115072,
+          "spread": 0.00246391,
+          "score": 0.00271938
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00549256,
-          "spread": 0.00134928,
-          "score": 0.00565587
+          "bias": 0.00561839,
+          "spread": 0.00100403,
+          "score": 0.00570739
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00475539,
-          "spread": 0.0027443,
-          "score": 0.00549043
+          "bias": 0.00476869,
+          "spread": 0.00287545,
+          "score": 0.00556854
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00374856,
-          "spread": 0.00848477,
-          "score": 0.00927594
+          "bias": 0.00438002,
+          "spread": 0.00690211,
+          "score": 0.00817458
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.01415934,
-          "spread": 0.02767077,
-          "score": 0.03108309
+          "bias": -0.00367308,
+          "spread": 0.02924935,
+          "score": 0.02947908
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.00211677,
-          "spread": 0.02288477,
-          "score": 0.02298246
+          "bias": 0.02264724,
+          "spread": 0.04510757,
+          "score": 0.05047366
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.53155603,
-          "spread": 1.16284115,
-          "score": 1.27857395
+          "bias": 0.11322002,
+          "spread": 0.48261944,
+          "score": 0.49572199
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.18635072,
+          "bias": -0.22947675,
           "spread": 0.0,
-          "score": 0.18635072
+          "score": 0.22947675
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.00429358,
-          "spread": 0.04671581,
-          "score": 0.04691271
+          "bias": 0.02031195,
+          "spread": 0.09244361,
+          "score": 0.0946488
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.0017531,
-          "spread": 0.00144952,
-          "score": 0.00227475
+          "bias": 0.00183888,
+          "spread": 0.00154338,
+          "score": 0.00240073
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00175091,
-          "spread": 0.00145715,
-          "score": 0.00227793
+          "bias": 0.00194543,
+          "spread": 0.00111063,
+          "score": 0.00224013
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00047739,
-          "spread": 0.00268846,
-          "score": 0.00273051
+          "bias": 0.00043188,
+          "spread": 0.00225715,
+          "score": 0.00229809
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.0027389,
-          "spread": 0.00281769,
-          "score": 0.00392949
+          "bias": 0.00285231,
+          "spread": 0.00263784,
+          "score": 0.00388508
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00452619,
-          "spread": 0.02264225,
-          "score": 0.02309021
+          "bias": 0.00632726,
+          "spread": 0.0219825,
+          "score": 0.02287498
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.00410405,
-          "spread": 0.03646108,
-          "score": 0.03669133
+          "bias": 0.01717332,
+          "spread": 0.04181022,
+          "score": 0.04519974
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.06115453,
-          "spread": 0.06440884,
-          "score": 0.08881653
+          "bias": 0.06232471,
+          "spread": 0.06468672,
+          "score": 0.08982618
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.00489365,
-          "spread": 0.00108319,
-          "score": 0.0050121
+          "bias": -0.00603097,
+          "spread": 0.0049315,
+          "score": 0.00779053
         },
         {
           "profile": "cp_0pct",
@@ -4774,207 +4774,207 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00302529,
-          "spread": 0.01045046,
-          "score": 0.01087954
+          "bias": 0.00393045,
+          "spread": 0.01145493,
+          "score": 0.01211049
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.0073205,
-          "spread": 0.00355856,
-          "score": 0.0081396
+          "bias": 0.00704251,
+          "spread": 0.00289967,
+          "score": 0.0076161
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00514756,
-          "spread": 0.00609086,
-          "score": 0.00797471
+          "bias": 0.00500677,
+          "spread": 0.00623312,
+          "score": 0.00799497
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00145167,
-          "spread": 0.00154505,
-          "score": 0.00212003
+          "bias": 0.00166824,
+          "spread": 0.00160466,
+          "score": 0.00231473
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.04051854,
-          "spread": 0.03846156,
-          "score": 0.05586631
+          "bias": 0.08554035,
+          "spread": 0.01519602,
+          "score": 0.08687963
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00045327,
-          "spread": 0.01155318,
-          "score": 0.01156207
+          "bias": 4.873e-05,
+          "spread": 0.00998868,
+          "score": 0.0099888
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00025189,
-          "spread": 0.00181665,
-          "score": 0.00183403
+          "bias": -0.00014359,
+          "spread": 0.00166377,
+          "score": 0.00166995
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00277519,
-          "spread": 0.00163931,
-          "score": 0.0032232
+          "bias": 0.0030185,
+          "spread": 0.00160091,
+          "score": 0.00341676
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00110619,
-          "spread": 0.00224526,
-          "score": 0.00250297
+          "bias": 0.00138435,
+          "spread": 0.00229722,
+          "score": 0.0026821
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00525472,
-          "spread": 0.00588761,
-          "score": 0.00789152
+          "bias": 0.00558691,
+          "spread": 0.0073989,
+          "score": 0.00927132
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00479199,
-          "spread": 0.01890071,
-          "score": 0.01949872
+          "bias": 0.00334306,
+          "spread": 0.01985988,
+          "score": 0.02013929
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.03817535,
-          "spread": 0.02589119,
-          "score": 0.04612712
+          "bias": -0.02965958,
+          "spread": 0.02642557,
+          "score": 0.03972407
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.54793685,
-          "spread": 0.80695049,
-          "score": 0.97539935
+          "bias": 0.09157272,
+          "spread": 0.19098454,
+          "score": 0.21180335
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.52223968,
-          "spread": 0.42964532,
-          "score": 0.67626133
+          "bias": 0.37568049,
+          "spread": 0.51963013,
+          "score": 0.64121081
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.00168012,
-          "spread": 0.01373714,
-          "score": 0.0138395
+          "bias": -0.03599165,
+          "spread": 0.05651906,
+          "score": 0.06700599
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00053624,
-          "spread": 0.00205503,
-          "score": 0.00212384
+          "bias": 0.00057945,
+          "spread": 0.00187765,
+          "score": 0.00196503
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 2.048e-05,
-          "spread": 0.00137693,
-          "score": 0.00137708
+          "bias": 0.00030501,
+          "spread": 0.00146164,
+          "score": 0.00149312
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00056581,
-          "spread": 0.00234531,
-          "score": 0.0024126
+          "bias": -0.00032733,
+          "spread": 0.00226901,
+          "score": 0.0022925
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00060354,
-          "spread": 0.00196422,
-          "score": 0.00205485
+          "bias": 0.00103429,
+          "spread": 0.00183814,
+          "score": 0.00210915
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00351647,
-          "spread": 0.01012223,
-          "score": 0.01071564
+          "bias": 0.00426695,
+          "spread": 0.01110748,
+          "score": 0.01189886
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.00360509,
-          "spread": 0.01961839,
-          "score": 0.01994688
+          "bias": -0.00566799,
+          "spread": 0.02001039,
+          "score": 0.02079764
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00651952,
-          "spread": 0.00434953,
-          "score": 0.00783725
+          "bias": -0.00477806,
+          "spread": 0.00657067,
+          "score": 0.00812425
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.0105423,
-          "spread": 0.01020969,
-          "score": 0.01467575
+          "bias": 0.00955149,
+          "spread": 0.00943788,
+          "score": 0.01342775
         },
         {
           "profile": "cp_0pct",
@@ -4990,207 +4990,207 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.0025931,
-          "spread": 0.00321616,
-          "score": 0.00413133
+          "bias": 0.00285577,
+          "spread": 0.00346278,
+          "score": 0.00448847
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.0013913,
-          "spread": 0.00423172,
-          "score": 0.00445457
+          "bias": 0.00139782,
+          "spread": 0.00377824,
+          "score": 0.00402853
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00312628,
-          "spread": 0.0051747,
-          "score": 0.00604576
+          "bias": 0.00350729,
+          "spread": 0.00556946,
+          "score": 0.00658179
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.0011962,
-          "spread": 0.00166181,
-          "score": 0.00204756
+          "bias": 0.00116152,
+          "spread": 0.00149745,
+          "score": 0.00189512
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.05061872,
-          "spread": 0.01167184,
-          "score": 0.05194696
+          "bias": 0.06947979,
+          "spread": 3.671e-05,
+          "score": 0.0694798
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00176762,
-          "spread": 0.00518217,
-          "score": 0.00547534
+          "bias": 0.00103448,
+          "spread": 0.00525216,
+          "score": 0.00535307
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00181887,
-          "spread": 0.00155731,
-          "score": 0.00239447
+          "bias": 0.00182005,
+          "spread": 0.00131157,
+          "score": 0.00224339
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00123018,
-          "spread": 0.00193753,
-          "score": 0.00229507
+          "bias": 0.00111361,
+          "spread": 0.00181386,
+          "score": 0.00212843
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00112518,
-          "spread": 0.00200786,
-          "score": 0.00230164
+          "bias": -0.00092276,
+          "spread": 0.00189833,
+          "score": 0.00211072
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00501964,
-          "spread": 0.00705376,
-          "score": 0.0086575
+          "bias": 0.00495699,
+          "spread": 0.00736656,
+          "score": 0.00887907
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00648093,
-          "spread": 0.01822605,
-          "score": 0.01934403
+          "bias": -0.00722689,
+          "spread": 0.02101058,
+          "score": 0.02221874
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.02147776,
-          "spread": 0.02196043,
-          "score": 0.03071734
+          "bias": 0.01925833,
+          "spread": 0.01513403,
+          "score": 0.02449331
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.04765378,
-          "spread": 0.28290728,
-          "score": 0.28689268
+          "bias": 0.01011593,
+          "spread": 0.29187106,
+          "score": 0.29204631
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.07543502,
+          "bias": -0.07211826,
           "spread": 0.0,
-          "score": 0.07543502
+          "score": 0.07211826
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.05000757,
-          "spread": 0.031735,
-          "score": 0.05922725
+          "bias": -0.01565797,
+          "spread": 0.01913503,
+          "score": 0.02472491
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00067557,
-          "spread": 0.00240732,
-          "score": 0.00250031
+          "bias": -0.00037587,
+          "spread": 0.00221597,
+          "score": 0.00224762
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00095659,
-          "spread": 0.00079251,
-          "score": 0.00124223
+          "bias": 0.00081866,
+          "spread": 0.00081002,
+          "score": 0.00115167
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00011274,
-          "spread": 0.00147593,
-          "score": 0.00148023
+          "bias": -0.00027179,
+          "spread": 0.00179072,
+          "score": 0.00181123
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00034164,
-          "spread": 0.00155137,
-          "score": 0.00158854
+          "bias": 0.00038866,
+          "spread": 0.00175262,
+          "score": 0.0017952
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00461324,
-          "spread": 0.00969486,
-          "score": 0.01073649
+          "bias": 0.00598241,
+          "spread": 0.01180151,
+          "score": 0.01323121
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.00291273,
-          "spread": 0.02065521,
-          "score": 0.02085957
+          "bias": 0.00219279,
+          "spread": 0.02109438,
+          "score": 0.02120805
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00145514,
-          "spread": 0.00707978,
-          "score": 0.00722777
+          "bias": 0.00151595,
+          "spread": 0.00601706,
+          "score": 0.00620509
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.0122773,
-          "spread": 0.03719934,
-          "score": 0.03917299
+          "bias": -0.02011108,
+          "spread": 0.03120267,
+          "score": 0.03712226
         },
         {
           "profile": "cp_0pct",
@@ -5206,252 +5206,252 @@
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00063138,
-          "spread": 0.00372325,
-          "score": 0.0037764
+          "bias": 3.489e-05,
+          "spread": 0.00403119,
+          "score": 0.00403134
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00191729,
-          "spread": 0.00287129,
-          "score": 0.00345258
+          "bias": 0.00191641,
+          "spread": 0.00240117,
+          "score": 0.00307217
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00288423,
-          "spread": 0.00409067,
-          "score": 0.00500524
+          "bias": 0.00256596,
+          "spread": 0.00394392,
+          "score": 0.00470517
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00076877,
-          "spread": 0.00101962,
-          "score": 0.00127696
+          "bias": 0.00081363,
+          "spread": 0.00106016,
+          "score": 0.00133639
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.01859592,
-          "spread": 0.02086086,
-          "score": 0.02794609
+          "bias": 0.01015523,
+          "spread": 0.01062758,
+          "score": 0.01469946
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00078911,
-          "spread": 0.0033031,
-          "score": 0.00339606
+          "bias": 0.00058764,
+          "spread": 0.0039283,
+          "score": 0.00397201
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00080831,
-          "spread": 0.00067271,
-          "score": 0.00105162
+          "bias": 0.00094976,
+          "spread": 0.0007022,
+          "score": 0.00118116
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00038974,
-          "spread": 0.00120537,
-          "score": 0.00126681
+          "bias": 0.00031866,
+          "spread": 0.00127709,
+          "score": 0.00131625
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.0005658,
-          "spread": 0.0025775,
-          "score": 0.00263887
+          "bias": 0.00076528,
+          "spread": 0.00254909,
+          "score": 0.00266149
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00586541,
-          "spread": 0.00573102,
-          "score": 0.00820046
+          "bias": 0.00625193,
+          "spread": 0.00535097,
+          "score": 0.00822919
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00513399,
-          "spread": 0.02519923,
-          "score": 0.0257169
+          "bias": -0.00603563,
+          "spread": 0.0263522,
+          "score": 0.02703456
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.00338803,
-          "spread": 0.02787695,
-          "score": 0.02808208
+          "bias": -0.00331842,
+          "spread": 0.0207453,
+          "score": 0.02100903
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.00716873,
-          "spread": 0.18195543,
-          "score": 0.1820966
+          "bias": 0.01390671,
+          "spread": 0.21942682,
+          "score": 0.21986706
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.19912049,
-          "spread": 0.13106473,
-          "score": 0.238384
+          "bias": -0.18476591,
+          "spread": 0.12878182,
+          "score": 0.22521812
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.00793166,
-          "spread": 0.04802201,
-          "score": 0.04867263
+          "bias": -0.01214075,
+          "spread": 0.03355661,
+          "score": 0.03568535
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -5.619e-05,
-          "spread": 0.001976,
-          "score": 0.0019768
+          "bias": -9.527e-05,
+          "spread": 0.00216331,
+          "score": 0.00216541
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00128386,
-          "spread": 0.00077982,
-          "score": 0.00150214
+          "bias": 0.00124966,
+          "spread": 0.00059968,
+          "score": 0.0013861
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00053019,
-          "spread": 0.00121547,
-          "score": 0.00132607
+          "bias": -0.00057999,
+          "spread": 0.00107188,
+          "score": 0.00121874
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00012278,
-          "spread": 0.00075049,
-          "score": 0.00076047
+          "bias": 0.00014203,
+          "spread": 0.00082034,
+          "score": 0.00083254
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": -0.00099672,
-          "spread": 0.00269039,
-          "score": 0.00286908
+          "bias": -0.00065785,
+          "spread": 0.00262482,
+          "score": 0.00270601
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.00472494,
-          "spread": 0.01529365,
-          "score": 0.0160069
+          "bias": 0.00052236,
+          "spread": 0.01443977,
+          "score": 0.01444922
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00553402,
-          "spread": 0.0041753,
-          "score": 0.00693243
+          "bias": -0.00438772,
+          "spread": 0.00334018,
+          "score": 0.00551443
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.03458825,
-          "spread": 0.0272283,
-          "score": 0.04401962
+          "bias": -0.03177083,
+          "spread": 0.02512779,
+          "score": 0.04050668
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
-          "bias": 0.02471168,
+          "bias": 0.02083987,
           "spread": 0.0,
-          "score": 0.02471168
+          "score": 0.02083987
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00060461,
-          "spread": 0.0049941,
-          "score": 0.00503057
+          "bias": 0.00165648,
+          "spread": 0.00557659,
+          "score": 0.00581741
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00276527,
-          "spread": 0.00180198,
-          "score": 0.00330059
+          "bias": 0.00285818,
+          "spread": 0.00197947,
+          "score": 0.00347671
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00085462,
-          "spread": 0.0032575,
-          "score": 0.00336774
+          "bias": 0.00079335,
+          "spread": 0.00306752,
+          "score": 0.00316846
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00364936,
-          "spread": 0.00068421,
-          "score": 0.00371294
+          "bias": 0.00367405,
+          "spread": 0.0006935,
+          "score": 0.00373893
         },
         {
           "profile": "cp_minus_10pct",
@@ -5467,162 +5467,162 @@
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00742793,
-          "spread": 0.01102315,
-          "score": 0.01329226
+          "bias": 0.00729472,
+          "spread": 0.00957345,
+          "score": 0.01203594
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00062883,
-          "spread": 0.00221527,
-          "score": 0.00230279
+          "bias": -0.00087846,
+          "spread": 0.0022492,
+          "score": 0.00241466
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00526864,
-          "spread": 0.00212801,
-          "score": 0.00568217
+          "bias": 0.00534453,
+          "spread": 0.00176876,
+          "score": 0.00562961
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00753313,
-          "spread": 0.00254172,
-          "score": 0.00795037
+          "bias": 0.00752509,
+          "spread": 0.00310285,
+          "score": 0.0081397
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00717831,
-          "spread": 0.00890075,
-          "score": 0.01143466
+          "bias": 0.00792915,
+          "spread": 0.0076232,
+          "score": 0.0109993
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.0097624,
-          "spread": 0.02763703,
-          "score": 0.02931057
+          "bias": 0.00172559,
+          "spread": 0.02796102,
+          "score": 0.02801421
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.00892362,
-          "spread": 0.02727317,
-          "score": 0.02869594
+          "bias": 0.03322946,
+          "spread": 0.04530635,
+          "score": 0.05618597
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.65801968,
-          "spread": 0.70471102,
-          "score": 0.96416157
+          "bias": 0.2669934,
+          "spread": 0.21611722,
+          "score": 0.34349983
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.04914662,
+          "bias": -0.16955813,
           "spread": 0.0,
-          "score": 0.04914662
+          "score": 0.16955813
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.00545718,
-          "spread": 0.0464651,
-          "score": 0.04678447
+          "bias": 0.03807663,
+          "spread": 0.08467439,
+          "score": 0.0928417
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00442514,
-          "spread": 0.00260038,
-          "score": 0.00513263
+          "bias": 0.00475917,
+          "spread": 0.00269822,
+          "score": 0.00547084
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00395129,
-          "spread": 0.00144662,
-          "score": 0.00420778
+          "bias": -0.00372832,
+          "spread": 0.00103078,
+          "score": 0.00386819
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00162072,
-          "spread": 0.00184381,
-          "score": 0.00245487
+          "bias": -0.0016975,
+          "spread": 0.00173659,
+          "score": 0.00242842
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00179258,
-          "spread": 0.00264263,
-          "score": 0.00319325
+          "bias": 0.00181111,
+          "spread": 0.00229297,
+          "score": 0.00292196
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00431439,
-          "spread": 0.02642064,
-          "score": 0.02677059
+          "bias": 0.00566659,
+          "spread": 0.02592867,
+          "score": 0.02654065
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.01807881,
-          "spread": 0.04199386,
-          "score": 0.0457201
+          "bias": 0.03251148,
+          "spread": 0.04539132,
+          "score": 0.0558334
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.07137476,
-          "spread": 0.07509777,
-          "score": 0.10360517
+          "bias": 0.07106752,
+          "spread": 0.07475615,
+          "score": 0.10314589
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.00230447,
-          "spread": 0.01609895,
-          "score": 0.01626305
+          "bias": -0.00263626,
+          "spread": 0.01715625,
+          "score": 0.01735762
         },
         {
           "profile": "cp_minus_10pct",
@@ -5638,207 +5638,207 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00205541,
-          "spread": 0.00958278,
-          "score": 0.00980074
+          "bias": 0.00341785,
+          "spread": 0.01046127,
+          "score": 0.01100545
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00669977,
-          "spread": 0.00282767,
-          "score": 0.00727204
+          "bias": 0.00623948,
+          "spread": 0.00230983,
+          "score": 0.0066533
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00659048,
-          "spread": 0.00618949,
-          "score": 0.00904125
+          "bias": 0.00623533,
+          "spread": 0.0061841,
+          "score": 0.00878194
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00145906,
-          "spread": 0.00145398,
-          "score": 0.00205984
+          "bias": 0.00166124,
+          "spread": 0.00150904,
+          "score": 0.00224431
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.03696118,
-          "spread": 0.03714049,
-          "score": 0.05239795
+          "bias": 0.07625808,
+          "spread": 0.00994028,
+          "score": 0.07690321
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00024632,
-          "spread": 0.01133615,
-          "score": 0.01133882
+          "bias": 0.00023161,
+          "spread": 0.01062233,
+          "score": 0.01062485
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00151924,
-          "spread": 0.00204543,
-          "score": 0.00254791
+          "bias": -0.00145461,
+          "spread": 0.00198255,
+          "score": 0.00245894
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.0027662,
-          "spread": 0.00102188,
-          "score": 0.00294892
+          "bias": 0.00301022,
+          "spread": 0.00099207,
+          "score": 0.00316948
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.0030959,
-          "spread": 0.00215776,
-          "score": 0.00377366
+          "bias": 0.00336566,
+          "spread": 0.00225574,
+          "score": 0.00405167
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00849134,
-          "spread": 0.00593335,
-          "score": 0.01035893
+          "bias": 0.00865511,
+          "spread": 0.00702797,
+          "score": 0.01114914
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00801353,
-          "spread": 0.01511539,
-          "score": 0.01710823
+          "bias": 0.00701585,
+          "spread": 0.01692721,
+          "score": 0.01832355
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.02130341,
-          "spread": 0.02856927,
-          "score": 0.0356376
+          "bias": -0.01336663,
+          "spread": 0.02972832,
+          "score": 0.03259509
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.09715598,
-          "spread": 0.13192813,
-          "score": 0.16384235
+          "bias": 0.15664088,
+          "spread": 0.081408,
+          "score": 0.17653223
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.50136254,
-          "spread": 0.35673996,
-          "score": 0.61532739
+          "bias": 0.33209945,
+          "spread": 0.50938131,
+          "score": 0.60807842
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.01167758,
-          "spread": 0.00952953,
-          "score": 0.01507242
+          "bias": -0.02426419,
+          "spread": 0.03979664,
+          "score": 0.04661034
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00401529,
-          "spread": 0.00180705,
-          "score": 0.00440318
+          "bias": 0.00406445,
+          "spread": 0.00206177,
+          "score": 0.00455749
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00551639,
-          "spread": 0.00080871,
-          "score": 0.00557535
+          "bias": -0.00525756,
+          "spread": 0.00124329,
+          "score": 0.00540257
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00278203,
-          "spread": 0.00209422,
-          "score": 0.00348216
+          "bias": -0.00252498,
+          "spread": 0.0021193,
+          "score": 0.00329651
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00018172,
-          "spread": 0.00128905,
-          "score": 0.0013018
+          "bias": 0.00012629,
+          "spread": 0.00156127,
+          "score": 0.00156637
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00418833,
-          "spread": 0.011851,
-          "score": 0.01256934
+          "bias": 0.00475532,
+          "spread": 0.01275614,
+          "score": 0.01361367
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.03005714,
-          "spread": 0.04489684,
-          "score": 0.05402924
+          "bias": 0.02658111,
+          "spread": 0.04121688,
+          "score": 0.04904475
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00288426,
-          "spread": 0.00860095,
-          "score": 0.00907167
+          "bias": -0.00097331,
+          "spread": 0.0122304,
+          "score": 0.01226906
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.02548896,
-          "spread": 0.01072605,
-          "score": 0.02765385
+          "bias": 0.02436996,
+          "spread": 0.00989574,
+          "score": 0.02630248
         },
         {
           "profile": "cp_minus_10pct",
@@ -5854,207 +5854,207 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00214136,
-          "spread": 0.00297953,
-          "score": 0.0036692
+          "bias": 0.00256449,
+          "spread": 0.00325645,
+          "score": 0.00414501
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00106713,
-          "spread": 0.00389613,
-          "score": 0.00403963
+          "bias": 0.00102136,
+          "spread": 0.003372,
+          "score": 0.00352329
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00439611,
-          "spread": 0.00483169,
-          "score": 0.0065323
+          "bias": 0.00474629,
+          "spread": 0.0051996,
+          "score": 0.00704011
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 9,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00119914,
-          "spread": 0.00156504,
-          "score": 0.00197162
+          "bias": 0.0011672,
+          "spread": 0.00141164,
+          "score": 0.00183169
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.05678738,
-          "spread": 0.01954476,
-          "score": 0.06005668
+          "bias": 0.05293025,
+          "spread": 0.0073713,
+          "score": 0.05344107
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00066378,
-          "spread": 0.00604108,
-          "score": 0.00607744
+          "bias": -0.0002229,
+          "spread": 0.00593667,
+          "score": 0.00594086
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00079098,
-          "spread": 0.00186226,
-          "score": 0.00202328
+          "bias": 0.00083815,
+          "spread": 0.00162531,
+          "score": 0.0018287
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00107266,
-          "spread": 0.00105271,
-          "score": 0.00150293
+          "bias": 0.0010264,
+          "spread": 0.0010564,
+          "score": 0.00147291
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00128715,
-          "spread": 0.00172451,
-          "score": 0.0021519
+          "bias": 0.0013471,
+          "spread": 0.00131689,
+          "score": 0.00188385
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00827487,
-          "spread": 0.00760233,
-          "score": 0.01123695
+          "bias": 0.00777963,
+          "spread": 0.00747686,
+          "score": 0.01079009
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.0007299,
-          "spread": 0.01659802,
-          "score": 0.01661406
+          "bias": -0.00092824,
+          "spread": 0.01802584,
+          "score": 0.01804972
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.02370732,
-          "spread": 0.01997036,
-          "score": 0.03099762
+          "bias": 0.02423445,
+          "spread": 0.01727606,
+          "score": 0.0297619
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.07100463,
-          "spread": 0.22843025,
-          "score": 0.23921128
+          "bias": 0.05044412,
+          "spread": 0.24606664,
+          "score": 0.251184
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.06471719,
+          "bias": -0.06263651,
           "spread": 0.0,
-          "score": 0.06471719
+          "score": 0.06263651
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.03657571,
-          "spread": 0.02464557,
-          "score": 0.04410427
+          "bias": -0.01167721,
+          "spread": 0.01427837,
+          "score": 0.0184453
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00294977,
-          "spread": 0.00170501,
-          "score": 0.00340709
+          "bias": 0.00298924,
+          "spread": 0.00168541,
+          "score": 0.00343164
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00411773,
-          "spread": 0.00048568,
-          "score": 0.00414628
+          "bias": -0.00405385,
+          "spread": 0.00063393,
+          "score": 0.00410312
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00188693,
-          "spread": 0.00145051,
-          "score": 0.00238002
+          "bias": -0.00205205,
+          "spread": 0.00181416,
+          "score": 0.00273899
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00013953,
-          "spread": 0.00133902,
-          "score": 0.00134627
+          "bias": -2.06e-06,
+          "spread": 0.00163092,
+          "score": 0.00163092
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00592145,
-          "spread": 0.01096924,
-          "score": 0.01246547
+          "bias": 0.00731269,
+          "spread": 0.01267913,
+          "score": 0.01463679
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.03119048,
-          "spread": 0.03523563,
-          "score": 0.04705736
+          "bias": 0.03109868,
+          "spread": 0.03153845,
+          "score": 0.04429223
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00385461,
-          "spread": 0.00416275,
-          "score": 0.00567332
+          "bias": 0.00527206,
+          "spread": 0.00590496,
+          "score": 0.00791601
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.00022302,
-          "spread": 0.03642657,
-          "score": 0.03642725
+          "bias": -0.00607625,
+          "spread": 0.03167156,
+          "score": 0.03224916
         },
         {
           "profile": "cp_minus_10pct",
@@ -6070,252 +6070,252 @@
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00070751,
-          "spread": 0.00365014,
-          "score": 0.00371808
+          "bias": -0.00022556,
+          "spread": 0.00400518,
+          "score": 0.00401153
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00163477,
-          "spread": 0.00256862,
-          "score": 0.00304471
+          "bias": 0.00174022,
+          "spread": 0.00235921,
+          "score": 0.00293159
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00395671,
-          "spread": 0.00382824,
-          "score": 0.00550554
+          "bias": 0.0036466,
+          "spread": 0.00377743,
+          "score": 0.0052504
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00080278,
-          "spread": 0.00098077,
-          "score": 0.00126743
+          "bias": 0.00084467,
+          "spread": 0.00101934,
+          "score": 0.00132382
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.0157979,
-          "spread": 0.0116396,
-          "score": 0.01962279
+          "bias": 0.01205237,
+          "spread": 0.00417338,
+          "score": 0.01275448
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.0003872,
-          "spread": 0.00428975,
-          "score": 0.00430718
+          "bias": -0.00020625,
+          "spread": 0.00450048,
+          "score": 0.0045052
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.0003882,
-          "spread": 0.00101314,
-          "score": 0.00108497
+          "bias": -0.00021994,
+          "spread": 0.00105454,
+          "score": 0.00107723
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00038509,
-          "spread": 0.00061643,
-          "score": 0.00072683
+          "bias": 0.00043962,
+          "spread": 0.00069179,
+          "score": 0.00081966
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00299684,
-          "spread": 0.00185392,
-          "score": 0.00352393
+          "bias": 0.00286353,
+          "spread": 0.00176481,
+          "score": 0.00336368
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00956486,
-          "spread": 0.00623533,
-          "score": 0.01141778
+          "bias": 0.00951212,
+          "spread": 0.00572226,
+          "score": 0.01110066
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00189586,
-          "spread": 0.02188078,
-          "score": 0.02196276
+          "bias": 0.00085021,
+          "spread": 0.02233342,
+          "score": 0.02234959
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.00356456,
-          "spread": 0.02593769,
-          "score": 0.02618148
+          "bias": 0.00239784,
+          "spread": 0.01964217,
+          "score": 0.01978799
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.02107486,
-          "spread": 0.17358316,
-          "score": 0.17485784
+          "bias": 0.02428565,
+          "spread": 0.19636587,
+          "score": 0.19786194
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.03181559,
+          "bias": -0.04594679,
           "spread": 0.0,
-          "score": 0.03181559
+          "score": 0.04594679
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.00566276,
-          "spread": 0.04929042,
-          "score": 0.04961464
+          "bias": -0.00427666,
+          "spread": 0.03169762,
+          "score": 0.03198483
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00355149,
-          "spread": 0.00138078,
-          "score": 0.00381047
+          "bias": 0.00351488,
+          "spread": 0.00140586,
+          "score": 0.00378561
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00329039,
-          "spread": 0.00088337,
-          "score": 0.0034069
+          "bias": -0.0031547,
+          "spread": 0.00064491,
+          "score": 0.00321994
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00223307,
-          "spread": 0.00117574,
-          "score": 0.00252368
+          "bias": -0.00214299,
+          "spread": 0.00091904,
+          "score": 0.00233175
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00047603,
-          "spread": 0.00073833,
-          "score": 0.00087849
+          "bias": -0.00054218,
+          "spread": 0.00072594,
+          "score": 0.00090606
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00021199,
-          "spread": 0.00158852,
-          "score": 0.0016026
+          "bias": 0.00052908,
+          "spread": 0.00135648,
+          "score": 0.00145601
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.03020777,
-          "spread": 0.03952326,
-          "score": 0.04974533
+          "bias": 0.02866544,
+          "spread": 0.03652193,
+          "score": 0.04642799
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.0024936,
-          "spread": 0.00257492,
-          "score": 0.00358445
+          "bias": -0.00117356,
+          "spread": 0.00216958,
+          "score": 0.00246665
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.02893845,
-          "spread": 0.02722839,
-          "score": 0.03973436
+          "bias": -0.0260846,
+          "spread": 0.02557641,
+          "score": 0.03653162
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
-          "bias": 0.02530955,
+          "bias": 0.0228982,
           "spread": 0.0,
-          "score": 0.02530955
+          "score": 0.0228982
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00085665,
-          "spread": 0.00455179,
-          "score": 0.0046317
+          "bias": 0.00126004,
+          "spread": 0.00467157,
+          "score": 0.00483852
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00241773,
-          "spread": 0.00171743,
-          "score": 0.00296563
+          "bias": 0.00221702,
+          "spread": 0.00170879,
+          "score": 0.00279913
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00205838,
-          "spread": 0.00327801,
-          "score": 0.0038707
+          "bias": 0.00211025,
+          "spread": 0.00316253,
+          "score": 0.00380194
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.0040082,
-          "spread": 0.00074342,
-          "score": 0.00407656
+          "bias": 0.00403615,
+          "spread": 0.00075129,
+          "score": 0.00410547
         },
         {
           "profile": "cp_plus_10pct",
@@ -6331,162 +6331,162 @@
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00959606,
-          "spread": 0.01101566,
-          "score": 0.01460921
+          "bias": 0.00855611,
+          "spread": 0.01029621,
+          "score": 0.01338727
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00309527,
-          "spread": 0.00284748,
-          "score": 0.00420581
+          "bias": 0.00292001,
+          "spread": 0.00304946,
+          "score": 0.00422204
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00587813,
-          "spread": 0.00142815,
-          "score": 0.00604913
+          "bias": 0.00580916,
+          "spread": 0.00122881,
+          "score": 0.0059377
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.0018644,
-          "spread": 0.00246093,
-          "score": 0.00308742
+          "bias": 0.00222115,
+          "spread": 0.00277908,
+          "score": 0.00355764
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00118892,
-          "spread": 0.00763488,
-          "score": 0.0077269
+          "bias": 0.00209072,
+          "spread": 0.00727813,
+          "score": 0.00757247
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.01897265,
-          "spread": 0.02743657,
-          "score": 0.03335755
+          "bias": -0.00785741,
+          "spread": 0.02798588,
+          "score": 0.029068
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.01889337,
-          "spread": 0.01574681,
-          "score": 0.02459515
+          "bias": 0.01262233,
+          "spread": 0.04641039,
+          "score": 0.04809624
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.191383,
-          "spread": 1.612965,
-          "score": 1.62427939
+          "bias": -0.20850347,
+          "spread": 1.08591181,
+          "score": 1.10574778
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.06663591,
-          "spread": 0.26981476,
-          "score": 0.27792148
+          "bias": 0.05950144,
+          "spread": 0.28140171,
+          "score": 0.28762362
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.0079944,
-          "spread": 0.04948985,
-          "score": 0.05013138
+          "bias": 0.01528655,
+          "spread": 0.07089151,
+          "score": 0.07252093
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00145852,
-          "spread": 0.00167378,
-          "score": 0.0022201
+          "bias": -0.00180586,
+          "spread": 0.00136306,
+          "score": 0.00226254
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00736441,
-          "spread": 0.00181472,
-          "score": 0.00758471
+          "bias": 0.00770701,
+          "spread": 0.00164469,
+          "score": 0.00788054
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00244968,
-          "spread": 0.00307073,
-          "score": 0.00392814
+          "bias": 0.00243351,
+          "spread": 0.00287535,
+          "score": 0.00376691
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.0036998,
-          "spread": 0.0033936,
-          "score": 0.00502046
+          "bias": 0.00319723,
+          "spread": 0.00285105,
+          "score": 0.00428378
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00411053,
-          "spread": 0.01907687,
-          "score": 0.01951469
+          "bias": 0.00681603,
+          "spread": 0.01799309,
+          "score": 0.01924083
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.01196371,
-          "spread": 0.03628781,
-          "score": 0.0382091
+          "bias": 0.00047033,
+          "spread": 0.04286446,
+          "score": 0.04286704
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.05247157,
-          "spread": 0.05495562,
-          "score": 0.0759828
+          "bias": 0.05086297,
+          "spread": 0.05283434,
+          "score": 0.07333832
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.01317814,
-          "spread": 0.00457167,
-          "score": 0.0139486
+          "bias": -0.01243128,
+          "spread": 0.00242625,
+          "score": 0.01266583
         },
         {
           "profile": "cp_plus_10pct",
@@ -6502,207 +6502,207 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00409944,
-          "spread": 0.01048005,
-          "score": 0.0112533
+          "bias": 0.00529972,
+          "spread": 0.01195483,
+          "score": 0.01307688
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00805516,
-          "spread": 0.00403738,
-          "score": 0.00901033
+          "bias": 0.00794592,
+          "spread": 0.00355446,
+          "score": 0.0087047
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00367309,
-          "spread": 0.00639725,
-          "score": 0.00737675
+          "bias": 0.00368187,
+          "spread": 0.00657171,
+          "score": 0.00753283
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00144427,
-          "spread": 0.00163612,
-          "score": 0.00218238
+          "bias": 0.00167524,
+          "spread": 0.00170028,
+          "score": 0.00238692
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.01900639,
-          "spread": 0.02598234,
-          "score": 0.03219201
+          "bias": 0.06932889,
+          "spread": 0.00034058,
+          "score": 0.06932973
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00061063,
-          "spread": 0.01161648,
-          "score": 0.01163252
+          "bias": 0.00053167,
+          "spread": 0.01051256,
+          "score": 0.01052599
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00098706,
-          "spread": 0.0015616,
-          "score": 0.0018474
+          "bias": 0.0011067,
+          "spread": 0.00136156,
+          "score": 0.0017546
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00269624,
-          "spread": 0.0026148,
-          "score": 0.00375591
+          "bias": 0.0029492,
+          "spread": 0.00261286,
+          "score": 0.00394016
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00104517,
-          "spread": 0.00276149,
-          "score": 0.00295266
+          "bias": -0.00078046,
+          "spread": 0.00295904,
+          "score": 0.00306023
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00268483,
-          "spread": 0.0057049,
-          "score": 0.00630509
+          "bias": 0.0023145,
+          "spread": 0.00672635,
+          "score": 0.00711341
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00295385,
-          "spread": 0.02391761,
-          "score": 0.02409932
+          "bias": 0.00015489,
+          "spread": 0.02489727,
+          "score": 0.02489775
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.05770845,
-          "spread": 0.02822254,
-          "score": 0.06424
+          "bias": -0.04907767,
+          "spread": 0.02958052,
+          "score": 0.05730292
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.92738805,
-          "spread": 1.58622499,
-          "score": 1.83743254
+          "bias": 0.01251598,
+          "spread": 0.31857177,
+          "score": 0.31881754
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.60505584,
-          "spread": 0.47472063,
-          "score": 0.76905932
+          "bias": 0.44008123,
+          "spread": 0.61149813,
+          "score": 0.75339329
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.01205914,
-          "spread": 0.01393833,
-          "score": 0.01843095
+          "bias": -0.04045651,
+          "spread": 0.06020368,
+          "score": 0.07253422
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00294177,
-          "spread": 0.00279153,
-          "score": 0.00405544
+          "bias": -0.00291088,
+          "spread": 0.00246373,
+          "score": 0.00381355
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00497137,
-          "spread": 0.00168264,
-          "score": 0.00524841
+          "bias": 0.00538352,
+          "spread": 0.00188219,
+          "score": 0.00570306
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00146744,
-          "spread": 0.00266471,
-          "score": 0.00304205
+          "bias": 0.00151453,
+          "spread": 0.00253472,
+          "score": 0.00295273
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00099538,
-          "spread": 0.00256317,
-          "score": 0.00274966
+          "bias": 0.00127254,
+          "spread": 0.00259867,
+          "score": 0.00289352
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00273732,
-          "spread": 0.00866636,
-          "score": 0.00908839
+          "bias": 0.00331403,
+          "spread": 0.00947352,
+          "score": 0.01003645
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.03343313,
-          "spread": 0.03905863,
-          "score": 0.05141353
+          "bias": -0.03890832,
+          "spread": 0.04495671,
+          "score": 0.05945556
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.01072096,
-          "spread": 0.00653446,
-          "score": 0.0125554
+          "bias": -0.00842212,
+          "spread": 0.00463819,
+          "score": 0.00961483
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.00531836,
-          "spread": 0.00919757,
-          "score": 0.01062451
+          "bias": -0.00446222,
+          "spread": 0.01032818,
+          "score": 0.01125089
         },
         {
           "profile": "cp_plus_10pct",
@@ -6718,210 +6718,1074 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00279132,
-          "spread": 0.00350476,
-          "score": 0.00448049
+          "bias": 0.00291001,
+          "spread": 0.00406977,
+          "score": 0.00500312
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00142065,
-          "spread": 0.00447801,
-          "score": 0.00469796
+          "bias": 0.00181993,
+          "spread": 0.00381341,
+          "score": 0.00422543
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00205756,
-          "spread": 0.00524916,
-          "score": 0.00563802
+          "bias": 0.00225913,
+          "spread": 0.00584531,
+          "score": 0.00626668
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 9,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00119327,
-          "spread": 0.00175863,
-          "score": 0.00212525
+          "bias": 0.00115584,
+          "spread": 0.00158331,
+          "score": 0.00196031
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.0412164,
-          "spread": 0.01024744,
-          "score": 0.04247118
+          "bias": 0.06678355,
+          "spread": 0.00788618,
+          "score": 0.06724756
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00314398,
-          "spread": 0.0043378,
-          "score": 0.00535734
+          "bias": 0.00219814,
+          "spread": 0.00475117,
+          "score": 0.00523502
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00277668,
-          "spread": 0.00161273,
-          "score": 0.00321105
+          "bias": 0.00275856,
+          "spread": 0.00133674,
+          "score": 0.00306538
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00139693,
-          "spread": 0.00286997,
-          "score": 0.00319189
+          "bias": 0.00123973,
+          "spread": 0.00279977,
+          "score": 0.00306197
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00349746,
-          "spread": 0.00251571,
-          "score": 0.00430825
+          "bias": -0.00340775,
+          "spread": 0.00241918,
+          "score": 0.00417914
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.0017191,
-          "spread": 0.00673,
-          "score": 0.00694609
+          "bias": 0.00203171,
+          "spread": 0.00693372,
+          "score": 0.00722526
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.01420695,
-          "spread": 0.02051197,
-          "score": 0.02495153
+          "bias": -0.0132954,
+          "spread": 0.02387796,
+          "score": 0.02732992
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.01354303,
-          "spread": 0.02425563,
-          "score": 0.02778038
+          "bias": 0.01524238,
+          "spread": 0.01778402,
+          "score": 0.02342225
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": -0.00239726,
-          "spread": 0.33561182,
-          "score": 0.33562039
+          "bias": -0.02359948,
+          "spread": 0.34376847,
+          "score": 0.34457756
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.10704404,
+          "bias": -0.26470859,
+          "spread": 0.17533212,
+          "score": 0.31750904
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.0199517,
+          "spread": 0.01740123,
+          "score": 0.02647401
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": -0.00421885,
+          "spread": 0.00304395,
+          "score": 0.00520233
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00553037,
+          "spread": 0.00108266,
+          "score": 0.00563535
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.00144691,
+          "spread": 0.00185581,
+          "score": 0.00235321
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00097688,
+          "spread": 0.0016519,
+          "score": 0.00191913
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00458187,
+          "spread": 0.01053324,
+          "score": 0.01148663
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.02541461,
+          "spread": 0.04144088,
+          "score": 0.04861326
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": -0.00139184,
+          "spread": 0.00842192,
+          "score": 0.00853615
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.03090716,
+          "spread": 0.03221323,
+          "score": 0.04464241
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -9.991e-05,
+          "spread": 0.00460037,
+          "score": 0.00460145
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.00225768,
+          "spread": 0.00262834,
+          "score": 0.00346486
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00141314,
+          "spread": 0.00399898,
+          "score": 0.00424132
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00078259,
+          "spread": 0.00110101,
+          "score": 0.0013508
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.00433348,
+          "spread": 0.02984062,
+          "score": 0.03015363
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.00122801,
+          "spread": 0.00333905,
+          "score": 0.0035577
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.00201739,
+          "spread": 0.00041688,
+          "score": 0.00206001
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00025782,
+          "spread": 0.00194113,
+          "score": 0.00195818
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.00135119,
+          "spread": 0.00322783,
+          "score": 0.00349923
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.00243341,
+          "spread": 0.00565668,
+          "score": 0.00615788
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.01216463,
+          "spread": 0.02879435,
+          "score": 0.03125848
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.00733065,
+          "spread": 0.02466773,
+          "score": 0.02573393
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.00705134,
+          "spread": 0.25308031,
+          "score": 0.25317853
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": 0.76698308,
+          "spread": 0.86102585,
+          "score": 1.15309521
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.01695799,
+          "spread": 0.02944276,
+          "score": 0.03397719
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": -0.00396827,
+          "spread": 0.00305626,
+          "score": 0.00500878
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00560199,
+          "spread": 0.00061746,
+          "score": 0.00563592
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.00088062,
+          "spread": 0.00106754,
+          "score": 0.00138388
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.0006181,
+          "spread": 0.00083305,
+          "score": 0.00103731
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": -0.00216643,
+          "spread": 0.00397375,
+          "score": 0.00452594
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.02364576,
+          "spread": 0.02308994,
+          "score": 0.03304947
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": -0.00828727,
+          "spread": 0.005567,
+          "score": 0.0099835
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.03814183,
+          "spread": 0.02624659,
+          "score": 0.04629992
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": 0.01966367,
           "spread": 0.0,
-          "score": 0.10704404
+          "score": 0.01966367
         },
         {
           "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": 0.00166431,
+          "spread": 0.00641286,
+          "score": 0.00662531
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.00333245,
+          "spread": 0.00201012,
+          "score": 0.00389177
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": -0.00048474,
+          "spread": 0.00283094,
+          "score": 0.00287214
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00390941,
+          "spread": 0.00072999,
+          "score": 0.00397698
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.00806156,
+          "spread": 0.0099895,
+          "score": 0.01283663
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.00153686,
+          "spread": 0.00255413,
+          "score": 0.00298086
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00589125,
+          "spread": 0.0010926,
+          "score": 0.00599171
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": 0.00387329,
+          "spread": 0.00259181,
+          "score": 0.00466046
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.00302703,
+          "spread": 0.00761249,
+          "score": 0.00819224
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.00821355,
+          "spread": 0.02777642,
+          "score": 0.02896535
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.01453496,
+          "spread": 0.04085728,
+          "score": 0.04336568
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.08233644,
+          "spread": 0.73779315,
+          "score": 0.74237323
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.21630104,
+          "spread": 0.0,
+          "score": 0.21630104
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.02154554,
+          "spread": 0.09106371,
+          "score": 0.09357783
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.00073697,
+          "spread": 0.00132257,
+          "score": 0.00151404
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.0037071,
+          "spread": 0.00128209,
+          "score": 0.00392254
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.00088567,
+          "spread": 0.00235096,
+          "score": 0.00251225
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00294277,
+          "spread": 0.00274789,
+          "score": 0.00402626
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00644862,
+          "spread": 0.02075983,
+          "score": 0.02173833
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": 0.00957122,
+          "spread": 0.04075422,
+          "score": 0.04186304
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.0585159,
+          "spread": 0.06092932,
+          "score": 0.08447777
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.00806664,
+          "spread": 0.00343649,
+          "score": 0.00876813
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": 0.00438238,
+          "spread": 0.01143465,
+          "score": 0.01224567
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.00715776,
+          "spread": 0.00310753,
+          "score": 0.00780322
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00487196,
+          "spread": 0.00627233,
+          "score": 0.00794217
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00167034,
+          "spread": 0.00163335,
+          "score": 0.00233621
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.08413934,
+          "spread": 0.00235004,
+          "score": 0.08417215
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.00020204,
+          "spread": 0.01015859,
+          "score": 0.0101606
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 6.684e-05,
+          "spread": 0.00151194,
+          "score": 0.00151341
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00315214,
+          "spread": 0.00191939,
+          "score": 0.00369053
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": 0.00070672,
+          "spread": 0.00240808,
+          "score": 0.00250964
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.00430877,
+          "spread": 0.00727353,
+          "score": 0.00845398
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": 0.00161356,
+          "spread": 0.02061197,
+          "score": 0.02067503
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.03610738,
+          "spread": 0.02905868,
+          "score": 0.04634814
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.06714712,
+          "spread": 0.22575769,
+          "score": 0.23553189
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": 0.38762462,
+          "spread": 0.57094807,
+          "score": 0.69009749
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.03251734,
+          "spread": 0.04997109,
+          "score": 0.05961952
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": -0.00050075,
+          "spread": 0.00190164,
+          "score": 0.00196646
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00181508,
+          "spread": 0.00144801,
+          "score": 0.00232191
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.00023102,
+          "spread": 0.00233589,
+          "score": 0.00234729
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00105196,
+          "spread": 0.00203681,
+          "score": 0.00229243
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00384713,
+          "spread": 0.01076646,
+          "score": 0.01143316
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.01552055,
+          "spread": 0.02390778,
+          "score": 0.02850385
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": -0.0056514,
+          "spread": 0.00566183,
+          "score": 0.00799966
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.00688681,
+          "spread": 0.0112451,
+          "score": 0.01318637
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": 0.00320374,
+          "spread": 0.00396585,
+          "score": 0.00509822
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.00172014,
+          "spread": 0.00393094,
+          "score": 0.00429082
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00301417,
+          "spread": 0.00557795,
+          "score": 0.00634025
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00115981,
+          "spread": 0.0015232,
+          "score": 0.0019145
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.06176395,
+          "spread": 0.00999785,
+          "score": 0.0625679
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.00133493,
+          "spread": 0.00503148,
+          "score": 0.00520556
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.00212308,
+          "spread": 0.00128271,
+          "score": 0.00248048
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00119434,
+          "spread": 0.00211686,
+          "score": 0.00243055
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.00186466,
+          "spread": 0.00203098,
+          "score": 0.00275714
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.00417228,
+          "spread": 0.00715462,
+          "score": 0.0082823
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.00790483,
+          "spread": 0.02174702,
+          "score": 0.02313913
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.01885555,
+          "spread": 0.01339917,
+          "score": 0.02313157
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.0015507,
+          "spread": 0.30743839,
+          "score": 0.3074423
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.0457467,
+          "spread": 0.02968802,
+          "score": 0.05453567
+        },
+        {
+          "profile": "cp_plus_3pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.05058289,
-          "spread": 0.03629246,
-          "score": 0.06225569
+          "bias": -0.01775932,
+          "spread": 0.01882362,
+          "score": 0.02587899
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.0042612,
-          "spread": 0.00324889,
-          "score": 0.00535846
+          "bias": -0.00161044,
+          "spread": 0.00246397,
+          "score": 0.00294358
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00566156,
-          "spread": 0.00089627,
-          "score": 0.00573206
+          "bias": 0.00229267,
+          "spread": 0.00091396,
+          "score": 0.00246813
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00146673,
-          "spread": 0.00166946,
-          "score": 0.00222226
+          "bias": 0.00023442,
+          "spread": 0.00184078,
+          "score": 0.00185565
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00063728,
-          "spread": 0.00166505,
-          "score": 0.00178284
+          "bias": 0.00055576,
+          "spread": 0.00166554,
+          "score": 0.00175582
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00337078,
-          "spread": 0.00891562,
-          "score": 0.00953155
+          "bias": 0.00569434,
+          "spread": 0.011232,
+          "score": 0.01259299
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.02571036,
-          "spread": 0.04139457,
-          "score": 0.04872918
+          "bias": -0.00663009,
+          "spread": 0.02496407,
+          "score": 0.0258295
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00274766,
-          "spread": 0.011357,
-          "score": 0.01168465
+          "bias": 0.00073596,
+          "spread": 0.00681076,
+          "score": 0.00685041
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.02424517,
-          "spread": 0.03946723,
-          "score": 0.04631944
+          "bias": -0.02459843,
+          "spread": 0.03128407,
+          "score": 0.03979668
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
@@ -6930,259 +7794,1123 @@
           "score": NaN
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00135573,
-          "spread": 0.00461703,
-          "score": 0.00481196
+          "bias": -9.853e-05,
+          "spread": 0.00412995,
+          "score": 0.00413113
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00214868,
-          "spread": 0.00304569,
-          "score": 0.00372734
+          "bias": 0.00192104,
+          "spread": 0.00264603,
+          "score": 0.00326984
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00183466,
-          "spread": 0.00429254,
-          "score": 0.00466818
+          "bias": 0.00237319,
+          "spread": 0.00384927,
+          "score": 0.00452205
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
+          "bias": 0.00080432,
+          "spread": 0.00107241,
+          "score": 0.00134052
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.01056689,
+          "spread": 0.01700042,
+          "score": 0.02001683
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.00039601,
+          "spread": 0.00327233,
+          "score": 0.0032962
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.00123257,
+          "spread": 0.00061275,
+          "score": 0.00137648
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00036556,
+          "spread": 0.00149276,
+          "score": 0.00153687
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": 7.784e-05,
+          "spread": 0.00267262,
+          "score": 0.00267375
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.0053646,
+          "spread": 0.00544548,
+          "score": 0.00764409
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.0077271,
+          "spread": 0.02736622,
+          "score": 0.02843621
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.00402735,
+          "spread": 0.02353688,
+          "score": 0.02387895
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.01399749,
+          "spread": 0.22147888,
+          "score": 0.22192076
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": 0.10496327,
+          "spread": 0.18124095,
+          "score": 0.20944109
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.01874225,
+          "spread": 0.03210796,
+          "score": 0.03717786
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": -0.00131374,
+          "spread": 0.00244569,
+          "score": 0.00277621
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00263954,
+          "spread": 0.00053495,
+          "score": 0.00269321
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": -3.267e-05,
+          "spread": 0.00106171,
+          "score": 0.00106222
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00028449,
+          "spread": 0.00088026,
+          "score": 0.00092509
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": -0.00113499,
+          "spread": 0.00307115,
+          "score": 0.00327417
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.00660812,
+          "spread": 0.01442082,
+          "score": 0.01586276
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": -0.00578968,
+          "spread": 0.00397991,
+          "score": 0.00702567
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.03449969,
+          "spread": 0.02542683,
+          "score": 0.04285735
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": 0.02069581,
+          "spread": 0.0,
+          "score": 0.02069581
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": 0.00153574,
+          "spread": 0.00565203,
+          "score": 0.00585695
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.00313997,
+          "spread": 0.00185025,
+          "score": 0.00364457
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00035262,
+          "spread": 0.00300251,
+          "score": 0.00302315
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00392994,
+          "spread": 0.00073893,
+          "score": 0.0039988
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.00871028,
+          "spread": 0.01039627,
+          "score": 0.01356287
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.00032751,
+          "spread": 0.00235575,
+          "score": 0.00237841
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00575813,
+          "spread": 0.00136481,
+          "score": 0.00591767
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": 0.00619112,
+          "spread": 0.0029586,
+          "score": 0.00686172
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.00629687,
+          "spread": 0.00785095,
+          "score": 0.01006419
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.00208498,
+          "spread": 0.0290842,
+          "score": 0.02915884
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.01685556,
+          "spread": 0.03778539,
+          "score": 0.04137446
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.02007625,
+          "spread": 0.38781211,
+          "score": 0.38833141
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.19788952,
+          "spread": 0.0,
+          "score": 0.19788952
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.0219547,
+          "spread": 0.07769686,
+          "score": 0.08073915
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.00314767,
+          "spread": 0.00189161,
+          "score": 0.00367233
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": -0.00062753,
+          "spread": 0.00121014,
+          "score": 0.00136317
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": -0.00065076,
+          "spread": 0.00230648,
+          "score": 0.00239653
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00227221,
+          "spread": 0.0026188,
+          "score": 0.00346714
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00607484,
+          "spread": 0.02485761,
+          "score": 0.02558915
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": 0.01496037,
+          "spread": 0.042082,
+          "score": 0.04466214
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.06867939,
+          "spread": 0.07213123,
+          "score": 0.09959806
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.00647296,
+          "spread": 0.01159406,
+          "score": 0.01327861
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": 0.00408536,
+          "spread": 0.01127425,
+          "score": 0.01199162
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.00730193,
+          "spread": 0.00280973,
+          "score": 0.00782385
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00584439,
+          "spread": 0.00673288,
+          "score": 0.00891564
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00171167,
+          "spread": 0.00163064,
+          "score": 0.00236407
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.07288381,
+          "spread": 0.02656246,
+          "score": 0.07757328
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": -4.997e-05,
+          "spread": 0.01058579,
+          "score": 0.01058591
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": -0.0008151,
+          "spread": 0.00181754,
+          "score": 0.00199195
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00322826,
+          "spread": 0.00142306,
+          "score": 0.003528
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": 0.0023787,
+          "spread": 0.00230431,
+          "score": 0.0033118
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.00703575,
+          "spread": 0.00763898,
+          "score": 0.01038537
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": 0.00355676,
+          "spread": 0.01869008,
+          "score": 0.0190255
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.03297725,
+          "spread": 0.02808974,
+          "score": 0.04331896
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.09305082,
+          "spread": 0.19559933,
+          "score": 0.2166046
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": 0.29503825,
+          "spread": 0.53393357,
+          "score": 0.61002674
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.03713315,
+          "spread": 0.05340907,
+          "score": 0.06504921
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.00230163,
+          "spread": 0.00196652,
+          "score": 0.00302733
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": -0.0024909,
+          "spread": 0.00144019,
+          "score": 0.00287728
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": -0.00152364,
+          "spread": 0.00223261,
+          "score": 0.00270297
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
           "bias": 0.00073475,
-          "spread": 0.00105852,
-          "score": 0.00128853
+          "spread": 0.00179698,
+          "score": 0.00194139
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00446926,
+          "spread": 0.01234685,
+          "score": 0.01313085
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.00705631,
+          "spread": 0.02158831,
+          "score": 0.02271226
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": -0.00336862,
+          "spread": 0.00979069,
+          "score": 0.010354
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.01616029,
+          "spread": 0.00956325,
+          "score": 0.01877793
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": 0.00280361,
+          "spread": 0.00359659,
+          "score": 0.00456023
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.00132214,
+          "spread": 0.00391654,
+          "score": 0.00413369
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00439918,
+          "spread": 0.00562179,
+          "score": 0.00713844
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.0011949,
+          "spread": 0.00152241,
+          "score": 0.00193534
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.07237458,
+          "spread": 0.00066944,
+          "score": 0.07237768
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.00020127,
+          "spread": 0.00611294,
+          "score": 0.00611626
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.00139703,
+          "spread": 0.00150501,
+          "score": 0.00205347
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00113859,
+          "spread": 0.00144694,
+          "score": 0.0018412
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": 0.00018886,
+          "spread": 0.00177495,
+          "score": 0.00178497
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.00654771,
+          "spread": 0.00735395,
+          "score": 0.00984648
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.00441393,
+          "spread": 0.02078947,
+          "score": 0.02125288
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.02064623,
+          "spread": 0.01457142,
+          "score": 0.0252704
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.01506167,
+          "spread": 0.30624196,
+          "score": 0.30661212
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.06852508,
+          "spread": 0.0,
+          "score": 0.06852508
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.01732742,
+          "spread": 0.02525785,
+          "score": 0.03063003
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.00133103,
+          "spread": 0.00195872,
+          "score": 0.00236817
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": -0.001601,
+          "spread": 0.00069021,
+          "score": 0.00174344
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": -0.00122409,
+          "spread": 0.00189864,
+          "score": 0.00225903
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00019941,
+          "spread": 0.0016418,
+          "score": 0.00165387
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00687204,
+          "spread": 0.01269869,
+          "score": 0.01443889
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": 0.00179037,
+          "spread": 0.02077889,
+          "score": 0.02085587
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.00320024,
+          "spread": 0.00574773,
+          "score": 0.0065786
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.01462716,
+          "spread": 0.03258886,
+          "score": 0.03572097
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -6.192e-05,
+          "spread": 0.00402094,
+          "score": 0.00402142
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.00191824,
+          "spread": 0.0026358,
+          "score": 0.00325992
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00330329,
+          "spread": 0.00416746,
+          "score": 0.00531784
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00084848,
+          "spread": 0.00108975,
+          "score": 0.00138111
+        },
+        {
+          "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.01069416,
-          "spread": 4.066e-05,
-          "score": 0.01069424
+          "bias": 0.00895455,
+          "spread": 0.01530747,
+          "score": 0.01773422
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00169091,
-          "spread": 0.00279375,
-          "score": 0.00326561
+          "bias": 0.00016833,
+          "spread": 0.00413777,
+          "score": 0.00414119
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00185592,
-          "spread": 0.00050607,
-          "score": 0.00192368
+          "bias": 0.00036437,
+          "spread": 0.00093429,
+          "score": 0.00100282
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00029575,
-          "spread": 0.00185184,
-          "score": 0.00187531
+          "bias": 0.00046906,
+          "spread": 0.00097376,
+          "score": 0.00108084
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00150084,
-          "spread": 0.00329412,
-          "score": 0.00361991
+          "bias": 0.00183719,
+          "spread": 0.00228505,
+          "score": 0.00293202
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.0022938,
-          "spread": 0.00605425,
-          "score": 0.00647422
+          "bias": 0.00805803,
+          "spread": 0.00606914,
+          "score": 0.01008793
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.01056055,
-          "spread": 0.02809278,
-          "score": 0.03001216
+          "bias": -0.00300753,
+          "spread": 0.02563418,
+          "score": 0.02581001
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.00957005,
-          "spread": 0.03237837,
-          "score": 0.03376307
+          "bias": -0.00107371,
+          "spread": 0.02264515,
+          "score": 0.02267059
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.00340568,
-          "spread": 0.21332741,
-          "score": 0.21335459
+          "bias": 0.02436886,
+          "spread": 0.21893555,
+          "score": 0.22028758
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.7194592,
-          "spread": 0.79857647,
-          "score": 1.07487019
+          "bias": -0.16077871,
+          "spread": 0.08337461,
+          "score": 0.18111079
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.0170104,
-          "spread": 0.03517503,
-          "score": 0.03907219
+          "bias": -0.01623304,
+          "spread": 0.03782435,
+          "score": 0.04116058
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00389391,
-          "spread": 0.00293796,
-          "score": 0.00487793
+          "bias": 0.00178515,
+          "spread": 0.00207325,
+          "score": 0.00273589
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00568756,
-          "spread": 0.0009022,
-          "score": 0.00575867
+          "bias": -0.0008769,
+          "spread": 0.00071875,
+          "score": 0.00113383
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00091427,
-          "spread": 0.00122538,
-          "score": 0.00152887
+          "bias": -0.00133307,
+          "spread": 0.0010737,
+          "score": 0.00171169
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00060265,
-          "spread": 0.0007311,
-          "score": 0.00094747
+          "bias": -0.00033374,
+          "spread": 0.00082534,
+          "score": 0.00089026
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": -0.00238932,
-          "spread": 0.00408143,
-          "score": 0.00472937
+          "bias": -0.00038369,
+          "spread": 0.00208635,
+          "score": 0.00212134
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.0202256,
-          "spread": 0.01833075,
-          "score": 0.02729636
+          "bias": 0.00498432,
+          "spread": 0.01587665,
+          "score": 0.01664066
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.0087324,
-          "spread": 0.00601106,
-          "score": 0.01060131
+          "bias": -0.00336093,
+          "spread": 0.00251403,
+          "score": 0.00419716
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.04020195,
-          "spread": 0.0290914,
-          "score": 0.04962365
+          "bias": -0.03100548,
+          "spread": 0.02613573,
+          "score": 0.0405514
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
-          "bias": 0.02253919,
+          "bias": 0.02294855,
           "spread": 0.0,
-          "score": 0.02253919
+          "score": 0.02294855
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00080453,
-          "spread": 0.00562775,
-          "score": 0.00568497
+          "bias": 0.00124071,
+          "spread": 0.00538133,
+          "score": 0.0055225
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00314433,
-          "spread": 0.00179331,
-          "score": 0.00361977
+          "bias": 0.00265124,
+          "spread": 0.00191669,
+          "score": 0.00327151
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00054591,
-          "spread": 0.0030638,
-          "score": 0.00311205
+          "bias": 0.00159796,
+          "spread": 0.00324151,
+          "score": 0.00361398
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00388261,
-          "spread": 0.00072157,
-          "score": 0.00394909
+          "bias": 0.00397417,
+          "spread": 0.00073137,
+          "score": 0.0040409
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
@@ -7191,601 +8919,601 @@
           "score": NaN
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00864193,
-          "spread": 0.00999533,
-          "score": 0.01321324
+          "bias": 0.00504061,
+          "spread": 0.00899795,
+          "score": 0.01031363
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00193512,
-          "spread": 0.00242659,
-          "score": 0.00310371
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00564955,
-          "spread": 0.00127822,
-          "score": 0.00579234
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00387106,
-          "spread": 0.00253995,
-          "score": 0.00462996
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00246706,
-          "spread": 0.00860463,
-          "score": 0.00895131
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": -0.01448535,
-          "spread": 0.02829529,
-          "score": 0.03178755
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": -0.00568544,
-          "spread": 0.0262654,
-          "score": 0.02687369
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.39970745,
-          "spread": 1.22382398,
-          "score": 1.28744366
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": -0.24938767,
-          "spread": 0.0,
-          "score": 0.24938767
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.0070523,
-          "spread": 0.05997944,
-          "score": 0.06039262
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00069936,
-          "spread": 0.00134013,
-          "score": 0.00151164
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00353566,
-          "spread": 0.00159382,
-          "score": 0.00387829
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": 0.0009549,
+          "bias": -0.00033596,
           "spread": 0.00271435,
-          "score": 0.00287742
+          "score": 0.00273506
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00324093,
-          "spread": 0.00303283,
-          "score": 0.00443866
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00437667,
-          "spread": 0.02166302,
-          "score": 0.02210072
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": -0.00327525,
-          "spread": 0.03413362,
-          "score": 0.0342904
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": 0.05744721,
-          "spread": 0.06025544,
-          "score": 0.08325202
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": -0.00793224,
-          "spread": 0.00154736,
-          "score": 0.00808176
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00358784,
-          "spread": 0.01020045,
-          "score": 0.01081303
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00767105,
-          "spread": 0.00361279,
-          "score": 0.00847923
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00470918,
-          "spread": 0.0061359,
-          "score": 0.0077347
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.00144945,
-          "spread": 0.00157237,
-          "score": 0.00213852
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": 0.03571354,
-          "spread": 0.03775849,
-          "score": 0.05197269
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": -3.618e-05,
-          "spread": 0.01136443,
-          "score": 0.01136449
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00026777,
-          "spread": 0.00178542,
-          "score": 0.00180539
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00272556,
-          "spread": 0.00196111,
-          "score": 0.00335777
+          "bias": 0.00514949,
+          "spread": 0.00134764,
+          "score": 0.00532291
         },
         {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.0002488,
-          "spread": 0.0023611,
-          "score": 0.00237417
+          "bias": 0.00768934,
+          "spread": 0.00329508,
+          "score": 0.00836562
         },
         {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00435273,
-          "spread": 0.00589863,
-          "score": 0.00733076
+          "bias": 0.01692781,
+          "spread": 0.00580596,
+          "score": 0.01789581
         },
         {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00541549,
-          "spread": 0.02303551,
-          "score": 0.02366352
+          "bias": 0.01318499,
+          "spread": 0.02502386,
+          "score": 0.02828493
         },
         {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.04547291,
-          "spread": 0.02571424,
-          "score": 0.05223991
+          "bias": 0.03887501,
+          "spread": 0.05594901,
+          "score": 0.06812898
         },
         {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.68313524,
-          "spread": 1.07937814,
-          "score": 1.27739224
+          "bias": 0.20520639,
+          "spread": 0.58724839,
+          "score": 0.6220694
         },
         {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.58540551,
-          "spread": 0.44340048,
-          "score": 0.73437293
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.00739159,
-          "spread": 0.01753343,
-          "score": 0.01902778
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00050918,
-          "spread": 0.00240227,
-          "score": 0.00245564
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00158575,
-          "spread": 0.00147923,
-          "score": 0.00216858
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00011754,
-          "spread": 0.00255155,
-          "score": 0.00255426
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00079059,
-          "spread": 0.00227302,
-          "score": 0.00240659
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00335366,
-          "spread": 0.00944376,
-          "score": 0.01002155
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": -0.00991358,
-          "spread": 0.01841008,
-          "score": 0.02090957
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00796177,
-          "spread": 0.00469488,
-          "score": 0.00924292
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": 0.0067867,
-          "spread": 0.01083209,
-          "score": 0.01278255
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00234966,
-          "spread": 0.00378076,
-          "score": 0.00445141
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00143706,
-          "spread": 0.00435213,
-          "score": 0.00458325
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00278935,
-          "spread": 0.00526591,
-          "score": 0.00595905
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.00119532,
-          "spread": 0.00169085,
-          "score": 0.00207069
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": 0.05324941,
-          "spread": 0.0083659,
-          "score": 0.05390258
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00212559,
-          "spread": 0.00439543,
-          "score": 0.00488241
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00211196,
-          "spread": 0.00150788,
-          "score": 0.00259501
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00125895,
-          "spread": 0.00223755,
-          "score": 0.00256741
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00178664,
-          "spread": 0.00210493,
-          "score": 0.00276095
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00404589,
-          "spread": 0.00713977,
-          "score": 0.00820644
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00792215,
-          "spread": 0.01969149,
-          "score": 0.02122535
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": 0.02073321,
-          "spread": 0.02149192,
-          "score": 0.0298625
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.03945949,
-          "spread": 0.29443126,
-          "score": 0.29706366
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": -0.08669789,
+          "bias": -0.27469083,
           "spread": 0.0,
-          "score": 0.08669789
+          "score": 0.27469083
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.00309567,
+          "spread": 0.09249005,
+          "score": 0.09254184
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": -0.00101447,
+          "spread": 0.00151958,
+          "score": 0.00182709
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00517043,
+          "spread": 0.00143487,
+          "score": 0.00536583
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.00133254,
+          "spread": 0.00274425,
+          "score": 0.00305066
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00302176,
+          "spread": 0.00264433,
+          "score": 0.00401541
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00638152,
+          "spread": 0.02038901,
+          "score": 0.02136435
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": 0.01623176,
+          "spread": 0.04769545,
+          "score": 0.05038181
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.05439288,
+          "spread": 0.05631077,
+          "score": 0.07829105
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.0105218,
+          "spread": 0.00196298,
+          "score": 0.01070334
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": 0.00606769,
+          "spread": 0.01132736,
+          "score": 0.01285013
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.00790585,
+          "spread": 0.00295661,
+          "score": 0.00844062
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.0045216,
+          "spread": 0.00637949,
+          "score": 0.00781938
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00167141,
+          "spread": 0.0016711,
+          "score": 0.00236351
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.07815033,
+          "spread": 0.00899089,
+          "score": 0.07866582
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": -0.00286507,
+          "spread": 0.01071406,
+          "score": 0.01109052
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": -0.00179999,
+          "spread": 0.00142931,
+          "score": 0.00229845
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00239099,
+          "spread": 0.00181081,
+          "score": 0.00299931
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": 0.00443632,
+          "spread": 0.00215385,
+          "score": 0.00493153
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.01658264,
+          "spread": 0.00675046,
+          "score": 0.01790398
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": 0.02148984,
+          "spread": 0.02298347,
+          "score": 0.03146511
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.01618775,
+          "spread": 0.02991567,
+          "score": 0.03401457
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.10664417,
+          "spread": 0.19619468,
+          "score": 0.22330547
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": 0.39820988,
+          "spread": 0.61878606,
+          "score": 0.73584461
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.03701948,
+          "spread": 0.05669441,
+          "score": 0.0677104
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": -0.0024304,
+          "spread": 0.00200943,
+          "score": 0.00315351
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00315283,
+          "spread": 0.00177616,
+          "score": 0.00361871
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.00074317,
+          "spread": 0.00251601,
+          "score": 0.00262347
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00117069,
+          "spread": 0.00228915,
+          "score": 0.00257114
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00360133,
+          "spread": 0.01055364,
+          "score": 0.01115119
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.01147476,
+          "spread": 0.02750272,
+          "score": 0.0298005
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": -0.00810976,
+          "spread": 0.00524759,
+          "score": 0.00965947
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.00116062,
+          "spread": 0.01076094,
+          "score": 0.01082335
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": 0.00406743,
+          "spread": 0.00342248,
+          "score": 0.00531576
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.00230567,
+          "spread": 0.00391925,
+          "score": 0.00454715
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00284706,
+          "spread": 0.00555995,
+          "score": 0.0062465
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 9,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00116274,
+          "spread": 0.00156092,
+          "score": 0.00194639
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.05983896,
+          "spread": 0.00586349,
+          "score": 0.06012555
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": -0.00092001,
+          "spread": 0.00519726,
+          "score": 0.00527806
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.00013765,
+          "spread": 0.001183,
+          "score": 0.00119098
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00057845,
+          "spread": 0.00205973,
+          "score": 0.00213941
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": 0.001911,
+          "spread": 0.00148538,
+          "score": 0.00242039
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.0158505,
+          "spread": 0.00837179,
+          "score": 0.01792555
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": 0.01080108,
+          "spread": 0.02071588,
+          "score": 0.0233626
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.03928695,
+          "spread": 0.0151617,
+          "score": 0.04211107
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.02053921,
+          "spread": 0.28971927,
+          "score": 0.29044641
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.23642671,
+          "spread": 0.1969516,
+          "score": 0.30771338
+        },
+        {
+          "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.05379738,
-          "spread": 0.03308122,
-          "score": 0.06315477
+          "bias": -0.01786033,
+          "spread": 0.02317502,
+          "score": 0.02925873
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00164359,
-          "spread": 0.00255391,
-          "score": 0.00303708
+          "bias": -0.00345256,
+          "spread": 0.00268551,
+          "score": 0.00437403
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00234835,
-          "spread": 0.00081319,
-          "score": 0.00248517
+          "bias": 0.00340142,
+          "spread": 0.00105959,
+          "score": 0.00356263
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00037747,
-          "spread": 0.00155725,
-          "score": 0.00160235
+          "bias": 0.00052533,
+          "spread": 0.00192156,
+          "score": 0.00199208
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00046304,
-          "spread": 0.0015073,
-          "score": 0.00157682
+          "bias": 0.00071403,
+          "spread": 0.00180134,
+          "score": 0.00193769
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00426565,
-          "spread": 0.00959929,
-          "score": 0.01050439
+          "bias": 0.00530086,
+          "spread": 0.01138414,
+          "score": 0.01255778
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.00433074,
-          "spread": 0.02421882,
-          "score": 0.02460298
+          "bias": -0.00173566,
+          "spread": 0.02896667,
+          "score": 0.02901862
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00036072,
-          "spread": 0.00814429,
-          "score": 0.00815228
+          "bias": -0.000761,
+          "spread": 0.00759,
+          "score": 0.00762806
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.01645398,
-          "spread": 0.03717875,
-          "score": 0.04065701
+          "bias": -0.03100202,
+          "spread": 0.03187875,
+          "score": 0.04446774
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
@@ -7794,259 +9522,259 @@
           "score": NaN
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00090061,
-          "spread": 0.00381062,
-          "score": 0.0039156
+          "bias": 0.00080648,
+          "spread": 0.00411298,
+          "score": 0.0041913
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00193751,
-          "spread": 0.00297441,
-          "score": 0.00354979
+          "bias": 0.00253263,
+          "spread": 0.00249918,
+          "score": 0.00355811
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00251523,
-          "spread": 0.00407151,
-          "score": 0.00478576
+          "bias": 0.00237374,
+          "spread": 0.00383109,
+          "score": 0.00450687
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00075857,
-          "spread": 0.00103128,
-          "score": 0.00128022
+          "bias": 0.00079684,
+          "spread": 0.0010912,
+          "score": 0.00135117
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.00785109,
-          "spread": 0.02187726,
-          "score": 0.02324337
+          "bias": 0.00409184,
+          "spread": 0.02611285,
+          "score": 0.02643149
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00088325,
-          "spread": 0.0032019,
-          "score": 0.00332149
+          "bias": -0.00227388,
+          "spread": 0.00389226,
+          "score": 0.0045078
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00113858,
-          "spread": 0.00057559,
-          "score": 0.00127581
+          "bias": -0.0003114,
+          "spread": 0.00056364,
+          "score": 0.00064395
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00035914,
-          "spread": 0.00143124,
-          "score": 0.00147561
+          "bias": -0.00029304,
+          "spread": 0.0014446,
+          "score": 0.00147402
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -3.98e-06,
-          "spread": 0.00291978,
-          "score": 0.00291978
+          "bias": 0.00336729,
+          "spread": 0.00225619,
+          "score": 0.00405328
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00446529,
-          "spread": 0.00582246,
-          "score": 0.00733756
+          "bias": 0.0160261,
+          "spread": 0.0064383,
+          "score": 0.01727101
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00764088,
-          "spread": 0.02597992,
-          "score": 0.02708024
+          "bias": 0.00997878,
+          "spread": 0.0254041,
+          "score": 0.02729367
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.00499548,
-          "spread": 0.03058035,
-          "score": 0.03098568
+          "bias": 0.0143426,
+          "spread": 0.02235418,
+          "score": 0.02655973
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.00953297,
-          "spread": 0.20149423,
-          "score": 0.20171961
+          "bias": 0.0316659,
+          "spread": 0.22423476,
+          "score": 0.22645961
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.05111206,
-          "spread": 0.11576103,
-          "score": 0.12654272
+          "bias": -0.15737029,
+          "spread": 0.11206077,
+          "score": 0.19319168
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.00955647,
-          "spread": 0.03617853,
-          "score": 0.0374194
+          "bias": -0.02237952,
+          "spread": 0.04125799,
+          "score": 0.04693681
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00121877,
-          "spread": 0.00231212,
-          "score": 0.00261367
+          "bias": -0.00292889,
+          "spread": 0.00277636,
+          "score": 0.00403567
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.0026821,
-          "spread": 0.000791,
-          "score": 0.00279631
+          "bias": 0.00371351,
+          "spread": 0.00039748,
+          "score": 0.00373472
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -5.012e-05,
-          "spread": 0.00120977,
-          "score": 0.0012108
+          "bias": 0.00026549,
+          "spread": 0.00110323,
+          "score": 0.00113473
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.0002936,
-          "spread": 0.00075944,
-          "score": 0.00081422
+          "bias": 0.00038031,
+          "spread": 0.00080335,
+          "score": 0.00088883
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": -0.00143207,
-          "spread": 0.00305694,
-          "score": 0.00337575
+          "bias": -0.00169079,
+          "spread": 0.00354742,
+          "score": 0.00392975
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.00269665,
-          "spread": 0.01155859,
-          "score": 0.01186899
+          "bias": -0.00239285,
+          "spread": 0.01300801,
+          "score": 0.01322627
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00656341,
-          "spread": 0.00478314,
-          "score": 0.00812138
+          "bias": -0.00788069,
+          "spread": 0.00495753,
+          "score": 0.00931033
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.03662865,
-          "spread": 0.02838951,
-          "score": 0.04634245
+          "bias": -0.03813694,
+          "spread": 0.02676244,
+          "score": 0.04659028
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
-          "bias": 0.0241424,
+          "bias": 0.02022686,
           "spread": 0.0,
-          "score": 0.0241424
+          "score": 0.02022686
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00105872,
-          "spread": 0.00520119,
-          "score": 0.00530785
+          "bias": 0.00246038,
+          "spread": 0.00539483,
+          "score": 0.00592939
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00281115,
-          "spread": 0.00162836,
-          "score": 0.00324871
+          "bias": 0.0034901,
+          "spread": 0.00191819,
+          "score": 0.00398249
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00036486,
-          "spread": 0.00325741,
-          "score": 0.00327778
+          "bias": 0.00023565,
+          "spread": 0.00292762,
+          "score": 0.00293708
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00390311,
-          "spread": 0.0007285,
-          "score": 0.00397052
+          "bias": 0.00396128,
+          "spread": 0.00074876,
+          "score": 0.00403143
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
@@ -8055,2578 +9783,850 @@
           "score": NaN
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00817353,
-          "spread": 0.01118498,
-          "score": 0.01385317
+          "bias": 0.00890095,
+          "spread": 0.00978139,
+          "score": 0.01322507
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00052633,
-          "spread": 0.00229654,
-          "score": 0.00235608
+          "bias": 0.00196328,
+          "spread": 0.00263296,
+          "score": 0.00328435
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00568705,
-          "spread": 0.00160442,
-          "score": 0.00590903
+          "bias": 0.00617848,
+          "spread": 0.00099467,
+          "score": 0.00625804
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00644465,
-          "spread": 0.00293441,
-          "score": 0.00708126
+          "bias": 0.00280182,
+          "spread": 0.00245286,
+          "score": 0.0037238
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00504668,
-          "spread": 0.00937942,
-          "score": 0.01065093
+          "bias": 0.00175818,
+          "spread": 0.00764288,
+          "score": 0.0078425
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.01431974,
-          "spread": 0.02932524,
-          "score": 0.03263472
+          "bias": -0.01362674,
+          "spread": 0.02938617,
+          "score": 0.0323919
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.00148213,
-          "spread": 0.02431746,
-          "score": 0.02436258
+          "bias": 0.00237559,
+          "spread": 0.04677618,
+          "score": 0.04683647
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.46431114,
-          "spread": 1.06193628,
-          "score": 1.15900539
+          "bias": -0.12371879,
+          "spread": 1.17081797,
+          "score": 1.17733643
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.11153346,
+          "bias": 0.01834031,
+          "spread": 0.28585803,
+          "score": 0.28644577
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.02023902,
+          "spread": 0.07027504,
+          "score": 0.07313138
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.00356626,
+          "spread": 0.00176004,
+          "score": 0.00397692
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.0037276,
+          "spread": 0.00137426,
+          "score": 0.00397286
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.00095576,
+          "spread": 0.00241927,
+          "score": 0.00260122
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.0032912,
+          "spread": 0.00246633,
+          "score": 0.00411275
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00807223,
+          "spread": 0.02081007,
+          "score": 0.02232084
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.00186646,
+          "spread": 0.04445192,
+          "score": 0.04449109
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.06234218,
+          "spread": 0.06436806,
+          "score": 0.08960912
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.00525055,
+          "spread": 0.00501992,
+          "score": 0.00726415
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": 0.00245991,
+          "spread": 0.01161268,
+          "score": 0.01187037
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.0056545,
+          "spread": 0.00374981,
+          "score": 0.00678487
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00392745,
+          "spread": 0.00617824,
+          "score": 0.00732089
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00170914,
+          "spread": 0.00165989,
+          "score": 0.00238252
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.05793875,
+          "spread": 0.0048552,
+          "score": 0.05814183
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.0009136,
+          "spread": 0.00959269,
+          "score": 0.0096361
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.00032458,
+          "spread": 0.00153904,
+          "score": 0.00157289
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00335111,
+          "spread": 0.00209733,
+          "score": 0.00395332
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": 6.979e-05,
+          "spread": 0.00258956,
+          "score": 0.0025905
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.00299066,
+          "spread": 0.00631283,
+          "score": 0.00698541
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": 0.00021135,
+          "spread": 0.02716105,
+          "score": 0.02716188
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.0589193,
+          "spread": 0.02774129,
+          "score": 0.06512345
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.01760271,
+          "spread": 0.30894534,
+          "score": 0.30944641
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": 0.42147921,
+          "spread": 0.59400185,
+          "score": 0.72834258
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.03556716,
+          "spread": 0.05522252,
+          "score": 0.06568523
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.0020414,
+          "spread": 0.00205365,
+          "score": 0.00289566
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00170358,
+          "spread": 0.00157134,
+          "score": 0.00231761
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 9e-05,
+          "spread": 0.00221142,
+          "score": 0.00221325
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00151191,
+          "spread": 0.00179862,
+          "score": 0.00234966
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00446709,
+          "spread": 0.01117565,
+          "score": 0.01203537
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.03795827,
+          "spread": 0.04489894,
+          "score": 0.05879409
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": -0.00388254,
+          "spread": 0.00607063,
+          "score": 0.00720601
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.01077916,
+          "spread": 0.01033665,
+          "score": 0.01493441
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": 0.00117203,
+          "spread": 0.00396713,
+          "score": 0.00413664
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.00018586,
+          "spread": 0.00428791,
+          "score": 0.00429194
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00243334,
+          "spread": 0.00579286,
+          "score": 0.00628319
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00118721,
+          "spread": 0.00154923,
+          "score": 0.00195182
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.05324759,
+          "spread": 0.00419176,
+          "score": 0.05341233
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.00251055,
+          "spread": 0.00426859,
+          "score": 0.00495214
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.00217776,
+          "spread": 0.00128526,
+          "score": 0.00252874
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00146583,
+          "spread": 0.00234894,
+          "score": 0.00276878
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.00222873,
+          "spread": 0.00196012,
+          "score": 0.00296805
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.00255785,
+          "spread": 0.00664177,
+          "score": 0.00711728
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.01243698,
+          "spread": 0.022807,
+          "score": 0.02597764
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.0086224,
+          "spread": 0.01732941,
+          "score": 0.01935599
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": -0.02503275,
+          "spread": 0.34266839,
+          "score": 0.34358153
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": 0.04581666,
+          "spread": 0.1254626,
+          "score": 0.13356658
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.02024798,
+          "spread": 0.02599528,
+          "score": 0.03295049
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.00096193,
+          "spread": 0.00251629,
+          "score": 0.00269389
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00219412,
+          "spread": 0.00099449,
+          "score": 0.00240898
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.00023976,
+          "spread": 0.00178177,
+          "score": 0.00179783
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00098412,
+          "spread": 0.00161977,
+          "score": 0.0018953
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00661912,
+          "spread": 0.01179713,
+          "score": 0.0135272
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.02871163,
+          "spread": 0.04430844,
+          "score": 0.05279768
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.00248743,
+          "spread": 0.00640081,
+          "score": 0.00686714
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.01970073,
+          "spread": 0.02963887,
+          "score": 0.03558906
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.00213817,
+          "spread": 0.00445263,
+          "score": 0.0049394
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.0003848,
+          "spread": 0.00309853,
+          "score": 0.00312233
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00153758,
+          "spread": 0.00401267,
+          "score": 0.00429717
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00084069,
+          "spread": 0.00110354,
+          "score": 0.00138728
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": -0.01774858,
+          "spread": 0.01859613,
+          "score": 0.02570658
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.00099632,
+          "spread": 0.00308504,
+          "score": 0.00324194
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.00139769,
+          "spread": 0.00062332,
+          "score": 0.00153038
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.000572,
+          "spread": 0.00156273,
+          "score": 0.00166413
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.00021384,
+          "spread": 0.00291156,
+          "score": 0.0029194
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.00303306,
+          "spread": 0.0049274,
+          "score": 0.00578608
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.01188804,
+          "spread": 0.02828257,
+          "score": 0.03067946
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.01068013,
+          "spread": 0.02415365,
+          "score": 0.02640954
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.00203469,
+          "spread": 0.23580516,
+          "score": 0.23581394
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": 0.68506983,
+          "spread": 0.75997562,
+          "score": 1.02317331
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.02455258,
+          "spread": 0.03557369,
+          "score": 0.04322403
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.00105139,
+          "spread": 0.00243623,
+          "score": 0.00265342
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00257037,
+          "spread": 0.00060572,
+          "score": 0.00264078
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 2.938e-05,
+          "spread": 0.00104075,
+          "score": 0.00104116
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00056748,
+          "spread": 0.0007322,
+          "score": 0.00092636
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": -0.0002799,
+          "spread": 0.00250576,
+          "score": 0.00252135
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.02451736,
+          "spread": 0.02366082,
+          "score": 0.0340725
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": -0.00399325,
+          "spread": 0.00323092,
+          "score": 0.00513662
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.03151821,
+          "spread": 0.02536509,
+          "score": 0.0404572
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": 0.02027116,
           "spread": 0.0,
-          "score": 0.11153346
+          "score": 0.02027116
         },
         {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.00497563,
-          "spread": 0.03420844,
-          "score": 0.0345684
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00342775,
-          "spread": 0.0020599,
-          "score": 0.00399908
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00107671,
-          "spread": 0.00144063,
-          "score": 0.00179853
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00093627,
-          "spread": 0.00253411,
-          "score": 0.00270154
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00219989,
-          "spread": 0.00272542,
-          "score": 0.00350249
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.004261,
-          "spread": 0.02533836,
-          "score": 0.02569413
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": 0.00081549,
-          "spread": 0.03745848,
-          "score": 0.03746736
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": 0.07157245,
-          "spread": 0.07535568,
-          "score": 0.10392831
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": -0.00305636,
-          "spread": 0.00777923,
-          "score": 0.00835809
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00219531,
-          "spread": 0.01060809,
-          "score": 0.01083287
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.0072461,
-          "spread": 0.00311882,
-          "score": 0.00788879
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00636501,
-          "spread": 0.00667884,
-          "score": 0.00922607
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.00149144,
-          "spread": 0.00156972,
-          "score": 0.00216527
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": 0.04173372,
-          "spread": 0.04044997,
-          "score": 0.05811973
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": -4.515e-05,
-          "spread": 0.01160506,
-          "score": 0.01160515
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00076992,
-          "spread": 0.00205814,
-          "score": 0.00219743
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": 0.0029117,
-          "spread": 0.00140028,
-          "score": 0.00323091
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00201359,
-          "spread": 0.00217278,
-          "score": 0.00296235
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.0067968,
-          "spread": 0.00629007,
-          "score": 0.00926075
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00702269,
-          "spread": 0.01836766,
-          "score": 0.01966441
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": -0.03975221,
-          "spread": 0.02798857,
-          "score": 0.04861685
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.55831571,
-          "spread": 0.82732654,
-          "score": 0.99809099
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": 0.55721619,
-          "spread": 0.4255502,
-          "score": 0.7011297
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.00306929,
-          "spread": 0.01441293,
-          "score": 0.01473612
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00240867,
-          "spread": 0.00216762,
-          "score": 0.00324041
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00268702,
-          "spread": 0.0011662,
-          "score": 0.00292918
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00182637,
-          "spread": 0.00233412,
-          "score": 0.00296374
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00023905,
-          "spread": 0.00178153,
-          "score": 0.0017975
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00370105,
-          "spread": 0.01134498,
-          "score": 0.01193341
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": -0.00161145,
-          "spread": 0.0200289,
-          "score": 0.02009362
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00542717,
-          "spread": 0.00583852,
-          "score": 0.00797135
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": 0.01870527,
-          "spread": 0.01182361,
-          "score": 0.02212883
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00272601,
-          "spread": 0.00335296,
-          "score": 0.00432128
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00091722,
-          "spread": 0.00431269,
-          "score": 0.00440914
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00410354,
-          "spread": 0.00519123,
-          "score": 0.00661725
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.00122996,
-          "spread": 0.00168925,
-          "score": 0.00208959
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": 0.04113863,
-          "spread": 0.00444081,
-          "score": 0.04137762
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00156085,
-          "spread": 0.00562048,
-          "score": 0.00583318
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00134539,
-          "spread": 0.00166595,
-          "score": 0.00214137
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00121639,
-          "spread": 0.00160611,
-          "score": 0.00201475
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": 5.36e-06,
-          "spread": 0.00211768,
-          "score": 0.00211768
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00691238,
-          "spread": 0.00755194,
-          "score": 0.01023782
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00333767,
-          "spread": 0.01847565,
-          "score": 0.0187747
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": 0.02125213,
-          "spread": 0.02158158,
-          "score": 0.0302889
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.04533503,
-          "spread": 0.28008428,
-          "score": 0.28372957
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": -0.08971119,
-          "spread": 0.0,
-          "score": 0.08971119
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.04888526,
-          "spread": 0.03007868,
-          "score": 0.0573977
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00108784,
-          "spread": 0.00220083,
-          "score": 0.002455
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": -0.0015338,
-          "spread": 0.00068376,
-          "score": 0.00167931
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00107491,
-          "spread": 0.00155451,
-          "score": 0.00188995
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00010129,
-          "spread": 0.00158794,
-          "score": 0.00159116
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00553416,
-          "spread": 0.01067148,
-          "score": 0.01202113
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": 0.00379324,
-          "spread": 0.0217058,
-          "score": 0.02203475
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00220217,
-          "spread": 0.00624094,
-          "score": 0.00661807
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": -0.00746629,
-          "spread": 0.03744639,
-          "score": 0.03818348
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00079811,
-          "spread": 0.00378926,
-          "score": 0.0038724
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00186617,
-          "spread": 0.00292307,
-          "score": 0.00346798
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00366616,
-          "spread": 0.00417365,
-          "score": 0.00555519
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.00080285,
-          "spread": 0.00104908,
-          "score": 0.00132104
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": 0.01084249,
-          "spread": 0.0180419,
-          "score": 0.02104923
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00054987,
-          "spread": 0.00386579,
-          "score": 0.0039047
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00030554,
-          "spread": 0.00086445,
-          "score": 0.00091685
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": 0.0004003,
-          "spread": 0.000899,
-          "score": 0.00098409
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00174333,
-          "spread": 0.00234102,
-          "score": 0.00291883
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00792784,
-          "spread": 0.00609463,
-          "score": 0.00999976
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00297659,
-          "spread": 0.02472919,
-          "score": 0.02490769
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": -0.00213398,
-          "spread": 0.02778487,
-          "score": 0.0278667
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.01995746,
-          "spread": 0.20046642,
-          "score": 0.2014574
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": -0.20233708,
-          "spread": 0.15391859,
-          "score": 0.25422672
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.01027906,
-          "spread": 0.04070719,
-          "score": 0.04198493
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": 0.0017283,
-          "spread": 0.00183759,
-          "score": 0.00252265
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00078605,
-          "spread": 0.00081771,
-          "score": 0.00113425
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00134819,
-          "spread": 0.00132377,
-          "score": 0.00188945
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00021304,
-          "spread": 0.00074605,
-          "score": 0.00077588
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": -0.0005018,
-          "spread": 0.00230831,
-          "score": 0.00236222
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": 0.00708674,
-          "spread": 0.01804426,
-          "score": 0.01938601
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00444826,
-          "spread": 0.00351854,
-          "score": 0.00567161
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": -0.03385743,
-          "spread": 0.02874826,
-          "score": 0.04441608
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": 0.02468725,
-          "spread": 0.0,
-          "score": 0.02468725
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00079405,
-          "spread": 0.0049507,
-          "score": 0.00501397
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00265,
-          "spread": 0.00185572,
-          "score": 0.00323515
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00147978,
-          "spread": 0.00342575,
-          "score": 0.00373169
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.00394691,
-          "spread": 0.0007202,
-          "score": 0.00401208
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00661706,
-          "spread": 0.00922722,
-          "score": 0.01135461
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": 3.79e-05,
-          "spread": 0.00267556,
-          "score": 0.00267582
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00496176,
-          "spread": 0.00173806,
-          "score": 0.00525737
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00756767,
-          "spread": 0.0029683,
-          "score": 0.00812899
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01557514,
-          "spread": 0.00698456,
-          "score": 0.01706953
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00411232,
-          "spread": 0.02478223,
-          "score": 0.02512111
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": 0.01550291,
-          "spread": 0.02571817,
-          "score": 0.03002939
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.52637475,
-          "spread": 1.12417591,
-          "score": 1.24130651
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": -0.14060345,
-          "spread": 0.0,
-          "score": 0.14060345
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.00288521,
-          "spread": 0.04864312,
-          "score": 0.04872861
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00115246,
-          "spread": 0.00144005,
-          "score": 0.00184443
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00485613,
-          "spread": 0.0016085,
-          "score": 0.00511559
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00152481,
-          "spread": 0.00308926,
-          "score": 0.00344508
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00293438,
-          "spread": 0.0028587,
-          "score": 0.00409667
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00409825,
-          "spread": 0.02137566,
-          "score": 0.02176498
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": 0.00136138,
-          "spread": 0.03371286,
-          "score": 0.03374034
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": 0.05338029,
-          "spread": 0.05632371,
-          "score": 0.07760036
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": -0.01319931,
-          "spread": 0.00270425,
-          "score": 0.01347349
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00451602,
-          "spread": 0.01050051,
-          "score": 0.01143045
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00822121,
-          "spread": 0.00352335,
-          "score": 0.0089444
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00490796,
-          "spread": 0.00625694,
-          "score": 0.00795219
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.00144598,
-          "spread": 0.00160819,
-          "score": 0.00216267
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": 0.04025691,
-          "spread": 0.02699892,
-          "score": 0.04847227
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00373696,
-          "spread": 0.01215933,
-          "score": 0.01272062
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00181173,
-          "spread": 0.00169969,
-          "score": 0.00248421
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00210815,
-          "spread": 0.00194144,
-          "score": 0.00286592
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00429808,
-          "spread": 0.00208434,
-          "score": 0.00477682
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01653806,
-          "spread": 0.0062512,
-          "score": 0.01768007
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": 0.02276978,
-          "spread": 0.02188121,
-          "score": 0.03157927
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": -0.02395174,
-          "spread": 0.02736613,
-          "score": 0.03636744
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.60641327,
-          "spread": 0.88115584,
-          "score": 1.06966008
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": 0.5894007,
-          "spread": 0.42488411,
-          "score": 0.72658082
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": 0.00486948,
-          "spread": 0.01095362,
-          "score": 0.01198723
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00215475,
-          "spread": 0.00238222,
-          "score": 0.00321215
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.0028627,
-          "spread": 0.00155389,
-          "score": 0.00325725
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00069938,
-          "spread": 0.00273098,
-          "score": 0.00281911
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00098519,
-          "spread": 0.00237259,
-          "score": 0.002569
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00308037,
-          "spread": 0.0098558,
-          "score": 0.01032596
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": -0.0066894,
-          "spread": 0.02168081,
-          "score": 0.02268933
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": -0.01034969,
-          "spread": 0.00549391,
-          "score": 0.01171747
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": -0.00262681,
-          "spread": 0.00899924,
-          "score": 0.00937478
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": 0.003156,
-          "spread": 0.00352762,
-          "score": 0.00473334
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00196585,
-          "spread": 0.00435437,
-          "score": 0.00477756
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": 0.0025576,
-          "spread": 0.00512425,
-          "score": 0.00572706
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.00119877,
-          "spread": 0.00173233,
-          "score": 0.00210666
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": 0.05168645,
-          "spread": 0.00028506,
-          "score": 0.05168724
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00029519,
-          "spread": 0.00444969,
-          "score": 0.00445947
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00030244,
-          "spread": 0.00133294,
-          "score": 0.00136682
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00063616,
-          "spread": 0.00215912,
-          "score": 0.00225089
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00172423,
-          "spread": 0.00143349,
-          "score": 0.00224229
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01583728,
-          "spread": 0.00829043,
-          "score": 0.01787598
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00908533,
-          "spread": 0.0190117,
-          "score": 0.02107103
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": 0.03590599,
-          "spread": 0.02154383,
-          "score": 0.04187334
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.05498829,
-          "spread": 0.28168127,
-          "score": 0.28699835
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": -0.06305462,
-          "spread": 0.0,
-          "score": 0.06305462
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.04972465,
-          "spread": 0.03857458,
-          "score": 0.06293282
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00333501,
-          "spread": 0.00277429,
-          "score": 0.00433808
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00351176,
-          "spread": 0.00098789,
-          "score": 0.00364807
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00071494,
-          "spread": 0.00165439,
-          "score": 0.00180226
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00051592,
-          "spread": 0.0016367,
-          "score": 0.00171609
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00422969,
-          "spread": 0.00956316,
-          "score": 0.01045678
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": -0.00313257,
-          "spread": 0.02639648,
-          "score": 0.02658171
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00262022,
-          "spread": 0.01015742,
-          "score": 0.01048993
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": -0.02247775,
-          "spread": 0.03657234,
-          "score": 0.04292768
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00046381,
-          "spread": 0.00402058,
-          "score": 0.00404724
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00258764,
-          "spread": 0.00284027,
-          "score": 0.00384227
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00249598,
-          "spread": 0.00412385,
-          "score": 0.00482038
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.00075026,
-          "spread": 0.00104886,
-          "score": 0.00128957
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": 0.0028275,
-          "spread": 0.00488873,
-          "score": 0.00564751
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00173513,
-          "spread": 0.00351113,
-          "score": 0.00391646
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00037688,
-          "spread": 0.00055671,
-          "score": 0.00067228
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00028239,
-          "spread": 0.00138095,
-          "score": 0.00140953
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": 0.0031397,
-          "spread": 0.0023701,
-          "score": 0.00393384
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01567834,
-          "spread": 0.00683311,
-          "score": 0.01710269
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": 0.01078248,
-          "spread": 0.0245812,
-          "score": 0.02684208
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": 0.01187344,
-          "spread": 0.02966728,
-          "score": 0.03195507
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.01348711,
-          "spread": 0.18734656,
-          "score": 0.1878314
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": -0.18911808,
-          "spread": 0.16427545,
-          "score": 0.25050364
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.02132468,
-          "spread": 0.04568745,
-          "score": 0.05041909
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": -0.0029835,
-          "spread": 0.00264515,
-          "score": 0.00398724
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00375416,
-          "spread": 0.00079731,
-          "score": 0.00383789
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00040449,
-          "spread": 0.00132395,
-          "score": 0.00138437
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00044678,
-          "spread": 0.0007833,
-          "score": 0.00090176
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": -0.00176542,
-          "spread": 0.00355347,
-          "score": 0.00396785
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": 0.00456364,
-          "spread": 0.01151765,
-          "score": 0.01238883
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00840765,
-          "spread": 0.00578361,
-          "score": 0.01020484
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": -0.04019255,
-          "spread": 0.02851991,
-          "score": 0.04928312
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": 0.02009082,
-          "spread": 0.0,
-          "score": 0.02009082
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00158144,
-          "spread": 0.00520071,
-          "score": 0.00543584
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00339548,
-          "spread": 0.00166485,
-          "score": 0.00378167
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00017994,
-          "spread": 0.00308173,
-          "score": 0.00308698
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.00393418,
-          "spread": 0.00073685,
-          "score": 0.00400259
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00963302,
-          "spread": 0.00968461,
-          "score": 0.01365967
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00221002,
-          "spread": 0.00269157,
-          "score": 0.00348264
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00606967,
-          "spread": 0.00135594,
-          "score": 0.00621928
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00264275,
-          "spread": 0.00248051,
-          "score": 0.00362451
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.0009266,
-          "spread": 0.00865051,
-          "score": 0.00869999
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": -0.0212011,
-          "spread": 0.03064934,
-          "score": 0.03726753
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": -0.02472189,
-          "spread": 0.01886369,
-          "score": 0.03109679
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.24874927,
-          "spread": 1.69106942,
-          "score": 1.7092665
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": 0.04722778,
-          "spread": 0.25294441,
-          "score": 0.25731564
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": 1.942e-05,
-          "spread": 0.04469054,
-          "score": 0.04469054
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00349488,
-          "spread": 0.00167921,
-          "score": 0.00387736
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00348321,
-          "spread": 0.00164604,
-          "score": 0.00385256
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00106415,
-          "spread": 0.00282022,
-          "score": 0.0030143
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00344935,
-          "spread": 0.00287166,
-          "score": 0.00448825
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00480396,
-          "spread": 0.02268124,
-          "score": 0.0231844
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": -0.01842774,
-          "spread": 0.03728284,
-          "score": 0.04158836
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": 0.0606176,
-          "spread": 0.06293909,
-          "score": 0.0873832
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": -0.00526373,
-          "spread": 0.00278864,
-          "score": 0.00595679
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00066505,
-          "spread": 0.01066193,
-          "score": 0.01068265
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00616139,
-          "spread": 0.0041546,
-          "score": 0.00743124
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00412958,
-          "spread": 0.0062451,
-          "score": 0.00748697
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.00148551,
-          "spread": 0.00159626,
-          "score": 0.00218055
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": 0.0039594,
-          "spread": 0.03028233,
-          "score": 0.03054008
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00051786,
-          "spread": 0.01063213,
-          "score": 0.01064474
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00040759,
-          "spread": 0.00178585,
-          "score": 0.00183177
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00300849,
-          "spread": 0.00212897,
-          "score": 0.00368558
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00031566,
-          "spread": 0.00238528,
-          "score": 0.00240608
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00237309,
-          "spread": 0.00532202,
-          "score": 0.00582713
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00237013,
-          "spread": 0.02776608,
-          "score": 0.02786705
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": -0.06258002,
-          "spread": 0.02820392,
-          "score": 0.06864197
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.88394426,
-          "spread": 1.51225619,
-          "score": 1.75164958
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": 0.61278167,
-          "spread": 0.49634276,
-          "score": 0.78857943
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.01395028,
-          "spread": 0.01526333,
-          "score": 0.020678
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00195643,
-          "spread": 0.00230014,
-          "score": 0.00301964
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.0014258,
-          "spread": 0.00136173,
-          "score": 0.0019716
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": 1.69e-05,
-          "spread": 0.0023179,
-          "score": 0.00231796
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00100188,
-          "spread": 0.00185876,
-          "score": 0.00211158
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00395944,
-          "spread": 0.01017079,
-          "score": 0.01091431
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": -0.03426394,
-          "spread": 0.039702,
-          "score": 0.05244298
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00592039,
-          "spread": 0.0042682,
-          "score": 0.00729852
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": 0.01051281,
-          "spread": 0.0098886,
-          "score": 0.01443272
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": 9.81e-05,
-          "spread": 0.00364221,
-          "score": 0.00364353
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00010342,
-          "spread": 0.00484006,
-          "score": 0.00484117
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00227233,
-          "spread": 0.00534353,
-          "score": 0.00580662
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.00122354,
-          "spread": 0.0017184,
-          "score": 0.0021095
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": 0.0517763,
-          "spread": 0.01706662,
-          "score": 0.05451655
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00323571,
-          "spread": 0.00479493,
-          "score": 0.00578457
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00230801,
-          "spread": 0.00149363,
-          "score": 0.00274916
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00145774,
-          "spread": 0.00252366,
-          "score": 0.00291443
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00233761,
-          "spread": 0.00205454,
-          "score": 0.00311216
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.0020799,
-          "spread": 0.00633455,
-          "score": 0.00666727
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": -0.01269188,
-          "spread": 0.02102046,
-          "score": 0.02455491
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": 0.00822032,
-          "spread": 0.02232379,
-          "score": 0.02378919
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.0112951,
-          "spread": 0.32403128,
-          "score": 0.32422809
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": -0.08882583,
-          "spread": 0.0,
-          "score": 0.08882583
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.04998577,
-          "spread": 0.02580735,
-          "score": 0.05625475
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00079451,
-          "spread": 0.00250668,
-          "score": 0.00262958
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00229033,
-          "spread": 0.00090046,
-          "score": 0.00246098
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00044326,
-          "spread": 0.0013629,
-          "score": 0.00143317
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00087892,
-          "spread": 0.00153473,
-          "score": 0.00176859
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.0053233,
-          "spread": 0.00997065,
-          "score": 0.01130271
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": -0.0266218,
-          "spread": 0.04025701,
-          "score": 0.04826331
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00117875,
-          "spread": 0.00758761,
-          "score": 0.00767862
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": -0.0106737,
-          "spread": 0.03752462,
-          "score": 0.03901314
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00316923,
-          "spread": 0.00440097,
-          "score": 0.00542333
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00036126,
-          "spread": 0.00316583,
-          "score": 0.00318637
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00185546,
-          "spread": 0.00431428,
-          "score": 0.00469635
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 12,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.00079433,
-          "spread": 0.00106337,
-          "score": 0.0013273
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": -0.01368169,
-          "spread": 0.0110569,
-          "score": 0.01759101
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00200775,
-          "spread": 0.00279185,
-          "score": 0.00343882
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00130737,
-          "spread": 0.00063975,
-          "score": 0.00145551
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00057287,
-          "spread": 0.00148703,
-          "score": 0.00159356
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00050361,
-          "spread": 0.00289955,
-          "score": 0.00294296
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00285478,
-          "spread": 0.00527829,
-          "score": 0.00600084
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": -0.01049671,
-          "spread": 0.02885836,
-          "score": 0.03070807
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": -0.01166125,
-          "spread": 0.03305922,
-          "score": 0.03505563
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": -0.00019511,
-          "spread": 0.20506082,
-          "score": 0.20506091
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": 0.65086509,
-          "spread": 0.72305415,
-          "score": 0.97284772
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.0155108,
-          "spread": 0.0445541,
-          "score": 0.04717682
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00116597,
-          "spread": 0.00216782,
-          "score": 0.00246149
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00261952,
-          "spread": 0.00088597,
-          "score": 0.00276529
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": -3.104e-05,
-          "spread": 0.0011463,
-          "score": 0.00114672
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00053054,
-          "spread": 0.00072164,
-          "score": 0.00089567
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": -0.00054766,
-          "spread": 0.00276529,
-          "score": 0.002819
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": -0.02125129,
-          "spread": 0.01796194,
-          "score": 0.02782532
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00502623,
-          "spread": 0.00399652,
-          "score": 0.00642146
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": -0.03361533,
-          "spread": 0.02777324,
-          "score": 0.0436044
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": 0.02365624,
-          "spread": 0.0,
-          "score": 0.02365624
-        },
-        {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00149843,
-          "spread": 0.00566578,
-          "score": 0.00586057
+          "bias": -0.00066756,
+          "spread": 0.00636872,
+          "score": 0.00640361
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00118089,
-          "spread": 0.00192173,
-          "score": 0.00225556
+          "bias": 0.00155321,
+          "spread": 0.00229944,
+          "score": 0.00277487
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00024043,
-          "spread": 0.00324402,
-          "score": 0.00325292
+          "bias": -0.00041084,
+          "spread": 0.00310342,
+          "score": 0.0031305
         }
       ]
     }

--- a/benchmarking/baselines/study_power_model_compare_baseline.json
+++ b/benchmarking/baselines/study_power_model_compare_baseline.json
@@ -2,8 +2,8 @@
   "schema": "power_model_compare_baseline_v2",
   "modes": {
     "prepost": {
-      "recorded_utc": "2026-07-03T08:27:44Z",
-      "git_commit": "e5ba2c7-dirty",
+      "recorded_utc": "2026-07-04T02:48:54Z",
+      "git_commit": "789bc1e-dirty",
       "n_replicates": 4,
       "seed": 0,
       "campaign_months": [
@@ -26,171 +26,171 @@
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00603729,
-          "spread": 0.00511716,
-          "score": 0.00791418
+          "bias": -0.00590994,
+          "spread": 0.00524659,
+          "score": 0.00790279
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.16547734,
+          "bias": 0.15151524,
           "spread": 0.0,
-          "score": 0.16547734
+          "score": 0.15151524
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.02001345,
-          "spread": 0.01146345,
-          "score": 0.02306402
+          "bias": -0.01913765,
+          "spread": 0.01280035,
+          "score": 0.02302387
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00289058,
-          "spread": 0.00675815,
-          "score": 0.00735038
+          "bias": -0.00339564,
+          "spread": 0.00503552,
+          "score": 0.00607345
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00803438,
-          "spread": 0.0036156,
-          "score": 0.00881043
+          "bias": -0.00799482,
+          "spread": 0.00392708,
+          "score": 0.00890725
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.0077826,
-          "spread": 0.011085,
-          "score": 0.01354423
+          "bias": -0.00721038,
+          "spread": 0.01384436,
+          "score": 0.01560948
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": -0.00793552,
-          "spread": 0.0262153,
-          "score": 0.02739004
+          "bias": -0.00642325,
+          "spread": 0.03074172,
+          "score": 0.03140559
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.04203237,
-          "spread": 0.06202266,
-          "score": 0.07492349
+          "bias": -0.04530385,
+          "spread": 0.06566345,
+          "score": 0.07977548
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.02008583,
-          "spread": 0.06190865,
-          "score": 0.06508549
+          "bias": 0.01764975,
+          "spread": 0.06086104,
+          "score": 0.06336861
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.18329376,
-          "spread": 0.34732732,
-          "score": 0.39272493
+          "bias": 0.1752514,
+          "spread": 0.36285118,
+          "score": 0.40295661
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.34588413,
-          "spread": 0.72640948,
-          "score": 0.80455364
+          "bias": 0.18739279,
+          "spread": 0.71607179,
+          "score": 0.7401857
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.47476086,
+          "bias": 0.24094315,
           "spread": 0.0,
-          "score": 0.47476086
+          "score": 0.24094315
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00505578,
-          "spread": 0.00563809,
-          "score": 0.00757291
+          "bias": -0.00455755,
+          "spread": 0.0051241,
+          "score": 0.00685768
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00176217,
-          "spread": 0.00691943,
-          "score": 0.00714029
+          "bias": 0.00025908,
+          "spread": 0.00580198,
+          "score": 0.00580777
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00917683,
-          "spread": 0.00887084,
-          "score": 0.01276347
+          "bias": 0.00647064,
+          "spread": 0.00870879,
+          "score": 0.01084953
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.0014994,
-          "spread": 0.01123554,
-          "score": 0.01133515
+          "bias": -0.00255331,
+          "spread": 0.00743421,
+          "score": 0.00786046
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.01139721,
-          "spread": 0.01980225,
-          "score": 0.02284788
+          "bias": 0.00806805,
+          "spread": 0.0156248,
+          "score": 0.01758487
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.1443337,
-          "spread": 0.13073625,
-          "score": 0.19474132
+          "bias": -0.14952226,
+          "spread": 0.13338856,
+          "score": 0.20037319
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.01265231,
-          "spread": 0.04603359,
-          "score": 0.04774067
+          "bias": 0.00797576,
+          "spread": 0.03767835,
+          "score": 0.03851326
         },
         {
           "profile": "cp_0pct",
@@ -215,36 +215,36 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.01505057,
-          "spread": 0.02087715,
-          "score": 0.02573665
+          "bias": -0.01361579,
+          "spread": 0.02609218,
+          "score": 0.02943114
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.01270485,
-          "spread": 0.01344291,
-          "score": 0.01849662
+          "bias": -0.01143414,
+          "spread": 0.01512843,
+          "score": 0.01896336
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.01062912,
-          "spread": 0.01107654,
-          "score": 0.01535147
+          "bias": -0.00931376,
+          "spread": 0.00996479,
+          "score": 0.01363977
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00177992,
-          "spread": 0.00420632,
-          "score": 0.00456741
+          "bias": -0.00172752,
+          "spread": 0.00436217,
+          "score": 0.00469179
         },
         {
           "profile": "cp_0pct",
@@ -260,162 +260,162 @@
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00453859,
-          "spread": 0.00458772,
-          "score": 0.00645337
+          "bias": -0.00718893,
+          "spread": 0.00544853,
+          "score": 0.00902038
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00108482,
-          "spread": 0.00430304,
-          "score": 0.00443768
+          "bias": -0.00102697,
+          "spread": 0.00394892,
+          "score": 0.00408027
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00388501,
-          "spread": 0.00421862,
-          "score": 0.00573498
+          "bias": -0.00350857,
+          "spread": 0.00405937,
+          "score": 0.0053655
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00062739,
-          "spread": 0.00727555,
-          "score": 0.00730255
+          "bias": 0.00040712,
+          "spread": 0.00810419,
+          "score": 0.00811441
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.0001448,
-          "spread": 0.00990472,
-          "score": 0.00990578
+          "bias": 0.00018809,
+          "spread": 0.01244876,
+          "score": 0.01245019
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -6.369e-05,
-          "spread": 0.00984506,
-          "score": 0.00984527
+          "bias": -0.00264637,
+          "spread": 0.01703156,
+          "score": 0.01723593
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.041141,
-          "spread": 0.0719781,
-          "score": 0.08290614
+          "bias": 0.03314424,
+          "spread": 0.06883026,
+          "score": 0.07639467
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.16837362,
-          "spread": 0.09132207,
-          "score": 0.19154477
+          "bias": 0.15397332,
+          "spread": 0.10463201,
+          "score": 0.18616026
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.09760823,
-          "spread": 0.57728421,
-          "score": 0.58547795
+          "bias": 0.07982816,
+          "spread": 0.3021172,
+          "score": 0.31248574
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.02814117,
-          "spread": 0.00842305,
-          "score": 0.0293747
+          "bias": 0.1513414,
+          "spread": 0.05802769,
+          "score": 0.16208465
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00379979,
-          "spread": 0.00270361,
-          "score": 0.00466347
+          "bias": -0.00306613,
+          "spread": 0.00112059,
+          "score": 0.00326449
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00078216,
-          "spread": 0.00449752,
-          "score": 0.00456503
+          "bias": 0.0004719,
+          "spread": 0.00244379,
+          "score": 0.00248893
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.0043107,
-          "spread": 0.00313616,
-          "score": 0.00533082
+          "bias": 0.00329019,
+          "spread": 0.0029934,
+          "score": 0.00444812
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00117692,
-          "spread": 0.00181326,
-          "score": 0.00216172
+          "bias": 0.00118638,
+          "spread": 0.00301301,
+          "score": 0.00323817
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.02788457,
-          "spread": 0.04321411,
-          "score": 0.05142965
+          "bias": 0.02778016,
+          "spread": 0.04525142,
+          "score": 0.05309829
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.14522503,
-          "spread": 0.05739087,
-          "score": 0.15615384
+          "bias": -0.15166403,
+          "spread": 0.0696654,
+          "score": 0.16689891
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00866587,
-          "spread": 0.04727916,
-          "score": 0.04806679
+          "bias": 0.0102531,
+          "spread": 0.04831375,
+          "score": 0.04938972
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.16279151,
+          "bias": 0.19296999,
           "spread": 0.0,
-          "score": 0.16279151
+          "score": 0.19296999
         },
         {
           "profile": "cp_0pct",
@@ -431,2358 +431,2358 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00214118,
-          "spread": 0.00496376,
-          "score": 0.00540588
+          "bias": -0.00388494,
+          "spread": 0.00486661,
+          "score": 0.00622709
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.0058912,
-          "spread": 0.00945105,
-          "score": 0.01113682
+          "bias": -0.00507975,
+          "spread": 0.01013057,
+          "score": 0.0113328
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00211571,
-          "spread": 0.01151507,
-          "score": 0.01170782
+          "bias": -0.00109698,
+          "spread": 0.01071347,
+          "score": 0.01076949
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00225221,
-          "spread": 0.00452042,
-          "score": 0.00505041
+          "bias": -0.00213816,
+          "spread": 0.00422496,
+          "score": 0.00473519
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.19113569,
+          "bias": 0.16926857,
           "spread": 0.0,
-          "score": 0.19113569
+          "score": 0.16926857
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00295965,
-          "spread": 0.00514362,
-          "score": 0.00593433
+          "bias": -0.0053057,
+          "spread": 0.00378346,
+          "score": 0.00651652
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00300557,
-          "spread": 0.00413532,
-          "score": 0.00511217
+          "bias": -0.00300595,
+          "spread": 0.00376066,
+          "score": 0.00481438
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.0031883,
-          "spread": 0.00505267,
-          "score": 0.00597451
+          "bias": -0.00309526,
+          "spread": 0.00464519,
+          "score": 0.00558197
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00024016,
-          "spread": 0.00496163,
-          "score": 0.00496743
+          "bias": 0.00022897,
+          "spread": 0.0050147,
+          "score": 0.00501992
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00543955,
-          "spread": 0.00756464,
-          "score": 0.00931732
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00184647,
-          "spread": 0.01367003,
-          "score": 0.01379417
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": 0.04739879,
-          "spread": 0.05525524,
-          "score": 0.07279964
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.3694275,
-          "spread": 0.37109029,
-          "score": 0.52362647
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": 0.87468662,
-          "spread": 0.72012377,
-          "score": 1.13298496
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.08875769,
-          "spread": 0.13039324,
-          "score": 0.15773498
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00175218,
-          "spread": 0.00317275,
-          "score": 0.00362443
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00124226,
-          "spread": 0.00174146,
-          "score": 0.00213914
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00029772,
-          "spread": 0.00138109,
-          "score": 0.00141282
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00150073,
-          "spread": 0.00125143,
-          "score": 0.00195404
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": -0.00056542,
-          "spread": 0.00270341,
-          "score": 0.0027619
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": -0.12804353,
-          "spread": 0.07186086,
-          "score": 0.14683027
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": 0.01072625,
-          "spread": 0.02111237,
-          "score": 0.0236809
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": 0.05325308,
-          "spread": 0.03567098,
-          "score": 0.06409609
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00389645,
-          "spread": 0.00868207,
-          "score": 0.00951634
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00454948,
-          "spread": 0.00988666,
-          "score": 0.0108832
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00277302,
-          "spread": 0.00923165,
-          "score": 0.00963914
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 3,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": -0.0055522,
-          "spread": 0.0047958,
-          "score": 0.00733667
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": 0.1292666,
-          "spread": 0.0,
-          "score": 0.1292666
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": -0.0211394,
-          "spread": 0.01039747,
-          "score": 0.02355805
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00595837,
-          "spread": 0.00579684,
-          "score": 0.00831297
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00661745,
-          "spread": 0.00434293,
-          "score": 0.00791528
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00383897,
-          "spread": 0.00931888,
-          "score": 0.01007865
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": -0.00173352,
-          "spread": 0.02129237,
-          "score": 0.02136282
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": -0.03148737,
-          "spread": 0.05393565,
-          "score": 0.06245405
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": 0.02764563,
-          "spread": 0.05297514,
-          "score": 0.05975489
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.19256046,
-          "spread": 0.31697084,
-          "score": 0.3708774
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": 0.4693952,
-          "spread": 0.54934847,
-          "score": 0.72257567
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": 0.51172696,
-          "spread": 0.0,
-          "score": 0.51172696
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00166036,
-          "spread": 0.00764673,
-          "score": 0.00782491
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00392909,
-          "spread": 0.00653044,
-          "score": 0.00762131
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00700643,
-          "spread": 0.00728767,
-          "score": 0.01010941
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00216385,
-          "spread": 0.01181677,
-          "score": 0.01201325
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.01197715,
-          "spread": 0.01780992,
-          "score": 0.02146265
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": -0.09821144,
-          "spread": 0.08469511,
-          "score": 0.12968712
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": 0.02042065,
-          "spread": 0.05154554,
-          "score": 0.05544317
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": -0.01377858,
-          "spread": 0.01905226,
-          "score": 0.02351251
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": -0.01218435,
-          "spread": 0.01371223,
-          "score": 0.01834349
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00791925,
-          "spread": 0.01055468,
-          "score": 0.01319529
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": -0.00156356,
-          "spread": 0.00390865,
-          "score": 0.00420978
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": -0.0036613,
-          "spread": 0.00299706,
-          "score": 0.00473154
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00300275,
-          "spread": 0.00438014,
-          "score": 0.00531057
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00365181,
-          "spread": 0.00454275,
-          "score": 0.00582857
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00380986,
-          "spread": 0.00633031,
-          "score": 0.00738836
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00407005,
-          "spread": 0.00741842,
-          "score": 0.00846157
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00400263,
-          "spread": 0.00831578,
-          "score": 0.00922894
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": 0.04756908,
-          "spread": 0.06453323,
-          "score": 0.08017079
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.17192375,
-          "spread": 0.06460849,
-          "score": 0.18366283
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": -0.02664223,
-          "spread": 0.45151114,
-          "score": 0.45229649
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": 0.05270958,
-          "spread": 0.04219387,
-          "score": 0.06751757
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00010967,
-          "spread": 0.00459479,
-          "score": 0.0045961
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00397197,
-          "spread": 0.00543315,
-          "score": 0.00673021
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00199641,
-          "spread": 0.00264855,
-          "score": 0.0033167
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": -3.819e-05,
-          "spread": 0.00276283,
-          "score": 0.0027631
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.02717434,
-          "spread": 0.04277799,
-          "score": 0.0506794
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": -0.08288663,
-          "spread": 0.02690217,
-          "score": 0.0871431
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": 0.01262495,
-          "spread": 0.05094161,
-          "score": 0.05248273
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": 0.16599011,
-          "spread": 0.0,
-          "score": 0.16599011
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00330847,
-          "spread": 0.00524018,
-          "score": 0.00619722
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00621301,
-          "spread": 0.00952077,
-          "score": 0.01136866
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00015875,
-          "spread": 0.01045077,
-          "score": 0.01045197
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 12,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": -0.002044,
-          "spread": 0.00424857,
-          "score": 0.00471469
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": 0.14786293,
-          "spread": 0.0,
-          "score": 0.14786293
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": 0.0005254,
-          "spread": 0.00715587,
-          "score": 0.00717513
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00363425,
-          "spread": 0.00388206,
-          "score": 0.00531772
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00360494,
-          "spread": 0.00490358,
-          "score": 0.00608611
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": 0.0022544,
-          "spread": 0.00409445,
-          "score": 0.00467405
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00857738,
-          "spread": 0.00700028,
-          "score": 0.01107138
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00507748,
-          "spread": 0.01207993,
-          "score": 0.01310365
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": 0.04854428,
-          "spread": 0.04638937,
-          "score": 0.06714552
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.32615525,
-          "spread": 0.29546495,
-          "score": 0.44008724
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": 0.96558837,
-          "spread": 0.47056452,
-          "score": 1.07414704
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.05829629,
-          "spread": 0.122408,
-          "score": 0.13558089
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00217352,
-          "spread": 0.00269581,
-          "score": 0.00346288
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00559292,
-          "spread": 0.00216511,
-          "score": 0.00599737
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00258274,
-          "spread": 0.00146632,
-          "score": 0.00296995
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00305137,
-          "spread": 0.00151663,
-          "score": 0.00340749
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": -0.00047345,
-          "spread": 0.00459587,
-          "score": 0.0046202
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": -0.07354749,
-          "spread": 0.03314393,
-          "score": 0.08067064
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": 0.01364211,
-          "spread": 0.02344788,
-          "score": 0.02712767
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": 0.06017136,
-          "spread": 0.03906927,
-          "score": 0.0717426
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00353564,
-          "spread": 0.00843719,
-          "score": 0.00914805
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00436716,
-          "spread": 0.0094171,
-          "score": 0.01038046
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00091522,
-          "spread": 0.00860137,
-          "score": 0.00864993
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": -0.00652192,
-          "spread": 0.00543844,
-          "score": 0.00849188
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": 0.11219165,
-          "spread": 0.0,
-          "score": 0.11219165
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": -0.01949512,
-          "spread": 0.01248962,
-          "score": 0.02315276
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00038508,
-          "spread": 0.00801978,
-          "score": 0.00802902
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00949726,
-          "spread": 0.00371672,
-          "score": 0.01019862
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": -0.01183482,
-          "spread": 0.01240483,
-          "score": 0.01714476
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": -0.01426506,
-          "spread": 0.02968834,
-          "score": 0.03293766
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": -0.04950815,
-          "spread": 0.06534442,
-          "score": 0.0819814
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": 0.0154917,
-          "spread": 0.08130944,
-          "score": 0.08277209
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.18355087,
-          "spread": 0.39569293,
-          "score": 0.43619241
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": 0.10431716,
-          "spread": 0.98752403,
-          "score": 0.99301852
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": 0.43658722,
-          "spread": 0.0,
-          "score": 0.43658722
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00875317,
-          "spread": 0.00466339,
-          "score": 0.00991793
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00814421,
-          "spread": 0.00671094,
-          "score": 0.01055296
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": 0.01168652,
-          "spread": 0.00940154,
-          "score": 0.0149988
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00042017,
-          "spread": 0.01098317,
-          "score": 0.0109912
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.01170161,
-          "spread": 0.02103084,
-          "score": 0.02406707
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": -0.1969047,
-          "spread": 0.17290725,
-          "score": 0.26204652
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00598086,
-          "spread": 0.03842914,
-          "score": 0.03889176
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": -0.01520116,
-          "spread": 0.02027389,
-          "score": 0.02533981
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": -0.01385899,
-          "spread": 0.0130063,
-          "score": 0.01900619
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": -0.01408884,
-          "spread": 0.01144185,
-          "score": 0.01814969
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": -0.00199665,
-          "spread": 0.00450466,
-          "score": 0.00492733
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00666292,
-          "spread": 0.00863858,
-          "score": 0.01090961
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00088324,
-          "spread": 0.00438512,
-          "score": 0.00447318
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": -0.0039887,
-          "spread": 0.00405506,
-          "score": 0.00568799
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00267747,
-          "spread": 0.00831237,
-          "score": 0.00873295
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": -0.00408261,
-          "spread": 0.01254487,
-          "score": 0.01319247
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00490623,
-          "spread": 0.00948719,
-          "score": 0.01068072
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": 0.0361861,
-          "spread": 0.08279284,
-          "score": 0.09035534
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.08468894,
-          "spread": 0.16287331,
-          "score": 0.18357541
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": 0.1965566,
-          "spread": 0.30584307,
-          "score": 0.36355809
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": 0.00484081,
-          "spread": 0.00603782,
-          "score": 0.00773878
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00729022,
-          "spread": 0.00331561,
-          "score": 0.00800878
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00576263,
-          "spread": 0.00346172,
-          "score": 0.00672246
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00622908,
-          "spread": 0.00399982,
-          "score": 0.00740271
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00211326,
-          "spread": 0.00247205,
-          "score": 0.00325221
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.02777728,
-          "spread": 0.0443061,
-          "score": 0.05229347
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": -0.20943243,
-          "spread": 0.10280961,
-          "score": 0.23330615
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00512658,
-          "spread": 0.04681607,
-          "score": 0.04709593
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": 0.1568382,
-          "spread": 0.0,
-          "score": 0.1568382
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": -0.0019843,
-          "spread": 0.00467322,
-          "score": 0.00507704
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": -0.0061581,
-          "spread": 0.01028687,
-          "score": 0.01198924
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00371575,
-          "spread": 0.01216881,
-          "score": 0.01272347
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": -0.0024604,
-          "spread": 0.00479241,
-          "score": 0.00538709
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": 0.22074436,
-          "spread": 0.0,
-          "score": 0.22074436
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00672887,
-          "spread": 0.00385574,
-          "score": 0.00775528
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00238842,
-          "spread": 0.00431465,
-          "score": 0.0049316
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00283409,
-          "spread": 0.00516071,
-          "score": 0.00588769
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00270458,
-          "spread": 0.00581015,
-          "score": 0.00640879
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.0024846,
-          "spread": 0.00816953,
-          "score": 0.008539
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": -0.0073942,
-          "spread": 0.01602438,
-          "score": 0.01764809
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": 0.04570139,
-          "spread": 0.0646058,
-          "score": 0.07913612
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.40377478,
-          "spread": 0.44042316,
-          "score": 0.59750032
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": 0.76834976,
-          "spread": 0.99359666,
-          "score": 1.25602376
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.12248411,
-          "spread": 0.15073173,
-          "score": 0.19422258
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": -0.0059004,
-          "spread": 0.00437105,
-          "score": 0.00734308
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00294194,
-          "spread": 0.00143581,
-          "score": 0.00327361
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00140717,
-          "spread": 0.00154243,
-          "score": 0.00208787
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00060733,
-          "spread": 0.00134548,
-          "score": 0.0014762
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": -0.00125551,
-          "spread": 0.00126813,
-          "score": 0.0017845
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": -0.18178354,
-          "spread": 0.11230039,
-          "score": 0.21367413
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00634076,
-          "spread": 0.01842968,
-          "score": 0.01948995
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": 0.04734815,
-          "spread": 0.03347808,
-          "score": 0.05798818
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00428081,
-          "spread": 0.00911061,
-          "score": 0.0100662
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00449615,
-          "spread": 0.01025062,
-          "score": 0.01119332
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00453484,
-          "spread": 0.00973436,
-          "score": 0.01073883
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": -0.0061829,
-          "spread": 0.00521367,
-          "score": 0.00808769
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": 0.21793617,
-          "spread": 0.0,
-          "score": 0.21793617
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": -0.02034563,
-          "spread": 0.0122955,
-          "score": 0.02377234
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00175254,
-          "spread": 0.00692618,
-          "score": 0.00714447
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00847195,
-          "spread": 0.0036239,
-          "score": 0.00921448
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00909494,
-          "spread": 0.01148037,
-          "score": 0.01464639
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": -0.01019325,
-          "spread": 0.02749455,
-          "score": 0.02932324
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": -0.04582491,
-          "spread": 0.06275554,
-          "score": 0.07770573
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": 0.01442569,
-          "spread": 0.0713446,
-          "score": 0.07278841
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.17729281,
-          "spread": 0.3585433,
-          "score": 0.39998254
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": 0.26669409,
-          "spread": 0.78768394,
-          "score": 0.83160791
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": 0.46946066,
-          "spread": 0.0,
-          "score": 0.46946066
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00629012,
-          "spread": 0.00461982,
-          "score": 0.00780438
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00403718,
-          "spread": 0.00653652,
-          "score": 0.00768276
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": 0.01015346,
-          "spread": 0.00937045,
-          "score": 0.01381659
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00081737,
-          "spread": 0.01095806,
-          "score": 0.0109885
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.01179713,
-          "spread": 0.02045706,
-          "score": 0.0236149
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": -0.16621634,
-          "spread": 0.14246693,
-          "score": 0.2189171
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": 0.01092231,
-          "spread": 0.04354897,
-          "score": 0.04489777
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": -0.01498304,
-          "spread": 0.02056654,
-          "score": 0.02544551
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": -0.01316692,
-          "spread": 0.01363438,
-          "score": 0.01895426
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": -0.01174519,
-          "spread": 0.01130187,
-          "score": 0.01629974
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": -0.00184497,
-          "spread": 0.00429588,
-          "score": 0.00467531
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00542365,
-          "spread": 0.00588647,
-          "score": 0.00800416
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00057827,
-          "spread": 0.00432289,
-          "score": 0.0043614
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00393965,
-          "spread": 0.00418143,
-          "score": 0.00574502
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00031974,
-          "spread": 0.00772736,
-          "score": 0.00773397
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": -0.00114211,
-          "spread": 0.01083337,
-          "score": 0.01089341
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00133951,
-          "spread": 0.01049458,
-          "score": 0.01057973
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": 0.03726363,
-          "spread": 0.0694135,
-          "score": 0.07878333
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.16900018,
-          "spread": 0.099481,
-          "score": 0.19610592
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": -0.13523397,
-          "spread": 0.60088593,
-          "score": 0.61591569
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": 0.00806027,
-          "spread": 0.01544729,
-          "score": 0.01742374
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00476607,
-          "spread": 0.00278471,
-          "score": 0.00551996
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00213161,
-          "spread": 0.00423665,
-          "score": 0.00474267
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00466733,
-          "spread": 0.00357906,
-          "score": 0.00588163
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00110261,
-          "spread": 0.00193034,
-          "score": 0.00222305
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.02727043,
-          "spread": 0.04324626,
-          "score": 0.05112646
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": -0.16479721,
-          "spread": 0.07235008,
-          "score": 0.1799796
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00700639,
-          "spread": 0.04787268,
-          "score": 0.04838268
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": 0.16098694,
-          "spread": 0.0,
-          "score": 0.16098694
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00228558,
-          "spread": 0.00548878,
-          "score": 0.00594564
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00598658,
-          "spread": 0.0097097,
-          "score": 0.0114069
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00239348,
-          "spread": 0.01171749,
-          "score": 0.01195944
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": -0.00231467,
-          "spread": 0.00460202,
-          "score": 0.00515134
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": 0.20943789,
-          "spread": 0.0,
-          "score": 0.20943789
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00416508,
-          "spread": 0.0047461,
-          "score": 0.00631453
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00289211,
-          "spread": 0.00421934,
-          "score": 0.00511538
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00305065,
-          "spread": 0.00508427,
-          "score": 0.00592927
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00089481,
-          "spread": 0.00507752,
-          "score": 0.00515576
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00493001,
-          "spread": 0.00766196,
-          "score": 0.00911102
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00280375,
-          "spread": 0.01388055,
-          "score": 0.01416088
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": 0.04873551,
-          "spread": 0.05739881,
-          "score": 0.07529789
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.38814796,
-          "spread": 0.39831128,
-          "score": 0.55615709
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": 0.84241629,
-          "spread": 0.81581921,
-          "score": 1.17270038
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.10124787,
-          "spread": 0.14607969,
-          "score": 0.1777369
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00311448,
-          "spread": 0.00360585,
-          "score": 0.00476468
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": -9.553e-05,
-          "spread": 0.00162563,
-          "score": 0.00162844
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": 3.25e-06,
-          "spread": 0.00158588,
-          "score": 0.00158588
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00136603,
-          "spread": 0.00116294,
-          "score": 0.00179401
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": -0.0008659,
-          "spread": 0.00227607,
-          "score": 0.00243522
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": -0.14290676,
-          "spread": 0.08470768,
-          "score": 0.16612565
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00936249,
-          "spread": 0.02023574,
-          "score": 0.02229667
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": 0.05051698,
-          "spread": 0.0348697,
-          "score": 0.06138291
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00351361,
+          "bias": 0.00647905,
           "spread": 0.00843785,
-          "score": 0.00914017
+          "score": 0.01063839
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.00076792,
+          "spread": 0.01522482,
+          "score": 0.01524417
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.04883774,
+          "spread": 0.05878311,
+          "score": 0.07642368
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.37397117,
+          "spread": 0.39433677,
+          "score": 0.54346658
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": 0.84233406,
+          "spread": 0.75840245,
+          "score": 1.13344649
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.04722723,
+          "spread": 0.13985304,
+          "score": 0.14761194
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": -0.00148592,
+          "spread": 0.00308955,
+          "score": 0.00342831
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": -0.00106802,
+          "spread": 0.00176468,
+          "score": 0.00206271
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": -0.00053192,
+          "spread": 0.00160692,
+          "score": 0.00169268
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": -0.00179264,
+          "spread": 0.0011507,
+          "score": 0.00213018
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": -0.00036222,
+          "spread": 0.00272319,
+          "score": 0.00274717
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.13121348,
+          "spread": 0.07071799,
+          "score": 0.14905707
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.01069174,
+          "spread": 0.02166034,
+          "score": 0.02415541
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.05462794,
+          "spread": 0.03948652,
+          "score": 0.06740472
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.00404436,
+          "spread": 0.00916264,
+          "score": 0.01001553
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.00451811,
+          "spread": 0.00902315,
+          "score": 0.01009111
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": -0.00225867,
+          "spread": 0.00882238,
+          "score": 0.00910692
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": -0.00543049,
+          "spread": 0.00491109,
+          "score": 0.00732181
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.10716488,
+          "spread": 0.0,
+          "score": 0.10716488
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": -0.01964753,
+          "spread": 0.0123913,
+          "score": 0.02322864
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": -0.00632667,
+          "spread": 0.00388087,
+          "score": 0.00742212
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00648528,
+          "spread": 0.00425204,
+          "score": 0.00775492
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.00370975,
+          "spread": 0.0119557,
+          "score": 0.01251803
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.00219034,
+          "spread": 0.02591076,
+          "score": 0.02600318
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.0376318,
+          "spread": 0.06006972,
+          "score": 0.07088388
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.02304361,
+          "spread": 0.04010619,
+          "score": 0.04625489
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.20650505,
+          "spread": 0.34529411,
+          "score": 0.40233364
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": 0.38354955,
+          "spread": 0.59710361,
+          "score": 0.70967808
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.30527846,
+          "spread": 0.0,
+          "score": 0.30527846
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": -0.00077907,
+          "spread": 0.00784927,
+          "score": 0.00788783
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": -0.00585762,
+          "spread": 0.00553902,
+          "score": 0.00806179
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.00373225,
+          "spread": 0.00710513,
+          "score": 0.00802575
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": -0.00386273,
+          "spread": 0.00869354,
+          "score": 0.00951306
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00804665,
+          "spread": 0.01257199,
+          "score": 0.01492661
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.1012951,
+          "spread": 0.09302521,
+          "score": 0.13752959
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.01678409,
+          "spread": 0.04436623,
+          "score": 0.04743488
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.01244095,
+          "spread": 0.02339032,
+          "score": 0.0264931
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.01121409,
+          "spread": 0.01449027,
+          "score": 0.01832276
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": -0.00644423,
+          "spread": 0.0098129,
+          "score": 0.01173972
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": -0.00151197,
+          "spread": 0.00405403,
+          "score": 0.0043268
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": -0.00475925,
+          "spread": 0.00243352,
+          "score": 0.00534532
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": -0.00294416,
+          "spread": 0.00411748,
+          "score": 0.00506179
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00340567,
+          "spread": 0.00424723,
+          "score": 0.00544403
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": 0.0036575,
+          "spread": 0.00716437,
+          "score": 0.00804397
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.00423248,
+          "spread": 0.00950951,
+          "score": 0.01040888
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": 0.00097594,
+          "spread": 0.01538858,
+          "score": 0.01541949
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.03996947,
+          "spread": 0.06194079,
+          "score": 0.07371716
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.16354799,
+          "spread": 0.07351758,
+          "score": 0.17931196
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": 0.05986372,
+          "spread": 0.30631757,
+          "score": 0.31211235
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.16904946,
+          "spread": 0.09550484,
+          "score": 0.19416203
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": -5.88e-06,
+          "spread": 0.00346445,
+          "score": 0.00346446
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": -0.0043293,
+          "spread": 0.00379862,
+          "score": 0.00575954
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.00109969,
+          "spread": 0.00412492,
+          "score": 0.00426899
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": -0.00043083,
+          "spread": 0.00389933,
+          "score": 0.00392306
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.02733881,
+          "spread": 0.04566316,
+          "score": 0.05322156
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.08882161,
+          "spread": 0.02777189,
+          "score": 0.09306211
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.01400158,
+          "spread": 0.05084332,
+          "score": 0.05273601
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.19921411,
+          "spread": 0.0,
+          "score": 0.19921411
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.00450805,
+          "spread": 0.00529426,
+          "score": 0.00695354
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.00466344,
+          "spread": 0.01004373,
+          "score": 0.01107358
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00055212,
+          "spread": 0.01009823,
+          "score": 0.01011331
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": -0.00193682,
+          "spread": 0.00397211,
+          "score": 0.00441916
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.11909327,
+          "spread": 0.0,
+          "score": 0.11909327
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": -0.00160698,
+          "spread": 0.00536962,
+          "score": 0.00560493
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": -0.00364148,
+          "spread": 0.00355886,
+          "score": 0.00509175
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00347636,
+          "spread": 0.00456382,
+          "score": 0.00573703
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": 0.00260735,
+          "spread": 0.00435385,
+          "score": 0.00507487
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.00912005,
+          "spread": 0.00740204,
+          "score": 0.01174587
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": 0.00513717,
+          "spread": 0.0126081,
+          "score": 0.0136145
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.04828167,
+          "spread": 0.04632518,
+          "score": 0.06691145
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.33240454,
+          "spread": 0.31917032,
+          "score": 0.46082803
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": 0.947253,
+          "spread": 0.48955273,
+          "score": 1.06627863
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.02065236,
+          "spread": 0.13157975,
+          "score": 0.13319065
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.00262049,
+          "spread": 0.00260176,
+          "score": 0.00369272
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": -0.00554926,
+          "spread": 0.00207403,
+          "score": 0.00592418
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": -0.0027192,
+          "spread": 0.00174865,
+          "score": 0.00323292
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": -0.00314228,
+          "spread": 0.00142096,
+          "score": 0.00344862
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": -1.41e-06,
+          "spread": 0.00477634,
+          "score": 0.00477634
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.07674344,
+          "spread": 0.02977752,
+          "score": 0.08231802
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.01434616,
+          "spread": 0.02426836,
+          "score": 0.02819158
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.0591561,
+          "spread": 0.04212885,
+          "score": 0.07262426
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.00411574,
+          "spread": 0.00890646,
+          "score": 0.00981144
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.00448543,
+          "spread": 0.00868571,
+          "score": 0.00977551
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": -0.0005272,
+          "spread": 0.00835944,
+          "score": 0.00837604
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": -0.00638937,
+          "spread": 0.00558237,
+          "score": 0.00848452
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.09906586,
+          "spread": 0.0,
+          "score": 0.09906586
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": -0.01737151,
+          "spread": 0.01343781,
+          "score": 0.02196234
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.00040861,
+          "spread": 0.00696666,
+          "score": 0.00697864
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00953532,
+          "spread": 0.00455394,
+          "score": 0.01056697
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.01206618,
+          "spread": 0.01577833,
+          "score": 0.01986324
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.01362128,
+          "spread": 0.03490692,
+          "score": 0.03747042
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.0559482,
+          "spread": 0.0754887,
+          "score": 0.09396141
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.00744879,
+          "spread": 0.06401613,
+          "score": 0.06444804
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.17212235,
+          "spread": 0.41528174,
+          "score": 0.44953869
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": 0.11131473,
+          "spread": 0.87843364,
+          "score": 0.88545843
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.27313382,
+          "spread": 0.0,
+          "score": 0.27313382
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": -0.00764268,
+          "spread": 0.00396769,
+          "score": 0.00861122
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00711507,
+          "spread": 0.00531616,
+          "score": 0.00888177
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.00947511,
+          "spread": 0.00926498,
+          "score": 0.01325208
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": -0.00083005,
+          "spread": 0.00766574,
+          "score": 0.00771055
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00846943,
+          "spread": 0.01744688,
+          "score": 0.01939394
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.20550607,
+          "spread": 0.17866447,
+          "score": 0.27231184
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.00314289,
+          "spread": 0.03059247,
+          "score": 0.03075348
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.0157341,
+          "spread": 0.02649037,
+          "score": 0.03081074
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.01294889,
+          "spread": 0.01429287,
+          "score": 0.01928626
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": -0.01273846,
+          "spread": 0.00985306,
+          "score": 0.01610438
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": -0.00194305,
+          "spread": 0.00467044,
+          "score": 0.00505851
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": -0.00905329,
+          "spread": 0.00892997,
+          "score": 0.01271638
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.00088251,
+          "spread": 0.0040521,
+          "score": 0.00414709
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00379284,
+          "spread": 0.00402469,
+          "score": 0.00553026
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.00255423,
+          "spread": 0.00944072,
+          "score": 0.00978015
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.00393702,
+          "spread": 0.01579345,
+          "score": 0.01627677
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.00841339,
+          "spread": 0.01809178,
+          "score": 0.01995239
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.02596617,
+          "spread": 0.08005191,
+          "score": 0.08415789
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.06663101,
+          "spread": 0.17781478,
+          "score": 0.18988888
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.05478595,
+          "spread": 0.35559766,
+          "score": 0.35979327
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.12476769,
+          "spread": 0.04116928,
+          "score": 0.1313845
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": -0.00689883,
+          "spread": 0.00277254,
+          "score": 0.00743511
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00509547,
+          "spread": 0.00156989,
+          "score": 0.00533182
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.00498275,
+          "spread": 0.00299976,
+          "score": 0.00581605
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00198623,
+          "spread": 0.00310676,
+          "score": 0.00368742
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.02742224,
+          "spread": 0.04512326,
+          "score": 0.05280235
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.21615064,
+          "spread": 0.11866451,
+          "score": 0.24658135
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.00603129,
+          "spread": 0.04715843,
+          "score": 0.04754255
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.1837499,
+          "spread": 0.0,
+          "score": 0.1837499
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.00373582,
+          "spread": 0.00452025,
+          "score": 0.00586421
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.00471259,
+          "spread": 0.01062217,
+          "score": 0.01162063
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": -0.00271963,
+          "spread": 0.01180431,
+          "score": 0.01211355
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": -0.00233955,
+          "spread": 0.00447799,
+          "score": 0.00505231
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.19119051,
+          "spread": 0.0,
+          "score": 0.19119051
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": -0.00869362,
+          "spread": 0.00269628,
+          "score": 0.00910214
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": -0.00242943,
+          "spread": 0.00401634,
+          "score": 0.00469395
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00277351,
+          "spread": 0.00484707,
+          "score": 0.00558448
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.0020399,
+          "spread": 0.00576907,
+          "score": 0.00611909
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.00394154,
+          "spread": 0.0086802,
+          "score": 0.00953319
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.00645203,
+          "spread": 0.01718426,
+          "score": 0.01835559
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.04319279,
+          "spread": 0.06415913,
+          "score": 0.07734346
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.39986542,
+          "spread": 0.45903281,
+          "score": 0.6087721
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": 0.73095534,
+          "spread": 1.06878378,
+          "score": 1.29483377
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.0519094,
+          "spread": 0.15034686,
+          "score": 0.15905585
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": -0.00582611,
+          "spread": 0.00443833,
+          "score": 0.00732409
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00301402,
+          "spread": 0.00155237,
+          "score": 0.0033903
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.0012918,
+          "spread": 0.00174282,
+          "score": 0.00216937
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": -0.00066704,
+          "spread": 0.00140359,
+          "score": 0.00155403
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": -0.00069728,
+          "spread": 0.00154199,
+          "score": 0.00169232
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.18763492,
+          "spread": 0.1123894,
+          "score": 0.21871955
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.00711075,
+          "spread": 0.02014192,
+          "score": 0.02136024
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.0475991,
+          "spread": 0.03614243,
+          "score": 0.05976579
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.00452471,
+          "spread": 0.00937182,
+          "score": 0.01040692
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.00413357,
+          "spread": 0.00930446,
+          "score": 0.01018132
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": -0.00387377,
+          "spread": 0.00940981,
+          "score": 0.01017598
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": -0.00605378,
+          "spread": 0.0053473,
+          "score": 0.00807724
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.13716425,
+          "spread": 0.0,
+          "score": 0.13716425
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": -0.01782395,
+          "spread": 0.01244126,
+          "score": 0.02173656
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": -0.00232203,
+          "spread": 0.00554423,
+          "score": 0.00601085
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00844908,
+          "spread": 0.00399905,
+          "score": 0.0093477
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.00857501,
+          "spread": 0.01422067,
+          "score": 0.01660597
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.00853518,
+          "spread": 0.03160858,
+          "score": 0.03274068
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.04770317,
+          "spread": 0.06869257,
+          "score": 0.0836317
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.01454282,
+          "spread": 0.05285219,
+          "score": 0.0548165
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.20012048,
+          "spread": 0.40726139,
+          "score": 0.45377312
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": 0.23829923,
+          "spread": 0.82133852,
+          "score": 0.85520962
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.27167519,
+          "spread": 0.0,
+          "score": 0.27167519
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": -0.00552432,
+          "spread": 0.00458512,
+          "score": 0.00717924
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00245861,
+          "spread": 0.00553067,
+          "score": 0.00605252
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.00742785,
+          "spread": 0.00891748,
+          "score": 0.01160579
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": -0.00204021,
+          "spread": 0.00758238,
+          "score": 0.00785206
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00774343,
+          "spread": 0.01595403,
+          "score": 0.01773391
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.16288504,
+          "spread": 0.14893739,
+          "score": 0.22071221
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.00615668,
+          "spread": 0.03708775,
+          "score": 0.03759529
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.01361826,
+          "spread": 0.02531926,
+          "score": 0.0287493
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.01171689,
+          "spread": 0.01497256,
+          "score": 0.01901218
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": -0.01073336,
+          "spread": 0.01013803,
+          "score": 0.0147643
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": -0.00179211,
+          "spread": 0.00445474,
+          "score": 0.00480171
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": -0.00749822,
+          "spread": 0.00630722,
+          "score": 0.00979818
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": -0.0004381,
+          "spread": 0.00388045,
+          "score": 0.0039051
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00359816,
+          "spread": 0.00404779,
+          "score": 0.00541584
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.00040652,
+          "spread": 0.00860153,
+          "score": 0.00861113
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.00129986,
+          "spread": 0.013571,
+          "score": 0.01363311
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.00471997,
+          "spread": 0.01668002,
+          "score": 0.01733496
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.03118128,
+          "spread": 0.07041279,
+          "score": 0.077008
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.15212227,
+          "spread": 0.11731031,
+          "score": 0.19210126
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": 0.03440847,
+          "spread": 0.37793326,
+          "score": 0.37949637
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.13571475,
+          "spread": 0.04887355,
+          "score": 0.14424672
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": -0.00421598,
+          "spread": 0.00105083,
+          "score": 0.00434496
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00189769,
+          "spread": 0.00220235,
+          "score": 0.00290716
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.00374085,
+          "spread": 0.0031195,
+          "score": 0.00487086
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00143854,
+          "spread": 0.00332508,
+          "score": 0.00362292
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.02811117,
+          "spread": 0.0458412,
+          "score": 0.0537741
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.16987999,
+          "spread": 0.08346613,
+          "score": 0.18927706
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.0103334,
+          "spread": 0.04824895,
+          "score": 0.04934309
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.18998443,
+          "spread": 0.0,
+          "score": 0.18998443
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.00373503,
+          "spread": 0.00485385,
+          "score": 0.00612457
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.00491036,
+          "spread": 0.01064772,
+          "score": 0.01172542
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": -0.00173268,
+          "spread": 0.01104535,
+          "score": 0.01118043
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": -0.00219861,
+          "spread": 0.00430089,
+          "score": 0.00483027
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.16099914,
+          "spread": 0.0,
+          "score": 0.16099914
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": -0.00599863,
+          "spread": 0.003535,
+          "score": 0.00696274
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": -0.00284192,
+          "spread": 0.00384387,
+          "score": 0.00478036
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00298031,
+          "spread": 0.00472572,
+          "score": 0.00558701
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.00041672,
+          "spread": 0.00517067,
+          "score": 0.00518743
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.00543353,
+          "spread": 0.00817642,
+          "score": 0.00981718
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.00249965,
+          "spread": 0.01580582,
+          "score": 0.01600225
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.04636341,
+          "spread": 0.05888745,
+          "score": 0.07494863
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.38428703,
+          "spread": 0.41739884,
+          "score": 0.56736083
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": 0.81215698,
+          "spread": 0.83680325,
+          "score": 1.1661212
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.0483725,
+          "spread": 0.13207454,
+          "score": 0.14065412
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": -0.00267759,
+          "spread": 0.00341006,
+          "score": 0.00433567
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 9.256e-05,
+          "spread": 0.00166987,
+          "score": 0.00167243
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": -2.885e-05,
+          "spread": 0.00172513,
+          "score": 0.00172537
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": -0.00138436,
+          "spread": 0.00129322,
+          "score": 0.00189443
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": -0.00025164,
+          "spread": 0.0022529,
+          "score": 0.00226691
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.14816369,
+          "spread": 0.08153045,
+          "score": 0.16911444
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.00985364,
+          "spread": 0.02066589,
+          "score": 0.02289483
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.05303001,
+          "spread": 0.03885584,
+          "score": 0.06574161
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.00439363,
+          "spread": 0.00984105,
+          "score": 0.0107773
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.004199,
-          "spread": 0.01006975,
-          "score": 0.01091015
+          "bias": -0.00433283,
+          "spread": 0.00916701,
+          "score": 0.01013941
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00323937,
-          "spread": 0.00954076,
-          "score": 0.01007569
+          "bias": -0.00272765,
+          "spread": 0.00894423,
+          "score": 0.0093509
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00612442,
-          "spread": 0.0052069,
-          "score": 0.00803867
+          "bias": -0.0059939,
+          "spread": 0.00533646,
+          "score": 0.00802525
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.13604135,
+          "bias": 0.1302007,
           "spread": 0.0,
-          "score": 0.13604135
+          "score": 0.1302007
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.02191577,
-          "spread": 0.01112828,
-          "score": 0.02457925
+          "bias": -0.02034771,
+          "spread": 0.0124143,
+          "score": 0.02383577
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00458013,
-          "spread": 0.00641316,
-          "score": 0.00788075
+          "bias": -0.00507315,
+          "spread": 0.00495404,
+          "score": 0.0070908
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00776487,
-          "spread": 0.00408249,
-          "score": 0.00877268
+          "bias": -0.00765446,
+          "spread": 0.00405491,
+          "score": 0.00866216
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00597953,
-          "spread": 0.01049776,
-          "score": 0.0120813
+          "bias": -0.00566708,
+          "spread": 0.01341087,
+          "score": 0.0145591
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": -0.00494771,
-          "spread": 0.02580625,
-          "score": 0.02627627
+          "bias": -0.00470613,
+          "spread": 0.029848,
+          "score": 0.03021674
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.03783345,
-          "spread": 0.06230707,
-          "score": 0.07289404
+          "bias": -0.0425895,
+          "spread": 0.0656197,
+          "score": 0.07822922
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.02310535,
-          "spread": 0.06447002,
-          "score": 0.06848533
+          "bias": 0.02410242,
+          "spread": 0.05498974,
+          "score": 0.06003997
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.18600269,
-          "spread": 0.34862899,
-          "score": 0.3951445
+          "bias": 0.211291,
+          "spread": 0.40506347,
+          "score": 0.45685917
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.32878505,
-          "spread": 0.74115416,
-          "score": 0.81080768
+          "bias": 0.25070584,
+          "spread": 0.76305456,
+          "score": 0.80318471
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.4838305,
+          "bias": 0.22232073,
           "spread": 0.0,
-          "score": 0.4838305
+          "score": 0.22232073
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.0037379,
-          "spread": 0.00634809,
-          "score": 0.00736682
+          "bias": -0.00281805,
+          "spread": 0.00669332,
+          "score": 0.00726237
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00137243,
-          "spread": 0.00639813,
-          "score": 0.00654368
+          "bias": -0.00233869,
+          "spread": 0.00556151,
+          "score": 0.00603323
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00797678,
-          "spread": 0.00841861,
-          "score": 0.0115975
+          "bias": 0.00561591,
+          "spread": 0.008323,
+          "score": 0.01004045
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00239369,
-          "spread": 0.01270026,
-          "score": 0.01292387
+          "bias": -0.00312217,
+          "spread": 0.00874087,
+          "score": 0.00928174
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.01179129,
-          "spread": 0.02048684,
-          "score": 0.02363779
+          "bias": 0.0083281,
+          "spread": 0.01486228,
+          "score": 0.01703657
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.14352285,
-          "spread": 0.13581073,
-          "score": 0.19759393
+          "bias": -0.14793379,
+          "spread": 0.13222629,
+          "score": 0.19841421
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.01507405,
-          "spread": 0.05103825,
-          "score": 0.05321776
+          "bias": 0.01229032,
+          "spread": 0.04297022,
+          "score": 0.04469331
         },
         {
           "profile": "rated_plus_5pct",
@@ -2807,36 +2807,36 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.01469945,
-          "spread": 0.02134866,
-          "score": 0.02591986
+          "bias": -0.0135268,
+          "spread": 0.02436741,
+          "score": 0.02787015
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.01247346,
-          "spread": 0.01396747,
-          "score": 0.01872638
+          "bias": -0.01220965,
+          "spread": 0.01592506,
+          "score": 0.02006697
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00952235,
-          "spread": 0.01088909,
-          "score": 0.01446538
+          "bias": -0.00839309,
+          "spread": 0.0101254,
+          "score": 0.01315172
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00179825,
-          "spread": 0.00427274,
-          "score": 0.00463573
+          "bias": -0.00174293,
+          "spread": 0.00443283,
+          "score": 0.00476317
         },
         {
           "profile": "rated_plus_5pct",
@@ -2852,162 +2852,162 @@
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00424436,
-          "spread": 0.00371695,
-          "score": 0.00564184
+          "bias": -0.00613392,
+          "spread": 0.00372552,
+          "score": 0.00717666
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00196493,
-          "spread": 0.0044314,
-          "score": 0.0048475
+          "bias": -0.00200767,
+          "spread": 0.0042103,
+          "score": 0.00466448
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00394607,
-          "spread": 0.00454224,
-          "score": 0.00601693
+          "bias": -0.00371197,
+          "spread": 0.00431128,
+          "score": 0.0056891
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00210147,
-          "spread": 0.00731888,
-          "score": 0.0076146
+          "bias": 0.0022488,
+          "spread": 0.00818687,
+          "score": 0.00849011
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00156628,
-          "spread": 0.00929126,
-          "score": 0.00942236
+          "bias": 0.00173316,
+          "spread": 0.01189571,
+          "score": 0.0120213
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00137392,
-          "spread": 0.00931487,
-          "score": 0.00941565
+          "bias": -0.00178517,
+          "spread": 0.01762742,
+          "score": 0.01771758
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.04744675,
-          "spread": 0.07517335,
-          "score": 0.08889447
+          "bias": 0.03770001,
+          "spread": 0.07190917,
+          "score": 0.08119248
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.16862874,
-          "spread": 0.08913199,
-          "score": 0.19073584
+          "bias": 0.15474408,
+          "spread": 0.11122613,
+          "score": 0.19057015
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.025893,
-          "spread": 0.50792756,
-          "score": 0.50858712
+          "bias": 0.05745015,
+          "spread": 0.35693762,
+          "score": 0.36153144
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.02850494,
-          "spread": 0.00555404,
-          "score": 0.02904099
+          "bias": 0.15445527,
+          "spread": 0.06800451,
+          "score": 0.16876328
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.0018846,
-          "spread": 0.00336243,
-          "score": 0.00385457
+          "bias": -0.00156576,
+          "spread": 0.00188793,
+          "score": 0.00245274
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00126465,
-          "spread": 0.00515937,
-          "score": 0.0053121
+          "bias": -0.00193445,
+          "spread": 0.00329127,
+          "score": 0.00381766
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00320506,
-          "spread": 0.00309884,
-          "score": 0.00445817
+          "bias": 0.00231377,
+          "spread": 0.00390918,
+          "score": 0.0045426
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00017545,
-          "spread": 0.002557,
-          "score": 0.00256301
+          "bias": 0.00063074,
+          "spread": 0.00398661,
+          "score": 0.0040362
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.02854262,
-          "spread": 0.045384,
-          "score": 0.05361333
+          "bias": 0.02880744,
+          "spread": 0.04822818,
+          "score": 0.05617674
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.14323384,
-          "spread": 0.05556656,
-          "score": 0.15363455
+          "bias": -0.15030774,
+          "spread": 0.06851497,
+          "score": 0.16518692
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.01074625,
-          "spread": 0.05158515,
-          "score": 0.0526926
+          "bias": 0.01269361,
+          "spread": 0.0522636,
+          "score": 0.053783
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.1725748,
+          "bias": 0.20219071,
           "spread": 0.0,
-          "score": 0.1725748
+          "score": 0.20219071
         },
         {
           "profile": "rated_plus_5pct",
@@ -3023,207 +3023,207 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00250389,
-          "spread": 0.00453247,
-          "score": 0.00517811
+          "bias": -0.0041039,
+          "spread": 0.00588599,
+          "score": 0.00717544
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00631163,
-          "spread": 0.00982502,
-          "score": 0.01167766
+          "bias": -0.00505717,
+          "spread": 0.01075532,
+          "score": 0.01188494
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00122029,
-          "spread": 0.01185232,
-          "score": 0.01191497
+          "bias": -0.00026044,
+          "spread": 0.01085579,
+          "score": 0.01085892
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00228214,
-          "spread": 0.00460717,
-          "score": 0.00514142
+          "bias": -0.00216586,
+          "spread": 0.00430639,
+          "score": 0.00482037
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.16423893,
+          "bias": 0.15122466,
           "spread": 0.0,
-          "score": 0.16423893
+          "score": 0.15122466
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00160042,
-          "spread": 0.00687226,
-          "score": 0.00705615
+          "bias": -0.00367241,
+          "spread": 0.00534181,
+          "score": 0.0064824
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.0034366,
-          "spread": 0.00420588,
-          "score": 0.00543136
+          "bias": -0.00347039,
+          "spread": 0.00395069,
+          "score": 0.00525848
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00351183,
-          "spread": 0.00526609,
-          "score": 0.00632966
+          "bias": -0.00340766,
+          "spread": 0.00485472,
+          "score": 0.00593131
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00088636,
-          "spread": 0.00461836,
-          "score": 0.00470265
+          "bias": 0.00137041,
+          "spread": 0.00477746,
+          "score": 0.00497012
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.0073306,
-          "spread": 0.00742827,
-          "score": 0.01043633
+          "bias": 0.00781048,
+          "spread": 0.0077448,
+          "score": 0.01099934
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00087019,
-          "spread": 0.01397825,
-          "score": 0.01400531
+          "bias": 0.00199987,
+          "spread": 0.01464657,
+          "score": 0.01478247
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.05065282,
-          "spread": 0.05546898,
-          "score": 0.07511668
+          "bias": 0.05069216,
+          "spread": 0.05585186,
+          "score": 0.07542629
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.36888636,
-          "spread": 0.36319066,
-          "score": 0.51767229
+          "bias": 0.37435994,
+          "spread": 0.39478979,
+          "score": 0.54406281
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.89402495,
-          "spread": 0.74579733,
-          "score": 1.16425696
+          "bias": 0.8551451,
+          "spread": 0.7691382,
+          "score": 1.15015073
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.09867156,
-          "spread": 0.13903804,
-          "score": 0.17049238
+          "bias": -0.04102452,
+          "spread": 0.1272645,
+          "score": 0.13371336
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00018807,
-          "spread": 0.00300069,
-          "score": 0.00300658
+          "bias": 0.00042188,
+          "spread": 0.00287325,
+          "score": 0.00290405
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.0034441,
-          "spread": 0.00204054,
-          "score": 0.00400321
+          "bias": -0.00325101,
+          "spread": 0.00195812,
+          "score": 0.00379517
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00144052,
-          "spread": 0.00146824,
-          "score": 0.0020569
+          "bias": -0.00155395,
+          "spread": 0.00157709,
+          "score": 0.00221404
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00237603,
-          "spread": 0.00133722,
-          "score": 0.00272648
+          "bias": -0.00249774,
+          "spread": 0.0012349,
+          "score": 0.00278634
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": -0.00070633,
-          "spread": 0.00371399,
-          "score": 0.00378056
+          "bias": -0.00025157,
+          "spread": 0.00369332,
+          "score": 0.00370188
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.1254501,
-          "spread": 0.07154789,
-          "score": 0.14441893
+          "bias": -0.13136713,
+          "spread": 0.06907233,
+          "score": 0.14841937
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.01246959,
-          "spread": 0.02292891,
-          "score": 0.02610029
+          "bias": 0.01278827,
+          "spread": 0.02368681,
+          "score": 0.02691849
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.05769268,
-          "spread": 0.03912961,
-          "score": 0.06971063
+          "bias": 0.05980249,
+          "spread": 0.04268276,
+          "score": 0.07347215
         },
         {
           "profile": "rated_plus_5pct",
@@ -3239,198 +3239,198 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00377104,
-          "spread": 0.00896141,
-          "score": 0.00972253
+          "bias": -0.00433595,
+          "spread": 0.00951912,
+          "score": 0.01046011
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00476345,
-          "spread": 0.01013694,
-          "score": 0.01120036
+          "bias": -0.00455204,
+          "spread": 0.0093149,
+          "score": 0.01036766
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00199561,
-          "spread": 0.0093877,
-          "score": 0.00959747
+          "bias": -0.00154645,
+          "spread": 0.00905058,
+          "score": 0.00918174
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00632655,
-          "spread": 0.00532187,
-          "score": 0.00826725
+          "bias": -0.00619852,
+          "spread": 0.00546557,
+          "score": 0.00826403
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.14799263,
+          "bias": 0.12401385,
           "spread": 0.0,
-          "score": 0.14799263
+          "score": 0.12401385
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.02660368,
-          "spread": 0.0142658,
-          "score": 0.03018723
+          "bias": -0.02221745,
+          "spread": 0.01342857,
+          "score": 0.02596039
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00461456,
-          "spread": 0.00800301,
-          "score": 0.00923809
+          "bias": -0.0041166,
+          "spread": 0.00675305,
+          "score": 0.00790885
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00965938,
-          "spread": 0.00364361,
-          "score": 0.01032374
+          "bias": -0.0096964,
+          "spread": 0.0040356,
+          "score": 0.01050268
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00356202,
-          "spread": 0.01061509,
-          "score": 0.01119679
+          "bias": -0.00430282,
+          "spread": 0.01369787,
+          "score": 0.01435778
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00596323,
-          "spread": 0.02587779,
-          "score": 0.02655598
+          "bias": 0.0037,
+          "spread": 0.03138539,
+          "score": 0.03160273
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.01966551,
-          "spread": 0.05803204,
-          "score": 0.06127357
+          "bias": -0.02867755,
+          "spread": 0.06655487,
+          "score": 0.07247036
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.04696263,
-          "spread": 0.09094044,
-          "score": 0.10235064
+          "bias": 0.03248782,
+          "spread": 0.0600332,
+          "score": 0.06826012
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.20222709,
-          "spread": 0.36746249,
-          "score": 0.41943352
+          "bias": 0.20315646,
+          "spread": 0.3744173,
+          "score": 0.42598223
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.21916323,
-          "spread": 0.88478423,
-          "score": 0.91152381
+          "bias": 0.23195809,
+          "spread": 0.73711614,
+          "score": 0.77275142
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.38607788,
+          "bias": 0.28497296,
           "spread": 0.0,
-          "score": 0.38607788
+          "score": 0.28497296
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00804239,
-          "spread": 0.00442253,
-          "score": 0.00917817
+          "bias": -0.00737744,
+          "spread": 0.00412198,
+          "score": 0.00845088
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00503001,
-          "spread": 0.00606976,
-          "score": 0.00788308
+          "bias": 0.00363554,
+          "spread": 0.00521766,
+          "score": 0.00635934
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.01041515,
-          "spread": 0.00918884,
-          "score": 0.01388921
+          "bias": 0.00737927,
+          "spread": 0.00902433,
+          "score": 0.01165728
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00109371,
-          "spread": 0.01132409,
-          "score": 0.01137678
+          "bias": -0.00214078,
+          "spread": 0.00797963,
+          "score": 0.00826181
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.01165905,
-          "spread": 0.02060536,
-          "score": 0.02367518
+          "bias": 0.00807565,
+          "spread": 0.01628869,
+          "score": 0.01818069
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.16346273,
-          "spread": 0.13867239,
-          "score": 0.21435973
+          "bias": -0.1709518,
+          "spread": 0.15424475,
+          "score": 0.23025194
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00737345,
-          "spread": 0.04124687,
-          "score": 0.04190074
+          "bias": 0.00313781,
+          "spread": 0.03515065,
+          "score": 0.03529042
         },
         {
           "profile": "ti_dependent_cp",
@@ -3455,687 +3455,39 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.01376417,
-          "spread": 0.01918537,
-          "score": 0.02361209
+          "bias": -0.01473681,
+          "spread": 0.02540682,
+          "score": 0.02937141
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.01268887,
-          "spread": 0.01300774,
-          "score": 0.01817165
+          "bias": -0.01124457,
+          "spread": 0.01449731,
+          "score": 0.018347
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.01251684,
-          "spread": 0.01176093,
-          "score": 0.0171753
+          "bias": -0.01070469,
+          "spread": 0.00991104,
+          "score": 0.01458832
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00190987,
-          "spread": 0.0043915,
-          "score": 0.00478883
+          "bias": -0.00185913,
+          "spread": 0.00455507,
+          "score": 0.00491986
         },
         {
           "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": -0.01314743,
-          "spread": 0.01000494,
-          "score": 0.01652131
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00335327,
-          "spread": 0.00437783,
-          "score": 0.00551451
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00458782,
-          "spread": 0.00432619,
-          "score": 0.00630587
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00482204,
-          "spread": 0.00772578,
-          "score": 0.00910713
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01459322,
-          "spread": 0.01060261,
-          "score": 0.01803822
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": 0.0240978,
-          "spread": 0.00698577,
-          "score": 0.02508993
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": 0.06377901,
-          "spread": 0.06919237,
-          "score": 0.09410284
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.20428363,
-          "spread": 0.09963569,
-          "score": 0.22728633
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": -0.05971305,
-          "spread": 0.56925881,
-          "score": 0.57238207
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": 0.01521298,
-          "spread": 0.01942504,
-          "score": 0.0246732
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00670165,
-          "spread": 0.00303719,
-          "score": 0.00735776
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00324131,
-          "spread": 0.00377127,
-          "score": 0.00497278
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00514181,
-          "spread": 0.00356579,
-          "score": 0.00625724
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.0012823,
-          "spread": 0.00180351,
-          "score": 0.0022129
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.02739414,
-          "spread": 0.04320041,
-          "score": 0.05115383
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": -0.16704956,
-          "spread": 0.08311663,
-          "score": 0.18658491
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00572876,
-          "spread": 0.04670187,
-          "score": 0.04705192
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": 0.15660899,
-          "spread": 0.0,
-          "score": 0.15660899
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00109558,
-          "spread": 0.00531939,
-          "score": 0.00543104
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": -0.0056843,
-          "spread": 0.00964003,
-          "score": 0.01119114
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": -0.0025455,
-          "spread": 0.01175374,
-          "score": 0.01202622
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": -0.0023773,
-          "spread": 0.00469087,
-          "score": 0.00525888
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": 0.1901363,
-          "spread": 0.0,
-          "score": 0.1901363
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": -0.0119902,
-          "spread": 0.00401405,
-          "score": 0.01264426
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00556008,
-          "spread": 0.00438005,
-          "score": 0.00707808
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00353905,
-          "spread": 0.00526233,
-          "score": 0.00634168
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00400487,
-          "spread": 0.0047152,
-          "score": 0.00618644
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01976477,
-          "spread": 0.00794768,
-          "score": 0.02130286
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": 0.02184445,
-          "spread": 0.01495427,
-          "score": 0.02647282
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": 0.0734446,
-          "spread": 0.06018429,
-          "score": 0.09495397
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.41949058,
-          "spread": 0.40414367,
-          "score": 0.58249845
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": 0.92120253,
-          "spread": 0.74922079,
-          "score": 1.18741143
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.1044552,
-          "spread": 0.15114838,
-          "score": 0.18373003
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00463484,
-          "spread": 0.00401138,
-          "score": 0.00612967
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00103515,
-          "spread": 0.00133464,
-          "score": 0.00168902
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00034841,
-          "spread": 0.00139632,
-          "score": 0.00143913
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00127362,
-          "spread": 0.00110409,
-          "score": 0.00168556
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": -0.00109677,
-          "spread": 0.00202839,
-          "score": 0.00230592
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": -0.14214649,
-          "spread": 0.08715383,
-          "score": 0.16673756
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00729933,
-          "spread": 0.02018604,
-          "score": 0.02146524
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": 0.04767958,
-          "spread": 0.03273429,
-          "score": 0.0578349
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00312029,
-          "spread": 0.00824048,
-          "score": 0.00881145
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00395541,
-          "spread": 0.0099317,
-          "score": 0.01069037
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00362136,
-          "spread": 0.00955295,
-          "score": 0.01021631
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": -0.00624619,
-          "spread": 0.00529831,
-          "score": 0.00819066
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": 0.1882736,
-          "spread": 0.0,
-          "score": 0.1882736
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": -0.02023111,
-          "spread": 0.01165802,
-          "score": 0.02334967
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00101067,
-          "spread": 0.00762596,
-          "score": 0.00769264
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00864158,
-          "spread": 0.00335141,
-          "score": 0.0092687
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": -0.01016817,
-          "spread": 0.01221391,
-          "score": 0.01589249
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": -0.01063097,
-          "spread": 0.03032381,
-          "score": 0.03213333
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": -0.04642471,
-          "spread": 0.0640283,
-          "score": 0.07908778
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": 0.01066672,
-          "spread": 0.06979739,
-          "score": 0.07060775
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.171503,
-          "spread": 0.39553669,
-          "score": 0.43111779
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": 0.16008454,
-          "spread": 0.96902454,
-          "score": 0.98215865
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": 0.45498521,
-          "spread": 0.0,
-          "score": 0.45498521
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00346499,
-          "spread": 0.00468562,
-          "score": 0.00582762
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00423195,
-          "spread": 0.00737978,
-          "score": 0.00850709
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": 0.01052192,
-          "spread": 0.00925652,
-          "score": 0.01401406
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": -8.02e-05,
-          "spread": 0.01063327,
-          "score": 0.01063358
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.0130411,
-          "spread": 0.01979804,
-          "score": 0.02370723
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": -0.19625702,
-          "spread": 0.17531417,
-          "score": 0.26315752
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": 0.01523279,
-          "spread": 0.04601866,
-          "score": 0.04847427
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": -0.01888993,
-          "spread": 0.02248484,
-          "score": 0.0293666
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": -0.01584911,
-          "spread": 0.01504841,
-          "score": 0.02185518
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": -0.01242181,
-          "spread": 0.01160748,
-          "score": 0.01700103
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": -0.00185338,
-          "spread": 0.00437404,
-          "score": 0.0047505
-        },
-        {
-          "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
@@ -4144,166 +3496,814 @@
           "score": NaN
         },
         {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": -0.01331717,
+          "spread": 0.0101256,
+          "score": 0.01672946
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": -0.00262529,
+          "spread": 0.00389239,
+          "score": 0.00469498
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00435533,
+          "spread": 0.00420609,
+          "score": 0.00605476
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": 0.00379036,
+          "spread": 0.00839436,
+          "score": 0.00921044
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.01232525,
+          "spread": 0.01271277,
+          "score": 0.01770667
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": 0.01814274,
+          "spread": 0.01348804,
+          "score": 0.02260721
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.05546259,
+          "spread": 0.07295015,
+          "score": 0.09163964
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.18054482,
+          "spread": 0.11047442,
+          "score": 0.21166254
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.01836268,
+          "spread": 0.43138972,
+          "score": 0.43178036
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.10941547,
+          "spread": 0.04231747,
+          "score": 0.11731374
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": -0.00622243,
+          "spread": 0.00171274,
+          "score": 0.00645384
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00233061,
+          "spread": 0.00185603,
+          "score": 0.00297936
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.00363276,
+          "spread": 0.00297712,
+          "score": 0.00469683
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00104014,
+          "spread": 0.00299026,
+          "score": 0.003166
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.02702385,
+          "spread": 0.04520804,
+          "score": 0.0526693
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.17215455,
+          "spread": 0.09031532,
+          "score": 0.19440691
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.00563555,
+          "spread": 0.04654105,
+          "score": 0.046881
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.18222609,
+          "spread": 0.0,
+          "score": 0.18222609
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.00288579,
+          "spread": 0.00487239,
+          "score": 0.00566286
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.00375256,
+          "spread": 0.01066295,
+          "score": 0.01130399
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": -0.0017236,
+          "spread": 0.01118891,
+          "score": 0.01132089
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": -0.00225941,
+          "spread": 0.00438412,
+          "score": 0.00493208
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.19344302,
+          "spread": 0.0,
+          "score": 0.19344302
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": -0.01214838,
+          "spread": 0.00335081,
+          "score": 0.01260203
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": -0.00491707,
+          "spread": 0.00411801,
+          "score": 0.00641371
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00342812,
+          "spread": 0.00486511,
+          "score": 0.00595158
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": 0.00329466,
+          "spread": 0.00477649,
+          "score": 0.00580256
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.0178468,
+          "spread": 0.00848423,
+          "score": 0.01976083
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": 0.01745707,
+          "spread": 0.01588766,
+          "score": 0.02360438
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.06652675,
+          "spread": 0.05874806,
+          "score": 0.08875327
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.39804185,
+          "spread": 0.40313184,
+          "score": 0.56652678
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": 0.88693294,
+          "spread": 0.79673823,
+          "score": 1.19224236
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.05900242,
+          "spread": 0.15183898,
+          "score": 0.16289985
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": -0.00448266,
+          "spread": 0.00389579,
+          "score": 0.00593897
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00104671,
+          "spread": 0.00146263,
+          "score": 0.00179858
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.00013945,
+          "spread": 0.00152372,
+          "score": 0.00153009
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": -0.00133532,
+          "spread": 0.00122245,
+          "score": 0.00181038
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": -0.00068486,
+          "spread": 0.00186728,
+          "score": 0.00198891
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.14918609,
+          "spread": 0.08805759,
+          "score": 0.17323576
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.00745576,
+          "spread": 0.02034892,
+          "score": 0.0216718
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.04755519,
+          "spread": 0.0363992,
+          "score": 0.05988654
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.00347535,
+          "spread": 0.00882782,
+          "score": 0.00948728
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.00354229,
+          "spread": 0.00927576,
+          "score": 0.00992913
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": -0.00304986,
+          "spread": 0.00905295,
+          "score": 0.00955289
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": -0.00611557,
+          "spread": 0.00543753,
+          "score": 0.00818334
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.162932,
+          "spread": 0.0,
+          "score": 0.162932
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": -0.01856236,
+          "spread": 0.01147791,
+          "score": 0.02182438
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": -0.00160866,
+          "spread": 0.00631268,
+          "score": 0.00651442
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00855711,
+          "spread": 0.00380189,
+          "score": 0.00936368
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.0093185,
+          "spread": 0.01507683,
+          "score": 0.01772414
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.0101933,
+          "spread": 0.0346538,
+          "score": 0.03612186
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.05347693,
+          "spread": 0.07111013,
+          "score": 0.08897433
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.00551058,
+          "spread": 0.05217365,
+          "score": 0.05246386
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.17287545,
+          "spread": 0.42040453,
+          "score": 0.45456121
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": 0.15658092,
+          "spread": 0.87333648,
+          "score": 0.88726218
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.28147777,
+          "spread": 0.0,
+          "score": 0.28147777
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": -0.00275191,
+          "spread": 0.00467228,
+          "score": 0.00542247
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00257437,
+          "spread": 0.00649773,
+          "score": 0.00698913
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.00783916,
+          "spread": 0.00947347,
+          "score": 0.0122963
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": -0.00093671,
+          "spread": 0.00704753,
+          "score": 0.00710951
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.009694,
+          "spread": 0.01559592,
+          "score": 0.01836318
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.20471669,
+          "spread": 0.18083483,
+          "score": 0.2731486
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.00907782,
+          "spread": 0.03982059,
+          "score": 0.04084221
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.01886602,
+          "spread": 0.02677444,
+          "score": 0.03275358
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.01429213,
+          "spread": 0.01649931,
+          "score": 0.02182871
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": -0.01103663,
+          "spread": 0.01074639,
+          "score": 0.01540429
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": -0.00179816,
+          "spread": 0.00453889,
+          "score": 0.0048821
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00679815,
-          "spread": 0.00900232,
-          "score": 0.01128081
+          "bias": -0.00995095,
+          "spread": 0.00970485,
+          "score": 0.01389984
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -3.267e-05,
-          "spread": 0.00428537,
-          "score": 0.0042855
+          "bias": -9.06e-06,
+          "spread": 0.00398877,
+          "score": 0.00398878
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.0038377,
-          "spread": 0.00405216,
-          "score": 0.00558104
+          "bias": -0.00348624,
+          "spread": 0.0038651,
+          "score": 0.00520508
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.000952,
-          "spread": 0.00834621,
-          "score": 0.00840033
+          "bias": -0.00108206,
+          "spread": 0.00940458,
+          "score": 0.00946662
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": -0.00099199,
-          "spread": 0.01207041,
-          "score": 0.01211111
+          "bias": -0.00102495,
+          "spread": 0.01480184,
+          "score": 0.01483728
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 9.143e-05,
-          "spread": 0.00813419,
-          "score": 0.0081347
+          "bias": -0.00305897,
+          "spread": 0.01612437,
+          "score": 0.01641197
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.03434502,
-          "spread": 0.07998429,
-          "score": 0.08704635
+          "bias": 0.02699251,
+          "spread": 0.07735994,
+          "score": 0.08193385
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.05231296,
-          "spread": 0.21423391,
-          "score": 0.22052849
+          "bias": 0.03198228,
+          "spread": 0.22405948,
+          "score": 0.22633054
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.18042392,
-          "spread": 0.31916494,
-          "score": 0.36663203
+          "bias": -0.04959803,
+          "spread": 0.34027327,
+          "score": 0.34386896
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.00845137,
-          "spread": 0.00306076,
-          "score": 0.00898855
+          "bias": 0.14575092,
+          "spread": 0.04554098,
+          "score": 0.15270007
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00178748,
-          "spread": 0.00238273,
-          "score": 0.00297867
+          "bias": -0.00143202,
+          "spread": 0.00110699,
+          "score": 0.00181
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00267457,
-          "spread": 0.0045979,
-          "score": 0.00531921
+          "bias": 0.00237242,
+          "spread": 0.00286178,
+          "score": 0.00371728
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00533882,
-          "spread": 0.00361792,
-          "score": 0.00644921
+          "bias": 0.00433418,
+          "spread": 0.00369241,
+          "score": 0.00569377
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00212609,
-          "spread": 0.00226251,
-          "score": 0.00310471
+          "bias": 0.00225359,
+          "spread": 0.00380344,
+          "score": 0.00442095
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.02861981,
-          "spread": 0.04352891,
-          "score": 0.05209472
+          "bias": 0.02869758,
+          "spread": 0.04557696,
+          "score": 0.05385917
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.21141614,
-          "spread": 0.1033811,
-          "score": 0.23533898
+          "bias": -0.21688074,
+          "spread": 0.11708208,
+          "score": 0.24646596
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.01028501,
-          "spread": 0.04797634,
-          "score": 0.04906639
+          "bias": 0.01209983,
+          "spread": 0.04923724,
+          "score": 0.05070218
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.16428676,
+          "bias": 0.19181805,
           "spread": 0.0,
-          "score": 0.16428676
+          "score": 0.19181805
         },
         {
           "profile": "ws_dependent_cp",
@@ -4319,207 +4319,207 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00551896,
-          "spread": 0.00520964,
-          "score": 0.00758942
+          "bias": -0.00766966,
+          "spread": 0.00486662,
+          "score": 0.00908338
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00845262,
-          "spread": 0.01023888,
-          "score": 0.01327711
+          "bias": -0.0071678,
+          "spread": 0.01160475,
+          "score": 0.01363993
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00337924,
-          "spread": 0.01199249,
-          "score": 0.0124595
+          "bias": -0.00234086,
+          "spread": 0.01144322,
+          "score": 0.0116802
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00231066,
-          "spread": 0.00465715,
-          "score": 0.00519886
+          "bias": -0.0021932,
+          "spread": 0.00435369,
+          "score": 0.00487491
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.24655405,
+          "bias": 0.20605606,
           "spread": 0.0,
-          "score": 0.24655405
+          "score": 0.20605606
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00421879,
-          "spread": 0.00398768,
-          "score": 0.00580516
+          "bias": -0.00620552,
+          "spread": 0.00283145,
+          "score": 0.00682097
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00292838,
-          "spread": 0.00426013,
-          "score": 0.00516954
+          "bias": -0.00299307,
+          "spread": 0.00400128,
+          "score": 0.00499687
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00305273,
-          "spread": 0.00510404,
-          "score": 0.0059473
+          "bias": -0.0029679,
+          "spread": 0.00468792,
+          "score": 0.00554842
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.0009306,
-          "spread": 0.00578175,
-          "score": 0.00585616
+          "bias": -0.0002458,
+          "spread": 0.00568732,
+          "score": 0.00569263
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00567074,
-          "spread": 0.00792646,
-          "score": 0.00974608
+          "bias": 0.00679622,
+          "spread": 0.00886034,
+          "score": 0.01116665
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00118166,
-          "spread": 0.01429997,
-          "score": 0.01434871
+          "bias": -0.00063001,
+          "spread": 0.01591712,
+          "score": 0.01592958
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.04926847,
-          "spread": 0.0604389,
-          "score": 0.07797591
+          "bias": 0.05047697,
+          "spread": 0.06216465,
+          "score": 0.08007726
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.39531439,
-          "spread": 0.42429365,
-          "score": 0.57991255
+          "bias": 0.40068333,
+          "spread": 0.44896738,
+          "score": 0.60176311
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.7765007,
-          "spread": 0.95149549,
-          "score": 1.22812744
+          "bias": 0.74317653,
+          "spread": 0.99659105,
+          "score": 1.24318345
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.10210007,
-          "spread": 0.14051752,
-          "score": 0.17369397
+          "bias": -0.06506684,
+          "spread": 0.14527571,
+          "score": 0.15918143
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00040635,
-          "spread": 0.00331257,
-          "score": 0.0033374
+          "bias": -0.00023702,
+          "spread": 0.00314436,
+          "score": 0.00315328
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00032956,
-          "spread": 0.0018202,
-          "score": 0.0018498
+          "bias": 0.00042391,
+          "spread": 0.00191777,
+          "score": 0.00196406
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00049913,
-          "spread": 0.00166206,
-          "score": 0.00173539
+          "bias": 0.00025909,
+          "spread": 0.001912,
+          "score": 0.00192947
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00074008,
-          "spread": 0.00116277,
-          "score": 0.00137831
+          "bias": -0.00102969,
+          "spread": 0.00127996,
+          "score": 0.00164273
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00031766,
-          "spread": 0.00275787,
-          "score": 0.0027761
+          "bias": 0.00047775,
+          "spread": 0.00269558,
+          "score": 0.00273759
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.18290992,
-          "spread": 0.11120086,
-          "score": 0.21405997
+          "bias": -0.186608,
+          "spread": 0.11152137,
+          "score": 0.21739265
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.01177845,
-          "spread": 0.02145349,
-          "score": 0.02447416
+          "bias": 0.01149964,
+          "spread": 0.02150511,
+          "score": 0.0243867
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.0543995,
-          "spread": 0.03543714,
-          "score": 0.06492378
+          "bias": 0.05617746,
+          "spread": 0.03957729,
+          "score": 0.06871877
         },
         {
           "profile": "ws_dependent_cp",
@@ -4535,33 +4535,33 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00735877,
-          "spread": 0.00903658,
-          "score": 0.01165381
+          "bias": -0.00790112,
+          "spread": 0.01047095,
+          "score": 0.01311749
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00668694,
-          "spread": 0.01069276,
-          "score": 0.01261151
+          "bias": -0.00656539,
+          "spread": 0.00993222,
+          "score": 0.01190602
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00431727,
-          "spread": 0.00989744,
-          "score": 0.01079806
+          "bias": -0.00361782,
+          "spread": 0.00944471,
+          "score": 0.01011391
         }
       ]
     },
     "toggle": {
-      "recorded_utc": "2026-07-03T08:27:44Z",
-      "git_commit": "e5ba2c7-dirty",
+      "recorded_utc": "2026-07-04T02:48:54Z",
+      "git_commit": "789bc1e-dirty",
       "n_replicates": 4,
       "seed": 0,
       "campaign_months": [
@@ -4585,9 +4585,9 @@
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.0039066,
-          "spread": 0.00085464,
-          "score": 0.00399899
+          "bias": 0.00382878,
+          "spread": 0.00071257,
+          "score": 0.00389452
         },
         {
           "profile": "cp_0pct",
@@ -4603,162 +4603,162 @@
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00834378,
-          "spread": 0.00856977,
-          "score": 0.01196075
+          "bias": 0.00912415,
+          "spread": 0.00978747,
+          "score": 0.01338075
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00157789,
-          "spread": 0.00255685,
-          "score": 0.00300454
+          "bias": 0.00139116,
+          "spread": 0.0024915,
+          "score": 0.00285357
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.0057023,
-          "spread": 0.00113975,
-          "score": 0.00581509
+          "bias": 0.00549256,
+          "spread": 0.00134928,
+          "score": 0.00565587
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00418658,
-          "spread": 0.00224521,
-          "score": 0.00475062
+          "bias": 0.00475539,
+          "spread": 0.0027443,
+          "score": 0.00549043
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00234863,
-          "spread": 0.0107037,
-          "score": 0.01095834
+          "bias": 0.00374856,
+          "spread": 0.00848477,
+          "score": 0.00927594
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00963823,
-          "spread": 0.03020925,
-          "score": 0.03170953
+          "bias": -0.01415934,
+          "spread": 0.02767077,
+          "score": 0.03108309
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.00472005,
-          "spread": 0.02695346,
-          "score": 0.02736362
+          "bias": -0.00211677,
+          "spread": 0.02288477,
+          "score": 0.02298246
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.32877327,
-          "spread": 0.86566552,
-          "score": 0.92599603
+          "bias": 0.53155603,
+          "spread": 1.16284115,
+          "score": 1.27857395
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.08473157,
+          "bias": -0.18635072,
           "spread": 0.0,
-          "score": 0.08473157
+          "score": 0.18635072
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.02216796,
-          "spread": 0.05972365,
-          "score": 0.06370504
+          "bias": -0.00429358,
+          "spread": 0.04671581,
+          "score": 0.04691271
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00180868,
-          "spread": 0.00198293,
-          "score": 0.0026839
+          "bias": 0.0017531,
+          "spread": 0.00144952,
+          "score": 0.00227475
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00254203,
-          "spread": 0.00101237,
-          "score": 0.00273621
+          "bias": 0.00175091,
+          "spread": 0.00145715,
+          "score": 0.00227793
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00041078,
-          "spread": 0.00229759,
-          "score": 0.00233403
+          "bias": 0.00047739,
+          "spread": 0.00268846,
+          "score": 0.00273051
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00254747,
-          "spread": 0.00253296,
-          "score": 0.00359242
+          "bias": 0.0027389,
+          "spread": 0.00281769,
+          "score": 0.00392949
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00594513,
-          "spread": 0.02220976,
-          "score": 0.02299169
+          "bias": 0.00452619,
+          "spread": 0.02264225,
+          "score": 0.02309021
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.00912077,
-          "spread": 0.04033772,
-          "score": 0.04135602
+          "bias": 0.00410405,
+          "spread": 0.03646108,
+          "score": 0.03669133
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.06450252,
-          "spread": 0.06814225,
-          "score": 0.09382932
+          "bias": 0.06115453,
+          "spread": 0.06440884,
+          "score": 0.08881653
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.0028948,
-          "spread": 0.00455305,
-          "score": 0.00539538
+          "bias": -0.00489365,
+          "spread": 0.00108319,
+          "score": 0.0050121
         },
         {
           "profile": "cp_0pct",
@@ -4774,207 +4774,207 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.0037329,
-          "spread": 0.01027083,
-          "score": 0.01092815
+          "bias": 0.00302529,
+          "spread": 0.01045046,
+          "score": 0.01087954
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00714118,
-          "spread": 0.00335582,
-          "score": 0.00789037
+          "bias": 0.0073205,
+          "spread": 0.00355856,
+          "score": 0.0081396
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00479573,
-          "spread": 0.00595962,
-          "score": 0.00764958
+          "bias": 0.00514756,
+          "spread": 0.00609086,
+          "score": 0.00797471
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00156682,
-          "spread": 0.00181773,
-          "score": 0.0023998
+          "bias": 0.00145167,
+          "spread": 0.00154505,
+          "score": 0.00212003
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.0470566,
-          "spread": 0.00449411,
-          "score": 0.04727072
+          "bias": 0.04051854,
+          "spread": 0.03846156,
+          "score": 0.05586631
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.003015,
-          "spread": 0.00865327,
-          "score": 0.00916348
+          "bias": -0.00045327,
+          "spread": 0.01155318,
+          "score": 0.01156207
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00031938,
-          "spread": 0.00230516,
-          "score": 0.00232718
+          "bias": -0.00025189,
+          "spread": 0.00181665,
+          "score": 0.00183403
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00264659,
-          "spread": 0.00149512,
-          "score": 0.00303971
+          "bias": 0.00277519,
+          "spread": 0.00163931,
+          "score": 0.0032232
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00060784,
-          "spread": 0.0028523,
-          "score": 0.00291635
+          "bias": 0.00110619,
+          "spread": 0.00224526,
+          "score": 0.00250297
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00449599,
-          "spread": 0.00696946,
-          "score": 0.00829382
+          "bias": 0.00525472,
+          "spread": 0.00588761,
+          "score": 0.00789152
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00639785,
-          "spread": 0.02368839,
-          "score": 0.02453716
+          "bias": 0.00479199,
+          "spread": 0.01890071,
+          "score": 0.01949872
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.03490567,
-          "spread": 0.02687633,
-          "score": 0.04405387
+          "bias": -0.03817535,
+          "spread": 0.02589119,
+          "score": 0.04612712
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.78790966,
-          "spread": 1.25954829,
-          "score": 1.48568621
+          "bias": 0.54793685,
+          "spread": 0.80695049,
+          "score": 0.97539935
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.59832554,
-          "spread": 0.58096192,
-          "score": 0.83397255
+          "bias": 0.52223968,
+          "spread": 0.42964532,
+          "score": 0.67626133
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.00231511,
-          "spread": 0.02030465,
-          "score": 0.02043621
+          "bias": -0.00168012,
+          "spread": 0.01373714,
+          "score": 0.0138395
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00014372,
-          "spread": 0.00254609,
-          "score": 0.00255015
+          "bias": 0.00053624,
+          "spread": 0.00205503,
+          "score": 0.00212384
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00016657,
-          "spread": 0.00074978,
-          "score": 0.00076806
+          "bias": 2.048e-05,
+          "spread": 0.00137693,
+          "score": 0.00137708
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00056241,
-          "spread": 0.00203165,
-          "score": 0.00210806
+          "bias": -0.00056581,
+          "spread": 0.00234531,
+          "score": 0.0024126
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00052949,
-          "spread": 0.00162819,
-          "score": 0.00171212
+          "bias": 0.00060354,
+          "spread": 0.00196422,
+          "score": 0.00205485
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00394516,
-          "spread": 0.01028494,
-          "score": 0.01101564
+          "bias": 0.00351647,
+          "spread": 0.01012223,
+          "score": 0.01071564
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.000873,
-          "spread": 0.01841638,
-          "score": 0.01843706
+          "bias": -0.00360509,
+          "spread": 0.01961839,
+          "score": 0.01994688
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00691975,
-          "spread": 0.00483455,
-          "score": 0.00844131
+          "bias": -0.00651952,
+          "spread": 0.00434953,
+          "score": 0.00783725
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.00626107,
-          "spread": 0.00602508,
-          "score": 0.00868922
+          "bias": 0.0105423,
+          "spread": 0.01020969,
+          "score": 0.01467575
         },
         {
           "profile": "cp_0pct",
@@ -4990,468 +4990,468 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00224657,
-          "spread": 0.00312427,
-          "score": 0.00384813
+          "bias": 0.0025931,
+          "spread": 0.00321616,
+          "score": 0.00413133
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00221719,
-          "spread": 0.00454037,
-          "score": 0.00505281
+          "bias": 0.0013913,
+          "spread": 0.00423172,
+          "score": 0.00445457
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00329793,
-          "spread": 0.00524841,
-          "score": 0.00619856
+          "bias": 0.00312628,
+          "spread": 0.0051747,
+          "score": 0.00604576
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00115594,
-          "spread": 0.00162224,
-          "score": 0.00199195
+          "bias": 0.0011962,
+          "spread": 0.00166181,
+          "score": 0.00204756
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.06560924,
-          "spread": 0.00790174,
-          "score": 0.06608336
+          "bias": 0.05061872,
+          "spread": 0.01167184,
+          "score": 0.05194696
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00216207,
-          "spread": 0.00382697,
-          "score": 0.00439548
+          "bias": 0.00176762,
+          "spread": 0.00518217,
+          "score": 0.00547534
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00197241,
-          "spread": 0.00198263,
-          "score": 0.00279665
+          "bias": 0.00181887,
+          "spread": 0.00155731,
+          "score": 0.00239447
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00108634,
-          "spread": 0.00173625,
-          "score": 0.00204809
+          "bias": 0.00123018,
+          "spread": 0.00193753,
+          "score": 0.00229507
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00111131,
-          "spread": 0.00205584,
-          "score": 0.00233699
+          "bias": -0.00112518,
+          "spread": 0.00200786,
+          "score": 0.00230164
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.0042168,
-          "spread": 0.00723829,
-          "score": 0.00837701
+          "bias": 0.00501964,
+          "spread": 0.00705376,
+          "score": 0.0086575
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00597619,
-          "spread": 0.02114189,
-          "score": 0.0219703
+          "bias": -0.00648093,
+          "spread": 0.01822605,
+          "score": 0.01934403
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.01606042,
-          "spread": 0.0217417,
-          "score": 0.02703033
+          "bias": 0.02147776,
+          "spread": 0.02196043,
+          "score": 0.03071734
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.02501051,
-          "spread": 0.27559885,
-          "score": 0.27673137
+          "bias": 0.04765378,
+          "spread": 0.28290728,
+          "score": 0.28689268
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.19324011,
-          "spread": 0.26556703,
-          "score": 0.32843201
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.04251972,
-          "spread": 0.03126981,
-          "score": 0.05277999
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00052802,
-          "spread": 0.00229788,
-          "score": 0.00235776
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00078074,
-          "spread": 0.00071425,
-          "score": 0.00105816
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": -0.0002832,
-          "spread": 0.00143579,
-          "score": 0.00146345
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.0002305,
-          "spread": 0.00152419,
-          "score": 0.00154152
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00503203,
-          "spread": 0.01003328,
-          "score": 0.01122444
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": 0.00479906,
-          "spread": 0.0236271,
-          "score": 0.02410956
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00041731,
-          "spread": 0.00583263,
-          "score": 0.00584754
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": -0.01726525,
-          "spread": 0.02678947,
-          "score": 0.03187106
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00036041,
-          "spread": 0.00427097,
-          "score": 0.00428615
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00203982,
-          "spread": 0.0028036,
-          "score": 0.00346713
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": 0.0026565,
-          "spread": 0.00406346,
-          "score": 0.00485476
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.0008406,
-          "spread": 0.00098244,
-          "score": 0.00129298
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": 0.03391355,
-          "spread": 0.00368828,
-          "score": 0.03411352
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00100641,
-          "spread": 0.00303748,
-          "score": 0.00319987
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00113146,
-          "spread": 0.00105121,
-          "score": 0.00154443
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00044959,
-          "spread": 0.00108952,
-          "score": 0.00117863
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00043725,
-          "spread": 0.00223872,
-          "score": 0.00228102
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00518349,
-          "spread": 0.00583579,
-          "score": 0.00780544
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00564258,
-          "spread": 0.02820094,
-          "score": 0.0287599
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": -0.00776719,
-          "spread": 0.02644289,
-          "score": 0.02756003
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": -0.00461563,
-          "spread": 0.19397839,
-          "score": 0.1940333
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": -0.18897104,
-          "spread": 0.16694543,
-          "score": 0.25215239
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.02135253,
-          "spread": 0.04420045,
-          "score": 0.04908778
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": -0.0001231,
-          "spread": 0.00232097,
-          "score": 0.00232424
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00132388,
-          "spread": 0.00058173,
-          "score": 0.00144605
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00041167,
-          "spread": 0.00128412,
-          "score": 0.0013485
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00032189,
-          "spread": 0.00034335,
-          "score": 0.00047065
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": -0.00097696,
-          "spread": 0.0020974,
-          "score": 0.00231377
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": 0.00578418,
-          "spread": 0.01438185,
-          "score": 0.01550143
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00653061,
-          "spread": 0.00426451,
-          "score": 0.00779967
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": -0.02918204,
-          "spread": 0.02427465,
-          "score": 0.03795853
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": 0.03230109,
+          "bias": -0.07543502,
           "spread": 0.0,
-          "score": 0.03230109
+          "score": 0.07543502
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.05000757,
+          "spread": 0.031735,
+          "score": 0.05922725
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": -0.00067557,
+          "spread": 0.00240732,
+          "score": 0.00250031
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00095659,
+          "spread": 0.00079251,
+          "score": 0.00124223
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": -0.00011274,
+          "spread": 0.00147593,
+          "score": 0.00148023
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00034164,
+          "spread": 0.00155137,
+          "score": 0.00158854
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00461324,
+          "spread": 0.00969486,
+          "score": 0.01073649
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": 0.00291273,
+          "spread": 0.02065521,
+          "score": 0.02085957
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.00145514,
+          "spread": 0.00707978,
+          "score": 0.00722777
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.0122773,
+          "spread": 0.03719934,
+          "score": 0.03917299
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.00063138,
+          "spread": 0.00372325,
+          "score": 0.0037764
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.00191729,
+          "spread": 0.00287129,
+          "score": 0.00345258
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00288423,
+          "spread": 0.00409067,
+          "score": 0.00500524
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00076877,
+          "spread": 0.00101962,
+          "score": 0.00127696
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.01859592,
+          "spread": 0.02086086,
+          "score": 0.02794609
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.00078911,
+          "spread": 0.0033031,
+          "score": 0.00339606
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.00080831,
+          "spread": 0.00067271,
+          "score": 0.00105162
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00038974,
+          "spread": 0.00120537,
+          "score": 0.00126681
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": 0.0005658,
+          "spread": 0.0025775,
+          "score": 0.00263887
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.00586541,
+          "spread": 0.00573102,
+          "score": 0.00820046
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.00513399,
+          "spread": 0.02519923,
+          "score": 0.0257169
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.00338803,
+          "spread": 0.02787695,
+          "score": 0.02808208
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.00716873,
+          "spread": 0.18195543,
+          "score": 0.1820966
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.19912049,
+          "spread": 0.13106473,
+          "score": 0.238384
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.00793166,
+          "spread": 0.04802201,
+          "score": 0.04867263
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": -5.619e-05,
+          "spread": 0.001976,
+          "score": 0.0019768
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00128386,
+          "spread": 0.00077982,
+          "score": 0.00150214
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": -0.00053019,
+          "spread": 0.00121547,
+          "score": 0.00132607
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00012278,
+          "spread": 0.00075049,
+          "score": 0.00076047
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": -0.00099672,
+          "spread": 0.00269039,
+          "score": 0.00286908
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": 0.00472494,
+          "spread": 0.01529365,
+          "score": 0.0160069
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": -0.00553402,
+          "spread": 0.0041753,
+          "score": 0.00693243
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.03458825,
+          "spread": 0.0272283,
+          "score": 0.04401962
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": 0.02471168,
+          "spread": 0.0,
+          "score": 0.02471168
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00141723,
-          "spread": 0.00597932,
-          "score": 0.00614498
+          "bias": 0.00060461,
+          "spread": 0.0049941,
+          "score": 0.00503057
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00308871,
-          "spread": 0.00190861,
-          "score": 0.00363083
+          "bias": 0.00276527,
+          "spread": 0.00180198,
+          "score": 0.00330059
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00070073,
-          "spread": 0.00304501,
-          "score": 0.0031246
+          "bias": 0.00085462,
+          "spread": 0.0032575,
+          "score": 0.00336774
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00372268,
-          "spread": 0.00080371,
-          "score": 0.00380845
+          "bias": 0.00364936,
+          "spread": 0.00068421,
+          "score": 0.00371294
         },
         {
           "profile": "cp_minus_10pct",
@@ -5467,162 +5467,162 @@
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00838225,
-          "spread": 0.01053657,
-          "score": 0.01346408
+          "bias": 0.00742793,
+          "spread": 0.01102315,
+          "score": 0.01329226
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00033179,
-          "spread": 0.00250307,
-          "score": 0.00252497
+          "bias": -0.00062883,
+          "spread": 0.00221527,
+          "score": 0.00230279
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00543726,
-          "spread": 0.00204226,
-          "score": 0.00580815
+          "bias": 0.00526864,
+          "spread": 0.00212801,
+          "score": 0.00568217
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00701184,
-          "spread": 0.00269114,
-          "score": 0.00751053
+          "bias": 0.00753313,
+          "spread": 0.00254172,
+          "score": 0.00795037
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00527047,
-          "spread": 0.01058941,
-          "score": 0.0118285
+          "bias": 0.00717831,
+          "spread": 0.00890075,
+          "score": 0.01143466
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00623538,
-          "spread": 0.02754422,
-          "score": 0.02824117
+          "bias": -0.0097624,
+          "spread": 0.02763703,
+          "score": 0.02931057
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.02268428,
-          "spread": 0.03425506,
-          "score": 0.0410851
+          "bias": 0.00892362,
+          "spread": 0.02727317,
+          "score": 0.02869594
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.64618596,
-          "spread": 0.65252875,
-          "score": 0.91834093
+          "bias": 0.65801968,
+          "spread": 0.70471102,
+          "score": 0.96416157
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.12931259,
+          "bias": -0.04914662,
           "spread": 0.0,
-          "score": 0.12931259
+          "score": 0.04914662
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.04746375,
-          "spread": 0.06871618,
-          "score": 0.08351479
+          "bias": 0.00545718,
+          "spread": 0.0464651,
+          "score": 0.04678447
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00479394,
-          "spread": 0.00293023,
-          "score": 0.00561855
+          "bias": 0.00442514,
+          "spread": 0.00260038,
+          "score": 0.00513263
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00323514,
-          "spread": 0.00078288,
-          "score": 0.00332852
+          "bias": -0.00395129,
+          "spread": 0.00144662,
+          "score": 0.00420778
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00155619,
-          "spread": 0.00169391,
-          "score": 0.00230023
+          "bias": -0.00162072,
+          "spread": 0.00184381,
+          "score": 0.00245487
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00166123,
-          "spread": 0.00231716,
-          "score": 0.00285113
+          "bias": 0.00179258,
+          "spread": 0.00264263,
+          "score": 0.00319325
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00596809,
-          "spread": 0.02587965,
-          "score": 0.02655889
+          "bias": 0.00431439,
+          "spread": 0.02642064,
+          "score": 0.02677059
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.02350493,
-          "spread": 0.04667617,
-          "score": 0.05226037
+          "bias": 0.01807881,
+          "spread": 0.04199386,
+          "score": 0.0457201
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.07203085,
-          "spread": 0.07636987,
-          "score": 0.10498
+          "bias": 0.07137476,
+          "spread": 0.07509777,
+          "score": 0.10360517
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.00522767,
-          "spread": 0.0085917,
-          "score": 0.01005713
+          "bias": -0.00230447,
+          "spread": 0.01609895,
+          "score": 0.01626305
         },
         {
           "profile": "cp_minus_10pct",
@@ -5638,207 +5638,207 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00317037,
-          "spread": 0.00912716,
-          "score": 0.00966211
+          "bias": 0.00205541,
+          "spread": 0.00958278,
+          "score": 0.00980074
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00632506,
-          "spread": 0.00267419,
-          "score": 0.00686715
+          "bias": 0.00669977,
+          "spread": 0.00282767,
+          "score": 0.00727204
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00605511,
-          "spread": 0.00603185,
-          "score": 0.00854678
+          "bias": 0.00659048,
+          "spread": 0.00618949,
+          "score": 0.00904125
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00156681,
-          "spread": 0.00170733,
-          "score": 0.0023173
+          "bias": 0.00145906,
+          "spread": 0.00145398,
+          "score": 0.00205984
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.03918906,
-          "spread": 0.00675225,
-          "score": 0.03976651
+          "bias": 0.03696118,
+          "spread": 0.03714049,
+          "score": 0.05239795
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00294787,
-          "spread": 0.00900639,
-          "score": 0.00947655
+          "bias": -0.00024632,
+          "spread": 0.01133615,
+          "score": 0.01133882
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00103664,
-          "spread": 0.00258354,
-          "score": 0.00278375
+          "bias": -0.00151924,
+          "spread": 0.00204543,
+          "score": 0.00254791
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00268235,
-          "spread": 0.000535,
-          "score": 0.00273518
+          "bias": 0.0027662,
+          "spread": 0.00102188,
+          "score": 0.00294892
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00272934,
-          "spread": 0.00247577,
-          "score": 0.00368493
+          "bias": 0.0030959,
+          "spread": 0.00215776,
+          "score": 0.00377366
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00819998,
-          "spread": 0.00747182,
-          "score": 0.01109359
+          "bias": 0.00849134,
+          "spread": 0.00593335,
+          "score": 0.01035893
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00878079,
-          "spread": 0.01986853,
-          "score": 0.02172236
+          "bias": 0.00801353,
+          "spread": 0.01511539,
+          "score": 0.01710823
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.01216321,
-          "spread": 0.02863749,
-          "score": 0.03111349
+          "bias": -0.02130341,
+          "spread": 0.02856927,
+          "score": 0.0356376
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.22206153,
-          "spread": 0.15754559,
-          "score": 0.27227181
+          "bias": 0.09715598,
+          "spread": 0.13192813,
+          "score": 0.16384235
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.59262362,
-          "spread": 0.44854952,
-          "score": 0.74323579
+          "bias": 0.50136254,
+          "spread": 0.35673996,
+          "score": 0.61532739
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.01705186,
-          "spread": 0.00999229,
-          "score": 0.0197639
+          "bias": 0.01167758,
+          "spread": 0.00952953,
+          "score": 0.01507242
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00373831,
-          "spread": 0.0021153,
-          "score": 0.00429528
+          "bias": 0.00401529,
+          "spread": 0.00180705,
+          "score": 0.00440318
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00544816,
-          "spread": 0.00061181,
-          "score": 0.0054824
+          "bias": -0.00551639,
+          "spread": 0.00080871,
+          "score": 0.00557535
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00273792,
-          "spread": 0.00231555,
-          "score": 0.00358581
+          "bias": -0.00278203,
+          "spread": 0.00209422,
+          "score": 0.00348216
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -7e-07,
-          "spread": 0.00120635,
-          "score": 0.00120635
+          "bias": -0.00018172,
+          "spread": 0.00128905,
+          "score": 0.0013018
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00477388,
-          "spread": 0.01213866,
-          "score": 0.01304365
+          "bias": 0.00418833,
+          "spread": 0.011851,
+          "score": 0.01256934
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.03045649,
-          "spread": 0.03882183,
-          "score": 0.04934301
+          "bias": 0.03005714,
+          "spread": 0.04489684,
+          "score": 0.05402924
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00262652,
-          "spread": 0.00950979,
-          "score": 0.00986584
+          "bias": -0.00288426,
+          "spread": 0.00860095,
+          "score": 0.00907167
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.01992041,
-          "spread": 0.00527709,
-          "score": 0.02060753
+          "bias": 0.02548896,
+          "spread": 0.01072605,
+          "score": 0.02765385
         },
         {
           "profile": "cp_minus_10pct",
@@ -5854,207 +5854,207 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00150793,
-          "spread": 0.00342054,
-          "score": 0.00373817
+          "bias": 0.00214136,
+          "spread": 0.00297953,
+          "score": 0.0036692
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00158835,
-          "spread": 0.00382652,
-          "score": 0.00414308
+          "bias": 0.00106713,
+          "spread": 0.00389613,
+          "score": 0.00403963
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00475638,
-          "spread": 0.00503047,
-          "score": 0.00692306
+          "bias": 0.00439611,
+          "spread": 0.00483169,
+          "score": 0.0065323
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 9,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00116133,
-          "spread": 0.00152937,
-          "score": 0.00192032
+          "bias": 0.00119914,
+          "spread": 0.00156504,
+          "score": 0.00197162
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.06387061,
-          "spread": 0.00303977,
-          "score": 0.0639429
+          "bias": 0.05678738,
+          "spread": 0.01954476,
+          "score": 0.06005668
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00146002,
-          "spread": 0.00433226,
-          "score": 0.00457166
+          "bias": 0.00066378,
+          "spread": 0.00604108,
+          "score": 0.00607744
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00092388,
-          "spread": 0.00225174,
-          "score": 0.0024339
+          "bias": 0.00079098,
+          "spread": 0.00186226,
+          "score": 0.00202328
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00096813,
-          "spread": 0.00082131,
-          "score": 0.00126958
+          "bias": 0.00107266,
+          "spread": 0.00105271,
+          "score": 0.00150293
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00129251,
-          "spread": 0.00170596,
-          "score": 0.0021403
+          "bias": 0.00128715,
+          "spread": 0.00172451,
+          "score": 0.0021519
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00694461,
-          "spread": 0.00719308,
-          "score": 0.0099984
+          "bias": 0.00827487,
+          "spread": 0.00760233,
+          "score": 0.01123695
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00144638,
-          "spread": 0.01846276,
-          "score": 0.01851932
+          "bias": -0.0007299,
+          "spread": 0.01659802,
+          "score": 0.01661406
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.01989934,
-          "spread": 0.02038072,
-          "score": 0.02848433
+          "bias": 0.02370732,
+          "spread": 0.01997036,
+          "score": 0.03099762
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.05910759,
-          "spread": 0.21878251,
-          "score": 0.22662633
+          "bias": 0.07100463,
+          "spread": 0.22843025,
+          "score": 0.23921128
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.04301681,
+          "bias": -0.06471719,
           "spread": 0.0,
-          "score": 0.04301681
+          "score": 0.06471719
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.02279764,
-          "spread": 0.02362582,
-          "score": 0.03283157
+          "bias": -0.03657571,
+          "spread": 0.02464557,
+          "score": 0.04410427
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00292662,
-          "spread": 0.00154652,
-          "score": 0.00331011
+          "bias": 0.00294977,
+          "spread": 0.00170501,
+          "score": 0.00340709
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00419175,
-          "spread": 0.00047997,
-          "score": 0.00421914
+          "bias": -0.00411773,
+          "spread": 0.00048568,
+          "score": 0.00414628
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00217785,
-          "spread": 0.00144719,
-          "score": 0.00261483
+          "bias": -0.00188693,
+          "spread": 0.00145051,
+          "score": 0.00238002
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.0004935,
-          "spread": 0.00138907,
-          "score": 0.00147413
+          "bias": -0.00013953,
+          "spread": 0.00133902,
+          "score": 0.00134627
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00613716,
-          "spread": 0.01147308,
-          "score": 0.01301139
+          "bias": 0.00592145,
+          "spread": 0.01096924,
+          "score": 0.01246547
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.0305281,
-          "spread": 0.03090809,
-          "score": 0.04344277
+          "bias": 0.03119048,
+          "spread": 0.03523563,
+          "score": 0.04705736
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.0041162,
-          "spread": 0.00513848,
-          "score": 0.00658385
+          "bias": 0.00385461,
+          "spread": 0.00416275,
+          "score": 0.00567332
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.00552417,
-          "spread": 0.02748382,
-          "score": 0.02803349
+          "bias": 0.00022302,
+          "spread": 0.03642657,
+          "score": 0.03642725
         },
         {
           "profile": "cp_minus_10pct",
@@ -6070,252 +6070,252 @@
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00030824,
-          "spread": 0.00414054,
-          "score": 0.004152
+          "bias": -0.00070751,
+          "spread": 0.00365014,
+          "score": 0.00371808
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00164487,
-          "spread": 0.00263528,
-          "score": 0.00310649
+          "bias": 0.00163477,
+          "spread": 0.00256862,
+          "score": 0.00304471
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00395804,
-          "spread": 0.00387226,
-          "score": 0.00553719
+          "bias": 0.00395671,
+          "spread": 0.00382824,
+          "score": 0.00550554
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00087013,
-          "spread": 0.00094641,
-          "score": 0.00128562
+          "bias": 0.00080278,
+          "spread": 0.00098077,
+          "score": 0.00126743
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.03696146,
-          "spread": 0.00254396,
-          "score": 0.0370489
+          "bias": 0.0157979,
+          "spread": 0.0116396,
+          "score": 0.01962279
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00045198,
-          "spread": 0.00335921,
-          "score": 0.00338948
+          "bias": 0.0003872,
+          "spread": 0.00428975,
+          "score": 0.00430718
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -7.933e-05,
-          "spread": 0.00142098,
-          "score": 0.0014232
+          "bias": -0.0003882,
+          "spread": 0.00101314,
+          "score": 0.00108497
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00053769,
-          "spread": 0.00044291,
-          "score": 0.00069662
+          "bias": 0.00038509,
+          "spread": 0.00061643,
+          "score": 0.00072683
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00265921,
-          "spread": 0.00160619,
-          "score": 0.00310665
+          "bias": 0.00299684,
+          "spread": 0.00185392,
+          "score": 0.00352393
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00901579,
-          "spread": 0.00598674,
-          "score": 0.01082245
+          "bias": 0.00956486,
+          "spread": 0.00623533,
+          "score": 0.01141778
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -7.714e-05,
-          "spread": 0.02298299,
-          "score": 0.02298312
+          "bias": 0.00189586,
+          "spread": 0.02188078,
+          "score": 0.02196276
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.00344926,
-          "spread": 0.02405554,
-          "score": 0.02430158
+          "bias": 0.00356456,
+          "spread": 0.02593769,
+          "score": 0.02618148
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.00560076,
-          "spread": 0.16135491,
-          "score": 0.16145208
+          "bias": 0.02107486,
+          "spread": 0.17358316,
+          "score": 0.17485784
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.00053188,
+          "bias": -0.03181559,
           "spread": 0.0,
-          "score": 0.00053188
+          "score": 0.03181559
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.00675788,
-          "spread": 0.04989725,
-          "score": 0.0503528
+          "bias": -0.00566276,
+          "spread": 0.04929042,
+          "score": 0.04961464
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.0035727,
-          "spread": 0.00154213,
-          "score": 0.00389132
+          "bias": 0.00355149,
+          "spread": 0.00138078,
+          "score": 0.00381047
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00322427,
-          "spread": 0.00088947,
-          "score": 0.00334471
+          "bias": -0.00329039,
+          "spread": 0.00088337,
+          "score": 0.0034069
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00197202,
-          "spread": 0.00119763,
-          "score": 0.0023072
+          "bias": -0.00223307,
+          "spread": 0.00117574,
+          "score": 0.00252368
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00045653,
-          "spread": 0.00024187,
-          "score": 0.00051665
+          "bias": -0.00047603,
+          "spread": 0.00073833,
+          "score": 0.00087849
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.0001107,
-          "spread": 0.00098358,
-          "score": 0.00098979
+          "bias": 0.00021199,
+          "spread": 0.00158852,
+          "score": 0.0016026
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.03258008,
-          "spread": 0.04134942,
-          "score": 0.05264253
+          "bias": 0.03020777,
+          "spread": 0.03952326,
+          "score": 0.04974533
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00320807,
-          "spread": 0.00190161,
-          "score": 0.00372933
+          "bias": -0.0024936,
+          "spread": 0.00257492,
+          "score": 0.00358445
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.02377473,
-          "spread": 0.02467718,
-          "score": 0.03426662
+          "bias": -0.02893845,
+          "spread": 0.02722839,
+          "score": 0.03973436
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
-          "bias": 0.03240609,
+          "bias": 0.02530955,
           "spread": 0.0,
-          "score": 0.03240609
+          "score": 0.02530955
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00125837,
-          "spread": 0.00526717,
-          "score": 0.0054154
+          "bias": 0.00085665,
+          "spread": 0.00455179,
+          "score": 0.0046317
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00251585,
-          "spread": 0.00189153,
-          "score": 0.0031476
+          "bias": 0.00241773,
+          "spread": 0.00171743,
+          "score": 0.00296563
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00201555,
-          "spread": 0.00317756,
-          "score": 0.00376289
+          "bias": 0.00205838,
+          "spread": 0.00327801,
+          "score": 0.0038707
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00409051,
-          "spread": 0.00090798,
-          "score": 0.00419007
+          "bias": 0.0040082,
+          "spread": 0.00074342,
+          "score": 0.00407656
         },
         {
           "profile": "cp_plus_10pct",
@@ -6331,2326 +6331,166 @@
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00883512,
-          "spread": 0.00786036,
-          "score": 0.01182559
+          "bias": 0.00959606,
+          "spread": 0.01101566,
+          "score": 0.01460921
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00330551,
-          "spread": 0.00298889,
-          "score": 0.00445644
+          "bias": 0.00309527,
+          "spread": 0.00284748,
+          "score": 0.00420581
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00601783,
-          "spread": 0.00089691,
-          "score": 0.0060843
+          "bias": 0.00587813,
+          "spread": 0.00142815,
+          "score": 0.00604913
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00141394,
-          "spread": 0.00183653,
-          "score": 0.00231778
+          "bias": 0.0018644,
+          "spread": 0.00246093,
+          "score": 0.00308742
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": -0.00017765,
-          "spread": 0.01148837,
-          "score": 0.01148975
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": -0.0158087,
-          "spread": 0.03138173,
-          "score": 0.0351387
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": -0.00494106,
-          "spread": 0.03008843,
-          "score": 0.03049144
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.09153947,
-          "spread": 1.46764464,
-          "score": 1.47049661
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": 0.06277389,
-          "spread": 0.26704032,
-          "score": 0.27431933
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.00868837,
-          "spread": 0.08250508,
-          "score": 0.08296129
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00148437,
-          "spread": 0.00125555,
-          "score": 0.00194417
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00768693,
-          "spread": 0.00163405,
-          "score": 0.00785869
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": 0.0023534,
-          "spread": 0.00286741,
-          "score": 0.00370952
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.0034063,
-          "spread": 0.00312519,
-          "score": 0.00462273
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00579675,
-          "spread": 0.01847154,
-          "score": 0.01935975
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": -0.00783828,
-          "spread": 0.03141596,
-          "score": 0.03237903
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": 0.05838,
-          "spread": 0.06430656,
-          "score": 0.08685366
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": -0.00533159,
-          "spread": 0.01237752,
-          "score": 0.01347697
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00509865,
-          "spread": 0.01047106,
-          "score": 0.01164643
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00809251,
-          "spread": 0.00390434,
-          "score": 0.00898513
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00346206,
-          "spread": 0.00592732,
-          "score": 0.00686432
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.00156683,
-          "spread": 0.00192812,
-          "score": 0.00248447
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": 0.04001067,
-          "spread": 0.01200823,
-          "score": 0.04177381
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00293544,
-          "spread": 0.00804695,
-          "score": 0.00856565
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00150878,
-          "spread": 0.00204203,
-          "score": 0.00253896
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00257288,
-          "spread": 0.00239953,
-          "score": 0.00351816
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00141506,
-          "spread": 0.00318786,
-          "score": 0.00348781
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00239829,
-          "spread": 0.00759097,
-          "score": 0.00796082
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00207203,
-          "spread": 0.02755426,
-          "score": 0.02763206
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": -0.05179024,
-          "spread": 0.03117744,
-          "score": 0.06045048
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 1.31950672,
-          "spread": 2.3111181,
-          "score": 2.66127129
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": 0.69146658,
-          "spread": 0.49847422,
-          "score": 0.85240986
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.002577,
-          "spread": 0.02697853,
-          "score": 0.02710133
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00329665,
-          "spread": 0.00337411,
-          "score": 0.00471726
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00502733,
-          "spread": 0.00126555,
-          "score": 0.00518418
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00136264,
-          "spread": 0.00232103,
-          "score": 0.00269146
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00107796,
-          "spread": 0.00229474,
-          "score": 0.00253532
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00328197,
-          "spread": 0.00903996,
-          "score": 0.00961728
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": -0.03100731,
-          "spread": 0.03940173,
-          "score": 0.0501393
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": -0.01071062,
-          "spread": 0.00567248,
-          "score": 0.01212
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": -0.00864889,
-          "spread": 0.0061331,
-          "score": 0.01060275
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00307467,
-          "spread": 0.00367093,
-          "score": 0.00478846
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00264365,
-          "spread": 0.00461933,
-          "score": 0.00532232
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": 0.0018215,
-          "spread": 0.00543578,
-          "score": 0.00573284
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.00115053,
-          "spread": 0.00171518,
-          "score": 0.00206533
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": 0.05793455,
-          "spread": 0.01775649,
-          "score": 0.0605946
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00345318,
-          "spread": 0.00259094,
-          "score": 0.00431711
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00292238,
-          "spread": 0.00173994,
-          "score": 0.00340113
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00123532,
-          "spread": 0.00282131,
-          "score": 0.00307991
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00360202,
-          "spread": 0.00266885,
-          "score": 0.004483
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00066644,
-          "spread": 0.00689543,
-          "score": 0.00692756
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": -0.01245214,
-          "spread": 0.02277192,
-          "score": 0.02595411
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": 0.01393345,
-          "spread": 0.02776536,
-          "score": 0.03106535
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": -0.00254354,
-          "spread": 0.32450658,
-          "score": 0.32451654
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": 0.55662158,
-          "spread": 0.61400609,
-          "score": 0.82875271
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.04808416,
-          "spread": 0.0372527,
-          "score": 0.0608264
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00416463,
-          "spread": 0.00310686,
-          "score": 0.00519583
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00540278,
-          "spread": 0.0008758,
-          "score": 0.0054733
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00136278,
-          "spread": 0.00147879,
-          "score": 0.00201096
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00050156,
-          "spread": 0.00160122,
-          "score": 0.00167794
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00389583,
-          "spread": 0.00924057,
-          "score": 0.01002824
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": -0.02342644,
-          "spread": 0.04650839,
-          "score": 0.05207522
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00318009,
-          "spread": 0.00915056,
-          "score": 0.0096874
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": -0.02753583,
-          "spread": 0.03024358,
-          "score": 0.04090105
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00052415,
-          "spread": 0.00523162,
-          "score": 0.00525781
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00239017,
-          "spread": 0.00302087,
-          "score": 0.00385209
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00144009,
-          "spread": 0.00434145,
-          "score": 0.00457407
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.00081108,
-          "spread": 0.00101848,
-          "score": 0.00130198
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": 0.03797575,
-          "spread": 0.03124969,
-          "score": 0.04918029
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00217652,
-          "spread": 0.00220018,
-          "score": 0.00309484
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00216861,
-          "spread": 0.00084598,
-          "score": 0.00232778
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": 0.0004523,
-          "spread": 0.00181315,
-          "score": 0.00186872
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": -0.0018387,
-          "spread": 0.00291979,
-          "score": 0.00345051
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00139419,
-          "spread": 0.00582725,
-          "score": 0.00599171
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": -0.0129045,
-          "spread": 0.03081445,
-          "score": 0.03340742
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": -0.01049551,
-          "spread": 0.03133165,
-          "score": 0.03304282
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": -0.01299387,
-          "spread": 0.21104209,
-          "score": 0.21144173
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": 0.6822182,
-          "spread": 0.71626621,
-          "score": 0.98917085
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.0272974,
-          "spread": 0.04590898,
-          "score": 0.05341144
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00400667,
-          "spread": 0.00304136,
-          "score": 0.00503023
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.0057793,
-          "spread": 0.00086544,
-          "score": 0.00584374
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00097104,
-          "spread": 0.0012405,
-          "score": 0.00157536
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00079018,
-          "spread": 0.00045366,
-          "score": 0.00091115
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": -0.00237259,
-          "spread": 0.00356739,
-          "score": 0.00428432
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": -0.01857688,
-          "spread": 0.01346109,
-          "score": 0.02294126
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00992532,
-          "spread": 0.00632969,
-          "score": 0.01177187
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": -0.03436401,
-          "spread": 0.02484904,
-          "score": 0.04240708
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": 0.02954247,
-          "spread": 0.0,
-          "score": 0.02954247
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00155989,
-          "spread": 0.00657894,
-          "score": 0.00676134
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00366174,
-          "spread": 0.00180189,
-          "score": 0.00408107
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00071519,
-          "spread": 0.00279097,
-          "score": 0.00288115
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.00396177,
-          "spread": 0.00087041,
-          "score": 0.00405626
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00865916,
-          "spread": 0.00890033,
-          "score": 0.01241761
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00208685,
-          "spread": 0.00256001,
-          "score": 0.00330282
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00579877,
-          "spread": 0.00104641,
-          "score": 0.00589243
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00343394,
-          "spread": 0.0021486,
-          "score": 0.00405073
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00134429,
-          "spread": 0.01110675,
-          "score": 0.01118781
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": -0.01136404,
-          "spread": 0.03011265,
-          "score": 0.03218561
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": -0.00051903,
-          "spread": 0.02956741,
-          "score": 0.02957196
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.28799324,
-          "spread": 1.07190123,
-          "score": 1.10991547
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": -0.23552075,
-          "spread": 0.0,
-          "score": 0.23552075
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": 0.01294077,
-          "spread": 0.0674916,
-          "score": 0.06872103
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00074586,
-          "spread": 0.00149789,
-          "score": 0.00167332
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00398658,
-          "spread": 0.00117354,
-          "score": 0.00415572
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00114247,
-          "spread": 0.00246829,
-          "score": 0.00271987
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.0029704,
-          "spread": 0.00259252,
-          "score": 0.00394264
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00587422,
-          "spread": 0.02119684,
-          "score": 0.02199573
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": 0.00523416,
-          "spread": 0.042369,
-          "score": 0.04269109
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": 0.06050742,
-          "spread": 0.0660959,
-          "score": 0.08960924
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": -0.00208737,
-          "spread": 0.00689545,
-          "score": 0.00720447
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00474261,
-          "spread": 0.01021422,
-          "score": 0.01126156
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00780487,
-          "spread": 0.00366735,
-          "score": 0.00862354
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00416255,
-          "spread": 0.00604509,
-          "score": 0.00733961
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.00156682,
-          "spread": 0.00185084,
-          "score": 0.00242499
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": 0.03183157,
-          "spread": 0.00099196,
-          "score": 0.03184702
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00273958,
-          "spread": 0.00873277,
-          "score": 0.0091524
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00070021,
-          "spread": 0.00222583,
-          "score": 0.00233337
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00263811,
-          "spread": 0.00176494,
-          "score": 0.00317406
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": -1.43e-05,
-          "spread": 0.00284497,
-          "score": 0.00284501
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00397309,
-          "spread": 0.00699416,
-          "score": 0.00804386
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00487874,
-          "spread": 0.02565078,
-          "score": 0.02611062
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": -0.03803705,
-          "spread": 0.02714221,
-          "score": 0.04672811
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.99773084,
-          "spread": 1.65585806,
-          "score": 1.93321824
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": 0.68157614,
-          "spread": 0.50635893,
-          "score": 0.84908503
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.01041324,
-          "spread": 0.02387808,
-          "score": 0.02604992
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00083751,
-          "spread": 0.00272599,
-          "score": 0.00285174
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00157998,
-          "spread": 0.00099217,
-          "score": 0.00186567
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00011896,
-          "spread": 0.00215949,
-          "score": 0.00216277
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00079489,
-          "spread": 0.00198941,
-          "score": 0.00214233
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00390843,
-          "spread": 0.00986201,
-          "score": 0.01060825
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": -0.00998119,
-          "spread": 0.02258674,
-          "score": 0.02469383
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00790795,
-          "spread": 0.0043584,
-          "score": 0.00902947
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": 0.00199151,
-          "spread": 0.00619831,
-          "score": 0.00651039
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00238297,
-          "spread": 0.00361198,
-          "score": 0.00432723
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00226705,
-          "spread": 0.00450999,
-          "score": 0.00504772
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00289289,
-          "spread": 0.00540302,
-          "score": 0.00612874
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.00115432,
-          "spread": 0.00165012,
-          "score": 0.00201379
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": 0.06506261,
-          "spread": 0.01590609,
-          "score": 0.0669787
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00242226,
-          "spread": 0.00313057,
-          "score": 0.00395825
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00226867,
-          "spread": 0.00181333,
-          "score": 0.00290431
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00116508,
-          "spread": 0.00200255,
-          "score": 0.00231681
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00201437,
-          "spread": 0.00237288,
-          "score": 0.0031126
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00316448,
-          "spread": 0.00714929,
-          "score": 0.00781833
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00775027,
-          "spread": 0.02285027,
-          "score": 0.02412885
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": 0.01680773,
-          "spread": 0.02098328,
-          "score": 0.0268849
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.01723016,
-          "spread": 0.29286325,
-          "score": 0.29336967
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": 0.45486238,
-          "spread": 0.51709703,
-          "score": 0.68868652
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.04346593,
-          "spread": 0.03266359,
-          "score": 0.05437092
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00160526,
-          "spread": 0.00247476,
-          "score": 0.00294979
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00215521,
-          "spread": 0.00085682,
-          "score": 0.00231928
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00030676,
-          "spread": 0.00144102,
-          "score": 0.00147331
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00033469,
-          "spread": 0.00162344,
-          "score": 0.00165758
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00468684,
-          "spread": 0.00998915,
-          "score": 0.01103402
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": -0.00502949,
-          "spread": 0.03144076,
-          "score": 0.0318405
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00114967,
-          "spread": 0.00726215,
-          "score": 0.00735259
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": -0.02141366,
-          "spread": 0.02744851,
-          "score": 0.03481329
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00032547,
-          "spread": 0.00479693,
-          "score": 0.00480796
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00206824,
-          "spread": 0.00278953,
-          "score": 0.00347262
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": 0.0023509,
-          "spread": 0.00409806,
-          "score": 0.00472449
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.00083175,
-          "spread": 0.00099325,
-          "score": 0.00129551
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": 0.03393492,
-          "spread": 0.00827729,
-          "score": 0.03492982
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00125549,
-          "spread": 0.00254922,
-          "score": 0.00284161
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00149614,
-          "spread": 0.00097919,
-          "score": 0.00178809
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00041279,
-          "spread": 0.00135164,
-          "score": 0.00141327
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00016578,
-          "spread": 0.00249968,
-          "score": 0.00250517
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00385535,
-          "spread": 0.00598653,
-          "score": 0.00712055
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00702087,
-          "spread": 0.02889027,
-          "score": 0.02973113
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": -0.0092701,
-          "spread": 0.02868986,
-          "score": 0.03015034
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": -0.00584089,
-          "spread": 0.18557261,
-          "score": 0.18566451
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": 0.0765344,
-          "spread": 0.09922991,
-          "score": 0.12531596
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.01858355,
-          "spread": 0.047656,
-          "score": 0.05115118
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00123311,
-          "spread": 0.00250785,
-          "score": 0.00279462
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.0027601,
-          "spread": 0.00065949,
-          "score": 0.0028378
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": 6.804e-05,
-          "spread": 0.00125819,
-          "score": 0.00126003
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00052699,
-          "spread": 0.00032761,
-          "score": 0.00062052
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": -0.00144162,
-          "spread": 0.00246971,
-          "score": 0.00285967
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": 0.00088047,
-          "spread": 0.01313615,
-          "score": 0.01316563
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00746953,
-          "spread": 0.00451991,
-          "score": 0.00873061
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": -0.0303922,
-          "spread": 0.02342063,
-          "score": 0.03836941
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": 0.02962849,
-          "spread": 0.0,
-          "score": 0.02962849
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00135194,
-          "spread": 0.00602714,
-          "score": 0.0061769
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00325913,
-          "spread": 0.00179534,
-          "score": 0.00372091
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00022106,
-          "spread": 0.00296841,
-          "score": 0.00297663
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 3,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.00398258,
-          "spread": 0.00087662,
-          "score": 0.00407792
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00842141,
-          "spread": 0.0099002,
-          "score": 0.01299747
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00085684,
-          "spread": 0.00253343,
-          "score": 0.0026744
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00582025,
-          "spread": 0.00155026,
-          "score": 0.00602317
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00582892,
-          "spread": 0.00237116,
-          "score": 0.00629275
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00441529,
-          "spread": 0.01065199,
-          "score": 0.01153082
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": -0.01081688,
-          "spread": 0.03097075,
-          "score": 0.03280537
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": 0.005548,
-          "spread": 0.03062767,
-          "score": 0.0311261
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.38091502,
-          "spread": 0.93194457,
-          "score": 1.00678545
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": -0.13292201,
-          "spread": 0.0,
-          "score": 0.13292201
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": 0.01221018,
-          "spread": 0.0628449,
-          "score": 0.06402007
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00379839,
-          "spread": 0.00245698,
-          "score": 0.00452377
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00027654,
-          "spread": 0.00088764,
-          "score": 0.00092972
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00057457,
-          "spread": 0.00234653,
-          "score": 0.00241585
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00202543,
-          "spread": 0.00263118,
-          "score": 0.00332047
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00592184,
-          "spread": 0.02493748,
-          "score": 0.02563096
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": 0.00453555,
-          "spread": 0.03361464,
-          "score": 0.03391925
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": 0.0681784,
-          "spread": 0.07340945,
-          "score": 0.10018604
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": 0.00382608,
-          "spread": 0.00204438,
-          "score": 0.00433801
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00345425,
-          "spread": 0.01004757,
-          "score": 0.01062476
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00669671,
-          "spread": 0.00301767,
-          "score": 0.00734522
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": 0.0057552,
-          "spread": 0.00620442,
-          "score": 0.0084627
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.00160867,
-          "spread": 0.00184766,
-          "score": 0.00244983
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": 0.03503034,
-          "spread": 0.00808711,
-          "score": 0.03595172
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": 0.0028437,
-          "spread": 0.00908927,
-          "score": 0.00952373
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00040383,
-          "spread": 0.00261214,
-          "score": 0.00264317
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00288479,
-          "spread": 0.00111553,
-          "score": 0.00309297
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00179322,
-          "spread": 0.00251909,
-          "score": 0.00309216
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00630825,
-          "spread": 0.00819302,
-          "score": 0.01034019
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00852858,
-          "spread": 0.02324803,
-          "score": 0.02476303
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": -0.02921761,
-          "spread": 0.02716401,
-          "score": 0.03989426
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.81368656,
-          "spread": 1.28903908,
-          "score": 1.5243712
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": 0.59641106,
-          "spread": 0.59212073,
-          "score": 0.84042436
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.0098678,
-          "spread": 0.01832431,
-          "score": 0.02081234
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": 0.0021177,
-          "spread": 0.00248753,
-          "score": 0.00326688
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00253035,
-          "spread": 0.00071289,
-          "score": 0.00262885
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00176342,
-          "spread": 0.00216068,
-          "score": 0.00278894
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 6.645e-05,
-          "spread": 0.00144209,
-          "score": 0.00144362
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00414127,
-          "spread": 0.01177472,
-          "score": 0.01248175
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": 0.00088795,
-          "spread": 0.01961483,
-          "score": 0.01963492
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00503523,
-          "spread": 0.00690747,
-          "score": 0.00854791
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": 0.01237277,
-          "spread": 0.00568331,
-          "score": 0.01361563
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00232447,
-          "spread": 0.00350987,
-          "score": 0.00420979
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00161662,
-          "spread": 0.00439459,
-          "score": 0.00468251
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00427596,
-          "spread": 0.00533741,
-          "score": 0.00683898
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
-          "condition": "overall",
-          "condition_bin": "overall",
           "bias": 0.00118892,
-          "spread": 0.00164909,
-          "score": 0.00203299
+          "spread": 0.00763488,
+          "score": 0.0077269
         },
         {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": 0.06243699,
-          "spread": 0.00979785,
-          "score": 0.06320108
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00197595,
-          "spread": 0.0037712,
-          "score": 0.0042575
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00153839,
-          "spread": 0.0022354,
-          "score": 0.0027136
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00115635,
-          "spread": 0.0012905,
-          "score": 0.00173278
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": -1.076e-05,
-          "spread": 0.00189645,
-          "score": 0.00189648
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00545537,
-          "spread": 0.00771831,
-          "score": 0.00945164
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00458444,
-          "spread": 0.02051086,
-          "score": 0.02101696
+          "bias": -0.01897265,
+          "spread": 0.02743657,
+          "score": 0.03335755
         },
         {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.01987181,
-          "spread": 0.0220643,
-          "score": 0.02969381
+          "bias": -0.01889337,
+          "spread": 0.01574681,
+          "score": 0.02459515
         },
         {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.04314693,
-          "spread": 0.27439772,
-          "score": 0.27776927
+          "bias": 0.191383,
+          "spread": 1.612965,
+          "score": 1.62427939
         },
         {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.67729485,
-          "spread": 0.72828788,
-          "score": 0.99455093
+          "bias": 0.06663591,
+          "spread": 0.26981476,
+          "score": 0.27792148
         },
         {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.05077049,
-          "spread": 0.03512189,
-          "score": 0.06173483
+          "bias": -0.0079944,
+          "spread": 0.04948985,
+          "score": 0.05013138
         },
         {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00104993,
-          "spread": 0.00201187,
-          "score": 0.00226936
+          "bias": -0.00145852,
+          "spread": 0.00167378,
+          "score": 0.0022201
         },
         {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00182819,
-          "spread": 0.00070228,
-          "score": 0.00195844
+          "bias": 0.00736441,
+          "spread": 0.00181472,
+          "score": 0.00758471
         },
         {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00110607,
-          "spread": 0.00159632,
-          "score": 0.00194207
+          "bias": 0.00244968,
+          "spread": 0.00307073,
+          "score": 0.00392814
         },
         {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00013464,
-          "spread": 0.00154361,
-          "score": 0.00154948
+          "bias": 0.0036998,
+          "spread": 0.0033936,
+          "score": 0.00502046
         },
         {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00562239,
-          "spread": 0.01111454,
-          "score": 0.01245569
+          "bias": 0.00411053,
+          "spread": 0.01907687,
+          "score": 0.01951469
         },
         {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.0057857,
-          "spread": 0.02513646,
-          "score": 0.02579372
+          "bias": -0.01196371,
+          "spread": 0.03628781,
+          "score": 0.0382091
         },
         {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00241375,
-          "spread": 0.00560204,
-          "score": 0.00609992
+          "bias": 0.05247157,
+          "spread": 0.05495562,
+          "score": 0.0759828
         },
         {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.01233157,
-          "spread": 0.02887213,
-          "score": 0.03139534
+          "bias": -0.01317814,
+          "spread": 0.00457167,
+          "score": 0.0139486
         },
         {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
           "bias": NaN,
@@ -8658,256 +6498,2416 @@
           "score": NaN
         },
         {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00019632,
-          "spread": 0.00430781,
-          "score": 0.00431228
+          "bias": 0.00409944,
+          "spread": 0.01048005,
+          "score": 0.0112533
         },
         {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00199623,
-          "spread": 0.00277031,
-          "score": 0.00341461
+          "bias": 0.00805516,
+          "spread": 0.00403738,
+          "score": 0.00901033
         },
         {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00356407,
-          "spread": 0.0042674,
-          "score": 0.00555997
+          "bias": 0.00367309,
+          "spread": 0.00639725,
+          "score": 0.00737675
         },
         {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00087604,
-          "spread": 0.00101026,
-          "score": 0.00133719
+          "bias": 0.00144427,
+          "spread": 0.00163612,
+          "score": 0.00218238
         },
         {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.02432801,
-          "spread": 0.00523959,
-          "score": 0.02488584
+          "bias": 0.01900639,
+          "spread": 0.02598234,
+          "score": 0.03219201
         },
         {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00097943,
-          "spread": 0.00359949,
-          "score": 0.00373036
+          "bias": -0.00061063,
+          "spread": 0.01161648,
+          "score": 0.01163252
         },
         {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00054673,
-          "spread": 0.00125425,
-          "score": 0.00136823
+          "bias": 0.00098706,
+          "spread": 0.0015616,
+          "score": 0.0018474
         },
         {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00052638,
-          "spread": 0.00078329,
-          "score": 0.00094373
+          "bias": 0.00269624,
+          "spread": 0.0026148,
+          "score": 0.00375591
         },
         {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00158848,
-          "spread": 0.0021109,
-          "score": 0.00264181
+          "bias": -0.00104517,
+          "spread": 0.00276149,
+          "score": 0.00295266
         },
         {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00753564,
-          "spread": 0.0061272,
-          "score": 0.00971229
+          "bias": 0.00268483,
+          "spread": 0.0057049,
+          "score": 0.00630509
         },
         {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00299797,
-          "spread": 0.02737105,
-          "score": 0.02753474
+          "bias": 0.00295385,
+          "spread": 0.02391761,
+          "score": 0.02409932
         },
         {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.00640855,
-          "spread": 0.02612867,
-          "score": 0.0269031
+          "bias": -0.05770845,
+          "spread": 0.02822254,
+          "score": 0.06424
         },
         {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.000171,
-          "spread": 0.19501119,
-          "score": 0.19501126
+          "bias": 0.92738805,
+          "spread": 1.58622499,
+          "score": 1.83743254
         },
         {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.17349248,
-          "spread": 0.17078553,
-          "score": 0.24344884
+          "bias": 0.60505584,
+          "spread": 0.47472063,
+          "score": 0.76905932
         },
         {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.02524398,
-          "spread": 0.04515936,
-          "score": 0.05173612
+          "bias": -0.01205914,
+          "spread": 0.01393833,
+          "score": 0.01843095
         },
         {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00173655,
-          "spread": 0.00196148,
-          "score": 0.00261974
+          "bias": -0.00294177,
+          "spread": 0.00279153,
+          "score": 0.00405544
         },
         {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00079611,
-          "spread": 0.00087107,
-          "score": 0.00118007
+          "bias": 0.00497137,
+          "spread": 0.00168264,
+          "score": 0.00524841
         },
         {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00136063,
-          "spread": 0.0013499,
-          "score": 0.00191665
+          "bias": 0.00146744,
+          "spread": 0.00266471,
+          "score": 0.00304205
         },
         {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00013622,
-          "spread": 0.00029002,
-          "score": 0.00032041
+          "bias": 0.00099538,
+          "spread": 0.00256317,
+          "score": 0.00274966
         },
         {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": -0.00075438,
-          "spread": 0.00167208,
-          "score": 0.00183438
+          "bias": 0.00273732,
+          "spread": 0.00866636,
+          "score": 0.00908839
         },
         {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.00949217,
-          "spread": 0.01778155,
-          "score": 0.02015651
+          "bias": -0.03343313,
+          "spread": 0.03905863,
+          "score": 0.05141353
         },
         {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00528561,
-          "spread": 0.00282829,
-          "score": 0.00599474
+          "bias": -0.01072096,
+          "spread": 0.00653446,
+          "score": 0.0125554
         },
         {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.02825209,
-          "spread": 0.02564897,
-          "score": 0.03815822
+          "bias": -0.00531836,
+          "spread": 0.00919757,
+          "score": 0.01062451
         },
         {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
-          "bias": 0.03393163,
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": 0.00279132,
+          "spread": 0.00350476,
+          "score": 0.00448049
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.00142065,
+          "spread": 0.00447801,
+          "score": 0.00469796
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00205756,
+          "spread": 0.00524916,
+          "score": 0.00563802
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00119327,
+          "spread": 0.00175863,
+          "score": 0.00212525
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.0412164,
+          "spread": 0.01024744,
+          "score": 0.04247118
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.00314398,
+          "spread": 0.0043378,
+          "score": 0.00535734
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.00277668,
+          "spread": 0.00161273,
+          "score": 0.00321105
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00139693,
+          "spread": 0.00286997,
+          "score": 0.00319189
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.00349746,
+          "spread": 0.00251571,
+          "score": 0.00430825
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.0017191,
+          "spread": 0.00673,
+          "score": 0.00694609
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.01420695,
+          "spread": 0.02051197,
+          "score": 0.02495153
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.01354303,
+          "spread": 0.02425563,
+          "score": 0.02778038
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": -0.00239726,
+          "spread": 0.33561182,
+          "score": 0.33562039
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.10704404,
           "spread": 0.0,
-          "score": 0.03393163
+          "score": 0.10704404
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.05058289,
+          "spread": 0.03629246,
+          "score": 0.06225569
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": -0.0042612,
+          "spread": 0.00324889,
+          "score": 0.00535846
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00566156,
+          "spread": 0.00089627,
+          "score": 0.00573206
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.00146673,
+          "spread": 0.00166946,
+          "score": 0.00222226
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00063728,
+          "spread": 0.00166505,
+          "score": 0.00178284
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00337078,
+          "spread": 0.00891562,
+          "score": 0.00953155
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.02571036,
+          "spread": 0.04139457,
+          "score": 0.04872918
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": -0.00274766,
+          "spread": 0.011357,
+          "score": 0.01168465
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.02424517,
+          "spread": 0.03946723,
+          "score": 0.04631944
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.00135573,
+          "spread": 0.00461703,
+          "score": 0.00481196
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.00214868,
+          "spread": 0.00304569,
+          "score": 0.00372734
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00183466,
+          "spread": 0.00429254,
+          "score": 0.00466818
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00073475,
+          "spread": 0.00105852,
+          "score": 0.00128853
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.01069416,
+          "spread": 4.066e-05,
+          "score": 0.01069424
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.00169091,
+          "spread": 0.00279375,
+          "score": 0.00326561
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.00185592,
+          "spread": 0.00050607,
+          "score": 0.00192368
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00029575,
+          "spread": 0.00185184,
+          "score": 0.00187531
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.00150084,
+          "spread": 0.00329412,
+          "score": 0.00361991
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.0022938,
+          "spread": 0.00605425,
+          "score": 0.00647422
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.01056055,
+          "spread": 0.02809278,
+          "score": 0.03001216
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.00957005,
+          "spread": 0.03237837,
+          "score": 0.03376307
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.00340568,
+          "spread": 0.21332741,
+          "score": 0.21335459
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": 0.7194592,
+          "spread": 0.79857647,
+          "score": 1.07487019
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.0170104,
+          "spread": 0.03517503,
+          "score": 0.03907219
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": -0.00389391,
+          "spread": 0.00293796,
+          "score": 0.00487793
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00568756,
+          "spread": 0.0009022,
+          "score": 0.00575867
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.00091427,
+          "spread": 0.00122538,
+          "score": 0.00152887
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00060265,
+          "spread": 0.0007311,
+          "score": 0.00094747
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": -0.00238932,
+          "spread": 0.00408143,
+          "score": 0.00472937
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.0202256,
+          "spread": 0.01833075,
+          "score": 0.02729636
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": -0.0087324,
+          "spread": 0.00601106,
+          "score": 0.01060131
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.04020195,
+          "spread": 0.0290914,
+          "score": 0.04962365
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": 0.02253919,
+          "spread": 0.0,
+          "score": 0.02253919
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": 0.00080453,
+          "spread": 0.00562775,
+          "score": 0.00568497
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.00314433,
+          "spread": 0.00179331,
+          "score": 0.00361977
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": -0.00054591,
+          "spread": 0.0030638,
+          "score": 0.00311205
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00388261,
+          "spread": 0.00072157,
+          "score": 0.00394909
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.00864193,
+          "spread": 0.00999533,
+          "score": 0.01321324
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.00193512,
+          "spread": 0.00242659,
+          "score": 0.00310371
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00564955,
+          "spread": 0.00127822,
+          "score": 0.00579234
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": 0.00387106,
+          "spread": 0.00253995,
+          "score": 0.00462996
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.00246706,
+          "spread": 0.00860463,
+          "score": 0.00895131
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.01448535,
+          "spread": 0.02829529,
+          "score": 0.03178755
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.00568544,
+          "spread": 0.0262654,
+          "score": 0.02687369
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.39970745,
+          "spread": 1.22382398,
+          "score": 1.28744366
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.24938767,
+          "spread": 0.0,
+          "score": 0.24938767
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.0070523,
+          "spread": 0.05997944,
+          "score": 0.06039262
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.00069936,
+          "spread": 0.00134013,
+          "score": 0.00151164
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00353566,
+          "spread": 0.00159382,
+          "score": 0.00387829
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.0009549,
+          "spread": 0.00271435,
+          "score": 0.00287742
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00324093,
+          "spread": 0.00303283,
+          "score": 0.00443866
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00437667,
+          "spread": 0.02166302,
+          "score": 0.02210072
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.00327525,
+          "spread": 0.03413362,
+          "score": 0.0342904
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.05744721,
+          "spread": 0.06025544,
+          "score": 0.08325202
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.00793224,
+          "spread": 0.00154736,
+          "score": 0.00808176
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": 0.00358784,
+          "spread": 0.01020045,
+          "score": 0.01081303
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.00767105,
+          "spread": 0.00361279,
+          "score": 0.00847923
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00470918,
+          "spread": 0.0061359,
+          "score": 0.0077347
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00144945,
+          "spread": 0.00157237,
+          "score": 0.00213852
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.03571354,
+          "spread": 0.03775849,
+          "score": 0.05197269
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": -3.618e-05,
+          "spread": 0.01136443,
+          "score": 0.01136449
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.00026777,
+          "spread": 0.00178542,
+          "score": 0.00180539
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00272556,
+          "spread": 0.00196111,
+          "score": 0.00335777
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": 0.0002488,
+          "spread": 0.0023611,
+          "score": 0.00237417
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.00435273,
+          "spread": 0.00589863,
+          "score": 0.00733076
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": 0.00541549,
+          "spread": 0.02303551,
+          "score": 0.02366352
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.04547291,
+          "spread": 0.02571424,
+          "score": 0.05223991
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.68313524,
+          "spread": 1.07937814,
+          "score": 1.27739224
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": 0.58540551,
+          "spread": 0.44340048,
+          "score": 0.73437293
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.00739159,
+          "spread": 0.01753343,
+          "score": 0.01902778
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": -0.00050918,
+          "spread": 0.00240227,
+          "score": 0.00245564
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00158575,
+          "spread": 0.00147923,
+          "score": 0.00216858
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.00011754,
+          "spread": 0.00255155,
+          "score": 0.00255426
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00079059,
+          "spread": 0.00227302,
+          "score": 0.00240659
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00335366,
+          "spread": 0.00944376,
+          "score": 0.01002155
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.00991358,
+          "spread": 0.01841008,
+          "score": 0.02090957
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": -0.00796177,
+          "spread": 0.00469488,
+          "score": 0.00924292
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.0067867,
+          "spread": 0.01083209,
+          "score": 0.01278255
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": 0.00234966,
+          "spread": 0.00378076,
+          "score": 0.00445141
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.00143706,
+          "spread": 0.00435213,
+          "score": 0.00458325
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00278935,
+          "spread": 0.00526591,
+          "score": 0.00595905
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00119532,
+          "spread": 0.00169085,
+          "score": 0.00207069
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.05324941,
+          "spread": 0.0083659,
+          "score": 0.05390258
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.00212559,
+          "spread": 0.00439543,
+          "score": 0.00488241
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.00211196,
+          "spread": 0.00150788,
+          "score": 0.00259501
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00125895,
+          "spread": 0.00223755,
+          "score": 0.00256741
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.00178664,
+          "spread": 0.00210493,
+          "score": 0.00276095
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.00404589,
+          "spread": 0.00713977,
+          "score": 0.00820644
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.00792215,
+          "spread": 0.01969149,
+          "score": 0.02122535
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.02073321,
+          "spread": 0.02149192,
+          "score": 0.0298625
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.03945949,
+          "spread": 0.29443126,
+          "score": 0.29706366
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.08669789,
+          "spread": 0.0,
+          "score": 0.08669789
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.05379738,
+          "spread": 0.03308122,
+          "score": 0.06315477
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": -0.00164359,
+          "spread": 0.00255391,
+          "score": 0.00303708
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00234835,
+          "spread": 0.00081319,
+          "score": 0.00248517
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.00037747,
+          "spread": 0.00155725,
+          "score": 0.00160235
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00046304,
+          "spread": 0.0015073,
+          "score": 0.00157682
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00426565,
+          "spread": 0.00959929,
+          "score": 0.01050439
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.00433074,
+          "spread": 0.02421882,
+          "score": 0.02460298
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.00036072,
+          "spread": 0.00814429,
+          "score": 0.00815228
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.01645398,
+          "spread": 0.03717875,
+          "score": 0.04065701
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.00090061,
+          "spread": 0.00381062,
+          "score": 0.0039156
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.00193751,
+          "spread": 0.00297441,
+          "score": 0.00354979
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00251523,
+          "spread": 0.00407151,
+          "score": 0.00478576
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00075857,
+          "spread": 0.00103128,
+          "score": 0.00128022
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.00785109,
+          "spread": 0.02187726,
+          "score": 0.02324337
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.00088325,
+          "spread": 0.0032019,
+          "score": 0.00332149
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.00113858,
+          "spread": 0.00057559,
+          "score": 0.00127581
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00035914,
+          "spread": 0.00143124,
+          "score": 0.00147561
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -3.98e-06,
+          "spread": 0.00291978,
+          "score": 0.00291978
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.00446529,
+          "spread": 0.00582246,
+          "score": 0.00733756
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.00764088,
+          "spread": 0.02597992,
+          "score": 0.02708024
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.00499548,
+          "spread": 0.03058035,
+          "score": 0.03098568
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.00953297,
+          "spread": 0.20149423,
+          "score": 0.20171961
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": 0.05111206,
+          "spread": 0.11576103,
+          "score": 0.12654272
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.00955647,
+          "spread": 0.03617853,
+          "score": 0.0374194
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": -0.00121877,
+          "spread": 0.00231212,
+          "score": 0.00261367
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.0026821,
+          "spread": 0.000791,
+          "score": 0.00279631
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": -5.012e-05,
+          "spread": 0.00120977,
+          "score": 0.0012108
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.0002936,
+          "spread": 0.00075944,
+          "score": 0.00081422
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": -0.00143207,
+          "spread": 0.00305694,
+          "score": 0.00337575
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.00269665,
+          "spread": 0.01155859,
+          "score": 0.01186899
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": -0.00656341,
+          "spread": 0.00478314,
+          "score": 0.00812138
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.03662865,
+          "spread": 0.02838951,
+          "score": 0.04634245
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": 0.0241424,
+          "spread": 0.0,
+          "score": 0.0241424
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": 0.00105872,
+          "spread": 0.00520119,
+          "score": 0.00530785
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.00281115,
+          "spread": 0.00162836,
+          "score": 0.00324871
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00036486,
+          "spread": 0.00325741,
+          "score": 0.00327778
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00390311,
+          "spread": 0.0007285,
+          "score": 0.00397052
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.00817353,
+          "spread": 0.01118498,
+          "score": 0.01385317
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.00052633,
+          "spread": 0.00229654,
+          "score": 0.00235608
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00568705,
+          "spread": 0.00160442,
+          "score": 0.00590903
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": 0.00644465,
+          "spread": 0.00293441,
+          "score": 0.00708126
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.00504668,
+          "spread": 0.00937942,
+          "score": 0.01065093
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.01431974,
+          "spread": 0.02932524,
+          "score": 0.03263472
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.00148213,
+          "spread": 0.02431746,
+          "score": 0.02436258
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.46431114,
+          "spread": 1.06193628,
+          "score": 1.15900539
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.11153346,
+          "spread": 0.0,
+          "score": 0.11153346
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.00497563,
+          "spread": 0.03420844,
+          "score": 0.0345684
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.00342775,
+          "spread": 0.0020599,
+          "score": 0.00399908
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": -0.00107671,
+          "spread": 0.00144063,
+          "score": 0.00179853
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": -0.00093627,
+          "spread": 0.00253411,
+          "score": 0.00270154
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00219989,
+          "spread": 0.00272542,
+          "score": 0.00350249
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.004261,
+          "spread": 0.02533836,
+          "score": 0.02569413
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": 0.00081549,
+          "spread": 0.03745848,
+          "score": 0.03746736
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.07157245,
+          "spread": 0.07535568,
+          "score": 0.10392831
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.00305636,
+          "spread": 0.00777923,
+          "score": 0.00835809
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": 0.00219531,
+          "spread": 0.01060809,
+          "score": 0.01083287
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.0072461,
+          "spread": 0.00311882,
+          "score": 0.00788879
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00636501,
+          "spread": 0.00667884,
+          "score": 0.00922607
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00149144,
+          "spread": 0.00156972,
+          "score": 0.00216527
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.04173372,
+          "spread": 0.04044997,
+          "score": 0.05811973
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": -4.515e-05,
+          "spread": 0.01160506,
+          "score": 0.01160515
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": -0.00076992,
+          "spread": 0.00205814,
+          "score": 0.00219743
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.0029117,
+          "spread": 0.00140028,
+          "score": 0.00323091
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": 0.00201359,
+          "spread": 0.00217278,
+          "score": 0.00296235
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.0067968,
+          "spread": 0.00629007,
+          "score": 0.00926075
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": 0.00702269,
+          "spread": 0.01836766,
+          "score": 0.01966441
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.03975221,
+          "spread": 0.02798857,
+          "score": 0.04861685
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.55831571,
+          "spread": 0.82732654,
+          "score": 0.99809099
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": 0.55721619,
+          "spread": 0.4255502,
+          "score": 0.7011297
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.00306929,
+          "spread": 0.01441293,
+          "score": 0.01473612
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.00240867,
+          "spread": 0.00216762,
+          "score": 0.00324041
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": -0.00268702,
+          "spread": 0.0011662,
+          "score": 0.00292918
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": -0.00182637,
+          "spread": 0.00233412,
+          "score": 0.00296374
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00023905,
+          "spread": 0.00178153,
+          "score": 0.0017975
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00370105,
+          "spread": 0.01134498,
+          "score": 0.01193341
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.00161145,
+          "spread": 0.0200289,
+          "score": 0.02009362
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": -0.00542717,
+          "spread": 0.00583852,
+          "score": 0.00797135
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.01870527,
+          "spread": 0.01182361,
+          "score": 0.02212883
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": 0.00272601,
+          "spread": 0.00335296,
+          "score": 0.00432128
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.00091722,
+          "spread": 0.00431269,
+          "score": 0.00440914
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00410354,
+          "spread": 0.00519123,
+          "score": 0.00661725
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00122996,
+          "spread": 0.00168925,
+          "score": 0.00208959
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.04113863,
+          "spread": 0.00444081,
+          "score": 0.04137762
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.00156085,
+          "spread": 0.00562048,
+          "score": 0.00583318
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.00134539,
+          "spread": 0.00166595,
+          "score": 0.00214137
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00121639,
+          "spread": 0.00160611,
+          "score": 0.00201475
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": 5.36e-06,
+          "spread": 0.00211768,
+          "score": 0.00211768
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.00691238,
+          "spread": 0.00755194,
+          "score": 0.01023782
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.00333767,
+          "spread": 0.01847565,
+          "score": 0.0187747
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.02125213,
+          "spread": 0.02158158,
+          "score": 0.0302889
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.04533503,
+          "spread": 0.28008428,
+          "score": 0.28372957
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.08971119,
+          "spread": 0.0,
+          "score": 0.08971119
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.04888526,
+          "spread": 0.03007868,
+          "score": 0.0573977
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.00108784,
+          "spread": 0.00220083,
+          "score": 0.002455
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": -0.0015338,
+          "spread": 0.00068376,
+          "score": 0.00167931
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": -0.00107491,
+          "spread": 0.00155451,
+          "score": 0.00188995
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00010129,
+          "spread": 0.00158794,
+          "score": 0.00159116
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00553416,
+          "spread": 0.01067148,
+          "score": 0.01202113
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": 0.00379324,
+          "spread": 0.0217058,
+          "score": 0.02203475
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.00220217,
+          "spread": 0.00624094,
+          "score": 0.00661807
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.00746629,
+          "spread": 0.03744639,
+          "score": 0.03818348
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.00079811,
+          "spread": 0.00378926,
+          "score": 0.0038724
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.00186617,
+          "spread": 0.00292307,
+          "score": 0.00346798
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00366616,
+          "spread": 0.00417365,
+          "score": 0.00555519
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00080285,
+          "spread": 0.00104908,
+          "score": 0.00132104
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.01084249,
+          "spread": 0.0180419,
+          "score": 0.02104923
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.00054987,
+          "spread": 0.00386579,
+          "score": 0.0039047
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.00030554,
+          "spread": 0.00086445,
+          "score": 0.00091685
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.0004003,
+          "spread": 0.000899,
+          "score": 0.00098409
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": 0.00174333,
+          "spread": 0.00234102,
+          "score": 0.00291883
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.00792784,
+          "spread": 0.00609463,
+          "score": 0.00999976
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.00297659,
+          "spread": 0.02472919,
+          "score": 0.02490769
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.00213398,
+          "spread": 0.02778487,
+          "score": 0.0278667
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.01995746,
+          "spread": 0.20046642,
+          "score": 0.2014574
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.20233708,
+          "spread": 0.15391859,
+          "score": 0.25422672
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.01027906,
+          "spread": 0.04070719,
+          "score": 0.04198493
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.0017283,
+          "spread": 0.00183759,
+          "score": 0.00252265
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": -0.00078605,
+          "spread": 0.00081771,
+          "score": 0.00113425
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": -0.00134819,
+          "spread": 0.00132377,
+          "score": 0.00188945
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": -0.00021304,
+          "spread": 0.00074605,
+          "score": 0.00077588
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": -0.0005018,
+          "spread": 0.00230831,
+          "score": 0.00236222
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": 0.00708674,
+          "spread": 0.01804426,
+          "score": 0.01938601
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": -0.00444826,
+          "spread": 0.00351854,
+          "score": 0.00567161
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.03385743,
+          "spread": 0.02874826,
+          "score": 0.04441608
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": 0.02468725,
+          "spread": 0.0,
+          "score": 0.02468725
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.001537,
-          "spread": 0.00593447,
-          "score": 0.00613028
+          "bias": 0.00079405,
+          "spread": 0.0049507,
+          "score": 0.00501397
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00291113,
-          "spread": 0.00202836,
-          "score": 0.00354809
+          "bias": 0.00265,
+          "spread": 0.00185572,
+          "score": 0.00323515
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00144712,
-          "spread": 0.00323575,
-          "score": 0.00354461
+          "bias": 0.00147978,
+          "spread": 0.00342575,
+          "score": 0.00373169
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.0040277,
-          "spread": 0.00088369,
-          "score": 0.0041235
+          "bias": 0.00394691,
+          "spread": 0.0007202,
+          "score": 0.00401208
         },
         {
           "profile": "ti_dependent_cp",
@@ -8923,162 +8923,162 @@
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00449783,
-          "spread": 0.00732465,
-          "score": 0.00859541
+          "bias": 0.00661706,
+          "spread": 0.00922722,
+          "score": 0.01135461
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00022356,
-          "spread": 0.00276504,
-          "score": 0.00277407
+          "bias": 3.79e-05,
+          "spread": 0.00267556,
+          "score": 0.00267582
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.0051647,
-          "spread": 0.00138639,
-          "score": 0.00534755
+          "bias": 0.00496176,
+          "spread": 0.00173806,
+          "score": 0.00525737
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00779309,
-          "spread": 0.00299856,
-          "score": 0.00835006
+          "bias": 0.00756767,
+          "spread": 0.0029683,
+          "score": 0.00812899
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01605845,
-          "spread": 0.00913712,
-          "score": 0.01847596
+          "bias": 0.01557514,
+          "spread": 0.00698456,
+          "score": 0.01706953
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.01069414,
-          "spread": 0.0262908,
-          "score": 0.02838258
+          "bias": 0.00411232,
+          "spread": 0.02478223,
+          "score": 0.02512111
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.02855271,
-          "spread": 0.03541363,
-          "score": 0.04549046
+          "bias": 0.01550291,
+          "spread": 0.02571817,
+          "score": 0.03002939
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.39761839,
-          "spread": 0.91851074,
-          "score": 1.00088079
+          "bias": 0.52637475,
+          "spread": 1.12417591,
+          "score": 1.24130651
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.15902711,
+          "bias": -0.14060345,
           "spread": 0.0,
-          "score": 0.15902711
+          "score": 0.14060345
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.01037356,
-          "spread": 0.07045548,
-          "score": 0.07121506
+          "bias": -0.00288521,
+          "spread": 0.04864312,
+          "score": 0.04872861
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00100614,
-          "spread": 0.00122335,
-          "score": 0.00158395
+          "bias": -0.00115246,
+          "spread": 0.00144005,
+          "score": 0.00184443
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00528386,
-          "spread": 0.0011424,
-          "score": 0.00540595
+          "bias": 0.00485613,
+          "spread": 0.0016085,
+          "score": 0.00511559
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.0015052,
-          "spread": 0.00278975,
-          "score": 0.00316991
+          "bias": 0.00152481,
+          "spread": 0.00308926,
+          "score": 0.00344508
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00320978,
-          "spread": 0.0027156,
-          "score": 0.00420443
+          "bias": 0.00293438,
+          "spread": 0.0028587,
+          "score": 0.00409667
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00600099,
-          "spread": 0.0205313,
-          "score": 0.02139033
+          "bias": 0.00409825,
+          "spread": 0.02137566,
+          "score": 0.02176498
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.01096752,
-          "spread": 0.03669204,
-          "score": 0.03829612
+          "bias": 0.00136138,
+          "spread": 0.03371286,
+          "score": 0.03374034
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.0560416,
-          "spread": 0.06161856,
-          "score": 0.0832917
+          "bias": 0.05338029,
+          "spread": 0.05632371,
+          "score": 0.07760036
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.0054954,
-          "spread": 0.00960564,
-          "score": 0.01106652
+          "bias": -0.01319931,
+          "spread": 0.00270425,
+          "score": 0.01347349
         },
         {
           "profile": "ti_dependent_cp",
@@ -9094,207 +9094,207 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00572429,
-          "spread": 0.00993017,
-          "score": 0.01146192
+          "bias": 0.00451602,
+          "spread": 0.01050051,
+          "score": 0.01143045
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00825586,
-          "spread": 0.00347805,
-          "score": 0.00895857
+          "bias": 0.00822121,
+          "spread": 0.00352335,
+          "score": 0.0089444
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00435976,
-          "spread": 0.00628737,
-          "score": 0.00765105
+          "bias": 0.00490796,
+          "spread": 0.00625694,
+          "score": 0.00795219
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00156497,
-          "spread": 0.0018933,
-          "score": 0.00245636
+          "bias": 0.00144598,
+          "spread": 0.00160819,
+          "score": 0.00216267
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.02580773,
-          "spread": 0.01499562,
-          "score": 0.02984807
+          "bias": 0.04025691,
+          "spread": 0.02699892,
+          "score": 0.04847227
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00156414,
-          "spread": 0.00822454,
-          "score": 0.00837196
+          "bias": -0.00373696,
+          "spread": 0.01215933,
+          "score": 0.01272062
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00171383,
-          "spread": 0.00194008,
-          "score": 0.00258866
+          "bias": -0.00181173,
+          "spread": 0.00169969,
+          "score": 0.00248421
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00195523,
-          "spread": 0.00158377,
-          "score": 0.0025162
+          "bias": 0.00210815,
+          "spread": 0.00194144,
+          "score": 0.00286592
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00449532,
-          "spread": 0.00231246,
-          "score": 0.00505523
+          "bias": 0.00429808,
+          "spread": 0.00208434,
+          "score": 0.00477682
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01819506,
-          "spread": 0.0074793,
-          "score": 0.01967232
+          "bias": 0.01653806,
+          "spread": 0.0062512,
+          "score": 0.01768007
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.02658921,
-          "spread": 0.02585663,
-          "score": 0.03708843
+          "bias": 0.02276978,
+          "spread": 0.02188121,
+          "score": 0.03157927
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.01304506,
-          "spread": 0.02670116,
-          "score": 0.02971743
+          "bias": -0.02395174,
+          "spread": 0.02736613,
+          "score": 0.03636744
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.93462539,
-          "spread": 1.4733722,
-          "score": 1.74480665
+          "bias": 0.60641327,
+          "spread": 0.88115584,
+          "score": 1.06966008
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.68510797,
-          "spread": 0.52572656,
-          "score": 0.86357475
+          "bias": 0.5894007,
+          "spread": 0.42488411,
+          "score": 0.72658082
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.01865221,
-          "spread": 0.03335915,
-          "score": 0.0382196
+          "bias": 0.00486948,
+          "spread": 0.01095362,
+          "score": 0.01198723
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.0026615,
-          "spread": 0.0028298,
-          "score": 0.00388476
+          "bias": -0.00215475,
+          "spread": 0.00238222,
+          "score": 0.00321215
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.002761,
-          "spread": 0.00104556,
-          "score": 0.00295234
+          "bias": 0.0028627,
+          "spread": 0.00155389,
+          "score": 0.00325725
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00071551,
-          "spread": 0.00216973,
-          "score": 0.00228466
+          "bias": 0.00069938,
+          "spread": 0.00273098,
+          "score": 0.00281911
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00102763,
-          "spread": 0.00213973,
-          "score": 0.00237371
+          "bias": 0.00098519,
+          "spread": 0.00237259,
+          "score": 0.002569
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00354742,
-          "spread": 0.00986731,
-          "score": 0.01048561
+          "bias": 0.00308037,
+          "spread": 0.0098558,
+          "score": 0.01032596
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.00276707,
-          "spread": 0.02129007,
-          "score": 0.02146914
+          "bias": -0.0066894,
+          "spread": 0.02168081,
+          "score": 0.02268933
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.01040182,
-          "spread": 0.0048354,
-          "score": 0.01147079
+          "bias": -0.01034969,
+          "spread": 0.00549391,
+          "score": 0.01171747
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.00594586,
-          "spread": 0.00584669,
-          "score": 0.00833888
+          "bias": -0.00262681,
+          "spread": 0.00899924,
+          "score": 0.00937478
         },
         {
           "profile": "ti_dependent_cp",
@@ -9310,1323 +9310,1323 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00357602,
-          "spread": 0.00363089,
-          "score": 0.0050962
+          "bias": 0.003156,
+          "spread": 0.00352762,
+          "score": 0.00473334
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00274068,
-          "spread": 0.00444017,
-          "score": 0.00521789
+          "bias": 0.00196585,
+          "spread": 0.00435437,
+          "score": 0.00477756
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00273342,
-          "spread": 0.0053762,
-          "score": 0.00603118
+          "bias": 0.0025576,
+          "spread": 0.00512425,
+          "score": 0.00572706
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00115673,
-          "spread": 0.00169064,
-          "score": 0.00204848
+          "bias": 0.00119877,
+          "spread": 0.00173233,
+          "score": 0.00210666
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.0675573,
-          "spread": 0.01730263,
-          "score": 0.06973787
+          "bias": 0.05168645,
+          "spread": 0.00028506,
+          "score": 0.05168724
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00064947,
-          "spread": 0.00328211,
-          "score": 0.00334576
+          "bias": -0.00029519,
+          "spread": 0.00444969,
+          "score": 0.00445947
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -1.456e-05,
-          "spread": 0.00141066,
-          "score": 0.00141073
+          "bias": 0.00030244,
+          "spread": 0.00133294,
+          "score": 0.00136682
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00050902,
-          "spread": 0.00191796,
-          "score": 0.00198436
+          "bias": 0.00063616,
+          "spread": 0.00215912,
+          "score": 0.00225089
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00228834,
-          "spread": 0.0015554,
-          "score": 0.00276691
+          "bias": 0.00172423,
+          "spread": 0.00143349,
+          "score": 0.00224229
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01631426,
-          "spread": 0.00852292,
-          "score": 0.01840639
+          "bias": 0.01583728,
+          "spread": 0.00829043,
+          "score": 0.01787598
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.01415664,
-          "spread": 0.02110153,
-          "score": 0.02541034
+          "bias": 0.00908533,
+          "spread": 0.0190117,
+          "score": 0.02107103
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.0405085,
-          "spread": 0.02489304,
-          "score": 0.04754579
+          "bias": 0.03590599,
+          "spread": 0.02154383,
+          "score": 0.04187334
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.05027382,
-          "spread": 0.28116377,
-          "score": 0.28562304
+          "bias": 0.05498829,
+          "spread": 0.28168127,
+          "score": 0.28699835
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.58864201,
-          "spread": 0.62075806,
-          "score": 0.85547646
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.04598496,
-          "spread": 0.03213154,
-          "score": 0.0560986
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00335509,
-          "spread": 0.00271734,
-          "score": 0.00431747
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00325981,
-          "spread": 0.00097449,
-          "score": 0.00340235
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00058961,
-          "spread": 0.00153983,
-          "score": 0.00164885
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00030557,
-          "spread": 0.00172469,
-          "score": 0.00175155
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00440792,
-          "spread": 0.00983718,
-          "score": 0.01077961
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": -0.00114326,
-          "spread": 0.03094177,
-          "score": 0.03096288
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00375731,
-          "spread": 0.00929705,
-          "score": 0.01002759
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": -0.0281851,
-          "spread": 0.02739987,
-          "score": 0.03930843
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": 0.0009359,
-          "spread": 0.00469151,
-          "score": 0.00478395
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.0025286,
-          "spread": 0.00250822,
-          "score": 0.0035616
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00234054,
-          "spread": 0.00419999,
-          "score": 0.00480812
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.00082482,
-          "spread": 0.00101034,
-          "score": 0.00130427
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": 0.03003438,
-          "spread": 0.01928881,
-          "score": 0.03569485
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00265235,
-          "spread": 0.00315077,
-          "score": 0.00411853
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00048438,
-          "spread": 0.00081978,
-          "score": 0.00095219
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00019673,
-          "spread": 0.00126057,
-          "score": 0.00127583
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00368716,
-          "spread": 0.00210953,
-          "score": 0.00424797
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01659768,
-          "spread": 0.0067814,
-          "score": 0.01792959
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": 0.01402942,
-          "spread": 0.02707674,
-          "score": 0.03049549
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": 0.01535203,
-          "spread": 0.03043868,
-          "score": 0.03409103
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.00730357,
-          "spread": 0.18181185,
-          "score": 0.18195848
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": -0.18055029,
-          "spread": 0.19924528,
-          "score": 0.26888118
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.02402128,
-          "spread": 0.04433797,
-          "score": 0.05042695
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00310636,
-          "spread": 0.00289452,
-          "score": 0.0042459
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00387832,
-          "spread": 0.00065565,
-          "score": 0.00393335
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00045834,
-          "spread": 0.00130878,
-          "score": 0.00138671
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00065275,
-          "spread": 0.00038406,
-          "score": 0.00075736
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": -0.00173423,
-          "spread": 0.00299339,
-          "score": 0.00345947
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": 0.00527659,
-          "spread": 0.01101159,
-          "score": 0.01221054
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00954507,
-          "spread": 0.00578722,
-          "score": 0.01116245
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": -0.03416483,
-          "spread": 0.02473938,
-          "score": 0.04218142
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": 0.02910341,
+          "bias": -0.06305462,
           "spread": 0.0,
-          "score": 0.02910341
+          "score": 0.06305462
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.04972465,
+          "spread": 0.03857458,
+          "score": 0.06293282
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": -0.00333501,
+          "spread": 0.00277429,
+          "score": 0.00433808
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00351176,
+          "spread": 0.00098789,
+          "score": 0.00364807
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.00071494,
+          "spread": 0.00165439,
+          "score": 0.00180226
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00051592,
+          "spread": 0.0016367,
+          "score": 0.00171609
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00422969,
+          "spread": 0.00956316,
+          "score": 0.01045678
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.00313257,
+          "spread": 0.02639648,
+          "score": 0.02658171
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": -0.00262022,
+          "spread": 0.01015742,
+          "score": 0.01048993
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.02247775,
+          "spread": 0.03657234,
+          "score": 0.04292768
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.00046381,
+          "spread": 0.00402058,
+          "score": 0.00404724
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.00258764,
+          "spread": 0.00284027,
+          "score": 0.00384227
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00249598,
+          "spread": 0.00412385,
+          "score": 0.00482038
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00075026,
+          "spread": 0.00104886,
+          "score": 0.00128957
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.0028275,
+          "spread": 0.00488873,
+          "score": 0.00564751
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": -0.00173513,
+          "spread": 0.00351113,
+          "score": 0.00391646
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": -0.00037688,
+          "spread": 0.00055671,
+          "score": 0.00067228
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00028239,
+          "spread": 0.00138095,
+          "score": 0.00140953
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": 0.0031397,
+          "spread": 0.0023701,
+          "score": 0.00393384
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.01567834,
+          "spread": 0.00683311,
+          "score": 0.01710269
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": 0.01078248,
+          "spread": 0.0245812,
+          "score": 0.02684208
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.01187344,
+          "spread": 0.02966728,
+          "score": 0.03195507
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.01348711,
+          "spread": 0.18734656,
+          "score": 0.1878314
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.18911808,
+          "spread": 0.16427545,
+          "score": 0.25050364
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00229082,
-          "spread": 0.00590915,
-          "score": 0.00633766
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.02132468,
+          "spread": 0.04568745,
+          "score": 0.05041909
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00381027,
-          "spread": 0.00174986,
-          "score": 0.00419287
+          "condition_bin": "(10.0, 12.0]",
+          "bias": -0.0029835,
+          "spread": 0.00264515,
+          "score": 0.00398724
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": 9.756e-05,
-          "spread": 0.00284111,
-          "score": 0.00284278
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.00401363,
-          "spread": 0.00089501,
-          "score": 0.00411221
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00973737,
-          "spread": 0.00821148,
-          "score": 0.01273754
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00241101,
-          "spread": 0.00273545,
-          "score": 0.00364632
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00624126,
-          "spread": 0.00102819,
-          "score": 0.00632539
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00229359,
-          "spread": 0.00174581,
-          "score": 0.00288243
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": -0.0009153,
-          "spread": 0.01151187,
-          "score": 0.0115482
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": -0.01761466,
-          "spread": 0.03247885,
-          "score": 0.03694796
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": -0.01320517,
-          "spread": 0.03006713,
-          "score": 0.03283914
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.13499887,
-          "spread": 1.52960239,
-          "score": 1.53554817
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": 0.01539985,
-          "spread": 0.27852025,
-          "score": 0.27894567
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": 0.00115142,
-          "spread": 0.06919458,
-          "score": 0.06920416
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00352277,
-          "spread": 0.00194175,
-          "score": 0.00402248
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.003912,
-          "spread": 0.00122961,
-          "score": 0.0041007
+          "bias": 0.00375416,
+          "spread": 0.00079731,
+          "score": 0.00383789
         },
         {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00114889,
-          "spread": 0.00243225,
-          "score": 0.00268994
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00317038,
-          "spread": 0.0024158,
-          "score": 0.0039859
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00674679,
-          "spread": 0.0219612,
-          "score": 0.02297419
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": -0.00805874,
-          "spread": 0.04101798,
-          "score": 0.04180213
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": 0.06336262,
-          "spread": 0.0685002,
-          "score": 0.09331183
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": 0.00264568,
-          "spread": 0.00622425,
-          "score": 0.0067632
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00247276,
-          "spread": 0.01108536,
-          "score": 0.0113578
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00610708,
-          "spread": 0.00391721,
-          "score": 0.00725541
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": 0.0036164,
-          "spread": 0.00639781,
-          "score": 0.00734918
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.00160495,
-          "spread": 0.00188063,
-          "score": 0.00247237
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": 0.02004076,
-          "spread": 0.01921241,
-          "score": 0.02776236
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00429199,
-          "spread": 0.0079937,
-          "score": 0.00907305
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00090691,
-          "spread": 0.00219178,
-          "score": 0.002372
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00292198,
-          "spread": 0.00206118,
-          "score": 0.00357581
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00085671,
-          "spread": 0.00273575,
-          "score": 0.00286676
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00212692,
-          "spread": 0.00704189,
-          "score": 0.00735609
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00283913,
-          "spread": 0.03069325,
-          "score": 0.03082428
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": -0.0607627,
-          "spread": 0.03285784,
-          "score": 0.06907781
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 1.25513343,
-          "spread": 2.19747445,
-          "score": 2.53066274
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": 0.67449923,
-          "spread": 0.51992814,
-          "score": 0.85163049
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.00107247,
-          "spread": 0.02560778,
-          "score": 0.02563023
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00170176,
-          "spread": 0.00268899,
-          "score": 0.00318224
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00154703,
-          "spread": 0.00116532,
-          "score": 0.00193682
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": 0.0001434,
-          "spread": 0.00197889,
-          "score": 0.00198407
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00119217,
-          "spread": 0.0016611,
-          "score": 0.00204463
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00471606,
-          "spread": 0.01058376,
-          "score": 0.01158694
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": -0.03213984,
-          "spread": 0.0427953,
-          "score": 0.05352016
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00585795,
-          "spread": 0.00437189,
-          "score": 0.00730952
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": 0.00646044,
-          "spread": 0.00591382,
-          "score": 0.00875846
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00025276,
-          "spread": 0.00409642,
-          "score": 0.00410421
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.0007902,
-          "spread": 0.00515422,
-          "score": 0.00521444
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00220113,
-          "spread": 0.00557766,
-          "score": 0.00599627
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.00118225,
-          "spread": 0.0016762,
-          "score": 0.00205119
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": 0.03811679,
-          "spread": 0.01020835,
-          "score": 0.03946011
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00379501,
-          "spread": 0.00293501,
-          "score": 0.00479754
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00247153,
-          "spread": 0.00183075,
-          "score": 0.00307573
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00136312,
-          "spread": 0.00230391,
-          "score": 0.00267695
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00259305,
-          "spread": 0.0023011,
-          "score": 0.00346684
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.0012124,
-          "spread": 0.00650187,
-          "score": 0.00661394
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": -0.01117089,
-          "spread": 0.02283034,
-          "score": 0.02541679
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": 0.00755049,
-          "spread": 0.02517989,
-          "score": 0.02628757
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.00804086,
-          "spread": 0.32142774,
-          "score": 0.3215283
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": 0.686666,
-          "spread": 0.75151019,
-          "score": 1.01797729
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.0461375,
-          "spread": 0.03298164,
-          "score": 0.05671383
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00076965,
-          "spread": 0.00255646,
-          "score": 0.0026698
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00205408,
-          "spread": 0.00087277,
-          "score": 0.00223181
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00034483,
-          "spread": 0.00144871,
-          "score": 0.00148918
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.0006624,
-          "spread": 0.00142445,
-          "score": 0.00157093
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00548464,
-          "spread": 0.01016741,
-          "score": 0.01155238
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": -0.02334253,
-          "spread": 0.04595014,
-          "score": 0.0515392
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00085614,
-          "spread": 0.00586038,
-          "score": 0.00592258
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": -0.01558768,
-          "spread": 0.02901086,
-          "score": 0.03293335
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00234973,
-          "spread": 0.00554524,
-          "score": 0.00602254
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.0004519,
-          "spread": 0.00323033,
-          "score": 0.00326179
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00167705,
-          "spread": 0.00432442,
-          "score": 0.00463822
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 12,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.00086823,
-          "spread": 0.0010231,
-          "score": 0.00134185
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": 0.01718972,
-          "spread": 0.01801158,
-          "score": 0.02489786
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00239915,
-          "spread": 0.00235467,
-          "score": 0.00336161
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00166696,
-          "spread": 0.00088917,
-          "score": 0.00188929
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00063684,
-          "spread": 0.00140372,
-          "score": 0.00154143
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00078428,
-          "spread": 0.00288995,
-          "score": 0.00299448
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.0021918,
-          "spread": 0.00547353,
-          "score": 0.00589606
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": -0.01215145,
-          "spread": 0.03071065,
-          "score": 0.03302729
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": -0.01641304,
-          "spread": 0.02785117,
-          "score": 0.03232762
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": -0.01020637,
-          "spread": 0.19506829,
-          "score": 0.19533512
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": 0.65368049,
-          "spread": 0.68470123,
-          "score": 0.94663295
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.02297114,
-          "spread": 0.05561589,
-          "score": 0.06017309
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00115585,
-          "spread": 0.00240563,
-          "score": 0.00266891
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00269429,
-          "spread": 0.00073975,
-          "score": 0.002794
-        },
-        {
-          "profile": "ws_dependent_cp",
+          "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 7.594e-05,
-          "spread": 0.00120918,
-          "score": 0.00121156
+          "bias": 0.00040449,
+          "spread": 0.00132395,
+          "score": 0.00138437
         },
         {
-          "profile": "ws_dependent_cp",
+          "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00071258,
-          "spread": 0.00038554,
-          "score": 0.00081019
+          "bias": 0.00044678,
+          "spread": 0.0007833,
+          "score": 0.00090176
         },
         {
-          "profile": "ws_dependent_cp",
+          "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": -0.00060658,
-          "spread": 0.0021937,
-          "score": 0.00227602
+          "bias": -0.00176542,
+          "spread": 0.00355347,
+          "score": 0.00396785
         },
         {
-          "profile": "ws_dependent_cp",
+          "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.01904575,
-          "spread": 0.01138655,
-          "score": 0.02218996
+          "bias": 0.00456364,
+          "spread": 0.01151765,
+          "score": 0.01238883
         },
         {
-          "profile": "ws_dependent_cp",
+          "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00595417,
-          "spread": 0.00392486,
-          "score": 0.00713138
+          "bias": -0.00840765,
+          "spread": 0.00578361,
+          "score": 0.01020484
         },
         {
-          "profile": "ws_dependent_cp",
+          "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.02811007,
-          "spread": 0.02457508,
-          "score": 0.03733779
+          "bias": -0.04019255,
+          "spread": 0.02851991,
+          "score": 0.04928312
         },
         {
-          "profile": "ws_dependent_cp",
+          "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
-          "bias": 0.03324814,
+          "bias": 0.02009082,
           "spread": 0.0,
-          "score": 0.03324814
+          "score": 0.02009082
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": 0.00158144,
+          "spread": 0.00520071,
+          "score": 0.00543584
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.00339548,
+          "spread": 0.00166485,
+          "score": 0.00378167
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00017994,
+          "spread": 0.00308173,
+          "score": 0.00308698
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00393418,
+          "spread": 0.00073685,
+          "score": 0.00400259
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.00963302,
+          "spread": 0.00968461,
+          "score": 0.01365967
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.00221002,
+          "spread": 0.00269157,
+          "score": 0.00348264
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00606967,
+          "spread": 0.00135594,
+          "score": 0.00621928
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": 0.00264275,
+          "spread": 0.00248051,
+          "score": 0.00362451
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.0009266,
+          "spread": 0.00865051,
+          "score": 0.00869999
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.0212011,
+          "spread": 0.03064934,
+          "score": 0.03726753
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.02472189,
+          "spread": 0.01886369,
+          "score": 0.03109679
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.24874927,
+          "spread": 1.69106942,
+          "score": 1.7092665
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": 0.04722778,
+          "spread": 0.25294441,
+          "score": 0.25731564
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 1.942e-05,
+          "spread": 0.04469054,
+          "score": 0.04469054
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.00349488,
+          "spread": 0.00167921,
+          "score": 0.00387736
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00348321,
+          "spread": 0.00164604,
+          "score": 0.00385256
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.00106415,
+          "spread": 0.00282022,
+          "score": 0.0030143
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00344935,
+          "spread": 0.00287166,
+          "score": 0.00448825
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00480396,
+          "spread": 0.02268124,
+          "score": 0.0231844
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.01842774,
+          "spread": 0.03728284,
+          "score": 0.04158836
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.0606176,
+          "spread": 0.06293909,
+          "score": 0.0873832
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.00526373,
+          "spread": 0.00278864,
+          "score": 0.00595679
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": 0.00066505,
+          "spread": 0.01066193,
+          "score": 0.01068265
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.00616139,
+          "spread": 0.0041546,
+          "score": 0.00743124
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00412958,
+          "spread": 0.0062451,
+          "score": 0.00748697
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00148551,
+          "spread": 0.00159626,
+          "score": 0.00218055
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.0039594,
+          "spread": 0.03028233,
+          "score": 0.03054008
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.00051786,
+          "spread": 0.01063213,
+          "score": 0.01064474
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.00040759,
+          "spread": 0.00178585,
+          "score": 0.00183177
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00300849,
+          "spread": 0.00212897,
+          "score": 0.00368558
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.00031566,
+          "spread": 0.00238528,
+          "score": 0.00240608
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.00237309,
+          "spread": 0.00532202,
+          "score": 0.00582713
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": 0.00237013,
+          "spread": 0.02776608,
+          "score": 0.02786705
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.06258002,
+          "spread": 0.02820392,
+          "score": 0.06864197
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.88394426,
+          "spread": 1.51225619,
+          "score": 1.75164958
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": 0.61278167,
+          "spread": 0.49634276,
+          "score": 0.78857943
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.01395028,
+          "spread": 0.01526333,
+          "score": 0.020678
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.00195643,
+          "spread": 0.00230014,
+          "score": 0.00301964
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.0014258,
+          "spread": 0.00136173,
+          "score": 0.0019716
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 1.69e-05,
+          "spread": 0.0023179,
+          "score": 0.00231796
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00100188,
+          "spread": 0.00185876,
+          "score": 0.00211158
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00395944,
+          "spread": 0.01017079,
+          "score": 0.01091431
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.03426394,
+          "spread": 0.039702,
+          "score": 0.05244298
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": -0.00592039,
+          "spread": 0.0042682,
+          "score": 0.00729852
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.01051281,
+          "spread": 0.0098886,
+          "score": 0.01443272
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": 9.81e-05,
+          "spread": 0.00364221,
+          "score": 0.00364353
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.00010342,
+          "spread": 0.00484006,
+          "score": 0.00484117
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00227233,
+          "spread": 0.00534353,
+          "score": 0.00580662
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00122354,
+          "spread": 0.0017184,
+          "score": 0.0021095
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.0517763,
+          "spread": 0.01706662,
+          "score": 0.05451655
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.00323571,
+          "spread": 0.00479493,
+          "score": 0.00578457
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.00230801,
+          "spread": 0.00149363,
+          "score": 0.00274916
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00145774,
+          "spread": 0.00252366,
+          "score": 0.00291443
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.00233761,
+          "spread": 0.00205454,
+          "score": 0.00311216
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.0020799,
+          "spread": 0.00633455,
+          "score": 0.00666727
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.01269188,
+          "spread": 0.02102046,
+          "score": 0.02455491
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.00822032,
+          "spread": 0.02232379,
+          "score": 0.02378919
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.0112951,
+          "spread": 0.32403128,
+          "score": 0.32422809
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.08882583,
+          "spread": 0.0,
+          "score": 0.08882583
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.04998577,
+          "spread": 0.02580735,
+          "score": 0.05625475
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.00079451,
+          "spread": 0.00250668,
+          "score": 0.00262958
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00229033,
+          "spread": 0.00090046,
+          "score": 0.00246098
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.00044326,
+          "spread": 0.0013629,
+          "score": 0.00143317
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00087892,
+          "spread": 0.00153473,
+          "score": 0.00176859
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.0053233,
+          "spread": 0.00997065,
+          "score": 0.01130271
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.0266218,
+          "spread": 0.04025701,
+          "score": 0.04826331
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.00117875,
+          "spread": 0.00758761,
+          "score": 0.00767862
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.0106737,
+          "spread": 0.03752462,
+          "score": 0.03901314
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.00316923,
+          "spread": 0.00440097,
+          "score": 0.00542333
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.00036126,
+          "spread": 0.00316583,
+          "score": 0.00318637
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00185546,
+          "spread": 0.00431428,
+          "score": 0.00469635
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00079433,
+          "spread": 0.00106337,
+          "score": 0.0013273
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": -0.01368169,
+          "spread": 0.0110569,
+          "score": 0.01759101
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.00200775,
+          "spread": 0.00279185,
+          "score": 0.00343882
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.00130737,
+          "spread": 0.00063975,
+          "score": 0.00145551
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00057287,
+          "spread": 0.00148703,
+          "score": 0.00159356
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.00050361,
+          "spread": 0.00289955,
+          "score": 0.00294296
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.00285478,
+          "spread": 0.00527829,
+          "score": 0.00600084
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.01049671,
+          "spread": 0.02885836,
+          "score": 0.03070807
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.01166125,
+          "spread": 0.03305922,
+          "score": 0.03505563
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": -0.00019511,
+          "spread": 0.20506082,
+          "score": 0.20506091
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": 0.65086509,
+          "spread": 0.72305415,
+          "score": 0.97284772
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.0155108,
+          "spread": 0.0445541,
+          "score": 0.04717682
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.00116597,
+          "spread": 0.00216782,
+          "score": 0.00246149
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00261952,
+          "spread": 0.00088597,
+          "score": 0.00276529
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": -3.104e-05,
+          "spread": 0.0011463,
+          "score": 0.00114672
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00053054,
+          "spread": 0.00072164,
+          "score": 0.00089567
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": -0.00054766,
+          "spread": 0.00276529,
+          "score": 0.002819
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.02125129,
+          "spread": 0.01796194,
+          "score": 0.02782532
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": -0.00502623,
+          "spread": 0.00399652,
+          "score": 0.00642146
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.03361533,
+          "spread": 0.02777324,
+          "score": 0.0436044
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": 0.02365624,
+          "spread": 0.0,
+          "score": 0.02365624
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00077941,
-          "spread": 0.00689798,
-          "score": 0.00694187
+          "bias": -0.00149843,
+          "spread": 0.00566578,
+          "score": 0.00586057
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00157229,
-          "spread": 0.00214643,
-          "score": 0.00266069
+          "bias": 0.00118089,
+          "spread": 0.00192173,
+          "score": 0.00225556
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00044078,
-          "spread": 0.00312896,
-          "score": 0.00315986
+          "bias": -0.00024043,
+          "spread": 0.00324402,
+          "score": 0.00325292
         }
       ]
     }

--- a/benchmarking/baselines/time_features.py
+++ b/benchmarking/baselines/time_features.py
@@ -81,6 +81,9 @@ def days_since_campaign_start(index: pd.DatetimeIndex, *, campaign_start: pd.Tim
         ``index``, holding ``(index - campaign_start) / 1 day`` as a float.
     """
     _require_tz_aware(index)
+    if campaign_start.tzinfo is None:
+        msg = "campaign_start must be timezone-aware (expected tz-aware UTC); got a tz-naive Timestamp."
+        raise ValueError(msg)
     days = (index - campaign_start) / pd.Timedelta(days=1)
     return pd.Series(days, index=index, name="days_since_campaign_start")
 

--- a/benchmarking/baselines/time_features.py
+++ b/benchmarking/baselines/time_features.py
@@ -1,0 +1,229 @@
+"""Explicitly-constructed time features for ML uplift methods.
+
+The counterfactual power-model methods normally drop the timestamp entirely before
+modelling: a bare timestamp is not a weather variable and folding it in naively risks
+leaking the treatment (design-note SS3 -- anything that could reflect the upgrade must not
+enter the model except through the treatment-invariant reference features). But time itself
+carries real, physically meaningful signal that is *not* weather: reference-turbine
+instrumentation drifts slowly over a campaign, the wind resource and air density have a
+seasonal cycle, and the diurnal cycle (via solar heating -> boundary-layer shear/turbulence,
+and directly via light for some effects) modulates conditions across the day. This module
+gives a model an explicit, named handle on each of those axes instead of leaving it to guess
+from an opaque clock value:
+
+* :func:`days_since_campaign_start` -- a continuous linear clock (in days, negative before
+  the campaign starts) for slow drift such as reference-anemometer calibration decay.
+* :func:`season_sin_cos` -- a smooth, cyclical encoding of time-of-year (sin/cos pair, so the
+  model sees December and January as adjacent rather than as opposite ends of a 0-364 ramp).
+* :func:`solar_altitude_azimuth` -- the sun's position (altitude plus a cyclical azimuth
+  encoding), a proxy for diurnal heating and boundary-layer state that is far more
+  informative than clock hour alone because it also depends on latitude, longitude and
+  season.
+
+All functions are pure and vectorized over a :class:`pandas.DatetimeIndex` that must be
+timezone-aware (the benchmarking harness works exclusively in UTC).
+
+The solar-position calculation implements the NOAA solar-position algorithm (the public NOAA
+Solar Calculator spreadsheet equations, itself based on Jean Meeus's *Astronomical
+Algorithms*). It deliberately omits the atmospheric refraction correction that the NOAA
+spreadsheet applies near the horizon -- refraction only matters for altitudes within a couple
+of degrees of the horizon, and skipping it keeps the implementation a direct, checkable
+transcription of the core geometry.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+# Vocabulary of configurable time-feature groups; "season" and "solar" each expand to
+# multiple columns (see season_sin_cos / solar_altitude_azimuth).
+TIME_FEATURE_NAMES: tuple[str, ...] = ("days_since_campaign_start", "season", "solar")
+
+# Day-of-year of June 21st in a non-leap year; the season angle's zero-crossing anchor.
+_JUNE21_DAY_OF_YEAR = 172
+# Mean length of a year in days (Gregorian calendar average, i.e. including leap years).
+_DAYS_PER_YEAR = 365.25
+_SECONDS_PER_DAY = 86_400.0
+_MINUTES_PER_DAY = 1_440.0
+
+# Julian date of the J2000.0 epoch (2000-01-01 12:00 UTC), the NOAA algorithm's time origin.
+_J2000_JULIAN_DATE = 2_451_545.0
+# Julian days per Julian century, used to convert Julian date into Julian centuries since J2000.
+_JULIAN_DAYS_PER_CENTURY = 36_525.0
+
+# Degrees of hour angle per minute of time (360 degrees / 1440 minutes per day).
+_DEGREES_PER_MINUTE = 0.25
+_MINUTES_PER_DEGREE_LONGITUDE = 4.0
+_DEGREES_PER_CIRCLE = 360.0
+
+
+def _require_tz_aware(index: pd.DatetimeIndex) -> None:
+    """Raise ``ValueError`` unless ``index`` is timezone-aware.
+
+    :param index: the index to check.
+    """
+    if index.tz is None:
+        msg = "index must be timezone-aware (expected tz-aware UTC); got a tz-naive DatetimeIndex."
+        raise ValueError(msg)
+
+
+def days_since_campaign_start(index: pd.DatetimeIndex, *, campaign_start: pd.Timestamp) -> pd.Series:
+    """Continuous days elapsed since ``campaign_start``, negative before it.
+
+    A linear clock feature for slow, monotonic drift (e.g. reference-anemometer calibration
+    decay) that a purely cyclical feature such as :func:`season_sin_cos` cannot represent.
+
+    :param index: timezone-aware timestamps to featurize.
+    :param campaign_start: the reference instant; must be comparable to ``index`` (i.e. also
+        timezone-aware).
+    :return: a :class:`pandas.Series` named ``"days_since_campaign_start"``, indexed by
+        ``index``, holding ``(index - campaign_start) / 1 day`` as a float.
+    """
+    _require_tz_aware(index)
+    days = (index - campaign_start) / pd.Timedelta(days=1)
+    return pd.Series(days, index=index, name="days_since_campaign_start")
+
+
+def season_sin_cos(index: pd.DatetimeIndex) -> pd.DataFrame:
+    """Time-of-year as a sin/cos pair anchored on the June 21st solstice.
+
+    The angle is ``2*pi * (fractional day-of-year offset from June 21) / 365.25``, so the
+    encoding is smooth and cyclical (no discontinuity at year end) and ``season_cos`` peaks
+    at +1 around the June solstice and -1 around the December solstice, giving a tree-based
+    model a direct handle on the seasonal cycle without a sharp day-365-to-day-1 jump.
+
+    :param index: timezone-aware timestamps to featurize.
+    :return: a :class:`pandas.DataFrame` with columns ``"season_sin"`` and ``"season_cos"``,
+        indexed by ``index``.
+    """
+    _require_tz_aware(index)
+    fractional_day_of_year = (
+        index.dayofyear.to_numpy(dtype=float)
+        + (
+            index.hour.to_numpy(dtype=float) * 3600.0
+            + index.minute.to_numpy(dtype=float) * 60.0
+            + index.second.to_numpy(dtype=float)
+            + index.microsecond.to_numpy(dtype=float) / 1.0e6
+        )
+        / _SECONDS_PER_DAY
+    )
+    offset_from_june21 = fractional_day_of_year - _JUNE21_DAY_OF_YEAR
+    angle = 2.0 * np.pi * offset_from_june21 / _DAYS_PER_YEAR
+    return pd.DataFrame({"season_sin": np.sin(angle), "season_cos": np.cos(angle)}, index=index)
+
+
+def solar_altitude_azimuth(index: pd.DatetimeIndex, *, latitude: float, longitude: float) -> pd.DataFrame:
+    """Solar altitude and azimuth via the NOAA solar-position algorithm.
+
+    A vectorized (numpy-only, no per-row loops) transcription of the NOAA Solar Calculator
+    spreadsheet equations: julian day/century from the UTC timestamps, the sun's geometric
+    mean longitude and anomaly, the equation-of-center correction to true longitude, apparent
+    longitude, mean and corrected obliquity of the ecliptic, solar declination, the equation
+    of time, true solar time (from longitude and equation of time), hour angle, and finally
+    solar zenith (-> altitude) and azimuth. Atmospheric refraction near the horizon is
+    **not** applied, so altitude is the true geometric altitude rather than the
+    apparent/refracted one; this keeps the implementation a direct, checkable transcription
+    of the core geometry (refraction only matters within a couple of degrees of the horizon).
+
+    :param index: timezone-aware timestamps to featurize (converted to UTC internally).
+    :param latitude: observer latitude in degrees, positive north.
+    :param longitude: observer longitude in degrees, positive east.
+    :return: a :class:`pandas.DataFrame` with columns ``"solar_altitude"`` (degrees, negative
+        below the horizon), ``"solar_azimuth_sin"`` and ``"solar_azimuth_cos"`` (sine and
+        cosine of the azimuth in radians, clockwise from north -- encoded cyclically because
+        azimuth wraps at 360 degrees and the downstream model is tree-based), indexed by
+        ``index``.
+    """
+    _require_tz_aware(index)
+    index_utc = index.tz_convert("UTC")
+
+    julian_date = index_utc.to_julian_date().to_numpy(dtype=float)
+    julian_century = (julian_date - _J2000_JULIAN_DATE) / _JULIAN_DAYS_PER_CENTURY
+
+    geom_mean_long_sun = np.mod(280.46646 + julian_century * (36000.76983 + julian_century * 0.0003032), 360.0)
+    geom_mean_anom_sun = 357.52911 + julian_century * (35999.05029 - 0.0001537 * julian_century)
+    eccent_earth_orbit = 0.016708634 - julian_century * (0.000042037 + 0.0000001267 * julian_century)
+
+    mean_anom_rad = np.radians(geom_mean_anom_sun)
+    sun_eq_of_ctr = (
+        np.sin(mean_anom_rad) * (1.914602 - julian_century * (0.004817 + 0.000014 * julian_century))
+        + np.sin(2.0 * mean_anom_rad) * (0.019993 - 0.000101 * julian_century)
+        + np.sin(3.0 * mean_anom_rad) * 0.000289
+    )
+
+    sun_true_long = geom_mean_long_sun + sun_eq_of_ctr
+    sun_app_long = sun_true_long - 0.00569 - 0.00478 * np.sin(np.radians(125.04 - 1934.136 * julian_century))
+
+    mean_obliq_ecliptic = (
+        23.0
+        + (26.0 + (21.448 - julian_century * (46.815 + julian_century * (0.00059 - julian_century * 0.001813))) / 60.0)
+        / 60.0
+    )
+    obliq_corr = mean_obliq_ecliptic + 0.00256 * np.cos(np.radians(125.04 - 1934.136 * julian_century))
+
+    sun_declin = np.degrees(np.arcsin(np.sin(np.radians(obliq_corr)) * np.sin(np.radians(sun_app_long))))
+
+    var_y = np.tan(np.radians(obliq_corr / 2.0)) ** 2
+    geom_mean_long_sun_rad = np.radians(geom_mean_long_sun)
+    equation_of_time = 4.0 * np.degrees(
+        var_y * np.sin(2.0 * geom_mean_long_sun_rad)
+        - 2.0 * eccent_earth_orbit * np.sin(mean_anom_rad)
+        + 4.0 * eccent_earth_orbit * var_y * np.sin(mean_anom_rad) * np.cos(2.0 * geom_mean_long_sun_rad)
+        - 0.5 * var_y * var_y * np.sin(4.0 * geom_mean_long_sun_rad)
+        - 1.25 * eccent_earth_orbit * eccent_earth_orbit * np.sin(2.0 * mean_anom_rad)
+    )
+
+    minutes_since_midnight = (
+        index_utc.hour.to_numpy(dtype=float) * 60.0
+        + index_utc.minute.to_numpy(dtype=float)
+        + index_utc.second.to_numpy(dtype=float) / 60.0
+        + index_utc.microsecond.to_numpy(dtype=float) / 60.0e6
+    )
+    true_solar_time = np.mod(
+        minutes_since_midnight + equation_of_time + _MINUTES_PER_DEGREE_LONGITUDE * longitude, _MINUTES_PER_DAY
+    )
+    hour_angle = np.where(
+        true_solar_time * _DEGREES_PER_MINUTE < 0.0,
+        true_solar_time * _DEGREES_PER_MINUTE + 180.0,
+        true_solar_time * _DEGREES_PER_MINUTE - 180.0,
+    )
+
+    lat_rad = np.radians(latitude)
+    declin_rad = np.radians(sun_declin)
+    hour_angle_rad = np.radians(hour_angle)
+
+    cos_zenith = np.clip(
+        np.sin(lat_rad) * np.sin(declin_rad) + np.cos(lat_rad) * np.cos(declin_rad) * np.cos(hour_angle_rad),
+        -1.0,
+        1.0,
+    )
+    zenith = np.degrees(np.arccos(cos_zenith))
+    altitude = 90.0 - zenith
+
+    zenith_rad = np.radians(zenith)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        azimuth_arg = np.clip(
+            (np.sin(lat_rad) * np.cos(zenith_rad) - np.sin(declin_rad)) / (np.cos(lat_rad) * np.sin(zenith_rad)),
+            -1.0,
+            1.0,
+        )
+    azimuth_base = np.degrees(np.arccos(azimuth_arg))
+    azimuth = np.where(
+        hour_angle > 0.0,
+        np.mod(azimuth_base + 180.0, _DEGREES_PER_CIRCLE),
+        np.mod(540.0 - azimuth_base, _DEGREES_PER_CIRCLE),
+    )
+    # Directly overhead (or a pole latitude), azimuth is undefined; the division above yields
+    # nan there, which np.mod propagates -- fall back to due-north (0 degrees) by convention.
+    azimuth = np.where(np.isnan(azimuth), 0.0, azimuth)
+
+    azimuth_rad = np.radians(azimuth)
+    return pd.DataFrame(
+        {
+            "solar_altitude": altitude,
+            "solar_azimuth_sin": np.sin(azimuth_rad),
+            "solar_azimuth_cos": np.cos(azimuth_rad),
+        },
+        index=index,
+    )

--- a/benchmarking/baselines/time_features.py
+++ b/benchmarking/baselines/time_features.py
@@ -40,8 +40,8 @@ import pandas as pd
 # multiple columns (see season_sin_cos / solar_altitude_azimuth).
 TIME_FEATURE_NAMES: tuple[str, ...] = ("days_since_campaign_start", "season", "solar")
 
-# Day-of-year of June 21st in a non-leap year; the season angle's zero-crossing anchor.
-_JUNE21_DAY_OF_YEAR = 172
+# Day-of-year of June 21st in a non-leap year (one later in leap years); the season anchor.
+_JUNE21_DAY_OF_YEAR_NON_LEAP = 172
 # Mean length of a year in days (Gregorian calendar average, i.e. including leap years).
 _DAYS_PER_YEAR = 365.25
 _SECONDS_PER_DAY = 86_400.0
@@ -98,17 +98,20 @@ def season_sin_cos(index: pd.DatetimeIndex) -> pd.DataFrame:
         indexed by ``index``.
     """
     _require_tz_aware(index)
+    index_utc = index.tz_convert("UTC")  # wall-clock fields below must read UTC, whatever tz came in
     fractional_day_of_year = (
-        index.dayofyear.to_numpy(dtype=float)
+        index_utc.dayofyear.to_numpy(dtype=float)
         + (
-            index.hour.to_numpy(dtype=float) * 3600.0
-            + index.minute.to_numpy(dtype=float) * 60.0
-            + index.second.to_numpy(dtype=float)
-            + index.microsecond.to_numpy(dtype=float) / 1.0e6
+            index_utc.hour.to_numpy(dtype=float) * 3600.0
+            + index_utc.minute.to_numpy(dtype=float) * 60.0
+            + index_utc.second.to_numpy(dtype=float)
+            + index_utc.microsecond.to_numpy(dtype=float) / 1.0e6
         )
         / _SECONDS_PER_DAY
     )
-    offset_from_june21 = fractional_day_of_year - _JUNE21_DAY_OF_YEAR
+    # June 21 is day 172 in a non-leap year but 173 in a leap year (the extra Feb 29 shifts it).
+    june21_day_of_year = _JUNE21_DAY_OF_YEAR_NON_LEAP + index_utc.is_leap_year.astype(float)
+    offset_from_june21 = fractional_day_of_year - june21_day_of_year
     angle = 2.0 * np.pi * offset_from_june21 / _DAYS_PER_YEAR
     return pd.DataFrame({"season_sin": np.sin(angle), "season_cos": np.cos(angle)}, index=index)
 
@@ -183,11 +186,9 @@ def solar_altitude_azimuth(index: pd.DatetimeIndex, *, latitude: float, longitud
     true_solar_time = np.mod(
         minutes_since_midnight + equation_of_time + _MINUTES_PER_DEGREE_LONGITUDE * longitude, _MINUTES_PER_DAY
     )
-    hour_angle = np.where(
-        true_solar_time * _DEGREES_PER_MINUTE < 0.0,
-        true_solar_time * _DEGREES_PER_MINUTE + 180.0,
-        true_solar_time * _DEGREES_PER_MINUTE - 180.0,
-    )
+    # true_solar_time is wrapped into [0, 1440) above, so the NOAA spreadsheet's negative branch
+    # cannot occur and the hour angle reduces to the single expression over [-180, 180).
+    hour_angle = true_solar_time * _DEGREES_PER_MINUTE - 180.0
 
     lat_rad = np.radians(latitude)
     declin_rad = np.radians(sun_declin)

--- a/benchmarking/synthetic/__init__.py
+++ b/benchmarking/synthetic/__init__.py
@@ -11,7 +11,12 @@ from benchmarking.synthetic.generator import SyntheticDataset, ToggleSchedule, g
 from benchmarking.synthetic.ground_truth import UpliftResult, true_uplift
 from benchmarking.synthetic.plots import plot_power_curve_comparison
 from benchmarking.synthetic.schema import ColumnSchema
-from benchmarking.synthetic.sources.hill_of_towie import HOT_COLUMNS, HOT_RATED_POWER_KW
+from benchmarking.synthetic.sources.hill_of_towie import (
+    HOT_ACTIVE_POWER_STAT_COLS,
+    HOT_COLUMNS,
+    HOT_HUB_HEIGHT_M,
+    HOT_RATED_POWER_KW,
+)
 from benchmarking.synthetic.upgrades import (
     ConditionCpChange,
     ConstantCpChange,
@@ -22,8 +27,10 @@ from benchmarking.synthetic.upgrades import (
 )
 
 __all__ = [
+    "HOT_ACTIVE_POWER_STAT_COLS",
     "HOT_COLUMNS",
     "HOT_CP_MODEL",
+    "HOT_HUB_HEIGHT_M",
     "HOT_RATED_POWER_KW",
     "ColumnSchema",
     "ConditionCpChange",

--- a/benchmarking/synthetic/sources/hill_of_towie.py
+++ b/benchmarking/synthetic/sources/hill_of_towie.py
@@ -366,13 +366,21 @@ _TAG_REACTIVE_POWER_MEAN = "wtc_ReactPwr_mean"
 _TAG_NACELLE_POSITION_MEAN = "wtc_NacelPos_mean"
 _TAG_AMBIENT_TEMP_MEAN = "wtc_AmbieTmp_mean"
 _TAG_AVAILABILITY = "wtc_ScReToOp_timeon"
+# Reference active-power companion statistics (Issue 11): within-period max/min/SD of active power.
+# The SD in particular is a calibration-stable, farm-sited turbulence proxy a method may opt into
+# as reference features; the mean stays the primary signal.
+_TAG_ACTIVE_POWER_MAX = "wtc_ActPower_max"
+_TAG_ACTIVE_POWER_MIN = "wtc_ActPower_min"
+_TAG_ACTIVE_POWER_SD = "wtc_ActPower_stddev"
 
 
 hill_of_towie_fields = [
     WPSBackupFileField(
         alias=DataColumns.active_power_mean, field_name=_TAG_ACTIVE_POWER_MEAN, table_name="tblSCTurGrid"
     ),
-    WPSBackupFileField(alias=DataColumns.active_power_sd, field_name="wtc_ActPower_stddev", table_name="tblSCTurGrid"),
+    WPSBackupFileField(alias=DataColumns.active_power_sd, field_name=_TAG_ACTIVE_POWER_SD, table_name="tblSCTurGrid"),
+    WPSBackupFileField(alias="ActivePowerMax", field_name=_TAG_ACTIVE_POWER_MAX, table_name="tblSCTurGrid"),
+    WPSBackupFileField(alias="ActivePowerMin", field_name=_TAG_ACTIVE_POWER_MIN, table_name="tblSCTurGrid"),
     WPSBackupFileField(alias="ReactivePowerMean", field_name="wtc_ReactPwr_mean", table_name="tblSCTurGrid"),
     WPSBackupFileField(alias=DataColumns.wind_speed_mean, field_name=_TAG_WIND_SPEED_MEAN, table_name="tblSCTurbine"),
     WPSBackupFileField(alias=DataColumns.wind_speed_sd, field_name=_TAG_WIND_SPEED_SD, table_name="tblSCTurbine"),
@@ -412,6 +420,16 @@ HOT_COLUMNS = ColumnSchema(
 # Baseline rated power of the Hill of Towie test turbines (kW); matches the synthetic generator's
 # baseline ``rated_power_kw`` default and caps the power-model counterfactual predictions.
 HOT_RATED_POWER_KW = 2300.0
+
+# Hub height of the Hill of Towie turbines (m); feeds the ERA5 hub-height wind-speed derivation.
+HOT_HUB_HEIGHT_M = 59.0
+
+# The reference active-power companion statistics (max/min/SD) a method may opt into as features.
+HOT_ACTIVE_POWER_STAT_COLS: tuple[str, ...] = (
+    _TAG_ACTIVE_POWER_MAX,
+    _TAG_ACTIVE_POWER_MIN,
+    _TAG_ACTIVE_POWER_SD,
+)
 
 
 def _unpack_hot_10min_year(

--- a/docs/v1/findings.md
+++ b/docs/v1/findings.md
@@ -7,6 +7,115 @@ from, not just conclusions.
 
 ---
 
+## F12 — reference active-power **minimum** accepted as a default feature; SD and max rejected (Issue 11)
+
+*2026-07-04 — Issue 11 verdicts. Candidates A/B'd one field at a time per the Issue 9 protocol:
+`study_power_model_compare.py --method-overrides '{"reference_stat_cols": [...]}'` against the committed
+benchmark — placebo (`cp_0pct`, both modes) screen first, full 7-profile sweep for survivors. The HoT
+loader now also unpacks `wtc_ActPower_max` / `wtc_ActPower_min` (the SD was already loaded); the fields
+reach the model via `build_reference_features(..., extra_cols=...)` /
+`PowerModelMethod.reference_stat_cols`.*
+
+### Verdicts (deltas vs the pre-change benchmark, in pp; negative = better)
+- **`wtc_ActPower_min` — ACCEPTED, now the default** (`reference_stat_cols=("wtc_ActPower_min",)` in the
+  HoT drivers). Better on every gate in both modes: overall P50 Δ|bias| −0.01 (prepost) / −0.006 (toggle),
+  Δspread ~0 / −0.009; conditional mean Δ|bias| **−0.46 (prepost)** / **−0.75 (toggle)**, Δscore −0.40 /
+  −1.30. Interpretation: the within-period minimum tells the model when a reference dipped (gust lulls,
+  brief curtailments) — a farm-sited variability signal the mean hides. **Benchmark JSON regenerated**
+  from this configuration's full sweep.
+- **`wtc_ActPower_stddev` — REJECTED.** The placebo screen alone disqualified it: conditional mean
+  Δ|bias| +2.8 / Δscore +3.98 (prepost), +0.65 / +1.38 (toggle), and it jumped to importance rank 5.
+  The within-period power SD is exactly the kind of channel the placebo gate exists for.
+- **`wtc_ActPower_max` — REJECTED.** Full sweep: it shifts the prepost overall bias **uniformly +0.33 pp
+  across all seven profiles** — a counterfactual level shift, not uplift tracking. That happens to offset
+  the structural −0.4 pp prepost headline bias (|bias| improves) but costs spread (+0.08; 240/469 cells
+  worse) and is an accidental cancellation — Issue 13 addresses that bias properly. Toggle-side it helps
+  (−1.13 conditional), but combined with `min` (trio minus SD) it is toxic: prepost conditional
+  Δ|bias| +3.4 / Δscore +5.2. Max and min together destabilise the matched conditional fits.
+- **Reference nacelle wind speed / wind-speed SD — rejected without trial** (recorded per the issue): a
+  reference anemometer is at high risk of calibration drift, which a prepost campaign reads as uplift;
+  reference *power* is the calibration-stable channel, and same-type references degrade like the test
+  turbine, giving a fairer counterfactual expectation.
+
+### Method note
+Importance rank alone was a poor red-flag here: `max`/`min` both ranked 3rd–4th (gain frac 3–4%), yet one
+was accepted and one rejected — the benchmark gates (placebo bias, spread, conditional cells) did the
+discriminating, not the ranking.
+
+---
+
+## F11 — explicit time features rejected: campaign-drift, season and solar all fail or add nothing (Issue 10)
+
+*2026-07-04 — Issue 10 verdicts. `benchmarking/baselines/time_features.py` ships the features
+(`days_since_campaign_start`, June-21-anchored `season` sin/cos, NOAA `solar` altitude/azimuth validated
+against an ephem reference to <0.01°) behind `PowerModelMethod.time_features` (+ `latitude`/`longitude`),
+default **off**. A/B'd one at a time on the placebo (`cp_0pct`, both modes) via
+`study_power_model_compare.py --method-overrides`.*
+
+### Verdicts (placebo deltas vs benchmark, pp)
+- **`days_since_campaign_start` — REJECTED.** Prepost is the anticipated failure, measured: overall
+  Δbias +0.23, Δspread **+1.08**, Δscore +0.97; conditional Δscore +5.3 with 54/67 cells worse. Trees
+  cannot extrapolate the feature past the changeover (every upgraded-row value exceeds the training
+  range, so predictions clamp at boundary leaves), which *adds* variance instead of absorbing drift.
+  Toggle is ~neutral (−0.001 overall) — but prepost and toggle share one code path, so it stays out.
+- **`season` — REJECTED.** Prepost overall slightly worse (Δscore +0.14, max Δ|bias| +0.26 at one
+  campaign length), conditional worse in both modes (+0.39 / +0.16). Against a <12-month baseline the
+  pair is a partial calendar proxy, as the issue warned.
+- **`solar` — REJECTED.** Neutral overall (≤0.03) but conditional worse in both modes (+0.90 / +0.29
+  Δscore) and negligible importance (rank 22–24 of 32, gain frac ≤0.0003) — the instantaneous weather
+  columns already carry the diurnal signal at this site.
+
+### Method note
+The feared "time feature dominating the importance ranking" red flag never fired — all three sat far
+down the ranking (gain frac ≤0.0006) *while still doing damage through spread*. The placebo benchmark
+gate, not the importance watch, is the effective detector for drift-importing features. The module stays
+in the tree for future sources (e.g. a site with genuine reference drift may re-litigate
+`days_since_campaign_start` in toggle-only form).
+
+---
+
+## F10 — ERA5 derived quantities: utility shipped; hub-height wind speed validated standalone; no derivation earns a default place in the full model (Issue 9)
+
+*2026-07-04 — Issue 9 verdicts. `benchmarking/baselines/era5_derived.py` is the shared derivation
+utility (shear exponent, hub-height ws via the shear power law + `hub_height_m` — `HOT_HUB_HEIGHT_M =
+59.0`, gust ratio, gust margin, veer, moist-air density), reused by
+`inspect_era5_matching_importance.py` and available to the CEM matching step; features reach the model
+via `PowerModelMethod.era5_derivations`, default **off**. Screened per candidate on the placebo, full
+sweeps for survivors (`study_power_model_compare.py --method-overrides`).*
+
+### The gust "TI proxy" is not one (measured against real SCADA TI)
+- `gust_ratio = wind_gusts_10m / wind_speed_10m` correlates with the test turbine's measured TI at
+  **Pearson +0.03** (Spearman +0.11; T01, ws>4 m/s, n≈195k) and implies TI ≈ 0.31 at the median vs the
+  real 0.17 — ERA5's hourly grid-scale gustiness is a different quantity from local 10-min turbulence.
+- Variants (per the issue's "play around" instruction): the absolute **gust margin** `gusts − ws_100m`
+  is the best simple correlate (+0.22), shear exponent −0.21, |veer| −0.21, `gusts/ws_100m` +0.11.
+  A LightGBM fit of TI on *all* ERA5 columns reaches held-out **R² = 0.38**, dominated by wind-direction
+  sin/cos (~31% of gain — wake/terrain sectors) — much of site TI is direction-determined and the model
+  already sees direction.
+
+### A/B verdicts (vs benchmark, pp)
+- **`wind_speed_hub` — validated, left opt-in.** With reference features removed (ERA5-only ranking, the
+  Issue 9 exploration) it *dominates*: 63% of gain, permutation importance 0.48 vs 0.10 for raw
+  `wind_speed_100m`. In the full model its full sweep improves overall P50 in both modes (prepost
+  Δ|bias| −0.02, Δspread −0.035 uniformly across profiles; toggle conditional −1.02 score) at a small
+  prepost conditional cost (+0.13). But combined with the accepted `wtc_ActPower_min` its marginal value
+  disappears (combo no better than `min` alone, toggle conditional diluted), so it is **not defaulted**;
+  it is the natural candidate for the F6 `matching_vars` revisit and for reference-poor sources.
+- **`shear_exponent`, `veer` — REJECTED (mode-split).** Both help toggle conditional (−0.41 / −0.47
+  score) and hurt prepost (+0.80 / +0.54); one code path, so out.
+- **`gust_ratio`, `gust_margin`, `air_density` — REJECTED.** Overall neutral; conditional worse
+  (gust_ratio prepost +1.33 score with the (6, ws) cell +5.9; gust_margin +0.34/+0.23; air_density
+  +0.60 prepost, 25/35 cells worse). Consistent with the TI-proxy result: these columns add split noise,
+  not cause.
+
+### Interpretation
+The reference active-power features already carry the site signal ERA5 derivations try to reconstruct —
+in the full model every derivation lands at gain frac ≤0.0012. ERA5 derivations matter where references
+are absent: the ERA5-only fit (R² 0.85) is where `wind_speed_hub` shines, which is exactly the CEM
+matching / AEP-extrapolation context (Issues 8/15), not the counterfactual feature set.
+
+---
+
 ## F9 — the matched two-direction conditional cross-prediction shipped as the sole conditional method, on by default
 
 *2026-07-03 — Issue 8 ship. The F7/F8 development-time A/B flag `bias_correct` is **removed**; the

--- a/docs/v1/findings.md
+++ b/docs/v1/findings.md
@@ -7,6 +7,44 @@ from, not just conclusions.
 
 ---
 
+## F13 — removal ablation: dropping the availability feature + five ERA5 columns improves the benchmark; low importance ≠ removable
+
+*2026-07-04 — follow-up to the Issue 9–11 additions: the same A/B protocol run in reverse (remove each
+currently-accepted feature group, keep any removal that noticeably improves the score). Two new
+ablation knobs on `PowerModelMethod`: `era5_exclude` (drops raw ERA5 columns + their sin/cos
+companions; guarded against excluding `matching_vars` while `conditional_uplift` is on) and
+`availability_feature` (drops the per-reference availability *feature*; `availability_col` stays
+required for the downtime filter). Screens on the placebo, confirmation via two full sweeps
+(`--method-overrides` on `study_power_model_compare.py`), all diffed against the post-F12 benchmark.*
+
+### The accepted removal set (now the driver default; benchmark regenerated)
+`availability_feature=False` + `era5_exclude = CURATED_ERA5_EXCLUDE = (apparent_temperature,
+dew_point_2m, precipitation, rain, snowfall)`. Full-sweep deltas (pp; negative = better):
+- **prepost overall**: Δ|bias| −0.19, Δspread −0.18, Δscore **−0.24** — the largest overall
+  improvement of the whole Issue 9–11 campaign, and it came from *removing* features. Per campaign
+  (placebo): 3 mo bias −0.59 → −0.12, 12 mo −0.21 → **0.00**, 6 mo overshoots mildly (−0.17 → +0.30).
+- **toggle**: overall neutral (≤0.006); conditional Δ|bias| −0.98, Δscore **−1.47**.
+- **prepost conditional**: the one cost, Δscore +0.54 (cells split 212 better / 183 worse) — accepted
+  against the overall-P50 gains (Phase 1 is judged on P50 accuracy/precision first).
+- Availability-alone (set A) shows nearly the same numbers; the ERA5 trims add a small consistent
+  extra (prepost conditional Δ|bias| +0.07 → −0.17 vs A). The removals stack cleanly — unlike the
+  F12 max+min interaction.
+
+### Why removing availability helps
+References are almost always available, and when one is not, its *power* column already carries the
+fact (0/NaN) — so the counter added noise and a mild maintenance-calendar proxy rather than wake
+information. The curated-feature physical argument ("the model should know whether a reference is
+waking") was measured and lost to the data.
+
+### Kept columns — low importance is not a removal licence
+Removing bottom-of-the-ranking columns often *hurt*: `pressure_msl` removal cost +2.09 pp prepost
+conditional score (the model evidently uses the msl-vs-surface pressure pair jointly), `weather_code`
+removal +0.49, `cloud_cover` removal +0.39 toggle conditional, humidity removal worse everywhere.
+Together with F12's rank-3/rank-4 accepted/rejected split, the lesson is symmetric: importance rank
+predicts neither a feature's value nor its removability — only the benchmark gates do.
+
+---
+
 ## F12 — reference active-power **minimum** accepted as a default feature; SD and max rejected (Issue 11)
 
 *2026-07-04 — Issue 11 verdicts. Candidates A/B'd one field at a time per the Issue 9 protocol:

--- a/tests/benchmarking/baselines/test_era5_derived.py
+++ b/tests/benchmarking/baselines/test_era5_derived.py
@@ -1,0 +1,140 @@
+"""Known-input tests for the shared ERA5 derivation utility (Issue 9)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from benchmarking.baselines.era5_derived import (
+    ERA5_DERIVATIONS,
+    air_density,
+    era5_derived_frame,
+    gust_margin,
+    gust_ratio,
+    hub_height_wind_speed,
+    shear_exponent,
+    vertical_veer,
+)
+
+_HOT_HUB_HEIGHT_M = 59.0
+
+
+def _series(values: list[float]) -> pd.Series:
+    return pd.Series(values, index=pd.date_range("2020-01-01", periods=len(values), freq="10min", tz="UTC"))
+
+
+class TestShearExponent:
+    def test_known_value(self) -> None:
+        # ws doubles from 10 m to 100 m -> alpha = ln(2)/ln(10)
+        alpha = shear_exponent(_series([5.0]), _series([10.0]))
+        np.testing.assert_allclose(alpha.to_numpy(), np.log(2.0) / np.log(10.0))
+
+    def test_zero_shear(self) -> None:
+        alpha = shear_exponent(_series([8.0]), _series([8.0]))
+        np.testing.assert_allclose(alpha.to_numpy(), 0.0)
+
+    def test_calm_is_nan(self) -> None:
+        alpha = shear_exponent(_series([0.0, -1.0, 5.0]), _series([5.0, 5.0, 0.0]))
+        assert alpha.isna().all()
+
+
+class TestHubHeightWindSpeed:
+    def test_power_law_interpolation(self) -> None:
+        # alpha = 0.2, ws_100m = 10 -> ws_59m = 10 * 0.59^0.2
+        ws = hub_height_wind_speed(_series([10.0]), _series([0.2]), hub_height_m=_HOT_HUB_HEIGHT_M)
+        np.testing.assert_allclose(ws.to_numpy(), 10.0 * 0.59**0.2)
+
+    def test_zero_alpha_keeps_speed(self) -> None:
+        ws = hub_height_wind_speed(_series([7.0]), _series([0.0]), hub_height_m=_HOT_HUB_HEIGHT_M)
+        np.testing.assert_allclose(ws.to_numpy(), 7.0)
+
+    def test_nan_alpha_propagates(self) -> None:
+        ws = hub_height_wind_speed(_series([7.0]), _series([np.nan]), hub_height_m=_HOT_HUB_HEIGHT_M)
+        assert ws.isna().all()
+
+
+class TestGustRatio:
+    def test_known_value(self) -> None:
+        ratio = gust_ratio(_series([7.5]), _series([5.0]))
+        np.testing.assert_allclose(ratio.to_numpy(), 1.5)
+
+    def test_calm_floor_is_nan(self) -> None:
+        ratio = gust_ratio(_series([3.0, 3.0]), _series([0.5, 0.0]))
+        assert ratio.isna().all()
+
+
+class TestGustMargin:
+    def test_known_value(self) -> None:
+        margin = gust_margin(_series([12.0]), _series([9.0]))
+        np.testing.assert_allclose(margin.to_numpy(), 3.0)
+
+
+class TestVerticalVeer:
+    @pytest.mark.parametrize(
+        ("wd_hi", "wd_lo", "expected"),
+        [
+            (30.0, 10.0, 20.0),  # simple positive veer
+            (10.0, 30.0, -20.0),  # simple negative
+            (350.0, 10.0, -20.0),  # wraps across north
+            (10.0, 350.0, 20.0),  # wraps the other way
+            (180.0, 0.0, 180.0),  # boundary maps to +180, not -180
+        ],
+    )
+    def test_wrapped_difference(self, wd_hi: float, wd_lo: float, expected: float) -> None:
+        veer = vertical_veer(_series([wd_hi]), _series([wd_lo]))
+        np.testing.assert_allclose(veer.to_numpy(), expected)
+
+
+class TestAirDensity:
+    def test_standard_dry_air(self) -> None:
+        # ISA sea level: 15 degC, 1013.25 hPa, dry -> 1.225 kg/m3
+        rho = air_density(_series([15.0]), _series([1013.25]), _series([0.0]))
+        np.testing.assert_allclose(rho.to_numpy(), 1.225, atol=0.001)
+
+    def test_humidity_reduces_density(self) -> None:
+        dry = air_density(_series([15.0]), _series([1013.25]), _series([0.0]))
+        moist = air_density(_series([15.0]), _series([1013.25]), _series([100.0]))
+        assert float(moist.iloc[0]) < float(dry.iloc[0])
+        np.testing.assert_allclose(moist.to_numpy(), 1.217, atol=0.002)
+
+
+class TestEra5DerivedFrame:
+    def _aligned(self, n: int = 4) -> pd.DataFrame:
+        idx = pd.date_range("2020-01-01", periods=n, freq="10min", tz="UTC")
+        rng = np.random.default_rng(0)
+        return pd.DataFrame(
+            {
+                "wind_speed_10m": rng.uniform(3, 10, n),
+                "wind_speed_100m": rng.uniform(5, 14, n),
+                "wind_gusts_10m": rng.uniform(5, 15, n),
+                "wind_direction_10m": rng.uniform(0, 360, n),
+                "wind_direction_100m": rng.uniform(0, 360, n),
+                "temperature_2m": rng.uniform(0, 20, n),
+                "surface_pressure": rng.uniform(980, 1030, n),
+                "relative_humidity_2m": rng.uniform(40, 100, n),
+            },
+            index=idx,
+        )
+
+    def test_all_derivations_present_and_finite(self) -> None:
+        frame = era5_derived_frame(self._aligned(), derivations=ERA5_DERIVATIONS, hub_height_m=_HOT_HUB_HEIGHT_M)
+        assert list(frame.columns) == list(ERA5_DERIVATIONS)
+        assert np.isfinite(frame.to_numpy(dtype=float)).all()
+
+    def test_subset_only_builds_requested(self) -> None:
+        frame = era5_derived_frame(self._aligned(), derivations=["gust_ratio", "veer"])
+        assert list(frame.columns) == ["gust_ratio", "veer"]
+
+    def test_unknown_derivation_raises(self) -> None:
+        with pytest.raises(ValueError, match="unknown ERA5 derivation"):
+            era5_derived_frame(self._aligned(), derivations=["nonsense"])
+
+    def test_hub_height_required(self) -> None:
+        with pytest.raises(ValueError, match="requires hub_height_m"):
+            era5_derived_frame(self._aligned(), derivations=["wind_speed_hub"])
+
+    def test_missing_raw_column_raises(self) -> None:
+        aligned = self._aligned().drop(columns=["wind_gusts_10m"])
+        with pytest.raises(ValueError, match="missing columns"):
+            era5_derived_frame(aligned, derivations=["gust_ratio"])

--- a/tests/benchmarking/baselines/test_power_model_features.py
+++ b/tests/benchmarking/baselines/test_power_model_features.py
@@ -87,6 +87,35 @@ class TestBuildReferenceFeatures:
                 only_test, test_wtg="T1", turbine_col=_TURBINE, active_power_col=_POWER, availability_col=_AVAIL
             )
 
+    def test_extra_cols_add_per_reference_features(self) -> None:
+        idx = _index(12)
+        scada = _scada(idx)
+        scada["wtc_ActPower_stddev"] = 7.0
+        feats = build_reference_features(
+            scada,
+            test_wtg="T1",
+            turbine_col=_TURBINE,
+            active_power_col=_POWER,
+            availability_col=_AVAIL,
+            extra_cols=("wtc_ActPower_stddev",),
+        )
+        # three references x three value columns; still nothing from the test turbine
+        assert len(feats.columns) == 9
+        assert f"wtc_ActPower_stddev{QUALIFIER}R2" in feats.columns
+        assert not any(c.endswith(f"{QUALIFIER}T1") for c in feats.columns)
+
+    def test_missing_extra_col_raises(self) -> None:
+        idx = _index(12)
+        with pytest.raises(ValueError, match="missing required reference-feature columns"):
+            build_reference_features(
+                _scada(idx),
+                test_wtg="T1",
+                turbine_col=_TURBINE,
+                active_power_col=_POWER,
+                availability_col=_AVAIL,
+                extra_cols=("wtc_ActPower_stddev",),
+            )
+
     def test_extra_test_turbine_column_never_reaches_features(self) -> None:
         idx = _index(12)
         scada = _scada(idx)

--- a/tests/benchmarking/baselines/test_power_model_features.py
+++ b/tests/benchmarking/baselines/test_power_model_features.py
@@ -104,6 +104,19 @@ class TestBuildReferenceFeatures:
         assert f"wtc_ActPower_stddev{QUALIFIER}R2" in feats.columns
         assert not any(c.endswith(f"{QUALIFIER}T1") for c in feats.columns)
 
+    def test_missing_availability_col_raises_even_when_not_featured(self) -> None:
+        idx = _index(12)
+        scada = _scada(idx).drop(columns=[_AVAIL])
+        with pytest.raises(ValueError, match="missing required reference-feature columns"):
+            build_reference_features(
+                scada,
+                test_wtg="T1",
+                turbine_col=_TURBINE,
+                active_power_col=_POWER,
+                availability_col=_AVAIL,
+                include_availability=False,
+            )
+
     def test_missing_extra_col_raises(self) -> None:
         idx = _index(12)
         with pytest.raises(ValueError, match="missing required reference-feature columns"):

--- a/tests/benchmarking/baselines/test_power_model_method.py
+++ b/tests/benchmarking/baselines/test_power_model_method.py
@@ -352,6 +352,64 @@ class TestFeatureConfig:
         assert {f"{_POWER_SD} @ R1", f"{_POWER_MAX} @ R2", f"{_POWER_MIN} @ R3"} <= fitted
         assert not any(name.endswith(" @ T1") for name in fitted)
 
+    def test_era5_exclude_drops_column_and_direction_companions(self, tmp_path: Path) -> None:
+        mi = self._prepost_mi()
+        method = PowerModelMethod(
+            active_power_col=_POWER,
+            availability_col=_AVAIL,
+            baseline_rated_power_kw=2300.0,
+            wind_speed_col=_WS,
+            era5_hourly_df=_toy_era5(pd.DatetimeIndex(mi.scada_df.index)),
+            conditional_uplift=False,
+            model_params=_FAST_PARAMS,
+            era5_exclude=("wind_speed_10m", "wind_direction_10m"),
+            out_dir=tmp_path,
+        )
+        out = method.estimate(mi)
+        assert out.p50_overall == pytest.approx(0.05, abs=0.02)
+        fitted = self._fitted_feature_names(tmp_path)
+        assert (
+            not {
+                "wind_speed_10m",
+                "wind_direction_10m",
+                "wind_direction_10m_sin",
+                "wind_direction_10m_cos",
+            }
+            & fitted
+        )
+        assert "wind_speed_100m" in fitted
+
+    def test_era5_exclude_of_matching_var_raises_with_conditional_on(self) -> None:
+        mi = self._prepost_mi(n=300)
+        method = PowerModelMethod(
+            active_power_col=_POWER,
+            availability_col=_AVAIL,
+            baseline_rated_power_kw=2300.0,
+            wind_speed_col=_WS,
+            era5_hourly_df=_toy_era5(pd.DatetimeIndex(mi.scada_df.index)),
+            era5_exclude=("wind_gusts_10m",),
+        )
+        with pytest.raises(ValueError, match="matching_vars"):
+            method.estimate(mi)
+
+    def test_availability_feature_off_removes_availability_columns(self, tmp_path: Path) -> None:
+        mi = self._prepost_mi()
+        method = PowerModelMethod(
+            active_power_col=_POWER,
+            availability_col=_AVAIL,
+            baseline_rated_power_kw=2300.0,
+            wind_speed_col=_WS,
+            conditional_uplift=False,
+            model_params=_FAST_PARAMS,
+            availability_feature=False,
+            out_dir=tmp_path,
+        )
+        out = method.estimate(mi)
+        assert out.p50_overall == pytest.approx(0.05, abs=0.02)
+        fitted = self._fitted_feature_names(tmp_path)
+        assert not any(name.startswith(_AVAIL) for name in fitted)
+        assert f"{_POWER} @ R1" in fitted
+
     def test_era5_derivations_without_era5_raises(self) -> None:
         method = PowerModelMethod(
             active_power_col=_POWER,

--- a/tests/benchmarking/baselines/test_power_model_method.py
+++ b/tests/benchmarking/baselines/test_power_model_method.py
@@ -32,6 +32,9 @@ _POWER = "wtc_ActPower_mean"
 _AVAIL = "wtc_ScReToOp_timeon"
 _WS = "wtc_AcWindSp_mean"
 _WS_SD = "wtc_AcWindSp_stddev"
+_POWER_MAX = "wtc_ActPower_max"
+_POWER_MIN = "wtc_ActPower_min"
+_POWER_SD = "wtc_ActPower_stddev"
 
 # Small/fast LightGBM so the toy data (a few thousand rows) is fit well.
 _FAST_PARAMS = {"n_estimators": 120, "learning_rate": 0.1, "num_leaves": 31, "min_child_samples": 20}
@@ -58,7 +61,18 @@ def _toy_scada(n: int, *, uplift: float, treated: np.ndarray, seed: int = 0) -> 
     }
     parts = [
         pd.DataFrame(
-            {_TURBINE: name, _POWER: power, _AVAIL: 600.0, _WS: power / 100.0, _WS_SD: power / 1000.0}, index=idx
+            {
+                _TURBINE: name,
+                _POWER: power,
+                _AVAIL: 600.0,
+                _WS: power / 100.0,
+                _WS_SD: power / 1000.0,
+                # active-power companion statistics (Issue 11 reference_stat_cols candidates)
+                _POWER_MAX: power * 1.15,
+                _POWER_MIN: power * 0.85,
+                _POWER_SD: np.abs(power) / 20.0,
+            },
+            index=idx,
         )
         for name, power in frames.items()
     ]
@@ -248,9 +262,128 @@ def _toy_era5(scada_idx: pd.DatetimeIndex, *, seed: int = 0) -> pd.DataFrame:
             "wind_speed_100m": ws,
             "wind_gusts_10m": ws * 1.4 + rng.uniform(0.0, 2.0, len(hours)),
             "wind_direction_100m": rng.uniform(200.0, 260.0, len(hours)),
+            # extra raw columns so the Issue 9 derivations have their inputs
+            "wind_speed_10m": ws * 0.75,
+            "wind_direction_10m": rng.uniform(190.0, 250.0, len(hours)),
+            "temperature_2m": rng.uniform(0.0, 15.0, len(hours)),
+            "surface_pressure": rng.uniform(980.0, 1030.0, len(hours)),
+            "relative_humidity_2m": rng.uniform(50.0, 100.0, len(hours)),
         },
         index=hours,
     )
+
+
+class TestFeatureConfig:
+    """The Issue 9/10/11 opt-in feature config: columns reach the model and estimates stay sound."""
+
+    def _prepost_mi(self, n: int = 4000, *, uplift: float = 0.05) -> MethodInput:
+        idx = pd.date_range("2019-01-01", periods=n, freq="10min", tz="UTC")
+        treated = np.asarray(idx >= idx[n // 2])
+        scada = _toy_scada(n, uplift=uplift, treated=treated)
+        return MethodInput(
+            scada_df=scada, test_wtg="T1", upgrade_timing=pd.Timestamp(idx[n // 2]), turbine_col=_TURBINE
+        )
+
+    def _fitted_feature_names(self, out_dir: Path) -> set[str]:
+        files = sorted(out_dir.rglob("*_feature_importance_*.csv"))
+        assert files, f"no feature-importance CSV under {out_dir}"
+        return set(pd.read_csv(files[-1])["feature"])
+
+    def test_era5_derivations_reach_model_and_recovery_holds(self, tmp_path: Path) -> None:
+        mi = self._prepost_mi()
+        method = PowerModelMethod(
+            active_power_col=_POWER,
+            availability_col=_AVAIL,
+            baseline_rated_power_kw=2300.0,
+            wind_speed_col=_WS,
+            era5_hourly_df=_toy_era5(pd.DatetimeIndex(mi.scada_df.index)),
+            conditional_uplift=False,
+            model_params=_FAST_PARAMS,
+            era5_derivations=("shear_exponent", "wind_speed_hub", "gust_ratio", "veer", "air_density"),
+            hub_height_m=59.0,
+            out_dir=tmp_path,
+        )
+        out = method.estimate(mi)
+        assert out.p50_overall == pytest.approx(0.05, abs=0.02)
+        fitted = self._fitted_feature_names(tmp_path)
+        assert {"shear_exponent", "wind_speed_hub", "gust_ratio", "veer", "air_density"} <= fitted
+
+    def test_time_features_reach_model_and_recovery_holds(self, tmp_path: Path) -> None:
+        mi = self._prepost_mi()
+        method = PowerModelMethod(
+            active_power_col=_POWER,
+            availability_col=_AVAIL,
+            baseline_rated_power_kw=2300.0,
+            wind_speed_col=_WS,
+            conditional_uplift=False,
+            model_params=_FAST_PARAMS,
+            time_features=("days_since_campaign_start", "season", "solar"),
+            latitude=57.5,
+            longitude=-3.25,
+            out_dir=tmp_path,
+        )
+        out = method.estimate(mi)
+        assert out.p50_overall == pytest.approx(0.05, abs=0.02)
+        fitted = self._fitted_feature_names(tmp_path)
+        assert {
+            "days_since_campaign_start",
+            "season_sin",
+            "season_cos",
+            "solar_altitude",
+            "solar_azimuth_sin",
+            "solar_azimuth_cos",
+        } <= fitted
+
+    def test_reference_stat_cols_reach_model_and_recovery_holds(self, tmp_path: Path) -> None:
+        mi = self._prepost_mi()
+        method = PowerModelMethod(
+            active_power_col=_POWER,
+            availability_col=_AVAIL,
+            baseline_rated_power_kw=2300.0,
+            wind_speed_col=_WS,
+            conditional_uplift=False,
+            model_params=_FAST_PARAMS,
+            reference_stat_cols=(_POWER_MAX, _POWER_MIN, _POWER_SD),
+            out_dir=tmp_path,
+        )
+        out = method.estimate(mi)
+        assert out.p50_overall == pytest.approx(0.05, abs=0.02)
+        fitted = self._fitted_feature_names(tmp_path)
+        assert {f"{_POWER_SD} @ R1", f"{_POWER_MAX} @ R2", f"{_POWER_MIN} @ R3"} <= fitted
+        assert not any(name.endswith(" @ T1") for name in fitted)
+
+    def test_era5_derivations_without_era5_raises(self) -> None:
+        method = PowerModelMethod(
+            active_power_col=_POWER,
+            availability_col=_AVAIL,
+            baseline_rated_power_kw=2300.0,
+            wind_speed_col=_WS,
+            era5_derivations=("gust_ratio",),
+        )
+        with pytest.raises(ValueError, match="need ERA5"):
+            method.estimate(self._prepost_mi(n=300))
+
+    def test_unknown_time_feature_raises(self) -> None:
+        method = PowerModelMethod(
+            active_power_col=_POWER,
+            availability_col=_AVAIL,
+            baseline_rated_power_kw=2300.0,
+            wind_speed_col=_WS,
+            time_features=("hour_of_week",),
+        )
+        with pytest.raises(ValueError, match="unknown time feature"):
+            method.estimate(self._prepost_mi(n=300))
+
+    def test_solar_requires_lat_long(self) -> None:
+        method = PowerModelMethod(
+            active_power_col=_POWER,
+            availability_col=_AVAIL,
+            baseline_rated_power_kw=2300.0,
+            wind_speed_col=_WS,
+            time_features=("solar",),
+        )
+        with pytest.raises(ValueError, match="latitude and longitude"):
+            method.estimate(self._prepost_mi(n=300))
 
 
 class TestRelevelConditional:

--- a/tests/benchmarking/baselines/test_time_features.py
+++ b/tests/benchmarking/baselines/test_time_features.py
@@ -1,0 +1,120 @@
+"""Tests for the explicit time features in ``benchmarking.baselines.time_features``.
+
+Checks known-input values for each feature (a plain linear day-count, a solstice-anchored
+sin/cos pair, and NOAA solar-position altitude/azimuth against hand-verified reference
+points), plus the shared tz-naive-index error path.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from benchmarking.baselines.time_features import (
+    TIME_FEATURE_NAMES,
+    days_since_campaign_start,
+    season_sin_cos,
+    solar_altitude_azimuth,
+)
+
+# Hill of Towie, Aberdeenshire -- a real wind_up test site, used as the solar-position fixture.
+_HILL_OF_TOWIE_LATITUDE = 57.50
+_HILL_OF_TOWIE_LONGITUDE = -3.25
+
+
+def test_time_feature_names_vocabulary() -> None:
+    assert TIME_FEATURE_NAMES == ("days_since_campaign_start", "season", "solar")
+
+
+def test_days_since_campaign_start_exact_values() -> None:
+    campaign_start = pd.Timestamp("2020-01-01 00:00:00", tz="UTC")
+    index = pd.DatetimeIndex(["2019-12-31 00:00:00", "2020-01-01 00:00:00", "2020-01-02 12:00:00"], tz="UTC")
+
+    result = days_since_campaign_start(index, campaign_start=campaign_start)
+
+    assert result.name == "days_since_campaign_start"
+    np.testing.assert_allclose(result.to_numpy(), [-1.0, 0.0, 1.5])
+    assert result.index.equals(index)
+
+
+def test_days_since_campaign_start_raises_on_tz_naive_index() -> None:
+    index = pd.DatetimeIndex(["2020-01-01 00:00:00"])
+    with pytest.raises(ValueError, match="timezone-aware"):
+        days_since_campaign_start(index, campaign_start=pd.Timestamp("2020-01-01", tz="UTC"))
+
+
+def test_season_sin_cos_june_solstice_noon() -> None:
+    index = pd.DatetimeIndex(["2018-06-21 12:00:00"], tz="UTC")
+
+    result = season_sin_cos(index)
+
+    assert list(result.columns) == ["season_sin", "season_cos"]
+    np.testing.assert_allclose(result["season_cos"].to_numpy(), [1.0], atol=0.01)
+    np.testing.assert_allclose(result["season_sin"].to_numpy(), [0.0], atol=0.02)
+
+
+def test_season_sin_cos_december_solstice() -> None:
+    index = pd.DatetimeIndex(["2018-12-21 00:00:00"], tz="UTC")
+
+    result = season_sin_cos(index)
+
+    np.testing.assert_allclose(result["season_cos"].to_numpy(), [-1.0], atol=0.01)
+
+
+def test_season_sin_cos_is_on_unit_circle() -> None:
+    index = pd.date_range("2018-01-01", periods=50, freq="7D", tz="UTC")
+
+    result = season_sin_cos(index)
+
+    magnitude_sq = result["season_sin"].to_numpy() ** 2 + result["season_cos"].to_numpy() ** 2
+    np.testing.assert_allclose(magnitude_sq, np.ones_like(magnitude_sq))
+
+
+def test_season_sin_cos_raises_on_tz_naive_index() -> None:
+    index = pd.DatetimeIndex(["2018-06-21 12:00:00"])
+    with pytest.raises(ValueError, match="timezone-aware"):
+        season_sin_cos(index)
+
+
+def test_solar_altitude_azimuth_hill_of_towie_summer_noon() -> None:
+    """Sun near its highest, roughly due south, at midsummer local noon."""
+    index = pd.DatetimeIndex(["2018-06-21 12:00:00"], tz="UTC")
+
+    result = solar_altitude_azimuth(index, latitude=_HILL_OF_TOWIE_LATITUDE, longitude=_HILL_OF_TOWIE_LONGITUDE)
+
+    assert result["solar_altitude"].to_numpy()[0] == pytest.approx(55.7, abs=1.0)
+    # Azimuth close to due south (180 degrees): sin small, cos close to -1.
+    assert result["solar_azimuth_sin"].to_numpy()[0] == pytest.approx(0.1, abs=0.15)
+    assert result["solar_azimuth_cos"].to_numpy()[0] == pytest.approx(-1.0, abs=0.05)
+
+
+def test_solar_altitude_azimuth_hill_of_towie_midnight_is_below_horizon() -> None:
+    index = pd.DatetimeIndex(["2018-06-21 00:00:00"], tz="UTC")
+
+    result = solar_altitude_azimuth(index, latitude=_HILL_OF_TOWIE_LATITUDE, longitude=_HILL_OF_TOWIE_LONGITUDE)
+
+    assert result["solar_altitude"].to_numpy()[0] < 0.0
+
+
+def test_solar_altitude_azimuth_equator_equinox_noon_near_zenith() -> None:
+    index = pd.DatetimeIndex(["2019-03-21 12:00:00"], tz="UTC")
+
+    result = solar_altitude_azimuth(index, latitude=0.0, longitude=0.0)
+
+    assert result["solar_altitude"].to_numpy()[0] > 85.0
+
+
+def test_solar_azimuth_sin_cos_on_unit_circle() -> None:
+    index = pd.date_range("2018-01-01", periods=100, freq="97min", tz="UTC")
+
+    result = solar_altitude_azimuth(index, latitude=_HILL_OF_TOWIE_LATITUDE, longitude=_HILL_OF_TOWIE_LONGITUDE)
+
+    magnitude_sq = result["solar_azimuth_sin"].to_numpy() ** 2 + result["solar_azimuth_cos"].to_numpy() ** 2
+    np.testing.assert_allclose(magnitude_sq, np.ones_like(magnitude_sq))
+
+
+def test_solar_altitude_azimuth_raises_on_tz_naive_index() -> None:
+    index = pd.DatetimeIndex(["2018-06-21 12:00:00"])
+    with pytest.raises(ValueError, match="timezone-aware"):
+        solar_altitude_azimuth(index, latitude=_HILL_OF_TOWIE_LATITUDE, longitude=_HILL_OF_TOWIE_LONGITUDE)

--- a/tests/benchmarking/baselines/test_time_features.py
+++ b/tests/benchmarking/baselines/test_time_features.py
@@ -38,6 +38,12 @@ def test_days_since_campaign_start_exact_values() -> None:
     assert result.index.equals(index)
 
 
+def test_days_since_campaign_start_raises_on_tz_naive_campaign_start() -> None:
+    index = pd.date_range("2018-06-21", periods=3, freq="D", tz="UTC")
+    with pytest.raises(ValueError, match="campaign_start must be timezone-aware"):
+        days_since_campaign_start(index, campaign_start=pd.Timestamp("2018-06-22"))
+
+
 def test_days_since_campaign_start_raises_on_tz_naive_index() -> None:
     index = pd.DatetimeIndex(["2020-01-01 00:00:00"])
     with pytest.raises(ValueError, match="timezone-aware"):

--- a/tests/benchmarking/baselines/test_time_features.py
+++ b/tests/benchmarking/baselines/test_time_features.py
@@ -71,6 +71,25 @@ def test_season_sin_cos_is_on_unit_circle() -> None:
     np.testing.assert_allclose(magnitude_sq, np.ones_like(magnitude_sq))
 
 
+def test_season_sin_cos_leap_year_anchor_stays_on_june21() -> None:
+    # 2020 is a leap year: June 21 is day-of-year 173, and the anchor must move with it.
+    index = pd.DatetimeIndex(["2020-06-21 12:00:00"], tz="UTC")
+
+    result = season_sin_cos(index)
+
+    np.testing.assert_allclose(result["season_cos"].to_numpy(), [1.0], atol=0.01)
+    np.testing.assert_allclose(result["season_sin"].to_numpy(), [0.0], atol=0.02)
+
+
+def test_season_sin_cos_non_utc_index_encodes_the_same_instants() -> None:
+    utc = pd.DatetimeIndex(["2018-06-21 12:00:00"], tz="UTC")
+    same_instant_elsewhere = utc.tz_convert("Australia/Sydney")
+
+    np.testing.assert_allclose(
+        season_sin_cos(same_instant_elsewhere).to_numpy(), season_sin_cos(utc).to_numpy(), atol=1e-12
+    )
+
+
 def test_season_sin_cos_raises_on_tz_naive_index() -> None:
     index = pd.DatetimeIndex(["2018-06-21 12:00:00"])
     with pytest.raises(ValueError, match="timezone-aware"):


### PR DESCRIPTION
## Issue 9 — ERA5 feature engineering: derived quantities + hub-height interpolation (WS2)

**Goal:** use ERA5 better. Today the model consumes the raw Open-Meteo columns (plus
direction sin/cos); derive the physically meaningful, §3-legal quantities that actually
drive turbine power and its scatter — including a turbulence proxy, which the model
currently lacks entirely (the F5 root cause: the §3 rule denies it the test turbine's own
ws/TI, so its residuals correlate with TI). This issue also establishes the shared
**candidate-by-candidate evaluation protocol** that Issues 10–11 reuse.

**Evaluation protocol (shared by Issues 9–11).** There are many ideas for improving the
input data available to the model; they must be tested **one by one** (or in the smallest
sensible groups) so each one's effect is known. Per candidate: add it, A/B via
`study_power_model_compare.py` against the committed benchmark, and accept only what earns
its place. Gates: **overall P50 no worse** — the placebo prepost bias is the sharpest read
(a feature that imports temporal drift shows up there); **conditional** mean |bias| /
`implied_shrinkage` improved or neutral; **feature importance sane** (the F2 lesson: a
channel can act as a calendar proxy; the Issue 5 voltage lesson: importance diagnostics
are the giveaway). Record every accepted **and rejected** candidate with evidence in
`findings.md`; regenerate the benchmark JSON whenever a default changes.

**Scope (the ERA5 candidates)**
- **Hub-height wind speed.** New optional `hub_height_m` config (Hill of Towie = 59 m).
  Compute the local shear exponent `alpha = ln(ws_100m/ws_10m)/ln(10)` per row and
  interpolate with the shear power law: `ws_hh = ws_100m · (hh/100)^alpha`.
- **Gust turbulence proxy:** `wind_gusts_10m / wind_speed_10m` — a unitless, TI-like
  quantity (guard the calm-wind denominator). Do a comparison to real (SCADA) TI and play around with the calculation if it the ERA5 derived TI is not realistic.
- **Shear exponent** `alpha` as a feature in its own right (F6 already validated it as a
  real independent signal and folded out the 10 m/100 m collinearity), **vertical veer**
  (`wind_direction_100m − wind_direction_10m`, wrapped to ±180°), **air density** (from
  temperature + surface pressure + humidity), and a **stability indicator** if the
  available fields allow.
- Build as a **shared ERA5-derivation utility** so every method *and* the CEM matching
  step reuse it (the shear derivation currently lives only in
  `inspect_era5_matching_importance.py`).
- Optionally revisit `matching_vars` afterwards (e.g. the gust proxy or `alpha` in place
  of raw gusts, per F6's deferral) — a separate benchmark regeneration if taken.

**Done when:** the derivation utility exists with unit tests (known-input checks); every
candidate has an accept/reject verdict recorded in `findings.md`; the benchmark is
regenerated under the accepted default set with overall P50 and conditional no worse.

---

## Issue 10 — Time features: campaign-relative drift, season, solar position (WS2)

**Goal:** today the timestamp is dropped before modelling, so the model cannot know about
anything that varies with time but not weather. Trial explicitly-constructed time features
— the headline motivation is **reference turbines changing over time**, a major bias risk
and one of the main challenges the method must deal with: a drift feature gives the model
a chance to absorb reference change instead of attributing it to the upgrade. It is also possible to ERA5 to drift over time vs the site due to ERA5 input data changes over time and site exposure changes over time (eg forestry growth, new neighbour wind farm, etc.)

**Scope (one by one, per the Issue 9 protocol)**
- **`time_since_campaign_start`** continuous value in unit of days (negative in the baseline). Lets the model track
  slow reference change relative to the campaign.
- **Time of year:** continuous value measuring the Julian day offset to a meteorologically meaningful anchor (say
  June 21), split into sin/cos components — tells the model roughly what season it is,
  potentially useful beyond the instantaneous weather data.
- **Time of day, as solar altitude + azimuth** computed from an optional lat/long config
  and the UTC timestamp (a physically meaningful encoding of diurnal cycle; calculation
  code exists in other projects and can be ported).
- **Known caveats to test against, not reasons to skip.** In prepost,
  `time_since_campaign_start` is treatment-collinear, and trees cannot extrapolate — for
  upgraded rows the feature exceeds every training value, so predictions clamp at the
  boundary leaves: it can encode baseline-internal drift but freezes it at the changeover.
  Season features against a < 12-month baseline are partial calendar proxies. Whether each
  helps or imports bias is exactly what the placebo gate decides — run it at multiple
  campaign lengths in **both** modes before accepting.
- The R-learner's "no timestamp features" rule (later-work list) was about shuffled
  cross-fitting; power_model has no cross-fitting, so trialling these is legitimate — but
  a time feature dominating the importance ranking is a red flag.

**Done when:** each time feature has an accept/reject verdict with placebo evidence in
both modes in `findings.md`; the benchmark is regenerated if any are accepted.

---

## Issue 11 — Reference power statistics features (max / min / SD) (WS2)

**Goal:** give the counterfactual a local variability/turbulence signal through the most
**calibration-stable channel** — the reference power signal. Bring in each reference's
active-power **max, min and SD** companion fields (present in the Hill of Towie open
data; usually available from any wind farm). Within-period power SD in particular is a
§3-legal turbulence proxy, sited at the farm rather than at ERA5's grid scale.

**Why reference power and not reference wind speed:** reference nacelle wind speed /
wind-speed SD were considered and **rejected**. A reference anemometer is at high risk of
changing calibration over time; in a prepost campaign that drift would be read as uplift
(a toggle campaign might tolerate it, but prepost and toggle share one code path, so the
risky feature stays out of both). Reference *power* is more likely to be stable — and
since references are usually the same turbine type as the test turbine, exposed to the
same performance-degradation tendencies, it leads to a fairer expectation of what the
test turbine could have produced.

**Scope**
- Wire the max/min/SD active-power fields through `build_reference_features` (same
  `"<tag> @ <turbine>"` naming; NaN-tolerant as today; `check_reference_only` still
  applies). Column names configurable like the existing `active_power_col`.
- A/B per the Issue 9 protocol: one field (or the trio) at a time, placebo gate,
  importance watch — power max/min/SD could in principle carry a drift signature too
  (e.g. a reference derate changes its max), which is precisely what the placebo run
  detects.
- Confirm the harness/synthetic path carries these columns unmodified for reference
  turbines (only the test turbine's signals are injected).

**Done when:** verdict per field recorded in `findings.md`; benchmark regenerated if
accepted; the rejected reference-anemometer alternative and its rationale are noted in
the findings entry.

---

## F12 — reference active-power **minimum** accepted as a default feature; SD and max rejected (Issue 11)

*2026-07-04 — Issue 11 verdicts. Candidates A/B'd one field at a time per the Issue 9 protocol:
`study_power_model_compare.py --method-overrides '{"reference_stat_cols": [...]}'` against the committed
benchmark — placebo (`cp_0pct`, both modes) screen first, full 7-profile sweep for survivors. The HoT
loader now also unpacks `wtc_ActPower_max` / `wtc_ActPower_min` (the SD was already loaded); the fields
reach the model via `build_reference_features(..., extra_cols=...)` /
`PowerModelMethod.reference_stat_cols`.*

### Verdicts (deltas vs the pre-change benchmark, in pp; negative = better)
- **`wtc_ActPower_min` — ACCEPTED, now the default** (`reference_stat_cols=("wtc_ActPower_min",)` in the
  HoT drivers). Better on every gate in both modes: overall P50 Δ|bias| −0.01 (prepost) / −0.006 (toggle),
  Δspread ~0 / −0.009; conditional mean Δ|bias| **−0.46 (prepost)** / **−0.75 (toggle)**, Δscore −0.40 /
  −1.30. Interpretation: the within-period minimum tells the model when a reference dipped (gust lulls,
  brief curtailments) — a farm-sited variability signal the mean hides. **Benchmark JSON regenerated**
  from this configuration's full sweep.
- **`wtc_ActPower_stddev` — REJECTED.** The placebo screen alone disqualified it: conditional mean
  Δ|bias| +2.8 / Δscore +3.98 (prepost), +0.65 / +1.38 (toggle), and it jumped to importance rank 5.
  The within-period power SD is exactly the kind of channel the placebo gate exists for.
- **`wtc_ActPower_max` — REJECTED.** Full sweep: it shifts the prepost overall bias **uniformly +0.33 pp
  across all seven profiles** — a counterfactual level shift, not uplift tracking. That happens to offset
  the structural −0.4 pp prepost headline bias (|bias| improves) but costs spread (+0.08; 240/469 cells
  worse) and is an accidental cancellation — Issue 13 addresses that bias properly. Toggle-side it helps
  (−1.13 conditional), but combined with `min` (trio minus SD) it is toxic: prepost conditional
  Δ|bias| +3.4 / Δscore +5.2. Max and min together destabilise the matched conditional fits.
- **Reference nacelle wind speed / wind-speed SD — rejected without trial** (recorded per the issue): a
  reference anemometer is at high risk of calibration drift, which a prepost campaign reads as uplift;
  reference *power* is the calibration-stable channel, and same-type references degrade like the test
  turbine, giving a fairer counterfactual expectation.

### Method note
Importance rank alone was a poor red-flag here: `max`/`min` both ranked 3rd–4th (gain frac 3–4%), yet one
was accepted and one rejected — the benchmark gates (placebo bias, spread, conditional cells) did the
discriminating, not the ranking.

---

## F11 — explicit time features rejected: campaign-drift, season and solar all fail or add nothing (Issue 10)

*2026-07-04 — Issue 10 verdicts. `benchmarking/baselines/time_features.py` ships the features
(`days_since_campaign_start`, June-21-anchored `season` sin/cos, NOAA `solar` altitude/azimuth validated
against an ephem reference to <0.01°) behind `PowerModelMethod.time_features` (+ `latitude`/`longitude`),
default **off**. A/B'd one at a time on the placebo (`cp_0pct`, both modes) via
`study_power_model_compare.py --method-overrides`.*

### Verdicts (placebo deltas vs benchmark, pp)
- **`days_since_campaign_start` — REJECTED.** Prepost is the anticipated failure, measured: overall
  Δbias +0.23, Δspread **+1.08**, Δscore +0.97; conditional Δscore +5.3 with 54/67 cells worse. Trees
  cannot extrapolate the feature past the changeover (every upgraded-row value exceeds the training
  range, so predictions clamp at boundary leaves), which *adds* variance instead of absorbing drift.
  Toggle is ~neutral (−0.001 overall) — but prepost and toggle share one code path, so it stays out.
- **`season` — REJECTED.** Prepost overall slightly worse (Δscore +0.14, max Δ|bias| +0.26 at one
  campaign length), conditional worse in both modes (+0.39 / +0.16). Against a <12-month baseline the
  pair is a partial calendar proxy, as the issue warned.
- **`solar` — REJECTED.** Neutral overall (≤0.03) but conditional worse in both modes (+0.90 / +0.29
  Δscore) and negligible importance (rank 22–24 of 32, gain frac ≤0.0003) — the instantaneous weather
  columns already carry the diurnal signal at this site.

### Method note
The feared "time feature dominating the importance ranking" red flag never fired — all three sat far
down the ranking (gain frac ≤0.0006) *while still doing damage through spread*. The placebo benchmark
gate, not the importance watch, is the effective detector for drift-importing features. The module stays
in the tree for future sources (e.g. a site with genuine reference drift may re-litigate
`days_since_campaign_start` in toggle-only form).

---

## F10 — ERA5 derived quantities: utility shipped; hub-height wind speed validated standalone; no derivation earns a default place in the full model (Issue 9)

*2026-07-04 — Issue 9 verdicts. `benchmarking/baselines/era5_derived.py` is the shared derivation
utility (shear exponent, hub-height ws via the shear power law + `hub_height_m` — `HOT_HUB_HEIGHT_M =
59.0`, gust ratio, gust margin, veer, moist-air density), reused by
`inspect_era5_matching_importance.py` and available to the CEM matching step; features reach the model
via `PowerModelMethod.era5_derivations`, default **off**. Screened per candidate on the placebo, full
sweeps for survivors (`study_power_model_compare.py --method-overrides`).*

### The gust "TI proxy" is not one (measured against real SCADA TI)
- `gust_ratio = wind_gusts_10m / wind_speed_10m` correlates with the test turbine's measured TI at
  **Pearson +0.03** (Spearman +0.11; T01, ws>4 m/s, n≈195k) and implies TI ≈ 0.31 at the median vs the
  real 0.17 — ERA5's hourly grid-scale gustiness is a different quantity from local 10-min turbulence.
- Variants (per the issue's "play around" instruction): the absolute **gust margin** `gusts − ws_100m`
  is the best simple correlate (+0.22), shear exponent −0.21, |veer| −0.21, `gusts/ws_100m` +0.11.
  A LightGBM fit of TI on *all* ERA5 columns reaches held-out **R² = 0.38**, dominated by wind-direction
  sin/cos (~31% of gain — wake/terrain sectors) — much of site TI is direction-determined and the model
  already sees direction.

### A/B verdicts (vs benchmark, pp)
- **`wind_speed_hub` — validated, left opt-in.** With reference features removed (ERA5-only ranking, the
  Issue 9 exploration) it *dominates*: 63% of gain, permutation importance 0.48 vs 0.10 for raw
  `wind_speed_100m`. In the full model its full sweep improves overall P50 in both modes (prepost
  Δ|bias| −0.02, Δspread −0.035 uniformly across profiles; toggle conditional −1.02 score) at a small
  prepost conditional cost (+0.13). But combined with the accepted `wtc_ActPower_min` its marginal value
  disappears (combo no better than `min` alone, toggle conditional diluted), so it is **not defaulted**;
  it is the natural candidate for the F6 `matching_vars` revisit and for reference-poor sources.
- **`shear_exponent`, `veer` — REJECTED (mode-split).** Both help toggle conditional (−0.41 / −0.47
  score) and hurt prepost (+0.80 / +0.54); one code path, so out.
- **`gust_ratio`, `gust_margin`, `air_density` — REJECTED.** Overall neutral; conditional worse
  (gust_ratio prepost +1.33 score with the (6, ws) cell +5.9; gust_margin +0.34/+0.23; air_density
  +0.60 prepost, 25/35 cells worse). Consistent with the TI-proxy result: these columns add split noise,
  not cause.

### Interpretation
The reference active-power features already carry the site signal ERA5 derivations try to reconstruct —
in the full model every derivation lands at gain frac ≤0.0012. ERA5 derivations matter where references
are absent: the ERA5-only fit (R² 0.85) is where `wind_speed_hub` shines, which is exactly the CEM
matching / AEP-extrapolation context (Issues 8/15), not the counterfactual feature set.

---