### PR TITLE
issue 12

### DIFF
--- a/benchmarking/baselines/example_prepost_study.py
+++ b/benchmarking/baselines/example_prepost_study.py
@@ -37,7 +37,7 @@ import pandas as pd
 
 from benchmarking.baselines.hot_context import build_hot_v0_context
 from benchmarking.baselines.naive_ratio import NaiveRatioMethod
-from benchmarking.baselines.power_model import CURATED_ERA5_EXCLUDE, PowerModelMethod
+from benchmarking.baselines.power_model import CURATED_ERA5_EXCLUDE, TUNED_MODEL_PARAMS, PowerModelMethod
 from benchmarking.baselines.v0_binned import V0BinnedMethod
 from benchmarking.harness import Method, StudyConfig, leaderboard, plot_campaign_curves, score_study
 from benchmarking.harness.example_hot_study import OracleMethod
@@ -150,6 +150,8 @@ def run_prepost_study(
                 # Removal-ablation accepted defaults (findings F13).
                 availability_feature=False,
                 era5_exclude=CURATED_ERA5_EXCLUDE,
+                # Issue 12 accepted default (findings F14): looser leaf capacity.
+                model_params=dict(TUNED_MODEL_PARAMS),
                 out_dir=out_dir / "power_model_runs",
             )
         )

--- a/benchmarking/baselines/example_toggle_study.py
+++ b/benchmarking/baselines/example_toggle_study.py
@@ -38,7 +38,7 @@ from benchmarking.baselines.example_prepost_study import (
 )
 from benchmarking.baselines.hot_context import build_hot_v0_context
 from benchmarking.baselines.naive_ratio import NaiveRatioMethod
-from benchmarking.baselines.power_model import CURATED_ERA5_EXCLUDE, PowerModelMethod
+from benchmarking.baselines.power_model import CURATED_ERA5_EXCLUDE, TUNED_MODEL_PARAMS, PowerModelMethod
 from benchmarking.baselines.v0_binned import V0BinnedMethod
 from benchmarking.harness import Method, StudyConfig, leaderboard, plot_campaign_curves, score_study
 from benchmarking.harness.example_hot_study import OracleMethod
@@ -118,6 +118,8 @@ def run_toggle_study(
                 # Removal-ablation accepted defaults (findings F13).
                 availability_feature=False,
                 era5_exclude=CURATED_ERA5_EXCLUDE,
+                # Issue 12 accepted default (findings F14): looser leaf capacity.
+                model_params=dict(TUNED_MODEL_PARAMS),
                 out_dir=out_dir / "power_model_runs",
             )
         )

--- a/benchmarking/baselines/inspect_prepost_hard_case.py
+++ b/benchmarking/baselines/inspect_prepost_hard_case.py
@@ -45,7 +45,7 @@ from benchmarking.baselines.hot_context import build_hot_v0_context
 from benchmarking.baselines.naive_ratio import NaiveRatioMethod
 from benchmarking.baselines.overnight_common import start_overnight_run
 from benchmarking.baselines.overnight_profiles import overnight_profiles
-from benchmarking.baselines.power_model import CURATED_ERA5_EXCLUDE, PowerModelMethod
+from benchmarking.baselines.power_model import CURATED_ERA5_EXCLUDE, TUNED_MODEL_PARAMS, PowerModelMethod
 from benchmarking.baselines.v0_binned import V0BinnedMethod
 from benchmarking.harness import (
     CONDITION_BINS,
@@ -166,6 +166,8 @@ def _power_model(out_dir: Path, era5_hourly_df: pd.DataFrame, *, save_plots: boo
         # Removal-ablation accepted defaults (findings F13).
         availability_feature=False,
         era5_exclude=CURATED_ERA5_EXCLUDE,
+        # Issue 12 accepted default (findings F14): looser leaf capacity.
+        model_params=dict(TUNED_MODEL_PARAMS),
         out_dir=out_dir,
         save_plots=save_plots,
     )

--- a/benchmarking/baselines/power_model/__init__.py
+++ b/benchmarking/baselines/power_model/__init__.py
@@ -7,6 +7,7 @@ baseline, predict the counterfactual over the upgraded window, and take the ener
 
 from __future__ import annotations
 
-from benchmarking.baselines.power_model.method import CURATED_ERA5_EXCLUDE, PowerModelMethod
+from benchmarking.baselines.power_model.fitting import OUTCOME_MODEL_FACTORIES
+from benchmarking.baselines.power_model.method import CURATED_ERA5_EXCLUDE, TUNED_MODEL_PARAMS, PowerModelMethod
 
-__all__ = ["CURATED_ERA5_EXCLUDE", "PowerModelMethod"]
+__all__ = ["CURATED_ERA5_EXCLUDE", "OUTCOME_MODEL_FACTORIES", "TUNED_MODEL_PARAMS", "PowerModelMethod"]

--- a/benchmarking/baselines/power_model/diagnostics.py
+++ b/benchmarking/baselines/power_model/diagnostics.py
@@ -74,8 +74,14 @@ class DiagnosticData:
 
 
 def feature_importance_long(data: DiagnosticData) -> pd.DataFrame:
-    """Long table of LightGBM gain/split importance for the (single) outcome power model."""
-    booster = data.outcome_model.booster_
+    """Long table of LightGBM gain/split importance for the (single) outcome power model.
+
+    An alternative learner injected via the model-factory seam has no ``booster_``; the table then
+    carries NaN importances (the feature *catalogue* still works) rather than failing the run.
+    """
+    booster = getattr(data.outcome_model, "booster_", None)
+    if booster is None:
+        return pd.DataFrame({"feature": data.feature_names, "gain": np.nan, "split_count": np.nan})
     return pd.DataFrame(
         {
             "feature": data.feature_names,

--- a/benchmarking/baselines/power_model/fitting.py
+++ b/benchmarking/baselines/power_model/fitting.py
@@ -114,6 +114,10 @@ def early_stopped_n_estimators(
         eval_set=[(x.iloc[valid_mask], y[valid_mask])],
         callbacks=[lightgbm.early_stopping(stopping_rounds=stopping_rounds, verbose=False)],
     )
+    # With the callback attached, best_iteration_ is a positive int whether or not early stopping
+    # triggered (= n_estimators when it never did). None/0 are LightGBM's "no early stopping ran"
+    # sentinels (0 is the Booster-level value), so both fall back to the ceiling — a plain
+    # `is not None` check would turn the 0 sentinel into a zero-tree model.
     best = getattr(model, "best_iteration_", None)
     chosen = int(best) if best else int(model.n_estimators)
     logger.info(

--- a/benchmarking/baselines/power_model/fitting.py
+++ b/benchmarking/baselines/power_model/fitting.py
@@ -1,0 +1,165 @@
+"""Outcome-model fitting strategies for the power model (Issue 12).
+
+Pure helpers behind ``PowerModelMethod``'s model-fundamentals knobs:
+
+* :func:`time_block_folds` — contiguous-block, round-robin fold assignment for time-ordered rows.
+  A shuffled split leaks autocorrelation (held-out rows sit minutes from training rows), so its
+  residuals are optimistic; contiguous blocks confine the leakage to the block edges, which makes
+  the held-out fit-quality diagnostics honest and gives the calibration a usable basis.
+* :func:`fit_calibration_line` — the post-hoc calibration-slope correction: a least-squares line
+  ``actual ~ a + b * predicted`` fit on out-of-fold baseline predictions, applied to the
+  counterfactual predictions (the cheap de-shrinking cousin of residual calibration).
+* :func:`early_stopped_n_estimators` — data-size-adaptive capacity: pick the LightGBM tree count
+  by early stopping on a time-blocked validation split, then refit on all rows at that capacity
+  (the 3-month toggle fit and the 2-year prepost baseline differ ~10x in rows but share one
+  capacity today).
+* :data:`OUTCOME_MODEL_FACTORIES` — the model-factory seam: named, JSON-addressable factories for
+  alternative outcome learners. Every factory maps ``seed -> unfitted sklearn-style regressor``
+  whose objective targets the **conditional mean** (the estimand is an energy ratio and energy is
+  a sum of conditional means, so median-type objectives are out; design note §2).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+logger = logging.getLogger(__name__)
+
+_MIN_CALIBRATION_ROWS = 100
+_MIN_PREDICTION_STD = 1e-12  # below this the predictions are effectively constant; a line fit is degenerate
+
+
+def time_block_folds(n: int, *, n_folds: int = 5, n_blocks: int = 25) -> np.ndarray:
+    """Assign ``n`` time-ordered rows to ``n_folds`` folds as round-robin contiguous blocks.
+
+    Rows must already be in time order (the power model's row arrays are — they follow the sorted
+    analysis index). The rows are cut into ``n_blocks`` contiguous, equal-length blocks and block
+    ``i`` goes to fold ``i % n_folds``, so every fold samples all seasons while staying contiguous
+    at the scale that matters for autocorrelation (only the block edges sit near training rows).
+    Returns an int array of fold ids, one per row.
+    """
+    if n_folds < 2 or n_blocks < n_folds:  # noqa: PLR2004
+        msg = f"need n_folds >= 2 and n_blocks >= n_folds, got n_folds={n_folds}, n_blocks={n_blocks}"
+        raise ValueError(msg)
+    block = np.minimum((np.arange(n) * n_blocks) // max(n, 1), n_blocks - 1)
+    return (block % n_folds).astype(int)
+
+
+@dataclass(frozen=True)
+class CalibrationLine:
+    """The post-hoc calibration line ``corrected = intercept + slope * predicted``.
+
+    ``slope`` is the predicted-vs-actual calibration slope (target ~= 1); a slope > 1 means the
+    model's predictions are compressed toward the mean (shrinkage) and the correction stretches
+    them back out.
+    """
+
+    intercept: float
+    slope: float
+
+    def apply(self, predicted: np.ndarray) -> np.ndarray:
+        """Return the calibrated predictions."""
+        return self.intercept + self.slope * np.asarray(predicted, dtype=float)
+
+
+IDENTITY_CALIBRATION = CalibrationLine(intercept=0.0, slope=1.0)
+
+
+def fit_calibration_line(y: np.ndarray, predicted: np.ndarray) -> CalibrationLine:
+    """Least-squares ``y ~ a + b * predicted`` over finite pairs (the calibration-slope fit).
+
+    ``predicted`` must be **out-of-fold** (a prediction of each row from a model not trained on
+    it) or the slope is optimistically ~1 by in-sample construction. Falls back to the identity
+    line when there are too few pairs or the predictions are degenerate (near-zero variance), so
+    applying the result is always safe.
+    """
+    y = np.asarray(y, dtype=float)
+    predicted = np.asarray(predicted, dtype=float)
+    finite = np.isfinite(y) & np.isfinite(predicted)
+    if int(finite.sum()) < _MIN_CALIBRATION_ROWS or float(np.std(predicted[finite])) <= _MIN_PREDICTION_STD:
+        return IDENTITY_CALIBRATION
+    slope, intercept = np.polyfit(predicted[finite], y[finite], deg=1)
+    return CalibrationLine(intercept=float(intercept), slope=float(slope))
+
+
+def early_stopped_n_estimators(
+    make_model: Callable[[], Any],
+    x: Any,  # noqa: ANN401 - pd.DataFrame
+    y: np.ndarray,
+    *,
+    valid_mask: np.ndarray,
+    stopping_rounds: int = 100,
+) -> int:
+    """Pick the LightGBM tree count by early stopping on the given validation rows.
+
+    ``make_model`` returns the probe regressor, already configured with the capacity **ceiling**
+    as its ``n_estimators``. The probe is fit on ``~valid_mask`` rows with ``valid_mask`` rows as
+    the eval set; the returned count is the best iteration (the ceiling itself when early stopping
+    never triggers), for the caller to refit on **all** rows at that capacity.
+    """
+    import lightgbm  # noqa: PLC0415 - optional dependency, imported lazily like the factories
+
+    train = ~np.asarray(valid_mask, dtype=bool)
+    model = make_model()
+    model.fit(
+        x.iloc[train],
+        y[train],
+        eval_set=[(x.iloc[valid_mask], y[valid_mask])],
+        callbacks=[lightgbm.early_stopping(stopping_rounds=stopping_rounds, verbose=False)],
+    )
+    best = getattr(model, "best_iteration_", None)
+    chosen = int(best) if best else int(model.n_estimators)
+    logger.info(
+        "early stopping picked n_estimators=%d (ceiling %d, n_train=%d)", chosen, model.n_estimators, int(train.sum())
+    )
+    return chosen
+
+
+def _make_hgb(seed: int) -> Any:  # noqa: ANN401
+    """Sklearn ``HistGradientBoostingRegressor`` — a same-family (boosted trees, L2) sanity check.
+
+    Capacity mirrors the LightGBM defaults where the knobs correspond (600 iterations, lr 0.03,
+    63 leaves, ``min_samples_leaf=200``); NaN handling is native, like LightGBM's.
+    """
+    from sklearn.ensemble import HistGradientBoostingRegressor  # noqa: PLC0415
+
+    return HistGradientBoostingRegressor(
+        loss="squared_error",
+        max_iter=600,
+        learning_rate=0.03,
+        max_leaf_nodes=63,
+        min_samples_leaf=200,
+        early_stopping=False,
+        random_state=seed,
+    )
+
+
+def _make_linear(seed: int) -> Any:  # noqa: ANN401 ARG001
+    """Deliberately low-variance structured baseline: median-impute -> standardise -> Ridge.
+
+    Lightly regularised so it is nearly shrinkage-free — a cross-check on the tree models'
+    conditional bias, valuable even though its overall accuracy is worse. Deterministic, so the
+    seed is unused.
+    """
+    from sklearn.impute import SimpleImputer  # noqa: PLC0415
+    from sklearn.linear_model import Ridge  # noqa: PLC0415
+    from sklearn.pipeline import make_pipeline  # noqa: PLC0415
+    from sklearn.preprocessing import StandardScaler  # noqa: PLC0415
+
+    return make_pipeline(SimpleImputer(strategy="median"), StandardScaler(), Ridge(alpha=1.0))
+
+
+# The model-factory seam: named factories (seed -> unfitted regressor) selectable by string on
+# ``PowerModelMethod.model_factory`` (JSON-addressable for --method-overrides A/B runs). All are
+# conditional-mean learners; a callable can be passed directly for anything not registered.
+OUTCOME_MODEL_FACTORIES: dict[str, Callable[[int], Any]] = {
+    "hgb": _make_hgb,
+    "linear": _make_linear,
+}

--- a/benchmarking/baselines/power_model/method.py
+++ b/benchmarking/baselines/power_model/method.py
@@ -248,7 +248,8 @@ class PowerModelMethod:
         ``actual ~ a + b * predicted`` on time-blocked out-of-fold baseline predictions and apply
         the line to the counterfactual predictions before the energy ratio (default ``False``).
         Applies to the overall headline only — the conditional two-direction step cancels its
-        per-bin shrinkage by construction.
+        per-bin shrinkage by construction. The line is fit with single-seed, non-early-stopped
+        models, so it cannot be combined with ``early_stopping`` or ``n_seed_ensemble > 1``.
     """
 
     active_power_col: str
@@ -736,6 +737,13 @@ class PowerModelMethod:
         if self.n_seed_ensemble > 1 and "random_state" in self.model_params:
             msg = "a fixed random_state in model_params would make every ensemble member identical."
             raise ValueError(msg)
+        if self.calibrate_slope and (self.early_stopping or self.n_seed_ensemble > 1):
+            msg = (
+                "calibrate_slope fits its out-of-fold line with single-seed, non-early-stopped models, "
+                "so combining it with early_stopping or n_seed_ensemble > 1 would calibrate against a "
+                "different model configuration than the predictions it corrects."
+            )
+            raise ValueError(msg)
 
     def _make_model(self, *, seed: int | None = None, extra_params: dict[str, Any] | None = None) -> Any:  # noqa: ANN401
         """One unfitted outcome model: the ``model_factory`` seam, or LightGBM with ``seed`` plumbed in.
@@ -940,6 +948,20 @@ class PowerModelMethod:
         }
         write_run_config(ctx, method_name=self.name, method_params=self._config_params(), extra=extra)
 
+    def _model_factory_label(self) -> str | None:
+        """Return a stable, diffable label for ``model_factory`` in the run-config YAML.
+
+        Registry names pass through; a callable is identified by ``module.qualname`` rather than
+        ``repr`` (whose memory address would make the YAML nondeterministic across runs).
+        """
+        if self.model_factory is None or isinstance(self.model_factory, str):
+            return self.model_factory
+        module = getattr(self.model_factory, "__module__", None)
+        qualname = getattr(self.model_factory, "__qualname__", None)
+        if qualname is None:  # e.g. functools.partial or a callable instance
+            return f"<callable {type(self.model_factory).__name__}>"
+        return f"{module}.{qualname}" if module else qualname
+
     def _config_params(self) -> dict[str, Any]:
         """Return the power-model configuration recorded in the run-config YAML."""
         return {
@@ -960,7 +982,7 @@ class PowerModelMethod:
             "era5_exclude": list(self.era5_exclude),
             "availability_feature": self.availability_feature,
             "model_params": self.model_params,
-            "model_factory": (repr(self.model_factory) if callable(self.model_factory) else self.model_factory),
+            "model_factory": self._model_factory_label(),
             "n_seed_ensemble": self.n_seed_ensemble,
             "early_stopping": self.early_stopping,
             "calibrate_slope": self.calibrate_slope,

--- a/benchmarking/baselines/power_model/method.py
+++ b/benchmarking/baselines/power_model/method.py
@@ -40,6 +40,14 @@ from benchmarking.baselines.power_model.features import (
     reference_mean_wind_speed,
     test_condition_signals,
 )
+from benchmarking.baselines.power_model.fitting import (
+    IDENTITY_CALIBRATION,
+    OUTCOME_MODEL_FACTORIES,
+    CalibrationLine,
+    early_stopped_n_estimators,
+    fit_calibration_line,
+    time_block_folds,
+)
 from benchmarking.baselines.power_model.matching import coarsened_exact_match
 from benchmarking.baselines.rlearner.nuisance import make_outcome_model
 from benchmarking.baselines.time_features import (
@@ -54,12 +62,21 @@ from benchmarking.harness.method import MethodInput, MethodOutput
 from benchmarking.synthetic import HOT_COLUMNS, ToggleSchedule, treated_mask
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from benchmarking.synthetic import ColumnSchema
 
 logger = logging.getLogger(__name__)
 
 _MIN_BASELINE_ROWS = 10
 _MIN_HOLDOUT_ROWS = 20  # below this, report the in-sample fit (no point splitting off a tiny valid set)
+# Time-blocked split shape shared by the holdout diagnostic, the early-stopping valid set and the
+# calibration OOF: 25 contiguous blocks round-robin over 5 folds, so each fold is ~20% of the rows
+# spread across the whole window (seasonally balanced) while staying contiguous at the block scale.
+_N_FOLDS = 5
+_N_BLOCKS = 25
+_MIN_EARLY_STOPPING_ROWS = 200  # below this a valid split is too small for early stopping to mean anything
+_EARLY_STOPPING_CEILING = 3000  # capacity ceiling when early stopping picks the tree count
 
 # The removal-ablation verdict (findings F13): raw Open-Meteo columns the curated feature set does
 # better without — redundant thermodynamic derivatives of temperature/humidity and the precipitation
@@ -73,6 +90,12 @@ CURATED_ERA5_EXCLUDE: tuple[str, ...] = (
     "rain",
     "snowfall",
 )
+
+# The Issue 12 capacity verdict (findings F14): loosening min_child_samples 200 -> 50 materially
+# improves prepost spread/score (placebo ALL Δscore -0.62 pp) at neutral overall P50; 20 overshoots
+# into overfit. A power_model-specific tuning — the design-note common params in
+# ``make_outcome_model`` (shared with the R-learner) are unchanged; drivers pass this instead.
+TUNED_MODEL_PARAMS: dict[str, Any] = {"min_child_samples": 50}
 
 # F6 matching set + bin widths for the bias-cancellation correction, verified on real HoT by the CEM
 # coverage sweep (docs/v1/findings.md F6). wind_speed_100m (dominant) is binned finest, wind_gusts_10m
@@ -211,6 +234,21 @@ class PowerModelMethod:
         ``matching_vars`` cannot be excluded while ``conditional_uplift`` is on.
     :param availability_feature: when ``False``, drop the per-reference availability *feature*
         (removal-ablation knob); ``availability_col`` itself stays required for the downtime filter
+    :param model_factory: the outcome-model seam (Issue 12): a registered factory name (see
+        :data:`~benchmarking.baselines.power_model.fitting.OUTCOME_MODEL_FACTORIES`) or a callable
+        ``seed -> unfitted sklearn-style regressor``. ``None`` (default) keeps the design-note
+        LightGBM model. A factory bakes in its own hyperparameters, so it cannot be combined with
+        ``model_params`` or ``early_stopping``.
+    :param n_seed_ensemble: fit this many models (seeds ``seed .. seed+K-1``) per training set and
+        average their predictions — variance reduction from the subsample/colsample noise (default 1)
+    :param early_stopping: pick the LightGBM tree count by early stopping on a time-blocked
+        validation split, then refit on all training rows at that capacity — data-size-adaptive
+        capacity instead of one fixed ``n_estimators`` for every fit size (default ``False``)
+    :param calibrate_slope: post-hoc calibration-slope correction (Issue 12): fit
+        ``actual ~ a + b * predicted`` on time-blocked out-of-fold baseline predictions and apply
+        the line to the counterfactual predictions before the energy ratio (default ``False``).
+        Applies to the overall headline only — the conditional two-direction step cancels its
+        per-bin shrinkage by construction.
     """
 
     active_power_col: str
@@ -238,9 +276,14 @@ class PowerModelMethod:
     reference_stat_cols: tuple[str, ...] = ()
     era5_exclude: tuple[str, ...] = ()
     availability_feature: bool = True
+    model_factory: str | Callable[[int], Any] | None = None
+    n_seed_ensemble: int = 1
+    early_stopping: bool = False
+    calibrate_slope: bool = False
 
     def estimate(self, mi: MethodInput) -> MethodOutput:
         """Estimate the test turbine's P50 uplift for one campaign and write diagnostics."""
+        self._validate_model_config()
         mi = restrict_to_campaign(mi, toggle_campaign_only=self.toggle_campaign_only)
         scada = mi.scada_df
         if self.availability_col not in scada.columns:
@@ -422,11 +465,14 @@ class PowerModelMethod:
     def _fit_direction(
         self, features: pd.DataFrame, y: np.ndarray, *, train: np.ndarray, predict: np.ndarray
     ) -> np.ndarray:
-        """Fit the outcome model on ``train`` rows and return clipped predictions for ``predict`` rows."""
-        model = self._make_model()
-        model.fit(features.iloc[train], y[train])
+        """Fit the outcome model(s) on ``train`` rows and return clipped predictions for ``predict`` rows.
+
+        No calibration here: the two-direction combine cancels the common per-bin shrinkage by
+        construction, so the slope correction is spent only on the overall headline.
+        """
+        models = self._fit_models(features.iloc[train], y[train])
         return _clip_predictions(
-            np.asarray(model.predict(features.iloc[predict]), dtype=float),
+            self._predict_mean(models, features.iloc[predict]),
             y_train=y[train],
             rated_power_kw=self.baseline_rated_power_kw,
         )
@@ -643,9 +689,10 @@ class PowerModelMethod:
     ) -> dict[str, Any]:
         """Fit on baseline, predict the upgraded counterfactual; also a held-out baseline fit metric.
 
-        The final model (for the counterfactual) is fit on **all** baseline rows. A separate model on
-        a baseline train split predicts a held-out baseline slice, giving an honest fit-quality number
-        that is not inflated by in-sample optimism.
+        The final model(s) (for the counterfactual) are fit on **all** baseline rows. A separate model
+        on a baseline train split predicts a held-out baseline slice, giving an honest fit-quality
+        number that is not inflated by in-sample optimism. When ``calibrate_slope`` is on, the
+        counterfactual predictions pass through the out-of-fold calibration line before clipping.
         """
         x_base = features.iloc[baseline_sel]
         y_base = y[baseline_sel]
@@ -655,53 +702,129 @@ class PowerModelMethod:
         y_valid, pred_valid, valid_local = self._holdout_fit(x_base, y_base)
         baseline_valid_pos = np.flatnonzero(baseline_sel)[valid_local]
 
-        final = self._make_model()
-        final.fit(x_base, y_base)
+        models = self._fit_models(x_base, y_base)
+        calibration = self._fit_calibration(x_base, y_base) if self.calibrate_slope else IDENTITY_CALIBRATION
         pred_up = _clip_predictions(
-            np.asarray(final.predict(x_up), dtype=float), y_train=y_base, rated_power_kw=self.baseline_rated_power_kw
+            calibration.apply(self._predict_mean(models, x_up)),
+            y_train=y_base,
+            rated_power_kw=self.baseline_rated_power_kw,
         )
         return {
-            "model": final,
+            "model": models[0],
             "pred_upgraded": pred_up,
             "y_upgraded": y_up,
             "y_baseline_valid": y_valid,
             "pred_baseline_valid": pred_valid,
             "baseline_valid_pos": baseline_valid_pos,  # positions over ``index`` of the held-out rows
+            "calibration": calibration,
         }
 
-    def _make_model(self) -> Any:  # noqa: ANN401
-        """Outcome model with ``seed`` plumbed into LightGBM's ``random_state`` (caller overrides win)."""
-        return make_outcome_model(**{"random_state": self.seed, **self.model_params})
+    def _validate_model_config(self) -> None:
+        """Fail loudly on model-fundamentals config combinations that would silently misbehave."""
+        if isinstance(self.model_factory, str) and self.model_factory not in OUTCOME_MODEL_FACTORIES:
+            msg = f"unknown model_factory {self.model_factory!r}; registered: {sorted(OUTCOME_MODEL_FACTORIES)}"
+            raise ValueError(msg)
+        if self.model_factory is not None and self.model_params:
+            msg = "model_factory bakes in its own hyperparameters; model_params would be silently ignored."
+            raise ValueError(msg)
+        if self.model_factory is not None and self.early_stopping:
+            msg = "early_stopping picks a LightGBM tree count; it cannot be combined with model_factory."
+            raise ValueError(msg)
+        if self.n_seed_ensemble < 1:
+            msg = f"n_seed_ensemble must be >= 1, got {self.n_seed_ensemble}"
+            raise ValueError(msg)
+        if self.n_seed_ensemble > 1 and "random_state" in self.model_params:
+            msg = "a fixed random_state in model_params would make every ensemble member identical."
+            raise ValueError(msg)
+
+    def _make_model(self, *, seed: int | None = None, extra_params: dict[str, Any] | None = None) -> Any:  # noqa: ANN401
+        """One unfitted outcome model: the ``model_factory`` seam, or LightGBM with ``seed`` plumbed in.
+
+        For the default LightGBM path a caller-supplied ``random_state`` in ``model_params`` still
+        wins over ``seed``; ``extra_params`` (the early-stopped capacity) wins over everything.
+        """
+        s = self.seed if seed is None else seed
+        if self.model_factory is not None:
+            factory = (
+                OUTCOME_MODEL_FACTORIES[self.model_factory]
+                if isinstance(self.model_factory, str)
+                else self.model_factory
+            )
+            return factory(s)
+        return make_outcome_model(**{"random_state": s, **self.model_params, **(extra_params or {})})
+
+    def _fit_models(self, x_train: pd.DataFrame, y_train: np.ndarray) -> list[Any]:
+        """Fit the outcome model(s) on one training set, honouring ``early_stopping`` / ``n_seed_ensemble``.
+
+        Early stopping runs once (a probe fit on a time-blocked split picks the tree count), then every
+        ensemble member is refit on **all** training rows at that capacity with its own seed.
+        """
+        extra: dict[str, Any] = {}
+        if self.early_stopping and len(y_train) >= _MIN_EARLY_STOPPING_ROWS:
+            ceiling = int(self.model_params.get("n_estimators", _EARLY_STOPPING_CEILING))
+            extra["n_estimators"] = early_stopped_n_estimators(
+                lambda: self._make_model(extra_params={"n_estimators": ceiling}),
+                x_train,
+                y_train,
+                valid_mask=time_block_folds(len(y_train), n_folds=_N_FOLDS, n_blocks=_N_BLOCKS) == 0,
+            )
+        models = []
+        for k in range(self.n_seed_ensemble):
+            model = self._make_model(seed=self.seed + k, extra_params=extra)
+            model.fit(x_train, y_train)
+            models.append(model)
+        return models
+
+    @staticmethod
+    def _predict_mean(models: list[Any], x: pd.DataFrame) -> np.ndarray:
+        """Seed-ensemble prediction: the mean over the fitted models (unclipped)."""
+        return np.mean([np.asarray(m.predict(x), dtype=float) for m in models], axis=0)
+
+    def _fit_calibration(self, x_base: pd.DataFrame, y_base: np.ndarray) -> CalibrationLine:
+        """Fit the calibration line on time-blocked out-of-fold baseline predictions (single-seed fits).
+
+        Every baseline row gets a prediction from a model not trained on its fold, so the slope is not
+        flattered by in-sample optimism (a shuffled or in-sample basis would read ~1 by construction).
+        """
+        n = len(y_base)
+        if n < _MIN_HOLDOUT_ROWS:
+            return IDENTITY_CALIBRATION
+        folds = time_block_folds(n, n_folds=_N_FOLDS, n_blocks=_N_BLOCKS)
+        oof = np.full(n, np.nan)
+        for f in range(_N_FOLDS):
+            hold = folds == f
+            model = self._make_model()
+            model.fit(x_base.iloc[~hold], y_base[~hold])
+            oof[hold] = np.asarray(model.predict(x_base.iloc[hold]), dtype=float)
+        line = fit_calibration_line(y_base, oof)
+        logger.info("%s calibration line: slope=%.4f intercept=%.2f (n=%d)", self.name, line.slope, line.intercept, n)
+        return line
 
     def _holdout_fit(self, x_base: pd.DataFrame, y_base: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
         """Train on a baseline train split, predict a held-out baseline slice (honest fit quality).
 
-        Also returns the held-out rows' positions **within the baseline block** so the caller can
-        line the residuals up with their conditions (ws/TI) for the diagnostics.
+        The held-out slice is **time-blocked** (fold 0 of the shared split shape), not shuffled — a
+        shuffled holdout sits minutes from its training rows, so autocorrelation makes its residuals
+        optimistic. Also returns the held-out rows' positions **within the baseline block** so the
+        caller can line the residuals up with their conditions (ws/TI) for the diagnostics.
         """
         n = len(y_base)
         if n < _MIN_HOLDOUT_ROWS:
-            model = self._make_model()
-            model.fit(x_base, y_base)
+            models = self._fit_models(x_base, y_base)
             pred = _clip_predictions(
-                np.asarray(model.predict(x_base), dtype=float),
+                self._predict_mean(models, x_base),
                 y_train=y_base,
                 rated_power_kw=self.baseline_rated_power_kw,
             )
             return y_base, pred, np.arange(n)
-        rng = np.random.default_rng(self.seed)
-        order = rng.permutation(n)
-        n_valid = n // 5
-        valid_idx = order[:n_valid]
-        train_idx = order[n_valid:]
-        model = self._make_model()
-        model.fit(x_base.iloc[train_idx], y_base[train_idx])
+        valid = time_block_folds(n, n_folds=_N_FOLDS, n_blocks=_N_BLOCKS) == 0
+        models = self._fit_models(x_base.iloc[~valid], y_base[~valid])
         pred_valid = _clip_predictions(
-            np.asarray(model.predict(x_base.iloc[valid_idx]), dtype=float),
-            y_train=y_base[train_idx],
+            self._predict_mean(models, x_base.iloc[valid]),
+            y_train=y_base[~valid],
             rated_power_kw=self.baseline_rated_power_kw,
         )
-        return y_base[valid_idx], pred_valid, valid_idx
+        return y_base[valid], pred_valid, np.flatnonzero(valid)
 
     def _run_dir(self, mi: MethodInput, index: pd.DatetimeIndex) -> Path:
         """Return the per-run output folder ``<out_dir>/power_model_<wtg>_<start>_<end>`` (a temp dir when unset).
@@ -837,4 +960,8 @@ class PowerModelMethod:
             "era5_exclude": list(self.era5_exclude),
             "availability_feature": self.availability_feature,
             "model_params": self.model_params,
+            "model_factory": (repr(self.model_factory) if callable(self.model_factory) else self.model_factory),
+            "n_seed_ensemble": self.n_seed_ensemble,
+            "early_stopping": self.early_stopping,
+            "calibrate_slope": self.calibrate_slope,
         }

--- a/benchmarking/baselines/study_power_model_compare.py
+++ b/benchmarking/baselines/study_power_model_compare.py
@@ -87,7 +87,7 @@ from benchmarking.baselines.example_prepost_study import (
 from benchmarking.baselines.example_toggle_study import DEFAULT_TOGGLE_PERIOD
 from benchmarking.baselines.hot_context import build_hot_v0_context
 from benchmarking.baselines.overnight_profiles import overnight_profiles
-from benchmarking.baselines.power_model import CURATED_ERA5_EXCLUDE, PowerModelMethod
+from benchmarking.baselines.power_model import CURATED_ERA5_EXCLUDE, TUNED_MODEL_PARAMS, PowerModelMethod
 from benchmarking.harness import (
     StudyConfig,
     conditional_leaderboard,
@@ -201,6 +201,8 @@ def _make_power_model(
         # redundant thermodynamic/precipitation ERA5 columns.
         "availability_feature": False,
         "era5_exclude": CURATED_ERA5_EXCLUDE,
+        # Issue 12 accepted default (findings F14): looser leaf capacity.
+        "model_params": dict(TUNED_MODEL_PARAMS),
         "out_dir": out_dir / "power_model_runs",
     }
     if overrides:

--- a/benchmarking/baselines/study_power_model_compare_baseline.json
+++ b/benchmarking/baselines/study_power_model_compare_baseline.json
@@ -2,8 +2,8 @@
   "schema": "power_model_compare_baseline_v2",
   "modes": {
     "prepost": {
-      "recorded_utc": "2026-07-04T11:35:03Z",
-      "git_commit": "1a478df-dirty",
+      "recorded_utc": "2026-07-04T15:12:20Z",
+      "git_commit": "47171a4-dirty",
       "n_replicates": 4,
       "seed": 0,
       "campaign_months": [
@@ -26,171 +26,171 @@
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00120936,
-          "spread": 0.00294773,
-          "score": 0.00318617
+          "bias": -0.00016895,
+          "spread": 0.00301475,
+          "score": 0.00301948
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.12207163,
+          "bias": 0.06908335,
           "spread": 0.0,
-          "score": 0.12207163
+          "score": 0.06908335
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.01237234,
-          "spread": 0.01481883,
-          "score": 0.01930473
+          "bias": -0.00912072,
+          "spread": 0.01147163,
+          "score": 0.01465557
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00208864,
-          "spread": 0.00451881,
-          "score": 0.00497816
+          "bias": 0.00223841,
+          "spread": 0.00420322,
+          "score": 0.00476209
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.0037385,
-          "spread": 0.0020399,
-          "score": 0.00425882
+          "bias": -0.0028987,
+          "spread": 0.00229472,
+          "score": 0.00369705
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00332704,
-          "spread": 0.01074896,
-          "score": 0.01125208
+          "bias": -0.00100239,
+          "spread": 0.01041473,
+          "score": 0.01046285
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": -0.00202179,
-          "spread": 0.02336512,
-          "score": 0.02345243
+          "bias": 0.0029679,
+          "spread": 0.01845849,
+          "score": 0.01869557
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.03297508,
-          "spread": 0.05049263,
-          "score": 0.0603064
+          "bias": -0.02875143,
+          "spread": 0.04128892,
+          "score": 0.05031321
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.06357861,
-          "spread": 0.09302898,
-          "score": 0.11267933
+          "bias": 0.07989222,
+          "spread": 0.10806762,
+          "score": 0.13439263
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.23462464,
-          "spread": 0.40448196,
-          "score": 0.46760494
+          "bias": 0.2637524,
+          "spread": 0.43798076,
+          "score": 0.51126556
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.18683716,
-          "spread": 0.79660277,
-          "score": 0.81822008
+          "bias": 0.2659076,
+          "spread": 0.77885138,
+          "score": 0.8229923
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.11040057,
-          "spread": 0.31772178,
-          "score": 0.33635608
+          "bias": -0.0941778,
+          "spread": 0.07660007,
+          "score": 0.12139616
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00041073,
-          "spread": 0.0075197,
-          "score": 0.00753091
+          "bias": -4.531e-05,
+          "spread": 0.00587507,
+          "score": 0.00587524
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00547481,
-          "spread": 0.0075027,
-          "score": 0.00928784
+          "bias": 0.0041206,
+          "spread": 0.00736971,
+          "score": 0.00844346
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.01136434,
-          "spread": 0.00847252,
-          "score": 0.01417504
+          "bias": 0.00895196,
+          "spread": 0.01064625,
+          "score": 0.01390971
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00140254,
-          "spread": 0.00850077,
-          "score": 0.0086157
+          "bias": -0.000362,
+          "spread": 0.00453073,
+          "score": 0.00454517
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.01358,
-          "spread": 0.01588256,
-          "score": 0.0208967
+          "bias": 0.01017731,
+          "spread": 0.0154395,
+          "score": 0.01849205
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.12110035,
-          "spread": 0.10670492,
-          "score": 0.16140395
+          "bias": -0.10197168,
+          "spread": 0.10777949,
+          "score": 0.14837332
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.0150516,
-          "spread": 0.04275081,
-          "score": 0.04532309
+          "bias": -0.00627086,
+          "spread": 0.02932543,
+          "score": 0.0299884
         },
         {
           "profile": "cp_0pct",
@@ -215,36 +215,36 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00998837,
-          "spread": 0.01933413,
-          "score": 0.02176181
+          "bias": -0.00157961,
+          "spread": 0.01519473,
+          "score": 0.01527662
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00794316,
-          "spread": 0.01078858,
-          "score": 0.01339728
+          "bias": -0.00421194,
+          "spread": 0.010672,
+          "score": 0.0114731
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00587845,
-          "spread": 0.00721646,
-          "score": 0.00930771
+          "bias": -0.00380189,
+          "spread": 0.00870777,
+          "score": 0.00950156
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00300067,
-          "spread": 0.00226196,
-          "score": 0.00375772
+          "bias": 0.0034204,
+          "spread": 0.00217975,
+          "score": 0.00405591
         },
         {
           "profile": "cp_0pct",
@@ -260,162 +260,162 @@
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00167303,
-          "spread": 0.00663827,
-          "score": 0.00684585
+          "bias": -0.00265019,
+          "spread": 0.00717478,
+          "score": 0.00764859
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00362049,
-          "spread": 0.00243486,
-          "score": 0.00436308
+          "bias": 0.00266841,
+          "spread": 0.00212948,
+          "score": 0.00341395
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00055699,
-          "spread": 0.00233296,
-          "score": 0.00239853
+          "bias": 0.00140732,
+          "spread": 0.00254222,
+          "score": 0.00290576
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00510153,
-          "spread": 0.00712748,
-          "score": 0.00876508
+          "bias": 0.00737318,
+          "spread": 0.00571102,
+          "score": 0.00932628
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00827919,
-          "spread": 0.00903417,
-          "score": 0.01225403
+          "bias": 0.01194715,
+          "spread": 0.0069784,
+          "score": 0.01383592
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.0109377,
-          "spread": 0.01704072,
-          "score": 0.02024893
+          "bias": 0.01162629,
+          "spread": 0.01248746,
+          "score": 0.01706187
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.07473308,
-          "spread": 0.06851502,
-          "score": 0.10138709
+          "bias": 0.08069209,
+          "spread": 0.07869795,
+          "score": 0.1127146
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.22495603,
-          "spread": 0.06418127,
-          "score": 0.23393258
+          "bias": 0.25575882,
+          "spread": 0.05998212,
+          "score": 0.26269836
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.0633299,
-          "spread": 0.57549817,
-          "score": 0.57897221
+          "bias": 0.0273517,
+          "spread": 0.56666323,
+          "score": 0.56732295
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.02334352,
-          "spread": 0.2631843,
-          "score": 0.26421752
+          "bias": -0.11440496,
+          "spread": 0.10943213,
+          "score": 0.15831578
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.0008957,
-          "spread": 0.00304593,
-          "score": 0.0031749
+          "bias": 0.00063006,
+          "spread": 0.00299925,
+          "score": 0.00306471
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00548623,
-          "spread": 0.00562033,
-          "score": 0.00785409
+          "bias": 0.00358803,
+          "spread": 0.0041472,
+          "score": 0.0054839
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00835267,
-          "spread": 0.00611441,
-          "score": 0.01035148
+          "bias": 0.00519448,
+          "spread": 0.00336545,
+          "score": 0.00618941
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00482663,
-          "spread": 0.00523108,
-          "score": 0.00711762
+          "bias": 0.00281973,
+          "spread": 0.00215309,
+          "score": 0.00354777
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.03109943,
-          "spread": 0.04755708,
-          "score": 0.05682298
+          "bias": 0.01311291,
+          "spread": 0.0130995,
+          "score": 0.01853497
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.11291816,
-          "spread": 0.06809725,
-          "score": 0.1318626
+          "bias": -0.11464084,
+          "spread": 0.06607063,
+          "score": 0.13231723
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.01166266,
-          "spread": 0.05043091,
-          "score": 0.0517619
+          "bias": -0.00476418,
+          "spread": 0.02536846,
+          "score": 0.02581194
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.1944361,
+          "bias": 0.18109937,
           "spread": 0.0,
-          "score": 0.1944361
+          "score": 0.18109937
         },
         {
           "profile": "cp_0pct",
@@ -431,207 +431,207 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00294472,
-          "spread": 0.00270175,
-          "score": 0.00399636
+          "bias": 0.00846941,
+          "spread": 0.0069988,
+          "score": 0.010987
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00094195,
-          "spread": 0.00677045,
-          "score": 0.00683566
+          "bias": 0.00194563,
+          "spread": 0.00532388,
+          "score": 0.00566826
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00189932,
-          "spread": 0.00784102,
-          "score": 0.00806778
+          "bias": 0.0031503,
+          "spread": 0.00724321,
+          "score": 0.00789864
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 4.315e-05,
-          "spread": 0.00338294,
-          "score": 0.00338321
+          "bias": 0.00053585,
+          "spread": 0.00320815,
+          "score": 0.0032526
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.14352619,
+          "bias": 0.13813931,
           "spread": 0.0,
-          "score": 0.14352619
+          "score": 0.13813931
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.0031906,
-          "spread": 0.00246498,
-          "score": 0.00403188
+          "bias": -0.00288089,
+          "spread": 0.0032175,
+          "score": 0.00431877
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00108787,
-          "spread": 0.00233406,
-          "score": 0.00257513
+          "bias": -0.00043278,
+          "spread": 0.00233664,
+          "score": 0.00237638
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00094637,
-          "spread": 0.00429957,
-          "score": 0.00440248
+          "bias": -0.00045517,
+          "spread": 0.00400878,
+          "score": 0.00403454
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00299573,
-          "spread": 0.00438947,
-          "score": 0.00531431
+          "bias": 0.00336842,
+          "spread": 0.00436983,
+          "score": 0.00551739
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01001108,
-          "spread": 0.00490168,
-          "score": 0.01114667
+          "bias": 0.00922135,
+          "spread": 0.00641766,
+          "score": 0.01123475
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00180225,
-          "spread": 0.01174672,
-          "score": 0.01188417
+          "bias": 0.00058048,
+          "spread": 0.01232549,
+          "score": 0.01233915
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.05311871,
-          "spread": 0.052568,
-          "score": 0.07473281
+          "bias": 0.05132899,
+          "spread": 0.04414552,
+          "score": 0.06770149
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.35855897,
-          "spread": 0.38891391,
-          "score": 0.5289788
+          "bias": 0.37368366,
+          "spread": 0.39407341,
+          "score": 0.54307764
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.82103771,
-          "spread": 0.71963603,
-          "score": 1.09177787
+          "bias": 0.8742901,
+          "spread": 0.73872644,
+          "score": 1.14459597
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.09832414,
-          "spread": 0.10476674,
-          "score": 0.14367917
+          "bias": -0.10420271,
+          "spread": 0.09169912,
+          "score": 0.13880538
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00046073,
-          "spread": 0.00251403,
-          "score": 0.0025559
+          "bias": 0.00051167,
+          "spread": 0.00276714,
+          "score": 0.00281404
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00098379,
-          "spread": 0.00336072,
-          "score": 0.00350176
+          "bias": 0.00086443,
+          "spread": 0.00246008,
+          "score": 0.00260753
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00124188,
-          "spread": 0.00316563,
-          "score": 0.00340051
+          "bias": 0.00144594,
+          "spread": 0.00198458,
+          "score": 0.00245546
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00036853,
-          "spread": 0.00134806,
-          "score": 0.00139753
+          "bias": -1.6e-07,
+          "spread": 0.0005908,
+          "score": 0.0005908
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00169876,
-          "spread": 0.00434743,
-          "score": 0.00466754
+          "bias": 0.0008949,
+          "spread": 0.00302055,
+          "score": 0.00315033
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.12648349,
-          "spread": 0.07016081,
-          "score": 0.1446396
+          "bias": -0.12464721,
+          "spread": 0.0698015,
+          "score": 0.14286069
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.01467869,
-          "spread": 0.02679489,
-          "score": 0.03055209
+          "bias": 0.00894075,
+          "spread": 0.01504116,
+          "score": 0.01749781
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.07044116,
-          "spread": 0.05057416,
-          "score": 0.08671622
+          "bias": 0.05339098,
+          "spread": 0.04155347,
+          "score": 0.06765565
         },
         {
           "profile": "cp_0pct",
@@ -647,198 +647,198 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00125573,
-          "spread": 0.0081073,
-          "score": 0.00820397
+          "bias": 0.00082169,
+          "spread": 0.0071036,
+          "score": 0.00715096
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.0016511,
-          "spread": 0.00823808,
-          "score": 0.00840191
+          "bias": 0.00032125,
+          "spread": 0.00681354,
+          "score": 0.00682111
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00033879,
-          "spread": 0.00781086,
-          "score": 0.0078182
+          "bias": 0.00025681,
+          "spread": 0.00713496,
+          "score": 0.00713958
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00105103,
-          "spread": 0.00276975,
-          "score": 0.00296247
+          "bias": -8.319e-05,
+          "spread": 0.00282093,
+          "score": 0.00282216
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.0896622,
+          "bias": 0.07825479,
           "spread": 0.0,
-          "score": 0.0896622
+          "score": 0.07825479
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.01436947,
-          "spread": 0.01495131,
-          "score": 0.02073701
+          "bias": -0.01261494,
+          "spread": 0.01148004,
+          "score": 0.01705661
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.0016897,
-          "spread": 0.00353612,
-          "score": 0.00391908
+          "bias": -0.0015053,
+          "spread": 0.0040732,
+          "score": 0.00434245
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00249134,
-          "spread": 0.00256771,
-          "score": 0.0035777
+          "bias": -0.00196589,
+          "spread": 0.00301779,
+          "score": 0.00360163
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00057387,
-          "spread": 0.00914196,
-          "score": 0.00915996
+          "bias": 0.00326579,
+          "spread": 0.00952025,
+          "score": 0.01006482
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00385933,
-          "spread": 0.01963781,
-          "score": 0.02001345
+          "bias": 0.00811631,
+          "spread": 0.01665766,
+          "score": 0.01852977
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.02410608,
-          "spread": 0.0449148,
-          "score": 0.05097492
+          "bias": -0.02018077,
+          "spread": 0.03863182,
+          "score": 0.04358533
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.06574782,
-          "spread": 0.07235291,
-          "score": 0.09776359
+          "bias": 0.08695532,
+          "spread": 0.08851129,
+          "score": 0.12407851
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.23169778,
-          "spread": 0.34400191,
-          "score": 0.41475435
+          "bias": 0.25695677,
+          "spread": 0.36421729,
+          "score": 0.44573649
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.33964473,
-          "spread": 0.62648756,
-          "score": 0.71263259
+          "bias": 0.29322666,
+          "spread": 0.65981012,
+          "score": 0.72203273
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.00906542,
-          "spread": 0.43589907,
-          "score": 0.43599332
+          "bias": -0.07374453,
+          "spread": 0.18769933,
+          "score": 0.2016663
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00268673,
-          "spread": 0.01074182,
-          "score": 0.01107273
+          "bias": 0.0034155,
+          "spread": 0.00972465,
+          "score": 0.01030701
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00081509,
-          "spread": 0.00785107,
-          "score": 0.00789326
+          "bias": -0.00257377,
+          "spread": 0.00835413,
+          "score": 0.00874162
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.0091186,
-          "spread": 0.0074532,
-          "score": 0.01177705
+          "bias": 0.00505902,
+          "spread": 0.01008945,
+          "score": 0.01128675
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00065549,
-          "spread": 0.00856267,
-          "score": 0.00858772
+          "bias": -0.00347498,
+          "spread": 0.00401143,
+          "score": 0.00530726
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.01293886,
-          "spread": 0.01368609,
-          "score": 0.01883409
+          "bias": 0.00870683,
+          "spread": 0.01325487,
+          "score": 0.01585876
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.07153959,
-          "spread": 0.07251678,
-          "score": 0.10186558
+          "bias": -0.05184434,
+          "spread": 0.07289313,
+          "score": 0.08944967
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.02177502,
-          "spread": 0.04975775,
-          "score": 0.05431377
+          "bias": -0.00158041,
+          "spread": 0.03740353,
+          "score": 0.0374369
         },
         {
           "profile": "cp_minus_10pct",
@@ -863,36 +863,36 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00956992,
-          "spread": 0.01859106,
-          "score": 0.02090959
+          "bias": -0.00149543,
+          "spread": 0.0179489,
+          "score": 0.01801109
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00755503,
-          "spread": 0.01095808,
-          "score": 0.01331007
+          "bias": -0.00432262,
+          "spread": 0.01116218,
+          "score": 0.01196993
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00371407,
-          "spread": 0.0073934,
-          "score": 0.00827386
+          "bias": -0.00105158,
+          "spread": 0.00846354,
+          "score": 0.00852861
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.002895,
-          "spread": 0.00211412,
-          "score": 0.00358477
+          "bias": 0.00328699,
+          "spread": 0.00203092,
+          "score": 0.00386379
         },
         {
           "profile": "cp_minus_10pct",
@@ -908,162 +908,162 @@
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00032589,
-          "spread": 0.00501012,
-          "score": 0.00502071
+          "bias": 0.00021613,
+          "spread": 0.00646895,
+          "score": 0.00647256
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00146461,
-          "spread": 0.00163766,
-          "score": 0.00219705
+          "bias": 0.00053886,
+          "spread": 0.0019241,
+          "score": 0.00199813
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00048363,
-          "spread": 0.00232793,
-          "score": 0.00237764
+          "bias": 0.00128805,
+          "spread": 0.00309272,
+          "score": 0.00335022
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00778453,
-          "spread": 0.00679812,
-          "score": 0.01033506
+          "bias": 0.00969937,
+          "spread": 0.00523976,
+          "score": 0.0110242
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01137612,
-          "spread": 0.00714018,
-          "score": 0.01343124
+          "bias": 0.0151468,
+          "spread": 0.00525788,
+          "score": 0.01603343
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.01294851,
-          "spread": 0.01753136,
-          "score": 0.02179478
+          "bias": 0.01446786,
+          "spread": 0.01245717,
+          "score": 0.01909189
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.07596016,
-          "spread": 0.05941033,
-          "score": 0.09643409
+          "bias": 0.08205695,
+          "spread": 0.06795682,
+          "score": 0.10654329
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.22150259,
-          "spread": 0.03855219,
-          "score": 0.22483254
+          "bias": 0.24768873,
+          "spread": 0.0317112,
+          "score": 0.24971045
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.01223292,
-          "spread": 0.46203135,
-          "score": 0.46219326
+          "bias": 0.07594973,
+          "spread": 0.4282179,
+          "score": 0.43490106
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.08798484,
-          "spread": 0.33872168,
-          "score": 0.34996244
+          "bias": -0.04077922,
+          "spread": 0.17268131,
+          "score": 0.17743105
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00410837,
-          "spread": 0.00430802,
-          "score": 0.00595296
+          "bias": 0.00375249,
+          "spread": 0.00421482,
+          "score": 0.00564322
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00057008,
-          "spread": 0.00671374,
-          "score": 0.0067379
+          "bias": -0.00179998,
+          "spread": 0.00444244,
+          "score": 0.00479325
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.0062025,
-          "spread": 0.00618177,
-          "score": 0.00875702
+          "bias": 0.00246414,
+          "spread": 0.00296485,
+          "score": 0.00385517
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00380554,
-          "spread": 0.00513381,
-          "score": 0.00639047
+          "bias": 0.00101575,
+          "spread": 0.00075504,
+          "score": 0.00126564
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.03083117,
-          "spread": 0.04655298,
-          "score": 0.05583674
+          "bias": 0.01264818,
+          "spread": 0.01389676,
+          "score": 0.01879086
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.05457938,
-          "spread": 0.03409597,
-          "score": 0.06435405
+          "bias": -0.05622529,
+          "spread": 0.03015875,
+          "score": 0.06380309
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.01641501,
-          "spread": 0.05150549,
-          "score": 0.054058
+          "bias": -0.00195644,
+          "spread": 0.02954977,
+          "score": 0.02961447
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.19937795,
+          "bias": 0.18877299,
           "spread": 0.0,
-          "score": 0.19937795
+          "score": 0.18877299
         },
         {
           "profile": "cp_minus_10pct",
@@ -1079,207 +1079,207 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00170127,
-          "spread": 0.00292315,
-          "score": 0.00338218
+          "bias": 0.00788366,
+          "spread": 0.00731416,
+          "score": 0.01075402
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.0015643,
-          "spread": 0.00740839,
-          "score": 0.00757174
+          "bias": 0.00183671,
+          "spread": 0.00526669,
+          "score": 0.00557778
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00340741,
-          "spread": 0.00759675,
-          "score": 0.00832593
+          "bias": 0.00454312,
+          "spread": 0.00634682,
+          "score": 0.00780526
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00011388,
-          "spread": 0.0031849,
-          "score": 0.00318694
+          "bias": 0.00057738,
+          "spread": 0.00301884,
+          "score": 0.00307356
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.11176534,
+          "bias": 0.10737095,
           "spread": 0.0,
-          "score": 0.11176534
+          "score": 0.10737095
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00055797,
-          "spread": 0.00517479,
-          "score": 0.00520479
+          "bias": 0.00066511,
+          "spread": 0.00479391,
+          "score": 0.00483983
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00173388,
-          "spread": 0.00204159,
-          "score": 0.00267851
+          "bias": -0.00114045,
+          "spread": 0.00222391,
+          "score": 0.00249928
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.0014788,
-          "spread": 0.00413664,
-          "score": 0.00439302
+          "bias": -0.00105168,
+          "spread": 0.00391048,
+          "score": 0.00404943
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00497604,
-          "spread": 0.00387083,
-          "score": 0.00630431
+          "bias": 0.00543238,
+          "spread": 0.00375554,
+          "score": 0.00660415
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01265144,
-          "spread": 0.00474559,
-          "score": 0.0135122
+          "bias": 0.01191023,
+          "spread": 0.00542832,
+          "score": 0.01308893
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00778036,
-          "spread": 0.01060958,
-          "score": 0.01315664
+          "bias": 0.00663651,
+          "spread": 0.0112,
+          "score": 0.01301857
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.05572183,
-          "spread": 0.04468634,
-          "score": 0.07142683
+          "bias": 0.05448575,
+          "spread": 0.04031565,
+          "score": 0.06777941
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.32524506,
-          "spread": 0.31614789,
-          "score": 0.45357892
+          "bias": 0.34007876,
+          "spread": 0.32220075,
+          "score": 0.46847293
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.92902579,
-          "spread": 0.4400985,
-          "score": 1.02799592
+          "bias": 0.96175829,
+          "spread": 0.47400706,
+          "score": 1.07222278
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.07710702,
-          "spread": 0.08771317,
-          "score": 0.11678652
+          "bias": -0.08546013,
+          "spread": 0.08832582,
+          "score": 0.12290193
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00438048,
-          "spread": 0.00235169,
-          "score": 0.00497183
+          "bias": 0.0040603,
+          "spread": 0.00231285,
+          "score": 0.00467282
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00328147,
-          "spread": 0.00356203,
-          "score": 0.00484315
+          "bias": -0.00320261,
+          "spread": 0.00299804,
+          "score": 0.00438691
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00071283,
-          "spread": 0.00309188,
-          "score": 0.00317299
+          "bias": -0.00037088,
+          "spread": 0.00175293,
+          "score": 0.00179174
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.0016607,
-          "spread": 0.00149006,
-          "score": 0.00223119
+          "bias": -0.00115122,
+          "spread": 0.0013135,
+          "score": 0.00174659
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00184109,
-          "spread": 0.00556922,
-          "score": 0.00586564
+          "bias": 0.00116299,
+          "spread": 0.00492523,
+          "score": 0.00506068
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.07174064,
-          "spread": 0.02877381,
-          "score": 0.07729587
+          "bias": -0.06974034,
+          "spread": 0.03093198,
+          "score": 0.07629222
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.01791244,
-          "spread": 0.02842609,
-          "score": 0.03359908
+          "bias": 0.0127267,
+          "spread": 0.01913397,
+          "score": 0.02297994
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.07573681,
-          "spread": 0.05392207,
-          "score": 0.09297125
+          "bias": 0.06003979,
+          "spread": 0.04368593,
+          "score": 0.07425118
         },
         {
           "profile": "cp_minus_10pct",
@@ -1295,198 +1295,198 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00166719,
-          "spread": 0.00845548,
-          "score": 0.00861827
+          "bias": 0.00087915,
+          "spread": 0.00722597,
+          "score": 0.00727925
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00228441,
-          "spread": 0.00795346,
-          "score": 0.00827503
+          "bias": -0.00040846,
+          "spread": 0.00671208,
+          "score": 0.0067245
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00118884,
-          "spread": 0.00715897,
-          "score": 0.00725701
+          "bias": 0.00152426,
+          "spread": 0.00662782,
+          "score": 0.00680084
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00136789,
-          "spread": 0.0031261,
-          "score": 0.00341227
+          "bias": -0.00025655,
+          "spread": 0.00320688,
+          "score": 0.00321713
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.11096596,
+          "bias": 0.108133,
           "spread": 0.0,
-          "score": 0.11096596
+          "score": 0.108133
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00989294,
-          "spread": 0.01505647,
-          "score": 0.01801576
+          "bias": -0.00917278,
+          "spread": 0.0132942,
+          "score": 0.01615164
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00584204,
-          "spread": 0.00602875,
-          "score": 0.00839495
+          "bias": 0.00551648,
+          "spread": 0.00479645,
+          "score": 0.0073101
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00499397,
-          "spread": 0.00275839,
-          "score": 0.00570512
+          "bias": -0.00406608,
+          "spread": 0.0020889,
+          "score": 0.00457127
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00759901,
-          "spread": 0.01271372,
-          "score": 0.0148116
+          "bias": -0.00396903,
+          "spread": 0.01182174,
+          "score": 0.01247023
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": -0.00730622,
-          "spread": 0.02857989,
-          "score": 0.029499
+          "bias": -0.00205064,
+          "spread": 0.02466697,
+          "score": 0.02475206
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.03881224,
-          "spread": 0.05607113,
-          "score": 0.06819356
+          "bias": -0.03378816,
+          "spread": 0.04924606,
+          "score": 0.05972281
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.06541148,
-          "spread": 0.11243163,
-          "score": 0.13007511
+          "bias": 0.08420959,
+          "spread": 0.12231169,
+          "score": 0.14849715
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.23631361,
-          "spread": 0.43039482,
-          "score": 0.49100287
+          "bias": 0.2578908,
+          "spread": 0.47566701,
+          "score": 0.54107926
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.43478116,
-          "spread": 0.96900339,
-          "score": 1.06207449
+          "bias": 0.15747284,
+          "spread": 0.93771082,
+          "score": 0.95084135
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.17898855,
-          "spread": 0.44414426,
-          "score": 0.47885387
+          "bias": -0.15381334,
+          "spread": 0.19470519,
+          "score": 0.24813032
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00500561,
-          "spread": 0.0073971,
-          "score": 0.00893158
+          "bias": -0.00345542,
+          "spread": 0.00429978,
+          "score": 0.00551616
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.01062112,
-          "spread": 0.00958686,
-          "score": 0.01430791
+          "bias": 0.0085149,
+          "spread": 0.0088842,
+          "score": 0.01230579
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.01257617,
-          "spread": 0.01207841,
-          "score": 0.01743697
+          "bias": 0.00967722,
+          "spread": 0.01304265,
+          "score": 0.01624066
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00145035,
-          "spread": 0.00807065,
-          "score": 0.00819993
+          "bias": -0.00055968,
+          "spread": 0.00648665,
+          "score": 0.00651075
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.01191047,
-          "spread": 0.01940325,
-          "score": 0.0227672
+          "bias": 0.00942854,
+          "spread": 0.0177043,
+          "score": 0.0200584
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.16010848,
-          "spread": 0.15607239,
-          "score": 0.22359185
+          "bias": -0.14161968,
+          "spread": 0.15727953,
+          "score": 0.21164353
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00720921,
-          "spread": 0.03805637,
-          "score": 0.03873319
+          "bias": -0.01250248,
+          "spread": 0.02461511,
+          "score": 0.02760825
         },
         {
           "profile": "cp_plus_10pct",
@@ -1511,36 +1511,36 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.01212325,
-          "spread": 0.0185166,
-          "score": 0.02213227
+          "bias": -0.00093778,
+          "spread": 0.01876127,
+          "score": 0.01878469
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.01008861,
-          "spread": 0.0082152,
-          "score": 0.01301036
+          "bias": -0.00431039,
+          "spread": 0.00990922,
+          "score": 0.01080611
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.0103711,
-          "spread": 0.0051581,
-          "score": 0.01158299
+          "bias": -0.00572124,
+          "spread": 0.00839842,
+          "score": 0.01016199
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00310628,
-          "spread": 0.00240997,
-          "score": 0.00393152
+          "bias": 0.00355396,
+          "spread": 0.0023294,
+          "score": 0.00424932
         },
         {
           "profile": "cp_plus_10pct",
@@ -1556,162 +1556,162 @@
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00293031,
-          "spread": 0.01037535,
-          "score": 0.01078122
+          "bias": -0.00329654,
+          "spread": 0.00960114,
+          "score": 0.01015131
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00581487,
-          "spread": 0.00367607,
-          "score": 0.0068794
+          "bias": 0.00481024,
+          "spread": 0.00279081,
+          "score": 0.00556121
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00067641,
-          "spread": 0.00250599,
-          "score": 0.00259567
+          "bias": 0.00139581,
+          "spread": 0.0022662,
+          "score": 0.00266157
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00212108,
-          "spread": 0.00796022,
-          "score": 0.00823797
+          "bias": 0.00454016,
+          "spread": 0.00677732,
+          "score": 0.00815752
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00509415,
-          "spread": 0.01105336,
-          "score": 0.01217075
+          "bias": 0.00922987,
+          "spread": 0.00898452,
+          "score": 0.01288069
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00749775,
-          "spread": 0.01684971,
-          "score": 0.01844259
+          "bias": 0.00918127,
+          "spread": 0.01507674,
+          "score": 0.0176523
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.07182245,
-          "spread": 0.08055147,
-          "score": 0.10792129
+          "bias": 0.07444438,
+          "spread": 0.08496186,
+          "score": 0.1129623
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.16595985,
-          "spread": 0.13529327,
-          "score": 0.21411899
+          "bias": 0.17782859,
+          "spread": 0.14754405,
+          "score": 0.23106764
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.24825245,
-          "spread": 0.33889456,
-          "score": 0.4200938
+          "bias": -0.10248773,
+          "spread": 0.56316086,
+          "score": 0.57241059
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.06289311,
-          "spread": 0.16250907,
-          "score": 0.17425482
+          "bias": -0.1123031,
+          "spread": 0.15037927,
+          "score": 0.18768567
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00274311,
-          "spread": 0.00388476,
-          "score": 0.00475563
+          "bias": -0.00242465,
+          "spread": 0.00309933,
+          "score": 0.00393508
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.01003943,
-          "spread": 0.0051134,
-          "score": 0.01126663
+          "bias": 0.00830147,
+          "spread": 0.00324099,
+          "score": 0.0089117
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.01004412,
-          "spread": 0.00655419,
-          "score": 0.0119934
+          "bias": 0.0069615,
+          "spread": 0.0039354,
+          "score": 0.00799687
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00541597,
-          "spread": 0.00575199,
-          "score": 0.00790051
+          "bias": 0.00331346,
+          "spread": 0.00374111,
+          "score": 0.00499749
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.0307486,
-          "spread": 0.04756738,
-          "score": 0.05664038
+          "bias": 0.01236245,
+          "spread": 0.01294514,
+          "score": 0.01789991
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.17145688,
-          "spread": 0.11314132,
-          "score": 0.20542254
+          "bias": -0.17707222,
+          "spread": 0.11778488,
+          "score": 0.2126684
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00712128,
-          "spread": 0.048952,
-          "score": 0.04946727
+          "bias": -0.00977548,
+          "spread": 0.02275134,
+          "score": 0.02476254
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.18471019,
+          "bias": 0.174475,
           "spread": 0.0,
-          "score": 0.18471019
+          "score": 0.174475
         },
         {
           "profile": "cp_plus_10pct",
@@ -1727,207 +1727,207 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00406034,
-          "spread": 0.00316616,
-          "score": 0.00514888
+          "bias": 0.00877584,
+          "spread": 0.00868639,
+          "score": 0.01234783
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00048829,
-          "spread": 0.00661821,
-          "score": 0.0066362
+          "bias": 0.002677,
+          "spread": 0.00468247,
+          "score": 0.00539369
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00066056,
-          "spread": 0.00846233,
-          "score": 0.00848807
+          "bias": 0.00160999,
+          "spread": 0.00770662,
+          "score": 0.007873
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -2.698e-05,
-          "spread": 0.00358059,
-          "score": 0.00358069
+          "bias": 0.00049447,
+          "spread": 0.00339741,
+          "score": 0.00343321
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.15931245,
+          "bias": 0.16084855,
           "spread": 0.0,
-          "score": 0.15931245
+          "score": 0.16084855
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00636788,
-          "spread": 0.00115051,
-          "score": 0.00647098
+          "bias": -0.00715256,
+          "spread": 0.00179146,
+          "score": 0.0073735
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00029661,
-          "spread": 0.00255771,
-          "score": 0.00257485
+          "bias": 0.00021264,
+          "spread": 0.0024553,
+          "score": 0.00246449
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00047277,
-          "spread": 0.00444058,
-          "score": 0.00446567
+          "bias": 5.1e-07,
+          "spread": 0.00418431,
+          "score": 0.00418431
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00061055,
-          "spread": 0.00511016,
-          "score": 0.0051465
+          "bias": 0.00158268,
+          "spread": 0.00506219,
+          "score": 0.00530383
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00776301,
-          "spread": 0.00567657,
-          "score": 0.00961706
+          "bias": 0.00668082,
+          "spread": 0.00744504,
+          "score": 0.0100031
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00399632,
-          "spread": 0.01338765,
-          "score": 0.01397139
+          "bias": -0.00349768,
+          "spread": 0.01527428,
+          "score": 0.01566964
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.05123575,
-          "spread": 0.05810948,
-          "score": 0.07747138
+          "bias": 0.05078987,
+          "spread": 0.05249071,
+          "score": 0.0730403
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.3769808,
-          "spread": 0.44148628,
-          "score": 0.58053825
+          "bias": 0.41214523,
+          "spread": 0.46235825,
+          "score": 0.61938586
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.71322948,
-          "spread": 1.00110909,
-          "score": 1.22919311
+          "bias": 0.77093733,
+          "spread": 1.06356398,
+          "score": 1.31358772
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.103947,
-          "spread": 0.12002327,
-          "score": 0.15877834
+          "bias": -0.12731091,
+          "spread": 0.11626236,
+          "score": 0.17240941
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00365048,
-          "spread": 0.00383766,
-          "score": 0.00529657
+          "bias": -0.0032016,
+          "spread": 0.00398459,
+          "score": 0.00511148
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00518674,
-          "spread": 0.00292542,
-          "score": 0.00595486
+          "bias": 0.00473674,
+          "spread": 0.00226507,
+          "score": 0.00525046
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.003146,
-          "spread": 0.00330017,
-          "score": 0.00455943
+          "bias": 0.00275821,
+          "spread": 0.00247124,
+          "score": 0.00370334
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00089968,
-          "spread": 0.00176542,
-          "score": 0.00198145
+          "bias": 0.00063185,
+          "spread": 0.0010934,
+          "score": 0.00126283
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00116337,
-          "spread": 0.00318498,
-          "score": 0.0033908
+          "bias": -2.311e-05,
+          "spread": 0.00167487,
+          "score": 0.00167503
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.18240299,
-          "spread": 0.11408167,
-          "score": 0.2151406
+          "bias": -0.17680819,
+          "spread": 0.11171677,
+          "score": 0.20914533
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.0104994,
-          "spread": 0.02441153,
-          "score": 0.02657367
+          "bias": 0.00380486,
+          "spread": 0.01172333,
+          "score": 0.01232531
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.06514802,
-          "spread": 0.04833989,
-          "score": 0.08112343
+          "bias": 0.04751507,
+          "spread": 0.04060043,
+          "score": 0.06249862
         },
         {
           "profile": "cp_plus_10pct",
@@ -1943,198 +1943,198 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00149291,
-          "spread": 0.00826294,
-          "score": 0.00839673
+          "bias": 0.00155337,
+          "spread": 0.00767499,
+          "score": 0.00783061
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.0012721,
-          "spread": 0.0084853,
-          "score": 0.00858012
+          "bias": 0.00069908,
+          "spread": 0.00700916,
+          "score": 0.00704393
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00183301,
-          "spread": 0.00838032,
-          "score": 0.00857845
+          "bias": -0.00092276,
+          "spread": 0.00754115,
+          "score": 0.00759739
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00125686,
-          "spread": 0.00300119,
-          "score": 0.00325374
+          "bias": -0.00019452,
+          "spread": 0.00307275,
+          "score": 0.00307891
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.13228286,
+          "bias": 0.06046989,
           "spread": 0.0,
-          "score": 0.13228286
+          "score": 0.06046989
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.01101027,
-          "spread": 0.01420275,
-          "score": 0.01797064
+          "bias": -0.0097195,
+          "spread": 0.01208851,
+          "score": 0.01551131
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00340302,
-          "spread": 0.00496217,
-          "score": 0.00601695
+          "bias": 0.00297597,
+          "spread": 0.00433629,
+          "score": 0.00525926
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.0042432,
-          "spread": 0.00227674,
-          "score": 0.00481542
+          "bias": -0.00304261,
+          "spread": 0.00193617,
+          "score": 0.00360642
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00457703,
-          "spread": 0.01132569,
-          "score": 0.01221558
+          "bias": -0.00182615,
+          "spread": 0.01078783,
+          "score": 0.0109413
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": -0.00475973,
-          "spread": 0.02485465,
-          "score": 0.0253063
+          "bias": 0.00151893,
+          "spread": 0.02112426,
+          "score": 0.0211788
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.03475382,
-          "spread": 0.05284287,
-          "score": 0.06324711
+          "bias": -0.02992135,
+          "spread": 0.04828985,
+          "score": 0.05680842
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.05758191,
-          "spread": 0.09380948,
-          "score": 0.11007223
+          "bias": 0.08072446,
+          "spread": 0.10050931,
+          "score": 0.128913
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.23340785,
-          "spread": 0.41164971,
-          "score": 0.4732174
+          "bias": 0.25803575,
+          "spread": 0.43625752,
+          "score": 0.50685607
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.12038303,
-          "spread": 0.82868243,
-          "score": 0.83738083
+          "bias": 0.2227821,
+          "spread": 0.80966259,
+          "score": 0.83975317
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.11489509,
-          "spread": 0.40066239,
-          "score": 0.41681079
+          "bias": -0.14906775,
+          "spread": 0.18918124,
+          "score": 0.24085418
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.0021266,
-          "spread": 0.00725091,
-          "score": 0.00755633
+          "bias": -0.00079742,
+          "spread": 0.0054878,
+          "score": 0.00554543
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00705676,
-          "spread": 0.00808803,
-          "score": 0.01073378
+          "bias": 0.00535453,
+          "spread": 0.00820187,
+          "score": 0.00979498
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.01189711,
-          "spread": 0.00967099,
-          "score": 0.01533197
+          "bias": 0.00852678,
+          "spread": 0.0113344,
+          "score": 0.0141836
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00196659,
-          "spread": 0.00828448,
-          "score": 0.0085147
+          "bias": -0.00095162,
+          "spread": 0.00475661,
+          "score": 0.00485087
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.01287465,
-          "spread": 0.01721664,
-          "score": 0.02149812
+          "bias": 0.00967763,
+          "spread": 0.01641662,
+          "score": 0.01905681
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.13573569,
-          "spread": 0.1260509,
-          "score": 0.1852377
+          "bias": -0.10881993,
+          "spread": 0.12978125,
+          "score": 0.16936632
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.01407683,
-          "spread": 0.04258955,
-          "score": 0.04485563
+          "bias": -0.00728661,
+          "spread": 0.02927925,
+          "score": 0.03017232
         },
         {
           "profile": "cp_plus_3pct",
@@ -2159,36 +2159,36 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.01107492,
-          "spread": 0.01973593,
-          "score": 0.02263097
+          "bias": -0.00161234,
+          "spread": 0.01722681,
+          "score": 0.0173021
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00825879,
-          "spread": 0.00975538,
-          "score": 0.01278182
+          "bias": -0.00498127,
+          "spread": 0.00961824,
+          "score": 0.01083161
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00688084,
-          "spread": 0.00678243,
-          "score": 0.00966164
+          "bias": -0.00411755,
+          "spread": 0.008217,
+          "score": 0.00919094
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00303237,
-          "spread": 0.00230633,
-          "score": 0.00380978
+          "bias": 0.00346054,
+          "spread": 0.00222461,
+          "score": 0.0041139
         },
         {
           "profile": "cp_plus_3pct",
@@ -2204,162 +2204,162 @@
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00230323,
-          "spread": 0.00720768,
-          "score": 0.00756674
+          "bias": -0.00223309,
+          "spread": 0.00852185,
+          "score": 0.00880958
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00425242,
-          "spread": 0.00285373,
-          "score": 0.00512122
+          "bias": 0.00345011,
+          "spread": 0.00212455,
+          "score": 0.00405179
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00057975,
-          "spread": 0.00230871,
-          "score": 0.00238039
+          "bias": 0.00139782,
+          "spread": 0.00251196,
+          "score": 0.00287469
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00430031,
-          "spread": 0.00748373,
-          "score": 0.00863127
+          "bias": 0.00614174,
+          "spread": 0.00617369,
+          "score": 0.00870836
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00751779,
-          "spread": 0.00962649,
-          "score": 0.01221419
+          "bias": 0.0110096,
+          "spread": 0.00841101,
+          "score": 0.01385483
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.01005615,
-          "spread": 0.01810125,
-          "score": 0.02070703
+          "bias": 0.01089798,
+          "spread": 0.01392544,
+          "score": 0.01768287
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.07439086,
-          "spread": 0.0691234,
-          "score": 0.10154824
+          "bias": 0.07524562,
+          "spread": 0.07762175,
+          "score": 0.10810661
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.22670622,
-          "spread": 0.06590753,
-          "score": 0.23609217
+          "bias": 0.25480312,
+          "spread": 0.06234877,
+          "score": 0.26232041
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.04191098,
-          "spread": 0.56928782,
-          "score": 0.57082848
+          "bias": 0.0440264,
+          "spread": 0.53700413,
+          "score": 0.53880586
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.00428396,
-          "spread": 0.24577445,
-          "score": 0.24581178
+          "bias": -0.08656641,
+          "spread": 0.14042996,
+          "score": 0.16496763
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00022237,
-          "spread": 0.00305873,
-          "score": 0.00306681
+          "bias": -0.00027518,
+          "spread": 0.00307265,
+          "score": 0.00308495
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00675298,
-          "spread": 0.00553345,
-          "score": 0.00873051
+          "bias": 0.00498061,
+          "spread": 0.00389246,
+          "score": 0.00632121
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.008815,
-          "spread": 0.0064671,
-          "score": 0.01093287
+          "bias": 0.00577958,
+          "spread": 0.00344858,
+          "score": 0.00673025
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00480252,
-          "spread": 0.00574728,
-          "score": 0.00748969
+          "bias": 0.00271869,
+          "spread": 0.00251828,
+          "score": 0.0037058
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.030689,
-          "spread": 0.04762843,
-          "score": 0.05665935
+          "bias": 0.01272146,
+          "spread": 0.01307251,
+          "score": 0.01824078
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.13076366,
-          "spread": 0.08265837,
-          "score": 0.15469822
+          "bias": -0.1361719,
+          "spread": 0.08284849,
+          "score": 0.15939466
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00976593,
-          "spread": 0.05027403,
-          "score": 0.05121378
+          "bias": -0.00735597,
+          "spread": 0.02459844,
+          "score": 0.02567477
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.19162498,
+          "bias": 0.17768452,
           "spread": 0.0,
-          "score": 0.19162498
+          "score": 0.17768452
         },
         {
           "profile": "cp_plus_3pct",
@@ -2375,207 +2375,207 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00353357,
-          "spread": 0.00305055,
-          "score": 0.00466819
+          "bias": 0.00768969,
+          "spread": 0.00752973,
+          "score": 0.01076235
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00080072,
-          "spread": 0.00669792,
-          "score": 0.00674561
+          "bias": 0.00242599,
+          "spread": 0.00499331,
+          "score": 0.00555144
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00166697,
-          "spread": 0.00793054,
-          "score": 0.00810384
+          "bias": 0.00306751,
+          "spread": 0.00736077,
+          "score": 0.00797437
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 2.259e-05,
-          "spread": 0.00344174,
-          "score": 0.00344181
+          "bias": 0.00052371,
+          "spread": 0.00326476,
+          "score": 0.0033065
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.14317606,
+          "bias": 0.14232805,
           "spread": 0.0,
-          "score": 0.14317606
+          "score": 0.14232805
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00431547,
-          "spread": 0.00199352,
-          "score": 0.00475367
+          "bias": -0.0043495,
+          "spread": 0.00216245,
+          "score": 0.00485741
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00083575,
-          "spread": 0.00232912,
-          "score": 0.00247453
+          "bias": -0.00032856,
+          "spread": 0.00237676,
+          "score": 0.00239936
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00074873,
-          "spread": 0.00435013,
-          "score": 0.00441409
+          "bias": -0.00026262,
+          "spread": 0.00407977,
+          "score": 0.00408822
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00212804,
-          "spread": 0.00474555,
-          "score": 0.00520085
+          "bias": 0.00287613,
+          "spread": 0.0047264,
+          "score": 0.00553272
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00904328,
-          "spread": 0.00529117,
-          "score": 0.01047747
+          "bias": 0.00849072,
+          "spread": 0.00673173,
+          "score": 0.01083552
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -7.776e-05,
-          "spread": 0.01213057,
-          "score": 0.01213082
+          "bias": 0.00012687,
+          "spread": 0.01320703,
+          "score": 0.01320763
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.05066861,
-          "spread": 0.0531005,
-          "score": 0.07339599
+          "bias": 0.05262409,
+          "spread": 0.04654431,
+          "score": 0.07025431
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.36132503,
-          "spread": 0.39581441,
-          "score": 0.5359336
+          "bias": 0.38888075,
+          "spread": 0.41967018,
+          "score": 0.57214622
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.7897756,
-          "spread": 0.79934043,
-          "score": 1.12369508
+          "bias": 0.84200403,
+          "spread": 0.83770549,
+          "score": 1.18773788
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.10643653,
-          "spread": 0.09189321,
-          "score": 0.14061685
+          "bias": -0.1164932,
+          "spread": 0.09270044,
+          "score": 0.14887591
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.0006366,
-          "spread": 0.0027475,
-          "score": 0.00282029
+          "bias": -0.00048309,
+          "spread": 0.00304511,
+          "score": 0.00308319
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00231312,
-          "spread": 0.00308162,
-          "score": 0.00385317
+          "bias": 0.00195704,
+          "spread": 0.00235358,
+          "score": 0.00306093
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00184655,
-          "spread": 0.0030839,
-          "score": 0.00359446
+          "bias": 0.00173082,
+          "spread": 0.00212271,
+          "score": 0.00273891
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -1.667e-05,
-          "spread": 0.00135643,
-          "score": 0.00135653
+          "bias": 9.585e-05,
+          "spread": 0.0008362,
+          "score": 0.00084167
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00158715,
-          "spread": 0.00353353,
-          "score": 0.00387361
+          "bias": 0.00058079,
+          "spread": 0.00243932,
+          "score": 0.0025075
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.14211312,
-          "spread": 0.08191143,
-          "score": 0.16402933
+          "bias": -0.13933794,
+          "spread": 0.08134033,
+          "score": 0.16134221
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.01360771,
-          "spread": 0.02567411,
-          "score": 0.02905735
+          "bias": 0.00687514,
+          "spread": 0.01468809,
+          "score": 0.01621751
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.06791827,
-          "spread": 0.05026685,
-          "score": 0.08449644
+          "bias": 0.0520188,
+          "spread": 0.04086756,
+          "score": 0.06615219
         },
         {
           "profile": "cp_plus_3pct",
@@ -2591,198 +2591,198 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00146805,
-          "spread": 0.00852011,
-          "score": 0.00864566
+          "bias": 0.00076455,
+          "spread": 0.00746535,
+          "score": 0.0075044
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00185979,
-          "spread": 0.00823651,
-          "score": 0.00844387
+          "bias": 0.00031206,
+          "spread": 0.00687414,
+          "score": 0.00688122
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00073719,
-          "spread": 0.00789142,
-          "score": 0.00792578
+          "bias": 6.369e-05,
+          "spread": 0.00726577,
+          "score": 0.00726605
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00121873,
-          "spread": 0.00300114,
-          "score": 0.00323916
+          "bias": -0.0001631,
+          "spread": 0.00306819,
+          "score": 0.00307252
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.14940647,
+          "bias": 0.11005497,
           "spread": 0.0,
-          "score": 0.14940647
+          "score": 0.11005497
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.01458256,
-          "spread": 0.01547577,
-          "score": 0.02126383
+          "bias": -0.01105196,
+          "spread": 0.01300433,
+          "score": 0.0170663
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00011134,
-          "spread": 0.00421872,
-          "score": 0.00422019
+          "bias": 0.00028958,
+          "spread": 0.0042105,
+          "score": 0.00422044
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00320506,
-          "spread": 0.0022304,
-          "score": 0.00390475
+          "bias": -0.00259802,
+          "spread": 0.00253113,
+          "score": 0.00362717
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00131211,
-          "spread": 0.01012895,
-          "score": 0.01021358
+          "bias": 0.00138348,
+          "spread": 0.01035419,
+          "score": 0.01044621
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.0006459,
-          "spread": 0.02264664,
-          "score": 0.02265585
+          "bias": 0.00698288,
+          "spread": 0.01878018,
+          "score": 0.02003636
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.03134492,
-          "spread": 0.05190288,
-          "score": 0.06063343
+          "bias": -0.02598117,
+          "spread": 0.04112222,
+          "score": 0.04864214
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.06836422,
-          "spread": 0.09264566,
-          "score": 0.11513854
+          "bias": 0.08534106,
+          "spread": 0.1096738,
+          "score": 0.13896561
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.2318546,
-          "spread": 0.39200014,
-          "score": 0.45543459
+          "bias": 0.25240743,
+          "spread": 0.41627772,
+          "score": 0.48682302
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.22196797,
-          "spread": 0.76269559,
-          "score": 0.79433893
+          "bias": 0.22162504,
+          "spread": 0.75298079,
+          "score": 0.78491893
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.07555541,
-          "spread": 0.09257135,
-          "score": 0.1194909
+          "bias": -0.06129618,
+          "spread": 0.14769098,
+          "score": 0.15990575
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00198359,
-          "spread": 0.00867807,
-          "score": 0.00890188
+          "bias": 0.00172272,
+          "spread": 0.00823771,
+          "score": 0.00841591
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00317234,
-          "spread": 0.00755752,
-          "score": 0.00819633
+          "bias": 0.00078378,
+          "spread": 0.00794256,
+          "score": 0.00798114
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.01095038,
-          "spread": 0.00799457,
-          "score": 0.01355817
+          "bias": 0.00740431,
+          "spread": 0.01050433,
+          "score": 0.01285165
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.0014848,
-          "spread": 0.0099788,
-          "score": 0.01008866
+          "bias": -0.00218493,
+          "spread": 0.00385149,
+          "score": 0.00442808
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.01371012,
-          "spread": 0.01559799,
-          "score": 0.02076691
+          "bias": 0.00914508,
+          "spread": 0.01458229,
+          "score": 0.01721266
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.11775178,
-          "spread": 0.11544516,
-          "score": 0.1649032
+          "bias": -0.09888408,
+          "spread": 0.10800958,
+          "score": 0.14643814
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.01803757,
-          "spread": 0.04976682,
-          "score": 0.05293477
+          "bias": -0.00352569,
+          "spread": 0.03430483,
+          "score": 0.03448553
         },
         {
           "profile": "rated_plus_5pct",
@@ -2807,36 +2807,36 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.01134585,
-          "spread": 0.01998614,
-          "score": 0.02298203
+          "bias": -0.00046466,
+          "spread": 0.01824497,
+          "score": 0.01825088
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.0078409,
-          "spread": 0.01261426,
-          "score": 0.01485259
+          "bias": -0.00436853,
+          "spread": 0.01100383,
+          "score": 0.01183927
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00409777,
-          "spread": 0.00887524,
-          "score": 0.00977556
+          "bias": -0.00238442,
+          "spread": 0.00883608,
+          "score": 0.00915215
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00306163,
-          "spread": 0.00229078,
-          "score": 0.00382378
+          "bias": 0.00348831,
+          "spread": 0.00220558,
+          "score": 0.00412709
         },
         {
           "profile": "rated_plus_5pct",
@@ -2852,162 +2852,162 @@
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00147872,
-          "spread": 0.00581659,
-          "score": 0.00600161
+          "bias": -0.00109535,
+          "spread": 0.00678535,
+          "score": 0.0068732
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00284794,
-          "spread": 0.0022112,
-          "score": 0.00360558
+          "bias": 0.00178909,
+          "spread": 0.00201226,
+          "score": 0.00269259
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00059154,
-          "spread": 0.0023575,
-          "score": 0.00243058
+          "bias": 0.00136469,
+          "spread": 0.00299308,
+          "score": 0.00328951
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00670399,
-          "spread": 0.00726206,
-          "score": 0.00988337
+          "bias": 0.00907235,
+          "spread": 0.00554328,
+          "score": 0.01063181
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00946876,
-          "spread": 0.00845388,
-          "score": 0.01269352
+          "bias": 0.01402929,
+          "spread": 0.00665075,
+          "score": 0.0155259
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.0116771,
-          "spread": 0.01878252,
-          "score": 0.02211646
+          "bias": 0.01291322,
+          "spread": 0.01485973,
+          "score": 0.01968661
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.07561952,
-          "spread": 0.0658453,
-          "score": 0.10026921
+          "bias": 0.07983896,
+          "spread": 0.07600521,
+          "score": 0.11023181
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.22347679,
-          "spread": 0.06379974,
-          "score": 0.23240542
+          "bias": 0.25567719,
+          "spread": 0.04874238,
+          "score": 0.26028186
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.00597907,
-          "spread": 0.52786327,
-          "score": 0.52789714
+          "bias": 0.03146144,
+          "spread": 0.5211242,
+          "score": 0.52207303
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.00206266,
-          "spread": 0.22927929,
-          "score": 0.22928857
+          "bias": -0.08768889,
+          "spread": 0.17562345,
+          "score": 0.19629808
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00264873,
-          "spread": 0.00351274,
-          "score": 0.00439944
+          "bias": 0.00245102,
+          "spread": 0.00362688,
+          "score": 0.00437741
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00342692,
-          "spread": 0.00643193,
-          "score": 0.00728791
+          "bias": 0.00090942,
+          "spread": 0.00483001,
+          "score": 0.00491488
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00781417,
-          "spread": 0.0066256,
-          "score": 0.01024499
+          "bias": 0.0040657,
+          "spread": 0.00336532,
+          "score": 0.00527781
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00438045,
-          "spread": 0.005715,
-          "score": 0.00720066
+          "bias": 0.00143407,
+          "spread": 0.00157855,
+          "score": 0.00213269
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.03238718,
-          "spread": 0.04982474,
-          "score": 0.05942587
+          "bias": 0.01318815,
+          "spread": 0.01399732,
+          "score": 0.01923155
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.11349,
-          "spread": 0.06847812,
-          "score": 0.13254899
+          "bias": -0.11582286,
+          "spread": 0.06890401,
+          "score": 0.13476905
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.01394611,
-          "spread": 0.05378306,
-          "score": 0.05556178
+          "bias": -0.00477817,
+          "spread": 0.02882741,
+          "score": 0.02922072
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.20318569,
+          "bias": 0.19386509,
           "spread": 0.0,
-          "score": 0.20318569
+          "score": 0.19386509
         },
         {
           "profile": "rated_plus_5pct",
@@ -3023,207 +3023,207 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00248097,
-          "spread": 0.00378367,
-          "score": 0.00452453
+          "bias": 0.00822943,
+          "spread": 0.0076138,
+          "score": 0.01121131
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00112259,
-          "spread": 0.00764851,
-          "score": 0.00773045
+          "bias": 0.00213836,
+          "spread": 0.00554957,
+          "score": 0.00594729
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00246932,
-          "spread": 0.00798579,
-          "score": 0.00835885
+          "bias": 0.00391696,
+          "spread": 0.00720577,
+          "score": 0.00820156
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 5.963e-05,
-          "spread": 0.00344792,
-          "score": 0.00344844
+          "bias": 0.00056192,
+          "spread": 0.00326931,
+          "score": 0.00331725
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.12113829,
+          "bias": 0.13185605,
           "spread": 0.0,
-          "score": 0.12113829
+          "score": 0.13185605
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00161726,
-          "spread": 0.00411674,
-          "score": 0.00442301
+          "bias": -0.00130731,
+          "spread": 0.00431633,
+          "score": 0.00450997
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.0014817,
-          "spread": 0.00235305,
-          "score": 0.0027807
+          "bias": -0.00089112,
+          "spread": 0.00249298,
+          "score": 0.00264746
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00116007,
-          "spread": 0.0044049,
-          "score": 0.0045551
+          "bias": -0.00075222,
+          "spread": 0.00408255,
+          "score": 0.00415127
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00402215,
-          "spread": 0.0042814,
-          "score": 0.00587436
+          "bias": 0.00465317,
+          "spread": 0.00435434,
+          "score": 0.00637277
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01140189,
-          "spread": 0.00525365,
-          "score": 0.01255404
+          "bias": 0.01109379,
+          "spread": 0.006267,
+          "score": 0.01274157
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.0040978,
-          "spread": 0.01156215,
-          "score": 0.01226684
+          "bias": 0.00276302,
+          "spread": 0.01272683,
+          "score": 0.01302331
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.05625165,
-          "spread": 0.05157257,
-          "score": 0.076315
+          "bias": 0.05485629,
+          "spread": 0.04687246,
+          "score": 0.07215428
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.35868519,
-          "spread": 0.37910046,
-          "score": 0.52189292
+          "bias": 0.37299287,
+          "spread": 0.38570965,
+          "score": 0.53655905
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.84046661,
-          "spread": 0.71169434,
-          "score": 1.1013142
+          "bias": 0.86761173,
+          "spread": 0.76141773,
+          "score": 1.1543427
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.09854897,
-          "spread": 0.09744882,
-          "score": 0.13859355
+          "bias": -0.11054606,
+          "spread": 0.10234208,
+          "score": 0.15064638
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00248376,
-          "spread": 0.00256693,
-          "score": 0.00357186
+          "bias": 0.00237674,
+          "spread": 0.00236643,
+          "score": 0.00335394
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00100764,
-          "spread": 0.00374987,
-          "score": 0.00388289
+          "bias": -0.0010802,
+          "spread": 0.00285084,
+          "score": 0.00304862
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00026649,
-          "spread": 0.00329633,
-          "score": 0.00330708
+          "bias": 0.0003611,
+          "spread": 0.00198115,
+          "score": 0.00201379
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00117245,
-          "spread": 0.00138115,
-          "score": 0.00181169
+          "bias": -0.00083792,
+          "spread": 0.00095423,
+          "score": 0.00126991
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00170008,
-          "spread": 0.00513741,
-          "score": 0.00541141
+          "bias": 0.00078786,
+          "spread": 0.00388999,
+          "score": 0.00396897
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.12568026,
-          "spread": 0.06999126,
-          "score": 0.14385515
+          "bias": -0.12484732,
+          "spread": 0.07024261,
+          "score": 0.1432511
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.01639208,
-          "spread": 0.02874957,
-          "score": 0.03309438
+          "bias": 0.01069351,
+          "spread": 0.01811955,
+          "score": 0.0210397
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.07599822,
-          "spread": 0.05473316,
-          "score": 0.093656
+          "bias": 0.05883636,
+          "spread": 0.04345697,
+          "score": 0.07314524
         },
         {
           "profile": "rated_plus_5pct",
@@ -3239,198 +3239,198 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00134962,
-          "spread": 0.00895912,
-          "score": 0.00906021
+          "bias": 0.0010922,
+          "spread": 0.00766929,
+          "score": 0.00774667
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00204644,
-          "spread": 0.0086806,
-          "score": 0.00891856
+          "bias": 7.047e-05,
+          "spread": 0.00711952,
+          "score": 0.00711987
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00050435,
-          "spread": 0.00754118,
-          "score": 0.00755803
+          "bias": 0.0010147,
+          "spread": 0.00726283,
+          "score": 0.00733337
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00129766,
-          "spread": 0.0030679,
-          "score": 0.00333106
+          "bias": -0.00021061,
+          "spread": 0.0031395,
+          "score": 0.00314656
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.12056824,
+          "bias": 0.10253626,
           "spread": 0.0,
-          "score": 0.12056824
+          "score": 0.10253626
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.01484544,
-          "spread": 0.01504515,
-          "score": 0.02113631
+          "bias": -0.01469739,
+          "spread": 0.01482734,
+          "score": 0.02087734
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00158726,
-          "spread": 0.00628073,
-          "score": 0.00647819
+          "bias": 0.00127363,
+          "spread": 0.00517319,
+          "score": 0.00532767
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00535787,
-          "spread": 0.00197553,
-          "score": 0.00571047
+          "bias": -0.00427276,
+          "spread": 0.00182667,
+          "score": 0.00464685
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00040532,
-          "spread": 0.01059349,
-          "score": 0.01060124
+          "bias": 0.0025637,
+          "spread": 0.01028459,
+          "score": 0.01059931
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01004271,
-          "spread": 0.0247902,
-          "score": 0.02674715
+          "bias": 0.01502161,
+          "spread": 0.02091197,
+          "score": 0.025748
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.01280818,
-          "spread": 0.05047022,
-          "score": 0.05207007
+          "bias": -0.01032624,
+          "spread": 0.0444181,
+          "score": 0.04560262
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.08871442,
-          "spread": 0.10478226,
-          "score": 0.13729374
+          "bias": 0.10029714,
+          "spread": 0.1087188,
+          "score": 0.14791651
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.25653665,
-          "spread": 0.39774766,
-          "score": 0.47330144
+          "bias": 0.2914696,
+          "spread": 0.46272407,
+          "score": 0.54687119
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.19128321,
-          "spread": 0.79617622,
-          "score": 0.818832
+          "bias": 0.31007907,
+          "spread": 0.79213194,
+          "score": 0.85065976
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.09218963,
-          "spread": 0.1997149,
-          "score": 0.21996583
+          "bias": -0.16226848,
+          "spread": 0.12433569,
+          "score": 0.20442706
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00260674,
-          "spread": 0.00554241,
-          "score": 0.00612482
+          "bias": -0.00263134,
+          "spread": 0.00486248,
+          "score": 0.0055288
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00912387,
-          "spread": 0.0065386,
-          "score": 0.0112249
+          "bias": 0.0056567,
+          "spread": 0.00807329,
+          "score": 0.0098578
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.01286825,
-          "spread": 0.00886872,
-          "score": 0.01562838
+          "bias": 0.00839201,
+          "spread": 0.01160804,
+          "score": 0.01432384
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00225205,
-          "spread": 0.00938533,
-          "score": 0.00965174
+          "bias": -0.00113493,
+          "spread": 0.00513537,
+          "score": 0.00525929
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.01359505,
-          "spread": 0.01687871,
-          "score": 0.02167294
+          "bias": 0.00905657,
+          "spread": 0.01608443,
+          "score": 0.01845888
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.12853745,
-          "spread": 0.13436776,
-          "score": 0.18594777
+          "bias": -0.11376003,
+          "spread": 0.13380106,
+          "score": 0.17562479
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.01158102,
-          "spread": 0.0381975,
-          "score": 0.03991452
+          "bias": -0.01304495,
+          "spread": 0.02384943,
+          "score": 0.02718393
         },
         {
           "profile": "ti_dependent_cp",
@@ -3455,36 +3455,36 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00820348,
-          "spread": 0.02259789,
-          "score": 0.02404083
+          "bias": 0.00075179,
+          "spread": 0.0195345,
+          "score": 0.01954896
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00712926,
-          "spread": 0.01010693,
-          "score": 0.01236836
+          "bias": -0.00333584,
+          "spread": 0.01034161,
+          "score": 0.01086632
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00685052,
-          "spread": 0.00788478,
-          "score": 0.01044507
+          "bias": -0.00440302,
+          "spread": 0.00780649,
+          "score": 0.00896258
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00306575,
-          "spread": 0.0023589,
-          "score": 0.00386823
+          "bias": 0.00350522,
+          "spread": 0.00227961,
+          "score": 0.00418129
         },
         {
           "profile": "ti_dependent_cp",
@@ -3500,162 +3500,162 @@
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00805838,
-          "spread": 0.0104324,
-          "score": 0.01318228
+          "bias": -0.00819245,
+          "spread": 0.01126598,
+          "score": 0.01392977
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00242133,
-          "spread": 0.00318991,
-          "score": 0.00400479
+          "bias": 0.00120503,
+          "spread": 0.00213787,
+          "score": 0.0024541
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 4.761e-05,
-          "spread": 0.0019866,
-          "score": 0.00198717
+          "bias": 0.00080652,
+          "spread": 0.00263363,
+          "score": 0.00275436
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00815621,
-          "spread": 0.00638179,
-          "score": 0.01035621
+          "bias": 0.0107091,
+          "spread": 0.00511682,
+          "score": 0.01186872
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.02031797,
-          "spread": 0.00873573,
-          "score": 0.02211635
+          "bias": 0.02461826,
+          "spread": 0.00717787,
+          "score": 0.02564333
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.02986307,
-          "spread": 0.01533687,
-          "score": 0.03357116
+          "bias": 0.03221439,
+          "spread": 0.01407122,
+          "score": 0.03515346
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.09434108,
-          "spread": 0.073079,
-          "score": 0.11933473
+          "bias": 0.1016489,
+          "spread": 0.08301803,
+          "score": 0.13124211
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.24542985,
-          "spread": 0.06453822,
-          "score": 0.25377351
+          "bias": 0.27500281,
+          "spread": 0.04955415,
+          "score": 0.27943185
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.03509813,
-          "spread": 0.58125646,
-          "score": 0.58231516
+          "bias": -0.03728392,
+          "spread": 0.62521726,
+          "score": 0.62632796
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.00257336,
-          "spread": 0.24307318,
-          "score": 0.2430868
+          "bias": -0.08714736,
+          "spread": 0.15628718,
+          "score": 0.17894229
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00187539,
-          "spread": 0.0032767,
-          "score": 0.00377543
+          "bias": -0.00212396,
+          "spread": 0.00294181,
+          "score": 0.00362842
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00766536,
-          "spread": 0.00500635,
-          "score": 0.0091554
+          "bias": 0.00537445,
+          "spread": 0.00336081,
+          "score": 0.00633875
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00899708,
-          "spread": 0.00622212,
-          "score": 0.01093902
+          "bias": 0.00529387,
+          "spread": 0.0035316,
+          "score": 0.00636375
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00448457,
-          "spread": 0.00541157,
-          "score": 0.00702826
+          "bias": 0.00241054,
+          "spread": 0.00315469,
+          "score": 0.00397024
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.0303588,
-          "spread": 0.04678408,
-          "score": 0.05577102
+          "bias": 0.01209832,
+          "spread": 0.01261247,
+          "score": 0.01747695
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.13451692,
-          "spread": 0.08929981,
-          "score": 0.16145977
+          "bias": -0.13678707,
+          "spread": 0.0920196,
+          "score": 0.16485845
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00689573,
-          "spread": 0.04867168,
-          "score": 0.04915775
+          "bias": -0.00886862,
+          "spread": 0.02349835,
+          "score": 0.02511622
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.18407063,
+          "bias": 0.1771376,
           "spread": 0.0,
-          "score": 0.18407063
+          "score": 0.1771376
         },
         {
           "profile": "ti_dependent_cp",
@@ -3671,207 +3671,207 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00426554,
-          "spread": 0.00325237,
-          "score": 0.00536402
+          "bias": 0.00937461,
+          "spread": 0.00764075,
+          "score": 0.01209398
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 5.33e-06,
-          "spread": 0.00683027,
-          "score": 0.00683027
+          "bias": 0.00381249,
+          "spread": 0.00466789,
+          "score": 0.00602697
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00161179,
-          "spread": 0.00789641,
-          "score": 0.00805923
+          "bias": 0.00306364,
+          "spread": 0.00749303,
+          "score": 0.00809514
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 3.08e-06,
-          "spread": 0.00350969,
-          "score": 0.00350969
+          "bias": 0.00051428,
+          "spread": 0.0033297,
+          "score": 0.00336919
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.17991698,
+          "bias": 0.14742519,
           "spread": 0.0,
-          "score": 0.17991698
+          "score": 0.14742519
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.009635,
-          "spread": 0.00146293,
-          "score": 0.00974542
+          "bias": -0.01009052,
+          "spread": 0.00239797,
+          "score": 0.01037154
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00276718,
-          "spread": 0.00247729,
-          "score": 0.00371406
+          "bias": -0.00233488,
+          "spread": 0.00267594,
+          "score": 0.00355138
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00124699,
-          "spread": 0.0044152,
-          "score": 0.00458791
+          "bias": -0.00068812,
+          "spread": 0.00410247,
+          "score": 0.00415978
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00599607,
-          "spread": 0.00394881,
-          "score": 0.00717955
+          "bias": 0.00668714,
+          "spread": 0.00408701,
+          "score": 0.00783719
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.02171046,
-          "spread": 0.00542486,
-          "score": 0.02237796
+          "bias": 0.02076038,
+          "spread": 0.00626011,
+          "score": 0.02168369
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.02013145,
-          "spread": 0.01336257,
-          "score": 0.02416265
+          "bias": 0.01969875,
+          "spread": 0.01310986,
+          "score": 0.0236624
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.07219902,
-          "spread": 0.05384097,
-          "score": 0.09006413
+          "bias": 0.07029836,
+          "spread": 0.0462499,
+          "score": 0.08414816
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.39652115,
-          "spread": 0.40897845,
-          "score": 0.56964234
+          "bias": 0.41026313,
+          "spread": 0.4132131,
+          "score": 0.58228936
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.86507966,
-          "spread": 0.74696168,
-          "score": 1.1429412
+          "bias": 0.90144576,
+          "spread": 0.77132686,
+          "score": 1.18640194
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.1088266,
-          "spread": 0.10522304,
-          "score": 0.1513774
+          "bias": -0.10502681,
+          "spread": 0.08894726,
+          "score": 0.13763084
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00245347,
-          "spread": 0.0035019,
-          "score": 0.00427584
+          "bias": -0.00222055,
+          "spread": 0.00357004,
+          "score": 0.00420429
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00313565,
-          "spread": 0.00303652,
-          "score": 0.00436495
+          "bias": 0.00286393,
+          "spread": 0.00203966,
+          "score": 0.003516
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00210807,
-          "spread": 0.00309069,
-          "score": 0.00374116
+          "bias": 0.00196043,
+          "spread": 0.00215633,
+          "score": 0.00291428
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 5.258e-05,
-          "spread": 0.00144984,
-          "score": 0.00145079
+          "bias": 0.00027218,
+          "spread": 0.00072845,
+          "score": 0.00077764
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00112696,
-          "spread": 0.00327063,
-          "score": 0.00345934
+          "bias": 0.00019046,
+          "spread": 0.0019773,
+          "score": 0.00198645
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.1435506,
-          "spread": 0.08791612,
-          "score": 0.16833305
+          "bias": -0.14168467,
+          "spread": 0.0878664,
+          "score": 0.16671848
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.01100978,
-          "spread": 0.02492745,
-          "score": 0.02725056
+          "bias": 0.00512652,
+          "spread": 0.01405932,
+          "score": 0.01496482
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.06344936,
-          "spread": 0.04768338,
-          "score": 0.07936955
+          "bias": 0.04818731,
+          "spread": 0.03874595,
+          "score": 0.06183256
         },
         {
           "profile": "ti_dependent_cp",
@@ -3887,198 +3887,198 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00036152,
-          "spread": 0.00811569,
-          "score": 0.00812374
+          "bias": 0.00218866,
+          "spread": 0.00772541,
+          "score": 0.00802946
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00066411,
-          "spread": 0.00861912,
-          "score": 0.00864467
+          "bias": 0.00143064,
+          "spread": 0.00683361,
+          "score": 0.00698176
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00100225,
-          "spread": 0.00805782,
-          "score": 0.00811991
+          "bias": -0.00024173,
+          "spread": 0.00730351,
+          "score": 0.00730751
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00126301,
-          "spread": 0.0030625,
-          "score": 0.00331271
+          "bias": -0.0001907,
+          "spread": 0.003135,
+          "score": 0.0031408
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.14033036,
+          "bias": 0.15377346,
           "spread": 0.0,
-          "score": 0.14033036
+          "score": 0.15377346
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.01184419,
-          "spread": 0.01364275,
-          "score": 0.01806681
+          "bias": -0.00899187,
+          "spread": 0.01083921,
+          "score": 0.0140834
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00395937,
-          "spread": 0.00567434,
-          "score": 0.00691916
+          "bias": 0.004027,
+          "spread": 0.00466306,
+          "score": 0.00616124
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00425899,
-          "spread": 0.00213262,
-          "score": 0.00476309
+          "bias": -0.00329965,
+          "spread": 0.00164475,
+          "score": 0.00368686
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00503126,
-          "spread": 0.0117479,
-          "score": 0.01277993
+          "bias": -0.002517,
+          "spread": 0.01102389,
+          "score": 0.01130759
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": -0.0053997,
-          "spread": 0.02725628,
-          "score": 0.027786
+          "bias": 0.00093,
+          "spread": 0.02343741,
+          "score": 0.02345586
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.03771078,
-          "spread": 0.05313258,
-          "score": 0.065155
+          "bias": -0.02983829,
+          "spread": 0.04496933,
+          "score": 0.05396818
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.05324166,
-          "spread": 0.10062625,
-          "score": 0.11384339
+          "bias": 0.07745126,
+          "spread": 0.11921795,
+          "score": 0.14216757
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.22392445,
-          "spread": 0.43889931,
-          "score": 0.49272179
+          "bias": 0.2568556,
+          "spread": 0.46646101,
+          "score": 0.53250416
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.07832105,
-          "spread": 0.89108057,
-          "score": 0.89451594
+          "bias": 0.12765508,
+          "spread": 0.89751716,
+          "score": 0.90654998
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.1355912,
-          "spread": 0.40996391,
-          "score": 0.4318048
+          "bias": -0.12736315,
+          "spread": 0.23091563,
+          "score": 0.26371083
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00111977,
-          "spread": 0.0079876,
-          "score": 0.00806571
+          "bias": 0.00127979,
+          "spread": 0.00613656,
+          "score": 0.00626859
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00742972,
-          "spread": 0.00908658,
-          "score": 0.01173741
+          "bias": 0.00557858,
+          "spread": 0.00887199,
+          "score": 0.01048011
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.01230292,
-          "spread": 0.01033308,
-          "score": 0.01606657
+          "bias": 0.00949963,
+          "spread": 0.01181231,
+          "score": 0.01515829
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00213778,
-          "spread": 0.00832559,
-          "score": 0.00859567
+          "bias": -0.00021539,
+          "spread": 0.00519596,
+          "score": 0.00520043
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.01385991,
-          "spread": 0.017404,
-          "score": 0.02224851
+          "bias": 0.01089552,
+          "spread": 0.0159429,
+          "score": 0.01931032
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.17028898,
-          "spread": 0.15659725,
-          "score": 0.23134614
+          "bias": -0.14148281,
+          "spread": 0.15395616,
+          "score": 0.209093
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.01650616,
-          "spread": 0.04397117,
-          "score": 0.04696719
+          "bias": -0.00469277,
+          "spread": 0.03164757,
+          "score": 0.0319936
         },
         {
           "profile": "ws_dependent_cp",
@@ -4103,36 +4103,36 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.01546282,
-          "spread": 0.01935687,
-          "score": 0.02477473
+          "bias": -0.00435461,
+          "spread": 0.01889112,
+          "score": 0.01938652
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.01213074,
-          "spread": 0.00965578,
-          "score": 0.01550449
+          "bias": -0.00659338,
+          "spread": 0.01114115,
+          "score": 0.01294596
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00806681,
-          "spread": 0.00674079,
-          "score": 0.01051245
+          "bias": -0.00506165,
+          "spread": 0.00874101,
+          "score": 0.01010077
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00308915,
-          "spread": 0.00234129,
-          "score": 0.00387615
+          "bias": 0.00352032,
+          "spread": 0.00225886,
+          "score": 0.00418271
         },
         {
           "profile": "ws_dependent_cp",
@@ -4148,162 +4148,162 @@
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00410972,
-          "spread": 0.01053816,
-          "score": 0.01131117
+          "bias": -0.00416996,
+          "spread": 0.01160001,
+          "score": 0.01232675
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00476844,
-          "spread": 0.00325215,
-          "score": 0.00577187
+          "bias": 0.00386081,
+          "spread": 0.00255467,
+          "score": 0.00462949
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00068133,
-          "spread": 0.00245985,
-          "score": 0.00255246
+          "bias": 0.00154438,
+          "spread": 0.00263669,
+          "score": 0.00305569
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00349093,
-          "spread": 0.00776182,
-          "score": 0.00851073
+          "bias": 0.00587269,
+          "spread": 0.00651478,
+          "score": 0.00877103
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.0081003,
-          "spread": 0.00916346,
-          "score": 0.01223045
+          "bias": 0.01180497,
+          "spread": 0.00830273,
+          "score": 0.01443235
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.011943,
-          "spread": 0.01699373,
-          "score": 0.0207707
+          "bias": 0.01253534,
+          "spread": 0.01473803,
+          "score": 0.01934798
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.07202508,
-          "spread": 0.07506215,
-          "score": 0.10402855
+          "bias": 0.07499664,
+          "spread": 0.08016367,
+          "score": 0.10977573
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.12249703,
-          "spread": 0.19668757,
-          "score": 0.23171431
+          "bias": 0.1376202,
+          "spread": 0.21393626,
+          "score": 0.25437775
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.13082906,
-          "spread": 0.57679566,
-          "score": 0.59144693
+          "bias": -0.05709027,
+          "spread": 0.50776975,
+          "score": 0.51096909
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.05507076,
-          "spread": 0.16599528,
-          "score": 0.17489203
+          "bias": -0.10542514,
+          "spread": 0.14272269,
+          "score": 0.17743795
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00292878,
-          "spread": 0.00329682,
-          "score": 0.00440986
+          "bias": 0.00229035,
+          "spread": 0.00270817,
+          "score": 0.00354681
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.0074039,
-          "spread": 0.00605124,
-          "score": 0.00956218
+          "bias": 0.00543632,
+          "spread": 0.00447288,
+          "score": 0.0070399
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00945546,
-          "spread": 0.00655528,
-          "score": 0.01150554
+          "bias": 0.00590142,
+          "spread": 0.00363381,
+          "score": 0.00693046
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00561303,
-          "spread": 0.00592773,
-          "score": 0.00816358
+          "bias": 0.00352459,
+          "spread": 0.00278848,
+          "score": 0.00449426
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.03175349,
-          "spread": 0.04804918,
-          "score": 0.05759347
+          "bias": 0.01387594,
+          "spread": 0.01298847,
+          "score": 0.01900637
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.17378702,
-          "spread": 0.1139387,
-          "score": 0.2078075
+          "bias": -0.17898477,
+          "spread": 0.11787425,
+          "score": 0.2143126
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.0125808,
-          "spread": 0.05041758,
-          "score": 0.05196354
+          "bias": -0.00502373,
+          "spread": 0.02663023,
+          "score": 0.02709995
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.19460533,
+          "bias": 0.18263025,
           "spread": 0.0,
-          "score": 0.19460533
+          "score": 0.18263025
         },
         {
           "profile": "ws_dependent_cp",
@@ -4319,207 +4319,207 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00013107,
-          "spread": 0.00264825,
-          "score": 0.00265149
+          "bias": 0.00529838,
+          "spread": 0.0084551,
+          "score": 0.00997805
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00338209,
-          "spread": 0.00752725,
-          "score": 0.00825215
+          "bias": 0.00039853,
+          "spread": 0.00530575,
+          "score": 0.0053207
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00077982,
-          "spread": 0.00855301,
-          "score": 0.00858849
+          "bias": 0.0022424,
+          "spread": 0.00776709,
+          "score": 0.00808431
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 4.993e-05,
-          "spread": 0.00348735,
-          "score": 0.0034877
+          "bias": 0.0005551,
+          "spread": 0.00330798,
+          "score": 0.00335423
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.19471163,
+          "bias": 0.1686651,
           "spread": 0.0,
-          "score": 0.19471163
+          "score": 0.1686651
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00390888,
-          "spread": 0.00135011,
-          "score": 0.00413548
+          "bias": -0.00392362,
+          "spread": 0.00180257,
+          "score": 0.00431788
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00094495,
-          "spread": 0.00244856,
-          "score": 0.00262457
+          "bias": -0.00040442,
+          "spread": 0.00249109,
+          "score": 0.00252371
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00076758,
-          "spread": 0.00439319,
-          "score": 0.00445974
+          "bias": -0.00025979,
+          "spread": 0.00405681,
+          "score": 0.00406512
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.0024109,
-          "spread": 0.00519439,
-          "score": 0.00572662
+          "bias": 0.00304859,
+          "spread": 0.00511232,
+          "score": 0.00595229
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01066365,
-          "spread": 0.00550608,
-          "score": 0.01200126
+          "bias": 0.00967833,
+          "spread": 0.00670514,
+          "score": 0.01177408
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00185423,
-          "spread": 0.01287714,
-          "score": 0.01300996
+          "bias": 0.00225083,
+          "spread": 0.01401554,
+          "score": 0.01419512
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.05543473,
-          "spread": 0.05409508,
-          "score": 0.07745507
+          "bias": 0.05347375,
+          "spread": 0.04883863,
+          "score": 0.07241998
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.37454174,
-          "spread": 0.42088753,
-          "score": 0.56340734
+          "bias": 0.4017357,
+          "spread": 0.44781866,
+          "score": 0.60160878
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.72276906,
-          "spread": 0.94902298,
-          "score": 1.19291229
+          "bias": 0.76613203,
+          "spread": 0.98930468,
+          "score": 1.25127217
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.09978606,
-          "spread": 0.11453335,
-          "score": 0.15190505
+          "bias": -0.13101628,
+          "spread": 0.10583398,
+          "score": 0.16842238
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00184394,
-          "spread": 0.00250061,
-          "score": 0.00310696
+          "bias": 0.00169958,
+          "spread": 0.00281801,
+          "score": 0.00329086
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00255261,
-          "spread": 0.00329835,
-          "score": 0.00417073
+          "bias": 0.00235833,
+          "spread": 0.00259461,
+          "score": 0.00350624
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.0022068,
-          "spread": 0.00339982,
-          "score": 0.00405324
+          "bias": 0.00206215,
+          "spread": 0.00237198,
+          "score": 0.00314305
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00059934,
-          "spread": 0.00146572,
-          "score": 0.00158352
+          "bias": 0.00070089,
+          "spread": 0.00089743,
+          "score": 0.0011387
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00264927,
-          "spread": 0.00382884,
-          "score": 0.00465603
+          "bias": 0.00149031,
+          "spread": 0.0026483,
+          "score": 0.00303884
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.18212567,
-          "spread": 0.11447043,
-          "score": 0.21511216
+          "bias": -0.17927833,
+          "spread": 0.1114627,
+          "score": 0.21110342
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.01540069,
-          "spread": 0.02569357,
-          "score": 0.02995565
+          "bias": 0.00907677,
+          "spread": 0.0147236,
+          "score": 0.0172966
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.07263917,
-          "spread": 0.05186623,
-          "score": 0.08925556
+          "bias": 0.05517742,
+          "spread": 0.041882,
+          "score": 0.06927229
         },
         {
           "profile": "ws_dependent_cp",
@@ -4535,33 +4535,33 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00406282,
-          "spread": 0.00946504,
-          "score": 0.01030017
+          "bias": -0.0017967,
+          "spread": 0.00798206,
+          "score": 0.00818178
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00392771,
-          "spread": 0.00898242,
-          "score": 0.00980361
+          "bias": -0.00139607,
+          "spread": 0.00735356,
+          "score": 0.00748491
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00181579,
-          "spread": 0.00819261,
-          "score": 0.00839142
+          "bias": -0.00105179,
+          "spread": 0.00762844,
+          "score": 0.00770061
         }
       ]
     },
     "toggle": {
-      "recorded_utc": "2026-07-04T11:35:03Z",
-      "git_commit": "1a478df-dirty",
+      "recorded_utc": "2026-07-04T15:12:20Z",
+      "git_commit": "47171a4-dirty",
       "n_replicates": 4,
       "seed": 0,
       "campaign_months": [
@@ -4585,9 +4585,9 @@
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.0038551,
-          "spread": 0.0007212,
-          "score": 0.00392198
+          "bias": 0.00353355,
+          "spread": 0.00066358,
+          "score": 0.00359532
         },
         {
           "profile": "cp_0pct",
@@ -4603,162 +4603,162 @@
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00815341,
-          "spread": 0.00914232,
-          "score": 0.0122499
+          "bias": 0.00748047,
+          "spread": 0.01391508,
+          "score": 0.01579832
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00115072,
-          "spread": 0.00246391,
-          "score": 0.00271938
+          "bias": 0.00070593,
+          "spread": 0.00242268,
+          "score": 0.00252343
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00561839,
-          "spread": 0.00100403,
-          "score": 0.00570739
+          "bias": 0.00548091,
+          "spread": 0.00128676,
+          "score": 0.00562993
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00476869,
-          "spread": 0.00287545,
-          "score": 0.00556854
+          "bias": 0.00394722,
+          "spread": 0.0023675,
+          "score": 0.00460278
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00438002,
-          "spread": 0.00690211,
-          "score": 0.00817458
+          "bias": 0.00381493,
+          "spread": 0.00405233,
+          "score": 0.00556553
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00367308,
-          "spread": 0.02924935,
-          "score": 0.02947908
+          "bias": -0.00079581,
+          "spread": 0.03108862,
+          "score": 0.0310988
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.02264724,
-          "spread": 0.04510757,
-          "score": 0.05047366
+          "bias": 0.02759907,
+          "spread": 0.05538432,
+          "score": 0.06187998
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.11322002,
-          "spread": 0.48261944,
-          "score": 0.49572199
+          "bias": 0.06965265,
+          "spread": 0.4830821,
+          "score": 0.48807766
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.22947675,
+          "bias": -0.14096221,
           "spread": 0.0,
-          "score": 0.22947675
+          "score": 0.14096221
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.02031195,
-          "spread": 0.09244361,
-          "score": 0.0946488
+          "bias": 0.01355152,
+          "spread": 0.01636823,
+          "score": 0.02125
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00183888,
-          "spread": 0.00154338,
-          "score": 0.00240073
+          "bias": 0.00060208,
+          "spread": 0.0017339,
+          "score": 0.00183546
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00194543,
-          "spread": 0.00111063,
-          "score": 0.00224013
+          "bias": 0.00191051,
+          "spread": 0.00091223,
+          "score": 0.00211713
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00043188,
-          "spread": 0.00225715,
-          "score": 0.00229809
+          "bias": 0.00165304,
+          "spread": 0.00204547,
+          "score": 0.00262992
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00285231,
-          "spread": 0.00263784,
-          "score": 0.00388508
+          "bias": 0.00215328,
+          "spread": 0.00155699,
+          "score": 0.00265722
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00632726,
-          "spread": 0.0219825,
-          "score": 0.02287498
+          "bias": 0.00370464,
+          "spread": 0.01909753,
+          "score": 0.01945354
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.01717332,
-          "spread": 0.04181022,
-          "score": 0.04519974
+          "bias": 0.01623147,
+          "spread": 0.03945832,
+          "score": 0.04266638
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.06232471,
-          "spread": 0.06468672,
-          "score": 0.08982618
+          "bias": 0.06356536,
+          "spread": 0.06364789,
+          "score": 0.08995337
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.00603097,
-          "spread": 0.0049315,
-          "score": 0.00779053
+          "bias": -0.0090114,
+          "spread": 0.00856435,
+          "score": 0.01243195
         },
         {
           "profile": "cp_0pct",
@@ -4774,207 +4774,207 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00393045,
-          "spread": 0.01145493,
-          "score": 0.01211049
+          "bias": 0.00426232,
+          "spread": 0.00932912,
+          "score": 0.0102567
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00704251,
-          "spread": 0.00289967,
-          "score": 0.0076161
+          "bias": 0.00796638,
+          "spread": 0.00360988,
+          "score": 0.00874611
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00500677,
-          "spread": 0.00623312,
-          "score": 0.00799497
+          "bias": 0.00382501,
+          "spread": 0.00459222,
+          "score": 0.00597655
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00166824,
-          "spread": 0.00160466,
-          "score": 0.00231473
+          "bias": 0.00111382,
+          "spread": 0.00139904,
+          "score": 0.00178827
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.08554035,
-          "spread": 0.01519602,
-          "score": 0.08687963
+          "bias": 0.09199061,
+          "spread": 0.00436394,
+          "score": 0.09209406
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 4.873e-05,
-          "spread": 0.00998868,
-          "score": 0.0099888
+          "bias": 0.00014859,
+          "spread": 0.01053079,
+          "score": 0.01053184
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00014359,
-          "spread": 0.00166377,
-          "score": 0.00166995
+          "bias": -0.00031877,
+          "spread": 0.00164359,
+          "score": 0.00167422
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.0030185,
-          "spread": 0.00160091,
-          "score": 0.00341676
+          "bias": 0.00260396,
+          "spread": 0.00153436,
+          "score": 0.0030224
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00138435,
-          "spread": 0.00229722,
-          "score": 0.0026821
+          "bias": -0.00072219,
+          "spread": 0.0019521,
+          "score": 0.00208141
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00558691,
-          "spread": 0.0073989,
-          "score": 0.00927132
+          "bias": 0.00357732,
+          "spread": 0.00667861,
+          "score": 0.00757634
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00334306,
-          "spread": 0.01985988,
-          "score": 0.02013929
+          "bias": 0.00469041,
+          "spread": 0.02190535,
+          "score": 0.02240188
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.02965958,
-          "spread": 0.02642557,
-          "score": 0.03972407
+          "bias": -0.02848612,
+          "spread": 0.03463453,
+          "score": 0.04484428
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.09157272,
-          "spread": 0.19098454,
-          "score": 0.21180335
+          "bias": 0.07167425,
+          "spread": 0.19567062,
+          "score": 0.20838472
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.37568049,
-          "spread": 0.51963013,
-          "score": 0.64121081
+          "bias": 0.39370194,
+          "spread": 0.44969101,
+          "score": 0.59768154
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.03599165,
-          "spread": 0.05651906,
-          "score": 0.06700599
+          "bias": -0.00202113,
+          "spread": 0.0174194,
+          "score": 0.01753627
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00057945,
-          "spread": 0.00187765,
-          "score": 0.00196503
+          "bias": 0.00011956,
+          "spread": 0.00299561,
+          "score": 0.00299799
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00030501,
-          "spread": 0.00146164,
-          "score": 0.00149312
+          "bias": -0.00014593,
+          "spread": 0.00162489,
+          "score": 0.00163143
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00032733,
-          "spread": 0.00226901,
-          "score": 0.0022925
+          "bias": -0.00030784,
+          "spread": 0.00205339,
+          "score": 0.00207634
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00103429,
-          "spread": 0.00183814,
-          "score": 0.00210915
+          "bias": 0.00021566,
+          "spread": 0.00132107,
+          "score": 0.00133855
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00426695,
-          "spread": 0.01110748,
-          "score": 0.01189886
+          "bias": 0.00244986,
+          "spread": 0.01054361,
+          "score": 0.01082449
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.00566799,
-          "spread": 0.02001039,
-          "score": 0.02079764
+          "bias": -0.00570082,
+          "spread": 0.0265959,
+          "score": 0.02720003
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00477806,
-          "spread": 0.00657067,
-          "score": 0.00812425
+          "bias": -0.00523091,
+          "spread": 0.00660029,
+          "score": 0.00842177
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.00955149,
-          "spread": 0.00943788,
-          "score": 0.01342775
+          "bias": 0.01369055,
+          "spread": 0.01409478,
+          "score": 0.01964927
         },
         {
           "profile": "cp_0pct",
@@ -4990,474 +4990,645 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00285577,
-          "spread": 0.00346278,
-          "score": 0.00448847
+          "bias": 0.00253323,
+          "spread": 0.00512995,
+          "score": 0.00572133
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00139782,
-          "spread": 0.00377824,
-          "score": 0.00402853
+          "bias": 0.00084402,
+          "spread": 0.00263243,
+          "score": 0.00276442
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00350729,
-          "spread": 0.00556946,
-          "score": 0.00658179
+          "bias": 0.0027108,
+          "spread": 0.00429787,
+          "score": 0.00508135
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00116152,
-          "spread": 0.00149745,
-          "score": 0.00189512
+          "bias": 0.00100521,
+          "spread": 0.00169069,
+          "score": 0.00196695
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.06947979,
-          "spread": 3.671e-05,
-          "score": 0.0694798
+          "bias": 0.08576204,
+          "spread": 0.01107903,
+          "score": 0.08647469
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00103448,
-          "spread": 0.00525216,
-          "score": 0.00535307
+          "bias": 0.00128811,
+          "spread": 0.00388221,
+          "score": 0.00409033
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00182005,
-          "spread": 0.00131157,
-          "score": 0.00224339
+          "bias": 0.0017,
+          "spread": 0.00163701,
+          "score": 0.00236004
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00111361,
-          "spread": 0.00181386,
-          "score": 0.00212843
+          "bias": 0.001087,
+          "spread": 0.00185746,
+          "score": 0.00215214
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00092276,
-          "spread": 0.00189833,
-          "score": 0.00211072
+          "bias": -0.00152444,
+          "spread": 0.00171278,
+          "score": 0.00229293
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00495699,
-          "spread": 0.00736656,
-          "score": 0.00887907
+          "bias": 0.00515748,
+          "spread": 0.00705418,
+          "score": 0.00873848
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00722689,
-          "spread": 0.02101058,
-          "score": 0.02221874
+          "bias": -0.00533376,
+          "spread": 0.02227027,
+          "score": 0.02290009
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.01925833,
-          "spread": 0.01513403,
-          "score": 0.02449331
+          "bias": 0.01130738,
+          "spread": 0.02425568,
+          "score": 0.02676181
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.01011593,
-          "spread": 0.29187106,
-          "score": 0.29204631
+          "bias": 0.0106919,
+          "spread": 0.27616556,
+          "score": 0.27637245
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.07211826,
+          "bias": 0.26835773,
+          "spread": 0.3630687,
+          "score": 0.45148062
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.01416058,
+          "spread": 0.03210956,
+          "score": 0.03509338
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": -0.0010779,
+          "spread": 0.00236062,
+          "score": 0.00259507
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00095068,
+          "spread": 0.00121713,
+          "score": 0.00154441
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": -0.00034086,
+          "spread": 0.001426,
+          "score": 0.00146617
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 5.323e-05,
+          "spread": 0.00113122,
+          "score": 0.00113248
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00426124,
+          "spread": 0.00772058,
+          "score": 0.00881848
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": 0.00402747,
+          "spread": 0.02244889,
+          "score": 0.02280731
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.00407757,
+          "spread": 0.00602508,
+          "score": 0.00727518
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.0160287,
+          "spread": 0.02599727,
+          "score": 0.0305414
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": 6.868e-05,
+          "spread": 0.00422753,
+          "score": 0.00422809
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.00145401,
+          "spread": 0.00241409,
+          "score": 0.00281815
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00282164,
+          "spread": 0.00394825,
+          "score": 0.00485286
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00070517,
+          "spread": 0.00106978,
+          "score": 0.00128128
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.07702443,
+          "spread": 0.03012782,
+          "score": 0.082707
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.00201337,
+          "spread": 0.00400958,
+          "score": 0.00448669
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.00090964,
+          "spread": 0.00076172,
+          "score": 0.00118645
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00027703,
+          "spread": 0.00108234,
+          "score": 0.00111723
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": 0.00045052,
+          "spread": 0.00190323,
+          "score": 0.00195582
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.00530534,
+          "spread": 0.00700544,
+          "score": 0.00878765
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.00391404,
+          "spread": 0.02915303,
+          "score": 0.0294146
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.01349524,
+          "spread": 0.02007159,
+          "score": 0.02418657
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.03441911,
+          "spread": 0.23145234,
+          "score": 0.23399756
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.20243665,
+          "spread": 0.11375018,
+          "score": 0.23220616
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.00677135,
+          "spread": 0.0385606,
+          "score": 0.03915062
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": -0.0001923,
+          "spread": 0.00198649,
+          "score": 0.00199578
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00120134,
+          "spread": 0.0006254,
+          "score": 0.00135438
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": -0.00060756,
+          "spread": 0.00124614,
+          "score": 0.00138636
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00042758,
+          "spread": 0.00043231,
+          "score": 0.00060804
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": -0.00035544,
+          "spread": 0.00230852,
+          "score": 0.00233572
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": 0.00190677,
+          "spread": 0.02047409,
+          "score": 0.02056269
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": -0.00323821,
+          "spread": 0.00341508,
+          "score": 0.00470625
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.03205142,
+          "spread": 0.02597873,
+          "score": 0.04125758
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": 0.01950999,
           "spread": 0.0,
-          "score": 0.07211826
+          "score": 0.01950999
         },
         {
           "profile": "cp_0pct",
-          "campaign_months": 9,
+          "campaign_months": 12,
           "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.01565797,
-          "spread": 0.01913503,
-          "score": 0.02472491
+          "condition_bin": "(4.0, 6.0]",
+          "bias": 0.00133102,
+          "spread": 0.00548241,
+          "score": 0.00564167
         },
         {
           "profile": "cp_0pct",
-          "campaign_months": 9,
+          "campaign_months": 12,
           "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00037587,
-          "spread": 0.00221597,
-          "score": 0.00224762
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.00281354,
+          "spread": 0.00214334,
+          "score": 0.00353694
         },
         {
           "profile": "cp_0pct",
-          "campaign_months": 9,
+          "campaign_months": 12,
           "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00081866,
-          "spread": 0.00081002,
-          "score": 0.00115167
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00044893,
+          "spread": 0.00326151,
+          "score": 0.00329226
         },
         {
-          "profile": "cp_0pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00027179,
-          "spread": 0.00179072,
-          "score": 0.00181123
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00337371,
+          "spread": 0.00064035,
+          "score": 0.00343394
         },
         {
-          "profile": "cp_0pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00038866,
-          "spread": 0.00175262,
-          "score": 0.0017952
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00598241,
-          "spread": 0.01180151,
-          "score": 0.01323121
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": 0.00219279,
-          "spread": 0.02109438,
-          "score": 0.02120805
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00151595,
-          "spread": 0.00601706,
-          "score": 0.00620509
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": -0.02011108,
-          "spread": 0.03120267,
-          "score": 0.03712226
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
           "bias": NaN,
           "spread": NaN,
           "score": NaN
         },
         {
-          "profile": "cp_0pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": 3.489e-05,
-          "spread": 0.00403119,
-          "score": 0.00403134
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00191641,
-          "spread": 0.00240117,
-          "score": 0.00307217
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00256596,
-          "spread": 0.00394392,
-          "score": 0.00470517
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.00081363,
-          "spread": 0.00106016,
-          "score": 0.00133639
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": 0.01015523,
-          "spread": 0.01062758,
-          "score": 0.01469946
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00058764,
-          "spread": 0.0039283,
-          "score": 0.00397201
+          "bias": 0.00731947,
+          "spread": 0.01495908,
+          "score": 0.01665379
         },
         {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00094976,
-          "spread": 0.0007022,
-          "score": 0.00118116
+          "bias": -0.00055129,
+          "spread": 0.0021138,
+          "score": 0.0021845
         },
         {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00031866,
-          "spread": 0.00127709,
-          "score": 0.00131625
+          "bias": 0.00516058,
+          "spread": 0.00171521,
+          "score": 0.00543815
         },
         {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00076528,
-          "spread": 0.00254909,
-          "score": 0.00266149
+          "bias": 0.0058683,
+          "spread": 0.00239494,
+          "score": 0.00633819
         },
         {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00625193,
-          "spread": 0.00535097,
-          "score": 0.00822919
+          "bias": 0.00635238,
+          "spread": 0.00314742,
+          "score": 0.00708936
         },
         {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00603563,
-          "spread": 0.0263522,
-          "score": 0.02703456
+          "bias": 0.00174521,
+          "spread": 0.02720435,
+          "score": 0.02726027
         },
         {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.00331842,
-          "spread": 0.0207453,
-          "score": 0.02100903
+          "bias": 0.03469809,
+          "spread": 0.04813567,
+          "score": 0.05933801
         },
         {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.01390671,
-          "spread": 0.21942682,
-          "score": 0.21986706
+          "bias": 0.35381325,
+          "spread": 0.27830953,
+          "score": 0.45015554
         },
         {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.18476591,
-          "spread": 0.12878182,
-          "score": 0.22521812
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.01214075,
-          "spread": 0.03355661,
-          "score": 0.03568535
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": -9.527e-05,
-          "spread": 0.00216331,
-          "score": 0.00216541
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00124966,
-          "spread": 0.00059968,
-          "score": 0.0013861
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00057999,
-          "spread": 0.00107188,
-          "score": 0.00121874
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00014203,
-          "spread": 0.00082034,
-          "score": 0.00083254
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": -0.00065785,
-          "spread": 0.00262482,
-          "score": 0.00270601
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": 0.00052236,
-          "spread": 0.01443977,
-          "score": 0.01444922
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00438772,
-          "spread": 0.00334018,
-          "score": 0.00551443
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": -0.03177083,
-          "spread": 0.02512779,
-          "score": 0.04050668
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": 0.02083987,
+          "bias": -0.16293081,
           "spread": 0.0,
-          "score": 0.02083987
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00165648,
-          "spread": 0.00557659,
-          "score": 0.00581741
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00285818,
-          "spread": 0.00197947,
-          "score": 0.00347671
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00079335,
-          "spread": 0.00306752,
-          "score": 0.00316846
+          "score": 0.16293081
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.00367405,
-          "spread": 0.0006935,
-          "score": 0.00373893
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.02156829,
+          "spread": 0.02113477,
+          "score": 0.03019718
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.00340116,
+          "spread": 0.00271645,
+          "score": 0.00435281
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": -0.00273568,
+          "spread": 0.00100341,
+          "score": 0.0029139
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.00026377,
+          "spread": 0.00163921,
+          "score": 0.0016603
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00160526,
+          "spread": 0.0015634,
+          "score": 0.00224078
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00343835,
+          "spread": 0.02334117,
+          "score": 0.02359306
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": 0.02955646,
+          "spread": 0.04568628,
+          "score": 0.05441342
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.06913967,
+          "spread": 0.06965696,
+          "score": 0.09814472
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.00158259,
+          "spread": 0.01482082,
+          "score": 0.01490507
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
           "bias": NaN,
           "spread": NaN,
           "score": NaN
@@ -5465,599 +5636,1292 @@
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": 0.00438832,
+          "spread": 0.00898483,
+          "score": 0.00999923
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.00675529,
+          "spread": 0.00282692,
+          "score": 0.00732294
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.0046028,
+          "spread": 0.00457111,
+          "score": 0.00648697
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00114668,
+          "spread": 0.00131736,
+          "score": 0.00174652
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.0909291,
+          "spread": 0.01463739,
+          "score": 0.09209969
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00729472,
-          "spread": 0.00957345,
-          "score": 0.01203594
+          "bias": 0.00149712,
+          "spread": 0.01064364,
+          "score": 0.01074842
         },
         {
           "profile": "cp_minus_10pct",
-          "campaign_months": 3,
+          "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00087846,
-          "spread": 0.0022492,
-          "score": 0.00241466
+          "bias": -0.00116228,
+          "spread": 0.00190238,
+          "score": 0.00222933
         },
         {
           "profile": "cp_minus_10pct",
-          "campaign_months": 3,
+          "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00534453,
-          "spread": 0.00176876,
-          "score": 0.00562961
+          "bias": 0.002474,
+          "spread": 0.00073245,
+          "score": 0.00258015
         },
         {
           "profile": "cp_minus_10pct",
-          "campaign_months": 3,
+          "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00752509,
-          "spread": 0.00310285,
-          "score": 0.0081397
+          "bias": 0.00104443,
+          "spread": 0.00154587,
+          "score": 0.00186562
         },
         {
           "profile": "cp_minus_10pct",
-          "campaign_months": 3,
+          "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00792915,
-          "spread": 0.0076232,
-          "score": 0.0109993
+          "bias": 0.00676555,
+          "spread": 0.00630957,
+          "score": 0.00925112
         },
         {
           "profile": "cp_minus_10pct",
-          "campaign_months": 3,
+          "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00172559,
-          "spread": 0.02796102,
-          "score": 0.02801421
+          "bias": 0.00553111,
+          "spread": 0.01718727,
+          "score": 0.01805535
         },
         {
           "profile": "cp_minus_10pct",
-          "campaign_months": 3,
+          "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.03322946,
-          "spread": 0.04530635,
-          "score": 0.05618597
+          "bias": -0.01652185,
+          "spread": 0.0353702,
+          "score": 0.03903873
         },
         {
           "profile": "cp_minus_10pct",
-          "campaign_months": 3,
+          "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.2669934,
-          "spread": 0.21611722,
-          "score": 0.34349983
+          "bias": 0.14209619,
+          "spread": 0.07747577,
+          "score": 0.16184506
         },
         {
           "profile": "cp_minus_10pct",
-          "campaign_months": 3,
+          "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.16955813,
+          "bias": 0.37138161,
+          "spread": 0.40965151,
+          "score": 0.5529364
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.00476487,
+          "spread": 0.01873144,
+          "score": 0.01932798
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.00315469,
+          "spread": 0.00319287,
+          "score": 0.00448848
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": -0.00452089,
+          "spread": 0.00111087,
+          "score": 0.00465537
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": -0.00178729,
+          "spread": 0.00185807,
+          "score": 0.00257814
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": -8.334e-05,
+          "spread": 0.00101358,
+          "score": 0.001017
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.0032305,
+          "spread": 0.01241265,
+          "score": 0.01282614
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": 0.02930705,
+          "spread": 0.04649989,
+          "score": 0.05496492
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": -0.00061464,
+          "spread": 0.01201537,
+          "score": 0.01203108
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.02675328,
+          "spread": 0.01445678,
+          "score": 0.03040948
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": 0.00276005,
+          "spread": 0.00475322,
+          "score": 0.00549645
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.00029555,
+          "spread": 0.00266532,
+          "score": 0.00268166
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00344103,
+          "spread": 0.00430008,
+          "score": 0.0055074
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00102229,
+          "spread": 0.00159111,
+          "score": 0.00189122
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.06435767,
+          "spread": 0.00738156,
+          "score": 0.0647796
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.00076481,
+          "spread": 0.00430588,
+          "score": 0.00437327
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.00092227,
+          "spread": 0.00181583,
+          "score": 0.00203662
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00092268,
+          "spread": 0.00127943,
+          "score": 0.00157743
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": 0.00040951,
+          "spread": 0.00137083,
+          "score": 0.00143069
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.00739054,
+          "spread": 0.00703601,
+          "score": 0.01020419
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": 0.00085819,
+          "spread": 0.01866382,
+          "score": 0.01868354
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.02166467,
+          "spread": 0.02031926,
+          "score": 0.02970236
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.04934412,
+          "spread": 0.21778154,
+          "score": 0.22330168
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.35563404,
+          "spread": 0.25971728,
+          "score": 0.44037329
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.00790295,
+          "spread": 0.03023524,
+          "score": 0.03125102
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.00233461,
+          "spread": 0.00176584,
+          "score": 0.00292721
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": -0.00343644,
+          "spread": 0.00113213,
+          "score": 0.00361813
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": -0.00184393,
+          "spread": 0.00138307,
+          "score": 0.00230499
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": -0.00035602,
+          "spread": 0.00106566,
+          "score": 0.00112355
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00538822,
+          "spread": 0.00878387,
+          "score": 0.01030481
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": 0.03365676,
+          "spread": 0.03802135,
+          "score": 0.05077796
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.00785913,
+          "spread": 0.00801526,
+          "score": 0.01122543
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.00485003,
+          "spread": 0.02595472,
+          "score": 0.02640398
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": 9.032e-05,
+          "spread": 0.00384184,
+          "score": 0.00384291
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.00120724,
+          "spread": 0.00211251,
+          "score": 0.00243313
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00347706,
+          "spread": 0.00384548,
+          "score": 0.00518437
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00074323,
+          "spread": 0.00102498,
+          "score": 0.00126609
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.07040581,
+          "spread": 0.00777631,
+          "score": 0.07083395
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.00111718,
+          "spread": 0.00428096,
+          "score": 0.00442433
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": -5.146e-05,
+          "spread": 0.00099579,
+          "score": 0.00099712
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00030527,
+          "spread": 0.00074428,
+          "score": 0.00080445
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": 0.00237376,
+          "spread": 0.0016222,
+          "score": 0.00287512
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.00891372,
+          "spread": 0.00708325,
+          "score": 0.01138538
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.00027019,
+          "spread": 0.02411511,
+          "score": 0.02411662
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.00512076,
+          "spread": 0.0204681,
+          "score": 0.02109894
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.03455414,
+          "spread": 0.20212441,
+          "score": 0.20505673
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.06777103,
           "spread": 0.0,
-          "score": 0.16955813
+          "score": 0.06777103
         },
         {
           "profile": "cp_minus_10pct",
-          "campaign_months": 3,
+          "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.03807663,
-          "spread": 0.08467439,
-          "score": 0.0928417
+          "bias": -0.00187558,
+          "spread": 0.04324757,
+          "score": 0.04328822
         },
         {
           "profile": "cp_minus_10pct",
-          "campaign_months": 3,
+          "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00475917,
-          "spread": 0.00269822,
-          "score": 0.00547084
+          "bias": 0.00305586,
+          "spread": 0.00144986,
+          "score": 0.00338236
         },
         {
           "profile": "cp_minus_10pct",
-          "campaign_months": 3,
+          "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00372832,
-          "spread": 0.00103078,
-          "score": 0.00386819
+          "bias": -0.0028457,
+          "spread": 0.00048822,
+          "score": 0.00288728
         },
         {
           "profile": "cp_minus_10pct",
-          "campaign_months": 3,
+          "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.0016975,
-          "spread": 0.00173659,
-          "score": 0.00242842
+          "bias": -0.00206069,
+          "spread": 0.00121841,
+          "score": 0.00239394
         },
         {
           "profile": "cp_minus_10pct",
-          "campaign_months": 3,
+          "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00181111,
-          "spread": 0.00229297,
-          "score": 0.00292196
+          "bias": -5.76e-05,
+          "spread": 0.00035876,
+          "score": 0.00036335
         },
         {
           "profile": "cp_minus_10pct",
-          "campaign_months": 3,
+          "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00566659,
-          "spread": 0.02592867,
-          "score": 0.02654065
+          "bias": 0.00101086,
+          "spread": 0.00142258,
+          "score": 0.00174516
         },
         {
           "profile": "cp_minus_10pct",
-          "campaign_months": 3,
+          "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.03251148,
-          "spread": 0.04539132,
-          "score": 0.0558334
+          "bias": 0.02591585,
+          "spread": 0.03730928,
+          "score": 0.04542702
         },
         {
           "profile": "cp_minus_10pct",
-          "campaign_months": 3,
+          "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.07106752,
-          "spread": 0.07475615,
-          "score": 0.10314589
+          "bias": 0.00036532,
+          "spread": 0.00269831,
+          "score": 0.00272292
         },
         {
           "profile": "cp_minus_10pct",
-          "campaign_months": 3,
+          "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.00263626,
-          "spread": 0.01715625,
-          "score": 0.01735762
+          "bias": -0.02644025,
+          "spread": 0.02925618,
+          "score": 0.03943363
         },
         {
           "profile": "cp_minus_10pct",
-          "campaign_months": 3,
+          "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00341785,
-          "spread": 0.01046127,
-          "score": 0.01100545
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00623948,
-          "spread": 0.00230983,
-          "score": 0.0066533
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00623533,
-          "spread": 0.0061841,
-          "score": 0.00878194
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.00166124,
-          "spread": 0.00150904,
-          "score": 0.00224431
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": 0.07625808,
-          "spread": 0.00994028,
-          "score": 0.07690321
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00023161,
-          "spread": 0.01062233,
-          "score": 0.01062485
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00145461,
-          "spread": 0.00198255,
-          "score": 0.00245894
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00301022,
-          "spread": 0.00099207,
-          "score": 0.00316948
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00336566,
-          "spread": 0.00225574,
-          "score": 0.00405167
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00865511,
-          "spread": 0.00702797,
-          "score": 0.01114914
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00701585,
-          "spread": 0.01692721,
-          "score": 0.01832355
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": -0.01336663,
-          "spread": 0.02972832,
-          "score": 0.03259509
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.15664088,
-          "spread": 0.081408,
-          "score": 0.17653223
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": 0.33209945,
-          "spread": 0.50938131,
-          "score": 0.60807842
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.02426419,
-          "spread": 0.03979664,
-          "score": 0.04661034
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00406445,
-          "spread": 0.00206177,
-          "score": 0.00455749
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00525756,
-          "spread": 0.00124329,
-          "score": 0.00540257
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00252498,
-          "spread": 0.0021193,
-          "score": 0.00329651
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00012629,
-          "spread": 0.00156127,
-          "score": 0.00156637
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00475532,
-          "spread": 0.01275614,
-          "score": 0.01361367
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": 0.02658111,
-          "spread": 0.04121688,
-          "score": 0.04904475
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00097331,
-          "spread": 0.0122304,
-          "score": 0.01226906
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": 0.02436996,
-          "spread": 0.00989574,
-          "score": 0.02630248
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00256449,
-          "spread": 0.00325645,
-          "score": 0.00414501
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00102136,
-          "spread": 0.003372,
-          "score": 0.00352329
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00474629,
-          "spread": 0.0051996,
-          "score": 0.00704011
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.0011672,
-          "spread": 0.00141164,
-          "score": 0.00183169
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": 0.05293025,
-          "spread": 0.0073713,
-          "score": 0.05344107
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": -0.0002229,
-          "spread": 0.00593667,
-          "score": 0.00594086
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00083815,
-          "spread": 0.00162531,
-          "score": 0.0018287
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": 0.0010264,
-          "spread": 0.0010564,
-          "score": 0.00147291
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": 0.0013471,
-          "spread": 0.00131689,
-          "score": 0.00188385
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00777963,
-          "spread": 0.00747686,
-          "score": 0.01079009
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00092824,
-          "spread": 0.01802584,
-          "score": 0.01804972
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": 0.02423445,
-          "spread": 0.01727606,
-          "score": 0.0297619
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.05044412,
-          "spread": 0.24606664,
-          "score": 0.251184
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": -0.06263651,
+          "bias": 0.02038977,
           "spread": 0.0,
-          "score": 0.06263651
+          "score": 0.02038977
         },
         {
           "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": 0.0020259,
+          "spread": 0.00451514,
+          "score": 0.00494882
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.00221669,
+          "spread": 0.00223986,
+          "score": 0.0031513
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00149298,
+          "spread": 0.00321343,
+          "score": 0.00354332
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00369338,
+          "spread": 0.00068943,
+          "score": 0.00375718
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.00680251,
+          "spread": 0.01241535,
+          "score": 0.0141568
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.00223108,
+          "spread": 0.00295246,
+          "score": 0.00370064
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00582514,
+          "spread": 0.00146635,
+          "score": 0.00600686
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": 0.00136358,
+          "spread": 0.00264149,
+          "score": 0.00297268
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.00183457,
+          "spread": 0.00505484,
+          "score": 0.00537745
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.00298136,
+          "spread": 0.03481333,
+          "score": 0.03494075
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.01699357,
+          "spread": 0.05905653,
+          "score": 0.06145287
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": -0.22330942,
+          "spread": 1.11172623,
+          "score": 1.13393223
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": 0.08292892,
+          "spread": 0.26297208,
+          "score": 0.27573813
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.00842962,
+          "spread": 0.01310715,
+          "score": 0.01558384
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": -0.00172253,
+          "spread": 0.00149341,
+          "score": 0.00227978
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00630654,
+          "spread": 0.00149783,
+          "score": 0.00648197
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.00281841,
+          "spread": 0.00238587,
+          "score": 0.00369267
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00278863,
+          "spread": 0.00211771,
+          "score": 0.00350159
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00421652,
+          "spread": 0.0143902,
+          "score": 0.01499522
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": 0.00070689,
+          "spread": 0.03634893,
+          "score": 0.03635581
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.05494878,
+          "spread": 0.05398633,
+          "score": 0.07703176
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.01289958,
+          "spread": 0.00272681,
+          "score": 0.01318463
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": 0.00506838,
+          "spread": 0.01002698,
+          "score": 0.01123516
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.00914378,
+          "spread": 0.004234,
+          "score": 0.01007648
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00231569,
+          "spread": 0.00463095,
+          "score": 0.00517765
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00108097,
+          "spread": 0.00148072,
+          "score": 0.00183331
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.11754493,
+          "spread": 0.01026161,
+          "score": 0.11799199
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": -0.00092733,
+          "spread": 0.00993098,
+          "score": 0.00997418
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.00076376,
+          "spread": 0.00156802,
+          "score": 0.00174413
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00258159,
+          "spread": 0.00249686,
+          "score": 0.0035915
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.00250991,
+          "spread": 0.0021984,
+          "score": 0.00333656
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.0006543,
+          "spread": 0.00711804,
+          "score": 0.00714805
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": 0.00076294,
+          "spread": 0.02504472,
+          "score": 0.02505634
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.04813812,
+          "spread": 0.02886311,
+          "score": 0.05612805
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": -0.01193198,
+          "spread": 0.31342482,
+          "score": 0.31365186
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": 0.50502003,
+          "spread": 0.55581116,
+          "score": 0.75098021
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.00025381,
+          "spread": 0.01802401,
+          "score": 0.0180258
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": -0.00301006,
+          "spread": 0.00305441,
+          "score": 0.00428834
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00438135,
+          "spread": 0.00171231,
+          "score": 0.00470406
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.00109428,
+          "spread": 0.00231055,
+          "score": 0.00255657
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00039896,
+          "spread": 0.00157782,
+          "score": 0.00162748
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00181233,
+          "spread": 0.00866043,
+          "score": 0.00884803
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.04232535,
+          "spread": 0.04690682,
+          "score": 0.06317978
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": -0.00961515,
+          "spread": 0.00501633,
+          "score": 0.01084503
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.0007419,
+          "spread": 0.0137958,
+          "score": 0.01381573
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": 0.0021408,
+          "spread": 0.00599649,
+          "score": 0.00636717
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.00150478,
+          "spread": 0.00264935,
+          "score": 0.00304687
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00153385,
+          "spread": 0.00468915,
+          "score": 0.00493364
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00098813,
+          "spread": 0.00179034,
+          "score": 0.00204493
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.0764484,
+          "spread": 0.00576954,
+          "score": 0.0766658
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.0019135,
+          "spread": 0.00372176,
+          "score": 0.00418485
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.00248103,
+          "spread": 0.0018007,
+          "score": 0.00306562
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.0014082,
+          "spread": 0.00266442,
+          "score": 0.00301366
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.00396788,
+          "spread": 0.00198125,
+          "score": 0.00443502
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.00195476,
+          "spread": 0.00736234,
+          "score": 0.00761742
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.01205117,
+          "spread": 0.02231875,
+          "score": 0.02536449
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.00455112,
+          "spread": 0.02828559,
+          "score": 0.02864939
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": -0.01610572,
+          "spread": 0.33481061,
+          "score": 0.33519776
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": 0.2971093,
+          "spread": 0.42275724,
+          "score": 0.51671812
+        },
+        {
+          "profile": "cp_plus_10pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.01167721,
-          "spread": 0.01427837,
-          "score": 0.0184453
+          "bias": -0.01279754,
+          "spread": 0.03893442,
+          "score": 0.04098373
         },
         {
-          "profile": "cp_minus_10pct",
+          "profile": "cp_plus_10pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00298924,
-          "spread": 0.00168541,
-          "score": 0.00343164
+          "bias": -0.0044399,
+          "spread": 0.00285179,
+          "score": 0.00527688
         },
         {
-          "profile": "cp_minus_10pct",
+          "profile": "cp_plus_10pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00405385,
-          "spread": 0.00063393,
-          "score": 0.00410312
+          "bias": 0.00508158,
+          "spread": 0.00154627,
+          "score": 0.00531162
         },
         {
-          "profile": "cp_minus_10pct",
+          "profile": "cp_plus_10pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00205205,
-          "spread": 0.00181416,
-          "score": 0.00273899
+          "bias": 0.00071285,
+          "spread": 0.00145799,
+          "score": 0.00162292
         },
         {
-          "profile": "cp_minus_10pct",
+          "profile": "cp_plus_10pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -2.06e-06,
-          "spread": 0.00163092,
-          "score": 0.00163092
+          "bias": 0.00037078,
+          "spread": 0.0012313,
+          "score": 0.00128591
         },
         {
-          "profile": "cp_minus_10pct",
+          "profile": "cp_plus_10pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00731269,
-          "spread": 0.01267913,
-          "score": 0.01463679
+          "bias": 0.0026625,
+          "spread": 0.00675594,
+          "score": 0.00726165
         },
         {
-          "profile": "cp_minus_10pct",
+          "profile": "cp_plus_10pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.03109868,
-          "spread": 0.03153845,
-          "score": 0.04429223
+          "bias": -0.02753296,
+          "spread": 0.03776565,
+          "score": 0.04673658
         },
         {
-          "profile": "cp_minus_10pct",
+          "profile": "cp_plus_10pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00527206,
-          "spread": 0.00590496,
-          "score": 0.00791601
+          "bias": 0.00024423,
+          "spread": 0.00726398,
+          "score": 0.00726808
         },
         {
-          "profile": "cp_minus_10pct",
+          "profile": "cp_plus_10pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.00607625,
-          "spread": 0.03167156,
-          "score": 0.03224916
+          "bias": -0.02678332,
+          "spread": 0.0265178,
+          "score": 0.03769006
         },
         {
-          "profile": "cp_minus_10pct",
+          "profile": "cp_plus_10pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
@@ -6066,430 +6930,430 @@
           "score": NaN
         },
         {
-          "profile": "cp_minus_10pct",
+          "profile": "cp_plus_10pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00022556,
-          "spread": 0.00400518,
-          "score": 0.00401153
+          "bias": -0.00073976,
+          "spread": 0.00442099,
+          "score": 0.00448246
         },
         {
-          "profile": "cp_minus_10pct",
+          "profile": "cp_plus_10pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00174022,
-          "spread": 0.00235921,
-          "score": 0.00293159
+          "bias": 0.00215039,
+          "spread": 0.00236787,
+          "score": 0.00319859
         },
         {
-          "profile": "cp_minus_10pct",
+          "profile": "cp_plus_10pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.0036466,
-          "spread": 0.00377743,
-          "score": 0.0052504
+          "bias": 0.00196597,
+          "spread": 0.00426288,
+          "score": 0.00469438
         },
         {
-          "profile": "cp_minus_10pct",
+          "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00084467,
-          "spread": 0.00101934,
-          "score": 0.00132382
+          "bias": 0.00066711,
+          "spread": 0.00111473,
+          "score": 0.0012991
         },
         {
-          "profile": "cp_minus_10pct",
+          "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.01205237,
-          "spread": 0.00417338,
-          "score": 0.01275448
+          "bias": 0.08905323,
+          "spread": 0.03743434,
+          "score": 0.09660128
         },
         {
-          "profile": "cp_minus_10pct",
+          "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00020625,
-          "spread": 0.00450048,
-          "score": 0.0045052
+          "bias": 0.00218796,
+          "spread": 0.00390845,
+          "score": 0.00447919
         },
         {
-          "profile": "cp_minus_10pct",
+          "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00021994,
-          "spread": 0.00105454,
-          "score": 0.00107723
+          "bias": 0.00179881,
+          "spread": 0.000539,
+          "score": 0.00187783
         },
         {
-          "profile": "cp_minus_10pct",
+          "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00043962,
-          "spread": 0.00069179,
-          "score": 0.00081966
+          "bias": 0.00030407,
+          "spread": 0.00176743,
+          "score": 0.00179339
         },
         {
-          "profile": "cp_minus_10pct",
+          "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00286353,
-          "spread": 0.00176481,
-          "score": 0.00336368
+          "bias": -0.00146009,
+          "spread": 0.00259057,
+          "score": 0.0029737
         },
         {
-          "profile": "cp_minus_10pct",
+          "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00951212,
-          "spread": 0.00572226,
-          "score": 0.01110066
+          "bias": 0.00170492,
+          "spread": 0.00694778,
+          "score": 0.00715391
         },
         {
-          "profile": "cp_minus_10pct",
+          "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00085021,
-          "spread": 0.02233342,
-          "score": 0.02234959
+          "bias": -0.01026733,
+          "spread": 0.03321877,
+          "score": 0.0347693
         },
         {
-          "profile": "cp_minus_10pct",
+          "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.00239784,
-          "spread": 0.01964217,
-          "score": 0.01978799
+          "bias": -0.02127983,
+          "spread": 0.02333751,
+          "score": 0.03158276
         },
         {
-          "profile": "cp_minus_10pct",
+          "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.02428565,
-          "spread": 0.19636587,
-          "score": 0.19786194
+          "bias": 0.02162906,
+          "spread": 0.26423588,
+          "score": 0.26511962
         },
         {
-          "profile": "cp_minus_10pct",
+          "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.04594679,
+          "bias": 0.77348912,
+          "spread": 0.90512767,
+          "score": 1.19060553
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.01464604,
+          "spread": 0.04286384,
+          "score": 0.04529697
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": -0.00370342,
+          "spread": 0.00258488,
+          "score": 0.0045163
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00519966,
+          "spread": 0.0007984,
+          "score": 0.0052606
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.0005644,
+          "spread": 0.00122672,
+          "score": 0.00135033
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00080484,
+          "spread": 0.0005275,
+          "score": 0.0009623
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": -0.0020563,
+          "spread": 0.00375288,
+          "score": 0.00427931
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.02533422,
+          "spread": 0.02096606,
+          "score": 0.03288463
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": -0.00689045,
+          "spread": 0.00541315,
+          "score": 0.00876244
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.03687513,
+          "spread": 0.02463179,
+          "score": 0.04434524
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": 0.01817093,
           "spread": 0.0,
-          "score": 0.04594679
+          "score": 0.01817093
         },
         {
-          "profile": "cp_minus_10pct",
+          "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.00427666,
-          "spread": 0.03169762,
-          "score": 0.03198483
+          "condition_bin": "(4.0, 6.0]",
+          "bias": 0.00115837,
+          "spread": 0.00595899,
+          "score": 0.00607053
         },
         {
-          "profile": "cp_minus_10pct",
+          "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00351488,
-          "spread": 0.00140586,
-          "score": 0.00378561
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.00328656,
+          "spread": 0.00221798,
+          "score": 0.00396496
         },
         {
-          "profile": "cp_minus_10pct",
+          "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": -0.0031547,
-          "spread": 0.00064491,
-          "score": 0.00321994
+          "condition_bin": "(8.0, 10.0]",
+          "bias": -0.00069999,
+          "spread": 0.00282222,
+          "score": 0.00290773
         },
         {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00214299,
-          "spread": 0.00091904,
-          "score": 0.00233175
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.0035815,
+          "spread": 0.00067107,
+          "score": 0.00364383
         },
         {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00054218,
-          "spread": 0.00072594,
-          "score": 0.00090606
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
         },
         {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00052908,
-          "spread": 0.00135648,
-          "score": 0.00145601
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.00722123,
+          "spread": 0.01336856,
+          "score": 0.01519423
         },
         {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": 0.02866544,
-          "spread": 0.03652193,
-          "score": 0.04642799
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.00121453,
+          "spread": 0.00257942,
+          "score": 0.00285105
         },
         {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00117356,
-          "spread": 0.00216958,
-          "score": 0.00246665
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00557423,
+          "spread": 0.00121979,
+          "score": 0.00570613
         },
         {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": -0.0260846,
-          "spread": 0.02557641,
-          "score": 0.03653162
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": 0.00308064,
+          "spread": 0.00263416,
+          "score": 0.00405329
         },
         {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": 0.0228982,
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.003257,
+          "spread": 0.00352999,
+          "score": 0.00480301
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": 0.00100712,
+          "spread": 0.03037448,
+          "score": 0.03039117
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.02712495,
+          "spread": 0.05958807,
+          "score": 0.06547137
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": -0.00680825,
+          "spread": 0.6814628,
+          "score": 0.68149681
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.1581287,
           "spread": 0.0,
-          "score": 0.0228982
+          "score": 0.1581287
         },
         {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00126004,
-          "spread": 0.00467157,
-          "score": 0.00483852
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00221702,
-          "spread": 0.00170879,
-          "score": 0.00279913
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00211025,
-          "spread": 0.00316253,
-          "score": 0.00380194
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.00403615,
-          "spread": 0.00075129,
-          "score": 0.00410547
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00855611,
-          "spread": 0.01029621,
-          "score": 0.01338727
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00292001,
-          "spread": 0.00304946,
-          "score": 0.00422204
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00580916,
-          "spread": 0.00122881,
-          "score": 0.0059377
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00222115,
-          "spread": 0.00277908,
-          "score": 0.00355764
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00209072,
-          "spread": 0.00727813,
-          "score": 0.00757247
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00785741,
-          "spread": 0.02798588,
-          "score": 0.029068
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": 0.01262233,
-          "spread": 0.04641039,
-          "score": 0.04809624
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": -0.20850347,
-          "spread": 1.08591181,
-          "score": 1.10574778
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": 0.05950144,
-          "spread": 0.28140171,
-          "score": 0.28762362
-        },
-        {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.01528655,
-          "spread": 0.07089151,
-          "score": 0.07252093
+          "bias": 0.01528571,
+          "spread": 0.01987935,
+          "score": 0.02507671
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00180586,
-          "spread": 0.00136306,
-          "score": 0.00226254
+          "bias": 0.00015469,
+          "spread": 0.00199031,
+          "score": 0.00199631
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00770701,
-          "spread": 0.00164469,
-          "score": 0.00788054
+          "bias": 0.00324922,
+          "spread": 0.0011674,
+          "score": 0.00345257
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00243351,
-          "spread": 0.00287535,
-          "score": 0.00376691
+          "bias": 0.0019417,
+          "spread": 0.00237627,
+          "score": 0.00306869
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00319723,
-          "spread": 0.00285105,
-          "score": 0.00428378
+          "bias": 0.00262006,
+          "spread": 0.00192661,
+          "score": 0.00325215
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00681603,
-          "spread": 0.01799309,
-          "score": 0.01924083
+          "bias": 0.00419339,
+          "spread": 0.01694906,
+          "score": 0.0174601
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.00047033,
-          "spread": 0.04286446,
-          "score": 0.04286704
+          "bias": 0.01217,
+          "spread": 0.03905425,
+          "score": 0.04090652
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.05086297,
-          "spread": 0.05283434,
-          "score": 0.07333832
+          "bias": 0.0616323,
+          "spread": 0.06094281,
+          "score": 0.08667507
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.01243128,
-          "spread": 0.00242625,
-          "score": 0.01266583
+          "bias": -0.01092281,
+          "spread": 0.00607802,
+          "score": 0.01250001
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
@@ -6498,214 +7362,214 @@
           "score": NaN
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00529972,
-          "spread": 0.01195483,
-          "score": 0.01307688
+          "bias": 0.00414851,
+          "spread": 0.00952603,
+          "score": 0.01039015
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00794592,
-          "spread": 0.00355446,
-          "score": 0.0087047
+          "bias": 0.00803385,
+          "spread": 0.00367609,
+          "score": 0.00883495
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00368187,
-          "spread": 0.00657171,
-          "score": 0.00753283
+          "bias": 0.00338326,
+          "spread": 0.00470911,
+          "score": 0.00579846
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00167524,
-          "spread": 0.00170028,
-          "score": 0.00238692
+          "bias": 0.00110397,
+          "spread": 0.00142354,
+          "score": 0.00180145
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.06932889,
-          "spread": 0.00034058,
-          "score": 0.06932973
+          "bias": 0.09866961,
+          "spread": 0.00681137,
+          "score": 0.09890443
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00053167,
-          "spread": 0.01051256,
-          "score": 0.01052599
+          "bias": 1.352e-05,
+          "spread": 0.00965361,
+          "score": 0.00965362
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.0011067,
-          "spread": 0.00136156,
-          "score": 0.0017546
+          "bias": 1.113e-05,
+          "spread": 0.00153564,
+          "score": 0.00153568
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.0029492,
-          "spread": 0.00261286,
-          "score": 0.00394016
+          "bias": 0.0025132,
+          "spread": 0.00188484,
+          "score": 0.00314146
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00078046,
-          "spread": 0.00295904,
-          "score": 0.00306023
+          "bias": -0.00107522,
+          "spread": 0.00196549,
+          "score": 0.00224037
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.0023145,
-          "spread": 0.00672635,
-          "score": 0.00711341
+          "bias": 0.00283291,
+          "spread": 0.00659782,
+          "score": 0.0071803
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00015489,
-          "spread": 0.02489727,
-          "score": 0.02489775
+          "bias": 0.00180873,
+          "spread": 0.02099981,
+          "score": 0.02107756
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.04907767,
-          "spread": 0.02958052,
-          "score": 0.05730292
+          "bias": -0.03559074,
+          "spread": 0.03247668,
+          "score": 0.04818128
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.01251598,
-          "spread": 0.31857177,
-          "score": 0.31881754
+          "bias": 0.04598061,
+          "spread": 0.22789235,
+          "score": 0.23248471
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.44008123,
-          "spread": 0.61149813,
-          "score": 0.75339329
+          "bias": 0.43692824,
+          "spread": 0.49042449,
+          "score": 0.65682758
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.04045651,
-          "spread": 0.06020368,
-          "score": 0.07253422
+          "bias": -0.0039587,
+          "spread": 0.01666001,
+          "score": 0.01712388
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00291088,
-          "spread": 0.00246373,
-          "score": 0.00381355
+          "bias": -0.00081558,
+          "spread": 0.00301061,
+          "score": 0.00311913
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00538352,
-          "spread": 0.00188219,
-          "score": 0.00570306
+          "bias": 0.001384,
+          "spread": 0.00141946,
+          "score": 0.00198251
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00151453,
-          "spread": 0.00253472,
-          "score": 0.00295273
+          "bias": 0.00013856,
+          "spread": 0.00215458,
+          "score": 0.00215903
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00127254,
-          "spread": 0.00259867,
-          "score": 0.00289352
+          "bias": 0.00029901,
+          "spread": 0.00143291,
+          "score": 0.00146378
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00331403,
-          "spread": 0.00947352,
-          "score": 0.01003645
+          "bias": 0.0022954,
+          "spread": 0.01009907,
+          "score": 0.01035664
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.03890832,
-          "spread": 0.04495671,
-          "score": 0.05945556
+          "bias": -0.01747039,
+          "spread": 0.03042646,
+          "score": 0.03508538
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00842212,
-          "spread": 0.00463819,
-          "score": 0.00961483
+          "bias": -0.00643228,
+          "spread": 0.00524436,
+          "score": 0.00829925
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.00446222,
-          "spread": 0.01032818,
-          "score": 0.01125089
+          "bias": 0.00895162,
+          "spread": 0.01378066,
+          "score": 0.01643283
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
@@ -6714,214 +7578,214 @@
           "score": NaN
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00291001,
-          "spread": 0.00406977,
-          "score": 0.00500312
+          "bias": 0.00214778,
+          "spread": 0.00537958,
+          "score": 0.00579248
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00181993,
-          "spread": 0.00381341,
-          "score": 0.00422543
+          "bias": 0.00092735,
+          "spread": 0.00281547,
+          "score": 0.00296426
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00225913,
-          "spread": 0.00584531,
-          "score": 0.00626668
+          "bias": 0.00246255,
+          "spread": 0.00445014,
+          "score": 0.00508605
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 9,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00115584,
-          "spread": 0.00158331,
-          "score": 0.00196031
+          "bias": 0.00100009,
+          "spread": 0.00172058,
+          "score": 0.00199012
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.06678355,
-          "spread": 0.00788618,
-          "score": 0.06724756
+          "bias": 0.09313775,
+          "spread": 0.01756766,
+          "score": 0.09478008
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00219814,
-          "spread": 0.00475117,
-          "score": 0.00523502
+          "bias": 0.00138911,
+          "spread": 0.0039418,
+          "score": 0.0041794
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00275856,
-          "spread": 0.00133674,
-          "score": 0.00306538
+          "bias": 0.00192217,
+          "spread": 0.00170643,
+          "score": 0.00257034
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00123973,
-          "spread": 0.00279977,
-          "score": 0.00306197
+          "bias": 0.00122649,
+          "spread": 0.00205811,
+          "score": 0.00239585
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00340775,
-          "spread": 0.00241918,
-          "score": 0.00417914
+          "bias": -0.00224203,
+          "spread": 0.00165136,
+          "score": 0.00278455
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00203171,
-          "spread": 0.00693372,
-          "score": 0.00722526
+          "bias": 0.0041235,
+          "spread": 0.00676135,
+          "score": 0.00791954
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.0132954,
-          "spread": 0.02387796,
-          "score": 0.02732992
+          "bias": -0.00798233,
+          "spread": 0.02162552,
+          "score": 0.0230517
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.01524238,
-          "spread": 0.01778402,
-          "score": 0.02342225
+          "bias": 0.00846698,
+          "spread": 0.02468443,
+          "score": 0.02609618
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": -0.02359948,
-          "spread": 0.34376847,
-          "score": 0.34457756
+          "bias": 0.00645677,
+          "spread": 0.29250189,
+          "score": 0.29257314
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.26470859,
-          "spread": 0.17533212,
-          "score": 0.31750904
+          "bias": 0.30079315,
+          "spread": 0.40670682,
+          "score": 0.5058527
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.0199517,
-          "spread": 0.01740123,
-          "score": 0.02647401
+          "bias": -0.01166599,
+          "spread": 0.03250925,
+          "score": 0.03453907
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00421885,
-          "spread": 0.00304395,
-          "score": 0.00520233
+          "bias": -0.0021061,
+          "spread": 0.00249182,
+          "score": 0.00326264
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00553037,
-          "spread": 0.00108266,
-          "score": 0.00563535
+          "bias": 0.00210471,
+          "spread": 0.00144278,
+          "score": 0.00255175
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00144691,
-          "spread": 0.00185581,
-          "score": 0.00235321
+          "bias": -0.00018358,
+          "spread": 0.00148573,
+          "score": 0.00149703
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00097688,
-          "spread": 0.0016519,
-          "score": 0.00191913
+          "bias": 0.00018421,
+          "spread": 0.00116471,
+          "score": 0.00117918
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00458187,
-          "spread": 0.01053324,
-          "score": 0.01148663
+          "bias": 0.00384383,
+          "spread": 0.0075441,
+          "score": 0.00846691
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.02541461,
-          "spread": 0.04144088,
-          "score": 0.04861326
+          "bias": -0.0078808,
+          "spread": 0.02289693,
+          "score": 0.02421521
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00139184,
-          "spread": 0.00842192,
-          "score": 0.00853615
+          "bias": 0.00304077,
+          "spread": 0.00614101,
+          "score": 0.00685261
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.03090716,
-          "spread": 0.03221323,
-          "score": 0.04464241
+          "bias": -0.01919546,
+          "spread": 0.02638994,
+          "score": 0.03263272
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
@@ -6930,259 +7794,259 @@
           "score": NaN
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -9.991e-05,
-          "spread": 0.00460037,
-          "score": 0.00460145
+          "bias": 6.552e-05,
+          "spread": 0.00408989,
+          "score": 0.00409041
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00225768,
-          "spread": 0.00262834,
-          "score": 0.00346486
+          "bias": 0.00178594,
+          "spread": 0.00248578,
+          "score": 0.00306084
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00141314,
-          "spread": 0.00399898,
-          "score": 0.00424132
+          "bias": 0.0026502,
+          "spread": 0.00386136,
+          "score": 0.00468334
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00078259,
-          "spread": 0.00110101,
-          "score": 0.0013508
+          "bias": 0.00069375,
+          "spread": 0.00108325,
+          "score": 0.00128636
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.00433348,
-          "spread": 0.02984062,
-          "score": 0.03015363
+          "bias": 0.08027554,
+          "spread": 0.02050294,
+          "score": 0.08285248
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00122801,
-          "spread": 0.00333905,
-          "score": 0.0035577
+          "bias": 0.00161866,
+          "spread": 0.00399878,
+          "score": 0.00431396
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00201739,
-          "spread": 0.00041688,
-          "score": 0.00206001
+          "bias": 0.00120684,
+          "spread": 0.00059914,
+          "score": 0.00134738
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00025782,
-          "spread": 0.00194113,
-          "score": 0.00195818
+          "bias": 0.0002716,
+          "spread": 0.00131087,
+          "score": 0.00133871
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00135119,
-          "spread": 0.00322783,
-          "score": 0.00349923
+          "bias": -0.00011247,
+          "spread": 0.00222618,
+          "score": 0.00222902
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00243341,
-          "spread": 0.00565668,
-          "score": 0.00615788
+          "bias": 0.0042254,
+          "spread": 0.00694833,
+          "score": 0.00813224
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.01216463,
-          "spread": 0.02879435,
-          "score": 0.03125848
+          "bias": -0.00596332,
+          "spread": 0.029936,
+          "score": 0.03052418
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.00733065,
-          "spread": 0.02466773,
-          "score": 0.02573393
+          "bias": -0.01404276,
+          "spread": 0.01979088,
+          "score": 0.02426681
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.00705134,
-          "spread": 0.25308031,
-          "score": 0.25317853
+          "bias": 0.0263759,
+          "spread": 0.24404182,
+          "score": 0.24546302
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.76698308,
-          "spread": 0.86102585,
-          "score": 1.15309521
+          "bias": 0.10109117,
+          "spread": 0.21007868,
+          "score": 0.23313617
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.01695799,
-          "spread": 0.02944276,
-          "score": 0.03397719
+          "bias": -0.01033364,
+          "spread": 0.04805108,
+          "score": 0.04914968
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00396827,
-          "spread": 0.00305626,
-          "score": 0.00500878
+          "bias": -0.00130051,
+          "spread": 0.00210059,
+          "score": 0.00247059
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00560199,
-          "spread": 0.00061746,
-          "score": 0.00563592
+          "bias": 0.00244984,
+          "spread": 0.00071499,
+          "score": 0.00255204
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00088062,
-          "spread": 0.00106754,
-          "score": 0.00138388
+          "bias": -0.00028436,
+          "spread": 0.00135436,
+          "score": 0.00138389
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.0006181,
-          "spread": 0.00083305,
-          "score": 0.00103731
+          "bias": 0.00056112,
+          "spread": 0.00058382,
+          "score": 0.00080975
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": -0.00216643,
-          "spread": 0.00397375,
-          "score": 0.00452594
+          "bias": -0.00094692,
+          "spread": 0.00273808,
+          "score": 0.0028972
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.02364576,
-          "spread": 0.02308994,
-          "score": 0.03304947
+          "bias": -0.00421772,
+          "spread": 0.01769555,
+          "score": 0.01819126
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00828727,
-          "spread": 0.005567,
-          "score": 0.0099835
+          "bias": -0.00410416,
+          "spread": 0.00381435,
+          "score": 0.00560298
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.03814183,
-          "spread": 0.02624659,
-          "score": 0.04629992
+          "bias": -0.03392907,
+          "spread": 0.0262782,
+          "score": 0.04291533
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
-          "bias": 0.01966367,
+          "bias": 0.02112563,
           "spread": 0.0,
-          "score": 0.01966367
+          "score": 0.02112563
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00166431,
-          "spread": 0.00641286,
-          "score": 0.00662531
+          "bias": 0.0012678,
+          "spread": 0.00542638,
+          "score": 0.00557251
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00333245,
-          "spread": 0.00201012,
-          "score": 0.00389177
+          "bias": 0.00314362,
+          "spread": 0.00212309,
+          "score": 0.00379339
         },
         {
-          "profile": "cp_plus_10pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00048474,
-          "spread": 0.00283094,
-          "score": 0.00287214
+          "bias": 2.313e-05,
+          "spread": 0.00316259,
+          "score": 0.00316267
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00390941,
-          "spread": 0.00072999,
-          "score": 0.00397698
+          "bias": 0.0036029,
+          "spread": 0.00067607,
+          "score": 0.00366578
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
@@ -7191,169 +8055,169 @@
           "score": NaN
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00806156,
-          "spread": 0.0099895,
-          "score": 0.01283663
+          "bias": 0.0071486,
+          "spread": 0.01579317,
+          "score": 0.01733571
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00153686,
-          "spread": 0.00255413,
-          "score": 0.00298086
+          "bias": 0.00024939,
+          "spread": 0.00225042,
+          "score": 0.0022642
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00589125,
-          "spread": 0.0010926,
-          "score": 0.00599171
+          "bias": 0.00569997,
+          "spread": 0.00134637,
+          "score": 0.00585682
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00387329,
-          "spread": 0.00259181,
-          "score": 0.00466046
+          "bias": 0.00490635,
+          "spread": 0.00270714,
+          "score": 0.00560365
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00302703,
-          "spread": 0.00761249,
-          "score": 0.00819224
+          "bias": 0.00475207,
+          "spread": 0.00396534,
+          "score": 0.00618919
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00821355,
-          "spread": 0.02777642,
-          "score": 0.02896535
+          "bias": -0.0032848,
+          "spread": 0.03213677,
+          "score": 0.03230421
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.01453496,
-          "spread": 0.04085728,
-          "score": 0.04336568
+          "bias": 0.02308009,
+          "spread": 0.04877907,
+          "score": 0.05396377
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.08233644,
-          "spread": 0.73779315,
-          "score": 0.74237323
+          "bias": 0.11362029,
+          "spread": 0.5630428,
+          "score": 0.57439252
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.21630104,
+          "bias": -0.15468446,
           "spread": 0.0,
-          "score": 0.21630104
+          "score": 0.15468446
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.02154554,
-          "spread": 0.09106371,
-          "score": 0.09357783
+          "bias": 0.01279891,
+          "spread": 0.01378319,
+          "score": 0.01880926
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00073697,
-          "spread": 0.00132257,
-          "score": 0.00151404
+          "bias": 0.00213989,
+          "spread": 0.00228155,
+          "score": 0.00312804
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.0037071,
-          "spread": 0.00128209,
-          "score": 0.00392254
+          "bias": -0.00026219,
+          "spread": 0.00082123,
+          "score": 0.00086207
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00088567,
-          "spread": 0.00235096,
-          "score": 0.00251225
+          "bias": 0.00089742,
+          "spread": 0.00191161,
+          "score": 0.00211178
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00294277,
-          "spread": 0.00274789,
-          "score": 0.00402626
+          "bias": 0.00194409,
+          "spread": 0.00152688,
+          "score": 0.00247201
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00644862,
-          "spread": 0.02075983,
-          "score": 0.02173833
+          "bias": 0.00462914,
+          "spread": 0.02077839,
+          "score": 0.0212878
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.00957122,
-          "spread": 0.04075422,
-          "score": 0.04186304
+          "bias": 0.01578187,
+          "spread": 0.03684477,
+          "score": 0.04008247
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.0585159,
-          "spread": 0.06092932,
-          "score": 0.08447777
+          "bias": 0.0707332,
+          "spread": 0.07172836,
+          "score": 0.100738
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.00806664,
-          "spread": 0.00343649,
-          "score": 0.00876813
+          "bias": -0.00891818,
+          "spread": 0.0150698,
+          "score": 0.01751093
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
@@ -7362,214 +8226,214 @@
           "score": NaN
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00438238,
-          "spread": 0.01143465,
-          "score": 0.01224567
+          "bias": 0.00447566,
+          "spread": 0.00902007,
+          "score": 0.01006942
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00715776,
-          "spread": 0.00310753,
-          "score": 0.00780322
+          "bias": 0.00772525,
+          "spread": 0.00376801,
+          "score": 0.00859519
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00487196,
-          "spread": 0.00627233,
-          "score": 0.00794217
+          "bias": 0.00437401,
+          "spread": 0.00472589,
+          "score": 0.00643941
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00167034,
-          "spread": 0.00163335,
-          "score": 0.00233621
+          "bias": 0.00114936,
+          "spread": 0.00142739,
+          "score": 0.00183262
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.08413934,
-          "spread": 0.00235004,
-          "score": 0.08417215
+          "bias": 0.09899347,
+          "spread": 0.00298228,
+          "score": 0.09903838
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00020204,
-          "spread": 0.01015859,
-          "score": 0.0101606
+          "bias": 0.0010332,
+          "spread": 0.01085735,
+          "score": 0.0109064
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 6.684e-05,
-          "spread": 0.00151194,
-          "score": 0.00151341
+          "bias": -0.00068341,
+          "spread": 0.00181952,
+          "score": 0.00194363
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00315214,
-          "spread": 0.00191939,
-          "score": 0.00369053
+          "bias": 0.00269546,
+          "spread": 0.00127051,
+          "score": 0.00297989
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00070672,
-          "spread": 0.00240808,
-          "score": 0.00250964
+          "bias": -4.051e-05,
+          "spread": 0.0018331,
+          "score": 0.00183354
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00430877,
-          "spread": 0.00727353,
-          "score": 0.00845398
+          "bias": 0.00541758,
+          "spread": 0.00719913,
+          "score": 0.00900986
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00161356,
-          "spread": 0.02061197,
-          "score": 0.02067503
+          "bias": 0.00281462,
+          "spread": 0.01904896,
+          "score": 0.01925578
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.03610738,
-          "spread": 0.02905868,
-          "score": 0.04634814
+          "bias": -0.02649286,
+          "spread": 0.03414651,
+          "score": 0.0432187
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.06714712,
-          "spread": 0.22575769,
-          "score": 0.23553189
+          "bias": 0.07634972,
+          "spread": 0.19149148,
+          "score": 0.20615108
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.38762462,
-          "spread": 0.57094807,
-          "score": 0.69009749
+          "bias": 0.4127347,
+          "spread": 0.4266298,
+          "score": 0.59360165
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.03251734,
-          "spread": 0.04997109,
-          "score": 0.05961952
+          "bias": 0.00560567,
+          "spread": 0.01622846,
+          "score": 0.01716935
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00050075,
-          "spread": 0.00190164,
-          "score": 0.00196646
+          "bias": 0.0016346,
+          "spread": 0.00307652,
+          "score": 0.0034838
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00181508,
-          "spread": 0.00144801,
-          "score": 0.00232191
+          "bias": -0.00221194,
+          "spread": 0.00144375,
+          "score": 0.00264142
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00023102,
-          "spread": 0.00233589,
-          "score": 0.00234729
+          "bias": -0.00100813,
+          "spread": 0.00193666,
+          "score": 0.00218334
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00105196,
-          "spread": 0.00203681,
-          "score": 0.00229243
+          "bias": -6.676e-05,
+          "spread": 0.00094238,
+          "score": 0.00094474
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00384713,
-          "spread": 0.01076646,
-          "score": 0.01143316
+          "bias": 0.00266549,
+          "spread": 0.01196121,
+          "score": 0.01225461
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.01552055,
-          "spread": 0.02390778,
-          "score": 0.02850385
+          "bias": -0.00303815,
+          "spread": 0.02577282,
+          "score": 0.02595127
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.0056514,
-          "spread": 0.00566183,
-          "score": 0.00799966
+          "bias": -0.00387547,
+          "spread": 0.00954827,
+          "score": 0.01030479
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.00688681,
-          "spread": 0.0112451,
-          "score": 0.01318637
+          "bias": 0.02074172,
+          "spread": 0.01433024,
+          "score": 0.02521061
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
@@ -7578,214 +8442,214 @@
           "score": NaN
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00320374,
-          "spread": 0.00396585,
-          "score": 0.00509822
+          "bias": 0.00274471,
+          "spread": 0.00515089,
+          "score": 0.00583654
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00172014,
-          "spread": 0.00393094,
-          "score": 0.00429082
+          "bias": 0.00068893,
+          "spread": 0.00282264,
+          "score": 0.0029055
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00301417,
-          "spread": 0.00557795,
-          "score": 0.00634025
+          "bias": 0.00312196,
+          "spread": 0.00446801,
+          "score": 0.00545067
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00115981,
-          "spread": 0.0015232,
-          "score": 0.0019145
+          "bias": 0.00103646,
+          "spread": 0.0017218,
+          "score": 0.00200968
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.06176395,
-          "spread": 0.00999785,
-          "score": 0.0625679
+          "bias": 0.08293762,
+          "spread": 0.00869238,
+          "score": 0.08339188
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00133493,
-          "spread": 0.00503148,
-          "score": 0.00520556
+          "bias": 0.0011088,
+          "spread": 0.00420478,
+          "score": 0.00434852
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00212308,
-          "spread": 0.00128271,
-          "score": 0.00248048
+          "bias": 0.00143916,
+          "spread": 0.00169173,
+          "score": 0.00222107
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00119434,
-          "spread": 0.00211686,
-          "score": 0.00243055
+          "bias": 0.00119311,
+          "spread": 0.00164098,
+          "score": 0.00202887
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00186466,
-          "spread": 0.00203098,
-          "score": 0.00275714
+          "bias": -0.00085776,
+          "spread": 0.00161737,
+          "score": 0.00183075
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00417228,
-          "spread": 0.00715462,
-          "score": 0.0082823
+          "bias": 0.00555284,
+          "spread": 0.00707597,
+          "score": 0.00899463
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00790483,
-          "spread": 0.02174702,
-          "score": 0.02313913
+          "bias": -0.00312761,
+          "spread": 0.02198199,
+          "score": 0.02220338
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.01885555,
-          "spread": 0.01339917,
-          "score": 0.02313157
+          "bias": 0.01207662,
+          "spread": 0.02175073,
+          "score": 0.02487848
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.0015507,
-          "spread": 0.30743839,
-          "score": 0.3074423
+          "bias": 0.02483164,
+          "spread": 0.27296511,
+          "score": 0.27409225
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.0457467,
-          "spread": 0.02968802,
-          "score": 0.05453567
+          "bias": 0.34000828,
+          "spread": 0.44275786,
+          "score": 0.5582474
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.01775932,
-          "spread": 0.01882362,
-          "score": 0.02587899
+          "bias": -0.01668154,
+          "spread": 0.03254351,
+          "score": 0.03656985
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00161044,
-          "spread": 0.00246397,
-          "score": 0.00294358
+          "bias": 0.00066713,
+          "spread": 0.0021361,
+          "score": 0.00223785
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00229267,
-          "spread": 0.00091396,
-          "score": 0.00246813
+          "bias": -0.00116379,
+          "spread": 0.0011578,
+          "score": 0.00164162
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00023442,
-          "spread": 0.00184078,
-          "score": 0.00185565
+          "bias": -0.00110647,
+          "spread": 0.00154252,
+          "score": 0.00189832
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00055576,
-          "spread": 0.00166554,
-          "score": 0.00175582
+          "bias": 3.127e-05,
+          "spread": 0.0012065,
+          "score": 0.0012069
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00569434,
-          "spread": 0.011232,
-          "score": 0.01259299
+          "bias": 0.00487515,
+          "spread": 0.00864157,
+          "score": 0.00992188
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.00663009,
-          "spread": 0.02496407,
-          "score": 0.0258295
+          "bias": 0.00560242,
+          "spread": 0.02284528,
+          "score": 0.0235222
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00073596,
-          "spread": 0.00681076,
-          "score": 0.00685041
+          "bias": 0.005961,
+          "spread": 0.00680963,
+          "score": 0.00905012
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.02459843,
-          "spread": 0.03128407,
-          "score": 0.03979668
+          "bias": -0.01195817,
+          "spread": 0.02692545,
+          "score": 0.02946146
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
@@ -7794,259 +8658,259 @@
           "score": NaN
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -9.853e-05,
-          "spread": 0.00412995,
-          "score": 0.00413113
+          "bias": 0.00022167,
+          "spread": 0.00409139,
+          "score": 0.00409739
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00192104,
-          "spread": 0.00264603,
-          "score": 0.00326984
+          "bias": 0.0013892,
+          "spread": 0.00243008,
+          "score": 0.00279914
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00237319,
-          "spread": 0.00384927,
-          "score": 0.00452205
+          "bias": 0.0032013,
+          "spread": 0.0041212,
+          "score": 0.00521849
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00080432,
-          "spread": 0.00107241,
-          "score": 0.00134052
+          "bias": 0.00073809,
+          "spread": 0.00109957,
+          "score": 0.00132432
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.01056689,
-          "spread": 0.01700042,
-          "score": 0.02001683
+          "bias": 0.08040743,
+          "spread": 0.01900135,
+          "score": 0.08262207
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00039601,
-          "spread": 0.00327233,
-          "score": 0.0032962
+          "bias": 0.00140933,
+          "spread": 0.00431096,
+          "score": 0.00453548
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00123257,
-          "spread": 0.00061275,
-          "score": 0.00137648
+          "bias": 0.00042395,
+          "spread": 0.00086685,
+          "score": 0.00096497
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00036556,
-          "spread": 0.00149276,
-          "score": 0.00153687
+          "bias": 0.00028067,
+          "spread": 0.00096039,
+          "score": 0.00100056
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 7.784e-05,
-          "spread": 0.00267262,
-          "score": 0.00267375
+          "bias": 0.00164751,
+          "spread": 0.00190365,
+          "score": 0.00251758
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.0053646,
-          "spread": 0.00544548,
-          "score": 0.00764409
+          "bias": 0.00757962,
+          "spread": 0.00720035,
+          "score": 0.01045446
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.0077271,
-          "spread": 0.02736622,
-          "score": 0.02843621
+          "bias": -0.00307202,
+          "spread": 0.02839799,
+          "score": 0.02856366
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.00402735,
-          "spread": 0.02353688,
-          "score": 0.02387895
+          "bias": -0.01017272,
+          "spread": 0.0209626,
+          "score": 0.02330053
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.01399749,
-          "spread": 0.22147888,
-          "score": 0.22192076
+          "bias": 0.03370273,
+          "spread": 0.23271487,
+          "score": 0.23514269
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.10496327,
-          "spread": 0.18124095,
-          "score": 0.20944109
+          "bias": -0.17295861,
+          "spread": 0.07605068,
+          "score": 0.18894017
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.01874225,
-          "spread": 0.03210796,
-          "score": 0.03717786
+          "bias": -0.01248889,
+          "spread": 0.04058834,
+          "score": 0.04246629
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00131374,
-          "spread": 0.00244569,
-          "score": 0.00277621
+          "bias": 0.00136395,
+          "spread": 0.00185853,
+          "score": 0.00230532
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00263954,
-          "spread": 0.00053495,
-          "score": 0.00269321
+          "bias": -0.00073628,
+          "spread": 0.00050432,
+          "score": 0.00089244
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -3.267e-05,
-          "spread": 0.00106171,
-          "score": 0.00106222
+          "bias": -0.0012977,
+          "spread": 0.00130579,
+          "score": 0.00184096
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00028449,
-          "spread": 0.00088026,
-          "score": 0.00092509
+          "bias": 0.00021134,
+          "spread": 0.00045057,
+          "score": 0.00049768
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": -0.00113499,
-          "spread": 0.00307115,
-          "score": 0.00327417
+          "bias": 0.00018673,
+          "spread": 0.00183709,
+          "score": 0.00184656
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.00660812,
-          "spread": 0.01442082,
-          "score": 0.01586276
+          "bias": 0.00355508,
+          "spread": 0.01957797,
+          "score": 0.01989813
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00578968,
-          "spread": 0.00397991,
-          "score": 0.00702567
+          "bias": -0.00183231,
+          "spread": 0.00304883,
+          "score": 0.00355707
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.03449969,
-          "spread": 0.02542683,
-          "score": 0.04285735
+          "bias": -0.03097349,
+          "spread": 0.02920934,
+          "score": 0.04257397
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
-          "bias": 0.02069581,
+          "bias": 0.02170118,
           "spread": 0.0,
-          "score": 0.02069581
+          "score": 0.02170118
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00153574,
-          "spread": 0.00565203,
-          "score": 0.00585695
+          "bias": 0.0016347,
+          "spread": 0.00511423,
+          "score": 0.00536913
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00313997,
-          "spread": 0.00185025,
-          "score": 0.00364457
+          "bias": 0.00286918,
+          "spread": 0.00218853,
+          "score": 0.00360859
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00035262,
-          "spread": 0.00300251,
-          "score": 0.00302315
+          "bias": 0.00090171,
+          "spread": 0.00344586,
+          "score": 0.00356188
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00392994,
-          "spread": 0.00073893,
-          "score": 0.0039988
+          "bias": 0.00363978,
+          "spread": 0.00066556,
+          "score": 0.00370013
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
@@ -8055,169 +8919,169 @@
           "score": NaN
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00871028,
-          "spread": 0.01039627,
-          "score": 0.01356287
+          "bias": 0.00366757,
+          "spread": 0.01233397,
+          "score": 0.0128677
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00032751,
-          "spread": 0.00235575,
-          "score": 0.00237841
+          "bias": -0.00037565,
+          "spread": 0.00281742,
+          "score": 0.00284235
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00575813,
-          "spread": 0.00136481,
-          "score": 0.00591767
+          "bias": 0.00501286,
+          "spread": 0.00152132,
+          "score": 0.00523863
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00619112,
-          "spread": 0.0029586,
-          "score": 0.00686172
+          "bias": 0.00627364,
+          "spread": 0.00305591,
+          "score": 0.00697833
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00629687,
-          "spread": 0.00785095,
-          "score": 0.01006419
+          "bias": 0.01588502,
+          "spread": 0.00408924,
+          "score": 0.01640291
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00208498,
-          "spread": 0.0290842,
-          "score": 0.02915884
+          "bias": 0.01658354,
+          "spread": 0.02928562,
+          "score": 0.03365504
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.01685556,
-          "spread": 0.03778539,
-          "score": 0.04137446
+          "bias": 0.04674347,
+          "spread": 0.06259371,
+          "score": 0.07812122
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.02007625,
-          "spread": 0.38781211,
-          "score": 0.38833141
+          "bias": 0.14735105,
+          "spread": 0.59027563,
+          "score": 0.60838939
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.19788952,
+          "bias": -0.16336723,
           "spread": 0.0,
-          "score": 0.19788952
+          "score": 0.16336723
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.0219547,
-          "spread": 0.07769686,
-          "score": 0.08073915
+          "bias": 0.01140363,
+          "spread": 0.01375527,
+          "score": 0.01786758
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00314767,
-          "spread": 0.00189161,
-          "score": 0.00367233
+          "bias": -0.00129853,
+          "spread": 0.00173028,
+          "score": 0.00216334
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00062753,
-          "spread": 0.00121014,
-          "score": 0.00136317
+          "bias": 0.00438535,
+          "spread": 0.00113884,
+          "score": 0.00453081
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00065076,
-          "spread": 0.00230648,
-          "score": 0.00239653
+          "bias": 0.0023909,
+          "spread": 0.00264133,
+          "score": 0.00356273
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00227221,
-          "spread": 0.0026188,
-          "score": 0.00346714
+          "bias": 0.00292662,
+          "spread": 0.00205555,
+          "score": 0.00357636
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00607484,
-          "spread": 0.02485761,
-          "score": 0.02558915
+          "bias": 0.00488492,
+          "spread": 0.01628827,
+          "score": 0.01700501
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.01496037,
-          "spread": 0.042082,
-          "score": 0.04466214
+          "bias": 0.01903327,
+          "spread": 0.04013033,
+          "score": 0.04441519
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.06867939,
-          "spread": 0.07213123,
-          "score": 0.09959806
+          "bias": 0.05574664,
+          "spread": 0.05388378,
+          "score": 0.07753161
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.00647296,
-          "spread": 0.01159406,
-          "score": 0.01327861
+          "bias": -0.01280956,
+          "spread": 0.00174622,
+          "score": 0.01292804
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
@@ -8226,214 +9090,214 @@
           "score": NaN
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00408536,
-          "spread": 0.01127425,
-          "score": 0.01199162
+          "bias": 0.00556406,
+          "spread": 0.00938034,
+          "score": 0.0109064
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00730193,
-          "spread": 0.00280973,
-          "score": 0.00782385
+          "bias": 0.00884016,
+          "spread": 0.00373449,
+          "score": 0.00959661
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00584439,
-          "spread": 0.00673288,
-          "score": 0.00891564
+          "bias": 0.00299941,
+          "spread": 0.00484759,
+          "score": 0.00570049
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00171167,
-          "spread": 0.00163064,
-          "score": 0.00236407
+          "bias": 0.00109261,
+          "spread": 0.0014559,
+          "score": 0.00182029
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.07288381,
-          "spread": 0.02656246,
-          "score": 0.07757328
+          "bias": 0.08827774,
+          "spread": 0.00840027,
+          "score": 0.08867651
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -4.997e-05,
-          "spread": 0.01058579,
-          "score": 0.01058591
+          "bias": -0.00393302,
+          "spread": 0.01065345,
+          "score": 0.01135626
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.0008151,
-          "spread": 0.00181754,
-          "score": 0.00199195
+          "bias": -0.00204594,
+          "spread": 0.00152544,
+          "score": 0.00255202
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00322826,
-          "spread": 0.00142306,
-          "score": 0.003528
+          "bias": 0.00200169,
+          "spread": 0.00170446,
+          "score": 0.00262906
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.0023787,
-          "spread": 0.00230431,
-          "score": 0.0033118
+          "bias": 0.00262023,
+          "spread": 0.00181137,
+          "score": 0.00318538
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00703575,
-          "spread": 0.00763898,
-          "score": 0.01038537
+          "bias": 0.01409662,
+          "spread": 0.00628938,
+          "score": 0.01543603
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00355676,
-          "spread": 0.01869008,
-          "score": 0.0190255
+          "bias": 0.0219969,
+          "spread": 0.02420922,
+          "score": 0.03271009
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.03297725,
-          "spread": 0.02808974,
-          "score": 0.04331896
+          "bias": -0.01108995,
+          "spread": 0.03069239,
+          "score": 0.03263449
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.09305082,
-          "spread": 0.19559933,
-          "score": 0.2166046
+          "bias": 0.08203692,
+          "spread": 0.19257586,
+          "score": 0.20932156
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.29503825,
-          "spread": 0.53393357,
-          "score": 0.61002674
+          "bias": 0.45095289,
+          "spread": 0.48826882,
+          "score": 0.664654
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.03713315,
-          "spread": 0.05340907,
-          "score": 0.06504921
+          "bias": 0.00304666,
+          "spread": 0.01770408,
+          "score": 0.01796431
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00230163,
-          "spread": 0.00196652,
-          "score": 0.00302733
+          "bias": -0.00231478,
+          "spread": 0.00298008,
+          "score": 0.00377347
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.0024909,
-          "spread": 0.00144019,
-          "score": 0.00287728
+          "bias": 0.0024317,
+          "spread": 0.00154558,
+          "score": 0.00288132
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00152364,
-          "spread": 0.00223261,
-          "score": 0.00270297
+          "bias": 0.00064029,
+          "spread": 0.00241594,
+          "score": 0.00249935
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00073475,
-          "spread": 0.00179698,
-          "score": 0.00194139
+          "bias": 0.00038845,
+          "spread": 0.00164638,
+          "score": 0.00169158
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00446926,
-          "spread": 0.01234685,
-          "score": 0.01313085
+          "bias": 0.00226417,
+          "spread": 0.01018708,
+          "score": 0.01043566
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.00705631,
-          "spread": 0.02158831,
-          "score": 0.02271226
+          "bias": -0.01136741,
+          "spread": 0.02981023,
+          "score": 0.03190404
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00336862,
-          "spread": 0.00979069,
-          "score": 0.010354
+          "bias": -0.00893693,
+          "spread": 0.00556757,
+          "score": 0.01052932
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.01616029,
-          "spread": 0.00956325,
-          "score": 0.01877793
+          "bias": 0.00195192,
+          "spread": 0.01372285,
+          "score": 0.01386098
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
@@ -8442,214 +9306,1078 @@
           "score": NaN
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00280361,
-          "spread": 0.00359659,
-          "score": 0.00456023
+          "bias": 0.00304627,
+          "spread": 0.00564417,
+          "score": 0.00641377
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00132214,
-          "spread": 0.00391654,
-          "score": 0.00413369
+          "bias": 0.00136255,
+          "spread": 0.0025871,
+          "score": 0.00292398
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00439918,
-          "spread": 0.00562179,
-          "score": 0.00713844
+          "bias": 0.00221476,
+          "spread": 0.00475265,
+          "score": 0.00524336
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.0011949,
-          "spread": 0.00152241,
-          "score": 0.00193534
+          "bias": 0.00099963,
+          "spread": 0.00176087,
+          "score": 0.00202483
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.07237458,
-          "spread": 0.00066944,
-          "score": 0.07237768
+          "bias": 0.0825368,
+          "spread": 0.01044052,
+          "score": 0.08319452
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00020127,
-          "spread": 0.00611294,
-          "score": 0.00611626
+          "bias": -0.00111444,
+          "spread": 0.0037374,
+          "score": 0.00390002
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00139703,
-          "spread": 0.00150501,
-          "score": 0.00205347
+          "bias": 5.733e-05,
+          "spread": 0.00163006,
+          "score": 0.00163107
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00113859,
-          "spread": 0.00144694,
-          "score": 0.0018412
+          "bias": 0.00067846,
+          "spread": 0.00190078,
+          "score": 0.00201824
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00018886,
-          "spread": 0.00177495,
-          "score": 0.00178497
+          "bias": 0.00124029,
+          "spread": 0.00142271,
+          "score": 0.00188744
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00654771,
-          "spread": 0.00735395,
-          "score": 0.00984648
+          "bias": 0.01564129,
+          "spread": 0.00811922,
+          "score": 0.01762304
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00441393,
-          "spread": 0.02078947,
-          "score": 0.02125288
+          "bias": 0.01046737,
+          "spread": 0.02045732,
+          "score": 0.02297973
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.02064623,
-          "spread": 0.01457142,
-          "score": 0.0252704
+          "bias": 0.02862514,
+          "spread": 0.02462979,
+          "score": 0.03776275
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.01506167,
-          "spread": 0.30624196,
-          "score": 0.30661212
+          "bias": 0.02903013,
+          "spread": 0.28080166,
+          "score": 0.28229828
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.06852508,
+          "bias": 0.04751063,
+          "spread": 0.13203447,
+          "score": 0.14032235
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.01798337,
+          "spread": 0.0364784,
+          "score": 0.04067032
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": -0.00367183,
+          "spread": 0.00257114,
+          "score": 0.00448253
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00310985,
+          "spread": 0.0014437,
+          "score": 0.00342862
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 5.159e-05,
+          "spread": 0.00160338,
+          "score": 0.00160421
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00012521,
+          "spread": 0.00129603,
+          "score": 0.00130207
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00341012,
+          "spread": 0.0074704,
+          "score": 0.00821193
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.00416722,
+          "spread": 0.02410842,
+          "score": 0.02446593
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.00139649,
+          "spread": 0.00659496,
+          "score": 0.00674119
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.02522038,
+          "spread": 0.02712807,
+          "score": 0.03704051
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": 0.00060731,
+          "spread": 0.00399776,
+          "score": 0.00404362
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.00238153,
+          "spread": 0.00226263,
+          "score": 0.003285
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00263557,
+          "spread": 0.00416745,
+          "score": 0.00493091
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00068439,
+          "spread": 0.00110226,
+          "score": 0.00129745
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.07004853,
+          "spread": 0.01472308,
+          "score": 0.07157909
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": -0.00114898,
+          "spread": 0.00395162,
+          "score": 0.00411528
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": -0.00042458,
+          "spread": 0.00043249,
+          "score": 0.00060607
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00031275,
+          "spread": 0.00134312,
+          "score": 0.00137906
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": 0.00328782,
+          "spread": 0.00193914,
+          "score": 0.00381707
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.01501978,
+          "spread": 0.00778789,
+          "score": 0.01691878
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": 0.01091874,
+          "spread": 0.02912557,
+          "score": 0.03110494
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.00265888,
+          "spread": 0.02031973,
+          "score": 0.02049295
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.04013684,
+          "spread": 0.23370496,
+          "score": 0.23712649
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.1896474,
+          "spread": 0.10767137,
+          "score": 0.21808086
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.0076086,
+          "spread": 0.04059166,
+          "score": 0.0412986
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": -0.00281582,
+          "spread": 0.00226233,
+          "score": 0.00361206
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00354242,
+          "spread": 0.00068489,
+          "score": 0.00360802
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": -5.9e-06,
+          "spread": 0.00124785,
+          "score": 0.00124787
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00064246,
+          "spread": 0.00061111,
+          "score": 0.00088669
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": -0.00124238,
+          "spread": 0.00310465,
+          "score": 0.00334401
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.00086785,
+          "spread": 0.01901529,
+          "score": 0.01903508
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": -0.00600519,
+          "spread": 0.00441064,
+          "score": 0.00745091
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.03512766,
+          "spread": 0.02551048,
+          "score": 0.04341356
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": 0.01873546,
           "spread": 0.0,
-          "score": 0.06852508
+          "score": 0.01873546
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": 0.00192415,
+          "spread": 0.0054627,
+          "score": 0.00579167
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.00348283,
+          "spread": 0.00211255,
+          "score": 0.00407344
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": -0.00010438,
+          "spread": 0.00303115,
+          "score": 0.00303295
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00362961,
+          "spread": 0.00068049,
+          "score": 0.00369285
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.00869716,
+          "spread": 0.01320598,
+          "score": 0.0158126
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.00140191,
+          "spread": 0.00275197,
+          "score": 0.00308848
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00600113,
+          "spread": 0.00134126,
+          "score": 0.0061492
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": 0.00208679,
+          "spread": 0.00222151,
+          "score": 0.00304792
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.00218279,
+          "spread": 0.00509531,
+          "score": 0.00554318
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.00634239,
+          "spread": 0.0323985,
+          "score": 0.03301346
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.00385045,
+          "spread": 0.0585123,
+          "score": 0.05863885
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": -0.22979992,
+          "spread": 1.09816439,
+          "score": 1.12195055
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": 0.05406184,
+          "spread": 0.25394169,
+          "score": 0.25963256
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.0070811,
+          "spread": 0.01284086,
+          "score": 0.01466389
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.0023388,
+          "spread": 0.00190277,
+          "score": 0.00301504
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00301613,
+          "spread": 0.00113894,
+          "score": 0.00322401
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.00207617,
+          "spread": 0.00228876,
+          "score": 0.00309013
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00299653,
+          "spread": 0.00178742,
+          "score": 0.00348914
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00579755,
+          "spread": 0.01719157,
+          "score": 0.01814281
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": 0.0038476,
+          "spread": 0.0385015,
+          "score": 0.03869327
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.06609374,
+          "spread": 0.06530208,
+          "score": 0.09291256
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.00683944,
+          "spread": 0.00661462,
+          "score": 0.00951479
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": 0.00251827,
+          "spread": 0.01038761,
+          "score": 0.0106885
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.00718837,
+          "spread": 0.00419259,
+          "score": 0.00832169
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00265786,
+          "spread": 0.00440822,
+          "score": 0.00514748
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00113478,
+          "spread": 0.00145555,
+          "score": 0.00184563
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.08494244,
+          "spread": 0.00499563,
+          "score": 0.08508921
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.00030129,
+          "spread": 0.01002141,
+          "score": 0.01002594
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.00020405,
+          "spread": 0.00168603,
+          "score": 0.00169833
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00282359,
+          "spread": 0.0019755,
+          "score": 0.00344605
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.00171352,
+          "spread": 0.00214596,
+          "score": 0.00274615
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.00079464,
+          "spread": 0.00698213,
+          "score": 0.0070272
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": 0.00040856,
+          "spread": 0.02810653,
+          "score": 0.0281095
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.05307734,
+          "spread": 0.02798846,
+          "score": 0.06000465
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": -0.00126203,
+          "spread": 0.31079807,
+          "score": 0.31080063
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": 0.47959695,
+          "spread": 0.49392255,
+          "score": 0.68845677
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.00165475,
+          "spread": 0.01808285,
+          "score": 0.0181584
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.00163945,
+          "spread": 0.00323007,
+          "score": 0.00362231
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00137004,
+          "spread": 0.00143353,
+          "score": 0.00198293
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.0003441,
+          "spread": 0.00222021,
+          "score": 0.00224671
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00067031,
+          "spread": 0.00125876,
+          "score": 0.00142611
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00319848,
+          "spread": 0.01055499,
+          "score": 0.01102897
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.0432923,
+          "spread": 0.04793829,
+          "score": 0.06459336
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": -0.00400006,
+          "spread": 0.00622655,
+          "score": 0.0074007
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.01521841,
+          "spread": 0.01443775,
+          "score": 0.02097734
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": 0.00012653,
+          "spread": 0.00565897,
+          "score": 0.00566039
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.00028678,
+          "spread": 0.00289808,
+          "score": 0.00291224
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00156483,
+          "spread": 0.00475325,
+          "score": 0.00500421
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00102531,
+          "spread": 0.00175236,
+          "score": 0.00203028
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.05746352,
+          "spread": 0.00868898,
+          "score": 0.05811673
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.00217943,
+          "spread": 0.00343273,
+          "score": 0.00406615
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.00203794,
+          "spread": 0.00177686,
+          "score": 0.00270378
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00141927,
+          "spread": 0.00227509,
+          "score": 0.00268148
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.00265873,
+          "spread": 0.00151775,
+          "score": 0.00306144
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.0026957,
+          "spread": 0.0068893,
+          "score": 0.00739793
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.01011212,
+          "spread": 0.02411004,
+          "score": 0.02614477
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.00201364,
+          "spread": 0.030514,
+          "score": 0.03058037
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": -0.01666415,
+          "spread": 0.31759297,
+          "score": 0.31802985
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": 0.40574755,
+          "spread": 0.52575279,
+          "score": 0.66411375
+        },
+        {
+          "profile": "ws_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.01732742,
-          "spread": 0.02525785,
-          "score": 0.03063003
+          "bias": -0.00971793,
+          "spread": 0.02765946,
+          "score": 0.02931695
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ws_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00133103,
-          "spread": 0.00195872,
-          "score": 0.00236817
+          "bias": 0.00024686,
+          "spread": 0.0025335,
+          "score": 0.00254549
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ws_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.001601,
-          "spread": 0.00069021,
-          "score": 0.00174344
+          "bias": 0.00204753,
+          "spread": 0.0013853,
+          "score": 0.00247213
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ws_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00122409,
-          "spread": 0.00189864,
-          "score": 0.00225903
+          "bias": -5.043e-05,
+          "spread": 0.0014973,
+          "score": 0.00149815
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ws_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00019941,
-          "spread": 0.0016418,
-          "score": 0.00165387
+          "bias": 0.00056139,
+          "spread": 0.00121304,
+          "score": 0.00133665
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ws_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00687204,
-          "spread": 0.01269869,
-          "score": 0.01443889
+          "bias": 0.00462439,
+          "spread": 0.00783975,
+          "score": 0.00910201
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ws_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.00179037,
-          "spread": 0.02077889,
-          "score": 0.02085587
+          "bias": -0.02975565,
+          "spread": 0.03827139,
+          "score": 0.04847781
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ws_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00320024,
-          "spread": 0.00574773,
-          "score": 0.0065786
+          "bias": 0.00464267,
+          "spread": 0.0061312,
+          "score": 0.00769064
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ws_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.01462716,
-          "spread": 0.03258886,
-          "score": 0.03572097
+          "bias": -0.01492455,
+          "spread": 0.02657682,
+          "score": 0.03048064
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ws_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
@@ -8658,1975 +10386,247 @@
           "score": NaN
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ws_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -6.192e-05,
-          "spread": 0.00402094,
-          "score": 0.00402142
+          "bias": -0.00256574,
+          "spread": 0.00490567,
+          "score": 0.00553612
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ws_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00191824,
-          "spread": 0.0026358,
-          "score": 0.00325992
+          "bias": 0.00040006,
+          "spread": 0.00267742,
+          "score": 0.00270714
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ws_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00330329,
-          "spread": 0.00416746,
-          "score": 0.00531784
+          "bias": 0.00199089,
+          "spread": 0.00394815,
+          "score": 0.00442171
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00084848,
-          "spread": 0.00108975,
-          "score": 0.00138111
+          "bias": 0.00072863,
+          "spread": 0.00111537,
+          "score": 0.00133227
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.00895455,
-          "spread": 0.01530747,
-          "score": 0.01773422
+          "bias": 0.06552194,
+          "spread": 0.02109468,
+          "score": 0.06883393
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00016833,
-          "spread": 0.00413777,
-          "score": 0.00414119
+          "bias": 0.00215894,
+          "spread": 0.00359302,
+          "score": 0.00419176
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00036437,
-          "spread": 0.00093429,
-          "score": 0.00100282
+          "bias": 0.00131051,
+          "spread": 0.00066602,
+          "score": 0.00147004
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00046906,
-          "spread": 0.00097376,
-          "score": 0.00108084
+          "bias": 0.00052379,
+          "spread": 0.00138169,
+          "score": 0.00147764
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00183719,
-          "spread": 0.00228505,
-          "score": 0.00293202
+          "bias": -0.00046363,
+          "spread": 0.0022857,
+          "score": 0.00233225
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00805803,
-          "spread": 0.00606914,
-          "score": 0.01008793
+          "bias": 0.00266881,
+          "spread": 0.00650313,
+          "score": 0.00702945
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00300753,
-          "spread": 0.02563418,
-          "score": 0.02581001
+          "bias": -0.00947483,
+          "spread": 0.03231247,
+          "score": 0.03367295
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.00107371,
-          "spread": 0.02264515,
-          "score": 0.02267059
+          "bias": -0.02160247,
+          "spread": 0.02095046,
+          "score": 0.030093
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.02436886,
-          "spread": 0.21893555,
-          "score": 0.22028758
+          "bias": 0.01742396,
+          "spread": 0.2569254,
+          "score": 0.25751554
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.16077871,
-          "spread": 0.08337461,
-          "score": 0.18111079
+          "bias": 0.67480768,
+          "spread": 0.77999176,
+          "score": 1.03138381
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.01623304,
-          "spread": 0.03782435,
-          "score": 0.04116058
+          "bias": -0.00583662,
+          "spread": 0.04209304,
+          "score": 0.04249577
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00178515,
-          "spread": 0.00207325,
-          "score": 0.00273589
+          "bias": 0.00092449,
+          "spread": 0.0021895,
+          "score": 0.00237668
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.0008769,
-          "spread": 0.00071875,
-          "score": 0.00113383
+          "bias": 0.00240516,
+          "spread": 0.00060165,
+          "score": 0.00247927
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00133307,
-          "spread": 0.0010737,
-          "score": 0.00171169
+          "bias": -0.00014696,
+          "spread": 0.0012123,
+          "score": 0.00122117
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00033374,
-          "spread": 0.00082534,
-          "score": 0.00089026
+          "bias": 0.00089419,
+          "spread": 0.00054074,
+          "score": 0.00104498
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": -0.00038369,
-          "spread": 0.00208635,
-          "score": 0.00212134
+          "bias": 1.588e-05,
+          "spread": 0.00242671,
+          "score": 0.00242676
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.00498432,
-          "spread": 0.01587665,
-          "score": 0.01664066
+          "bias": -0.02626381,
+          "spread": 0.01944044,
+          "score": 0.03267596
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00336093,
-          "spread": 0.00251403,
-          "score": 0.00419716
+          "bias": -0.00267321,
+          "spread": 0.00328237,
+          "score": 0.0042332
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.03100548,
-          "spread": 0.02613573,
-          "score": 0.0405514
+          "bias": -0.03128215,
+          "spread": 0.02631204,
+          "score": 0.0408766
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
-          "bias": 0.02294855,
+          "bias": 0.02012885,
           "spread": 0.0,
-          "score": 0.02294855
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00124071,
-          "spread": 0.00538133,
-          "score": 0.0055225
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00265124,
-          "spread": 0.00191669,
-          "score": 0.00327151
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00159796,
-          "spread": 0.00324151,
-          "score": 0.00361398
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.00397417,
-          "spread": 0.00073137,
-          "score": 0.0040409
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00504061,
-          "spread": 0.00899795,
-          "score": 0.01031363
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00033596,
-          "spread": 0.00271435,
-          "score": 0.00273506
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00514949,
-          "spread": 0.00134764,
-          "score": 0.00532291
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00768934,
-          "spread": 0.00329508,
-          "score": 0.00836562
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01692781,
-          "spread": 0.00580596,
-          "score": 0.01789581
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": 0.01318499,
-          "spread": 0.02502386,
-          "score": 0.02828493
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": 0.03887501,
-          "spread": 0.05594901,
-          "score": 0.06812898
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.20520639,
-          "spread": 0.58724839,
-          "score": 0.6220694
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": -0.27469083,
-          "spread": 0.0,
-          "score": 0.27469083
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": 0.00309567,
-          "spread": 0.09249005,
-          "score": 0.09254184
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00101447,
-          "spread": 0.00151958,
-          "score": 0.00182709
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00517043,
-          "spread": 0.00143487,
-          "score": 0.00536583
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00133254,
-          "spread": 0.00274425,
-          "score": 0.00305066
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00302176,
-          "spread": 0.00264433,
-          "score": 0.00401541
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00638152,
-          "spread": 0.02038901,
-          "score": 0.02136435
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": 0.01623176,
-          "spread": 0.04769545,
-          "score": 0.05038181
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": 0.05439288,
-          "spread": 0.05631077,
-          "score": 0.07829105
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": -0.0105218,
-          "spread": 0.00196298,
-          "score": 0.01070334
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00606769,
-          "spread": 0.01132736,
-          "score": 0.01285013
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00790585,
-          "spread": 0.00295661,
-          "score": 0.00844062
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": 0.0045216,
-          "spread": 0.00637949,
-          "score": 0.00781938
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.00167141,
-          "spread": 0.0016711,
-          "score": 0.00236351
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": 0.07815033,
-          "spread": 0.00899089,
-          "score": 0.07866582
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00286507,
-          "spread": 0.01071406,
-          "score": 0.01109052
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00179999,
-          "spread": 0.00142931,
-          "score": 0.00229845
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00239099,
-          "spread": 0.00181081,
-          "score": 0.00299931
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00443632,
-          "spread": 0.00215385,
-          "score": 0.00493153
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01658264,
-          "spread": 0.00675046,
-          "score": 0.01790398
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": 0.02148984,
-          "spread": 0.02298347,
-          "score": 0.03146511
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": -0.01618775,
-          "spread": 0.02991567,
-          "score": 0.03401457
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.10664417,
-          "spread": 0.19619468,
-          "score": 0.22330547
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": 0.39820988,
-          "spread": 0.61878606,
-          "score": 0.73584461
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.03701948,
-          "spread": 0.05669441,
-          "score": 0.0677104
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": -0.0024304,
-          "spread": 0.00200943,
-          "score": 0.00315351
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00315283,
-          "spread": 0.00177616,
-          "score": 0.00361871
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00074317,
-          "spread": 0.00251601,
-          "score": 0.00262347
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00117069,
-          "spread": 0.00228915,
-          "score": 0.00257114
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00360133,
-          "spread": 0.01055364,
-          "score": 0.01115119
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": -0.01147476,
-          "spread": 0.02750272,
-          "score": 0.0298005
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00810976,
-          "spread": 0.00524759,
-          "score": 0.00965947
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": -0.00116062,
-          "spread": 0.01076094,
-          "score": 0.01082335
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00406743,
-          "spread": 0.00342248,
-          "score": 0.00531576
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00230567,
-          "spread": 0.00391925,
-          "score": 0.00454715
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00284706,
-          "spread": 0.00555995,
-          "score": 0.0062465
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.00116274,
-          "spread": 0.00156092,
-          "score": 0.00194639
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": 0.05983896,
-          "spread": 0.00586349,
-          "score": 0.06012555
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00092001,
-          "spread": 0.00519726,
-          "score": 0.00527806
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00013765,
-          "spread": 0.001183,
-          "score": 0.00119098
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00057845,
-          "spread": 0.00205973,
-          "score": 0.00213941
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": 0.001911,
-          "spread": 0.00148538,
-          "score": 0.00242039
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.0158505,
-          "spread": 0.00837179,
-          "score": 0.01792555
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": 0.01080108,
-          "spread": 0.02071588,
-          "score": 0.0233626
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": 0.03928695,
-          "spread": 0.0151617,
-          "score": 0.04211107
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.02053921,
-          "spread": 0.28971927,
-          "score": 0.29044641
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": -0.23642671,
-          "spread": 0.1969516,
-          "score": 0.30771338
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.01786033,
-          "spread": 0.02317502,
-          "score": 0.02925873
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00345256,
-          "spread": 0.00268551,
-          "score": 0.00437403
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00340142,
-          "spread": 0.00105959,
-          "score": 0.00356263
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00052533,
-          "spread": 0.00192156,
-          "score": 0.00199208
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00071403,
-          "spread": 0.00180134,
-          "score": 0.00193769
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00530086,
-          "spread": 0.01138414,
-          "score": 0.01255778
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": -0.00173566,
-          "spread": 0.02896667,
-          "score": 0.02901862
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": -0.000761,
-          "spread": 0.00759,
-          "score": 0.00762806
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": -0.03100202,
-          "spread": 0.03187875,
-          "score": 0.04446774
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00080648,
-          "spread": 0.00411298,
-          "score": 0.0041913
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00253263,
-          "spread": 0.00249918,
-          "score": 0.00355811
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00237374,
-          "spread": 0.00383109,
-          "score": 0.00450687
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.00079684,
-          "spread": 0.0010912,
-          "score": 0.00135117
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": 0.00409184,
-          "spread": 0.02611285,
-          "score": 0.02643149
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00227388,
-          "spread": 0.00389226,
-          "score": 0.0045078
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": -0.0003114,
-          "spread": 0.00056364,
-          "score": 0.00064395
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00029304,
-          "spread": 0.0014446,
-          "score": 0.00147402
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00336729,
-          "spread": 0.00225619,
-          "score": 0.00405328
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.0160261,
-          "spread": 0.0064383,
-          "score": 0.01727101
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00997878,
-          "spread": 0.0254041,
-          "score": 0.02729367
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": 0.0143426,
-          "spread": 0.02235418,
-          "score": 0.02655973
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.0316659,
-          "spread": 0.22423476,
-          "score": 0.22645961
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": -0.15737029,
-          "spread": 0.11206077,
-          "score": 0.19319168
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.02237952,
-          "spread": 0.04125799,
-          "score": 0.04693681
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00292889,
-          "spread": 0.00277636,
-          "score": 0.00403567
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00371351,
-          "spread": 0.00039748,
-          "score": 0.00373472
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00026549,
-          "spread": 0.00110323,
-          "score": 0.00113473
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00038031,
-          "spread": 0.00080335,
-          "score": 0.00088883
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": -0.00169079,
-          "spread": 0.00354742,
-          "score": 0.00392975
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": -0.00239285,
-          "spread": 0.01300801,
-          "score": 0.01322627
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00788069,
-          "spread": 0.00495753,
-          "score": 0.00931033
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": -0.03813694,
-          "spread": 0.02676244,
-          "score": 0.04659028
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": 0.02022686,
-          "spread": 0.0,
-          "score": 0.02022686
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00246038,
-          "spread": 0.00539483,
-          "score": 0.00592939
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.0034901,
-          "spread": 0.00191819,
-          "score": 0.00398249
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00023565,
-          "spread": 0.00292762,
-          "score": 0.00293708
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.00396128,
-          "spread": 0.00074876,
-          "score": 0.00403143
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00890095,
-          "spread": 0.00978139,
-          "score": 0.01322507
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00196328,
-          "spread": 0.00263296,
-          "score": 0.00328435
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00617848,
-          "spread": 0.00099467,
-          "score": 0.00625804
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00280182,
-          "spread": 0.00245286,
-          "score": 0.0037238
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00175818,
-          "spread": 0.00764288,
-          "score": 0.0078425
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": -0.01362674,
-          "spread": 0.02938617,
-          "score": 0.0323919
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": 0.00237559,
-          "spread": 0.04677618,
-          "score": 0.04683647
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": -0.12371879,
-          "spread": 1.17081797,
-          "score": 1.17733643
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": 0.01834031,
-          "spread": 0.28585803,
-          "score": 0.28644577
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": 0.02023902,
-          "spread": 0.07027504,
-          "score": 0.07313138
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00356626,
-          "spread": 0.00176004,
-          "score": 0.00397692
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.0037276,
-          "spread": 0.00137426,
-          "score": 0.00397286
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00095576,
-          "spread": 0.00241927,
-          "score": 0.00260122
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.0032912,
-          "spread": 0.00246633,
-          "score": 0.00411275
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00807223,
-          "spread": 0.02081007,
-          "score": 0.02232084
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": -0.00186646,
-          "spread": 0.04445192,
-          "score": 0.04449109
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": 0.06234218,
-          "spread": 0.06436806,
-          "score": 0.08960912
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": -0.00525055,
-          "spread": 0.00501992,
-          "score": 0.00726415
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00245991,
-          "spread": 0.01161268,
-          "score": 0.01187037
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.0056545,
-          "spread": 0.00374981,
-          "score": 0.00678487
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00392745,
-          "spread": 0.00617824,
-          "score": 0.00732089
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.00170914,
-          "spread": 0.00165989,
-          "score": 0.00238252
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": 0.05793875,
-          "spread": 0.0048552,
-          "score": 0.05814183
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": 0.0009136,
-          "spread": 0.00959269,
-          "score": 0.0096361
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00032458,
-          "spread": 0.00153904,
-          "score": 0.00157289
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00335111,
-          "spread": 0.00209733,
-          "score": 0.00395332
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": 6.979e-05,
-          "spread": 0.00258956,
-          "score": 0.0025905
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00299066,
-          "spread": 0.00631283,
-          "score": 0.00698541
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00021135,
-          "spread": 0.02716105,
-          "score": 0.02716188
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": -0.0589193,
-          "spread": 0.02774129,
-          "score": 0.06512345
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.01760271,
-          "spread": 0.30894534,
-          "score": 0.30944641
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": 0.42147921,
-          "spread": 0.59400185,
-          "score": 0.72834258
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.03556716,
-          "spread": 0.05522252,
-          "score": 0.06568523
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": 0.0020414,
-          "spread": 0.00205365,
-          "score": 0.00289566
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00170358,
-          "spread": 0.00157134,
-          "score": 0.00231761
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": 9e-05,
-          "spread": 0.00221142,
-          "score": 0.00221325
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00151191,
-          "spread": 0.00179862,
-          "score": 0.00234966
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00446709,
-          "spread": 0.01117565,
-          "score": 0.01203537
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": -0.03795827,
-          "spread": 0.04489894,
-          "score": 0.05879409
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00388254,
-          "spread": 0.00607063,
-          "score": 0.00720601
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": 0.01077916,
-          "spread": 0.01033665,
-          "score": 0.01493441
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00117203,
-          "spread": 0.00396713,
-          "score": 0.00413664
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00018586,
-          "spread": 0.00428791,
-          "score": 0.00429194
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00243334,
-          "spread": 0.00579286,
-          "score": 0.00628319
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.00118721,
-          "spread": 0.00154923,
-          "score": 0.00195182
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": 0.05324759,
-          "spread": 0.00419176,
-          "score": 0.05341233
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00251055,
-          "spread": 0.00426859,
-          "score": 0.00495214
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00217776,
-          "spread": 0.00128526,
-          "score": 0.00252874
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00146583,
-          "spread": 0.00234894,
-          "score": 0.00276878
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00222873,
-          "spread": 0.00196012,
-          "score": 0.00296805
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00255785,
-          "spread": 0.00664177,
-          "score": 0.00711728
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": -0.01243698,
-          "spread": 0.022807,
-          "score": 0.02597764
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": 0.0086224,
-          "spread": 0.01732941,
-          "score": 0.01935599
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": -0.02503275,
-          "spread": 0.34266839,
-          "score": 0.34358153
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": 0.04581666,
-          "spread": 0.1254626,
-          "score": 0.13356658
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.02024798,
-          "spread": 0.02599528,
-          "score": 0.03295049
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00096193,
-          "spread": 0.00251629,
-          "score": 0.00269389
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00219412,
-          "spread": 0.00099449,
-          "score": 0.00240898
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00023976,
-          "spread": 0.00178177,
-          "score": 0.00179783
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00098412,
-          "spread": 0.00161977,
-          "score": 0.0018953
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00661912,
-          "spread": 0.01179713,
-          "score": 0.0135272
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": -0.02871163,
-          "spread": 0.04430844,
-          "score": 0.05279768
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00248743,
-          "spread": 0.00640081,
-          "score": 0.00686714
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": -0.01970073,
-          "spread": 0.02963887,
-          "score": 0.03558906
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00213817,
-          "spread": 0.00445263,
-          "score": 0.0049394
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.0003848,
-          "spread": 0.00309853,
-          "score": 0.00312233
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00153758,
-          "spread": 0.00401267,
-          "score": 0.00429717
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 12,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.00084069,
-          "spread": 0.00110354,
-          "score": 0.00138728
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": -0.01774858,
-          "spread": 0.01859613,
-          "score": 0.02570658
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00099632,
-          "spread": 0.00308504,
-          "score": 0.00324194
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00139769,
-          "spread": 0.00062332,
-          "score": 0.00153038
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": 0.000572,
-          "spread": 0.00156273,
-          "score": 0.00166413
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00021384,
-          "spread": 0.00291156,
-          "score": 0.0029194
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00303306,
-          "spread": 0.0049274,
-          "score": 0.00578608
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": -0.01188804,
-          "spread": 0.02828257,
-          "score": 0.03067946
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": -0.01068013,
-          "spread": 0.02415365,
-          "score": 0.02640954
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.00203469,
-          "spread": 0.23580516,
-          "score": 0.23581394
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": 0.68506983,
-          "spread": 0.75997562,
-          "score": 1.02317331
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.02455258,
-          "spread": 0.03557369,
-          "score": 0.04322403
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00105139,
-          "spread": 0.00243623,
-          "score": 0.00265342
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00257037,
-          "spread": 0.00060572,
-          "score": 0.00264078
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": 2.938e-05,
-          "spread": 0.00104075,
-          "score": 0.00104116
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00056748,
-          "spread": 0.0007322,
-          "score": 0.00092636
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": -0.0002799,
-          "spread": 0.00250576,
-          "score": 0.00252135
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": -0.02451736,
-          "spread": 0.02366082,
-          "score": 0.0340725
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00399325,
-          "spread": 0.00323092,
-          "score": 0.00513662
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": -0.03151821,
-          "spread": 0.02536509,
-          "score": 0.0404572
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": 0.02027116,
-          "spread": 0.0,
-          "score": 0.02027116
+          "score": 0.02012885
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00066756,
-          "spread": 0.00636872,
-          "score": 0.00640361
+          "bias": -0.00103548,
+          "spread": 0.0061405,
+          "score": 0.00622719
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00155321,
-          "spread": 0.00229944,
-          "score": 0.00277487
+          "bias": 0.00165358,
+          "spread": 0.00226572,
+          "score": 0.00280496
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00041084,
-          "spread": 0.00310342,
-          "score": 0.0031305
+          "bias": -0.00059076,
+          "spread": 0.00333506,
+          "score": 0.00338698
         }
       ]
     }

--- a/docs/v1/findings.md
+++ b/docs/v1/findings.md
@@ -7,6 +7,93 @@ from, not just conclusions.
 
 ---
 
+## F14 — outcome-model fundamentals: `min_child_samples` 200→50 accepted; linear_tree, early stopping, calibration slope, seed ensembling and alternative learners rejected; the toggle headline bias localised to small-fit tree shrinkage (Issue 12)
+
+*2026-07-04 — Issue 12 verdicts. New module `benchmarking/baselines/power_model/fitting.py`
+(time-blocked folds, calibration line, early-stopped capacity pick, and the model-factory registry
+`OUTCOME_MODEL_FACTORIES`) behind four new `PowerModelMethod` knobs — `model_factory` (str or
+callable), `n_seed_ensemble`, `early_stopping`, `calibrate_slope` — all defaulting to today's
+behaviour (a default-config re-run diffs the benchmark at ≤0.001 pp everywhere). The baseline
+holdout *diagnostic* switched from a shuffled 20% split to a time-blocked fold (Issue 13's honest
+display item; estimates unchanged). Candidates A/B'd per the Issue 9 protocol:
+`study_power_model_compare.py --method-overrides` placebo screens (`cp_0pct`, both modes), full
+7-profile sweep for the survivor, all diffed against the post-F13 benchmark.*
+
+### Framing principles (recorded here so they aren't relitigated)
+- **The objective targets the conditional mean.** The estimand is an energy ratio and energy is a
+  sum of conditional means, so L2 stays (design note §2). Power conditional on features is skewed
+  (near cut-in, around rated), so median-type objectives — MAE, Huber in its robust regime,
+  quantile-0.5 — estimate the median and bias the energy sum. The F5 shrinkage is a
+  *regularisation* artefact, not a loss artefact; changing objective does not fix it. Legitimate
+  within the mean family: Tweedie / variance-weighted L2 (efficiency candidates, untried).
+  Quantile objectives are out of scope for the point estimate (they return in Issue 16/WS4).
+- **Tune on uplift metrics, never on prediction RMSE.** More regularisation can improve held-out
+  RMSE while worsening shrinkage. Yardsticks: placebo bias on the harness, per-bin residual
+  flatness, the predicted-vs-actual **calibration slope** (target ≈ 1) on a time-blocked held-out
+  baseline, and replicate spread.
+
+### ACCEPTED — `min_child_samples` 200→50 (now the driver default; benchmark regenerated)
+- Placebo screen: prepost ALL Δscore **−0.62**, Δspread −0.75 (score cells 31 better / 9 worse);
+  toggle overall better at every campaign. Dose-response check at `min_child_samples=20`
+  overshoots (prepost ALL only −0.12, overall biases drift positive) — 50 is the sweet spot.
+- Full 7-profile sweep: **prepost ALL Δscore −0.36, Δspread −0.41** (cells: score 216 better / 86
+  worse of 469); overall P50 neutral-or-better at every campaign in both modes (prepost 3-month
+  placebo |bias| 0.121 → 0.018). The accepted cost: a few large toggle ti cells at 9/12 months
+  regress (9-month ti Δscore +3.2; toggle conditional mean +0.29 even though score cells split
+  159 better / 145 worse) — accepted against the overall-P50/precision gains, the F13 precedent.
+- Shipped as `TUNED_MODEL_PARAMS = {"min_child_samples": 50}` passed by the four HoT drivers;
+  the design-note common params in `make_outcome_model` (shared with the R-learner) are unchanged.
+
+### REJECTED — everything else, each with a one-screen placebo verdict
+- **`linear_tree=True`** — mode-split (the F10 shear/veer pattern): toggle mildly better (ALL
+  Δscore −0.36) but prepost overall bias worse at every campaign (+0.32/+0.28/+0.11 pp) and
+  prepost conditional much worse (3-month ti Δscore +8.4). The hoped-for F5 edge-extrapolation fix
+  adds bias/variance under the prepost weather shift instead.
+- **`early_stopping`** (time-blocked valid split, refit at the picked capacity) — neutral overall
+  in both modes *including the 3-month-toggle small-fit regime it was aimed at*; conditional
+  slightly net-worse; +~15% runtime. The fixed design-note capacity is validated across the ~10×
+  fit-size range.
+- **`calibrate_slope`** — prepost neutral (nothing to correct), toggle **overcorrects**: bias
+  flips sign (3-month +0.39 → −0.38) with a spread cost (Δspread +0.60) — the F7 short-campaign
+  failure mode. Root cause: the line is fit on out-of-fold predictions from 80%-sized fits, which
+  shrink more than the 100% fit it is applied to, and that gap is largest exactly where the
+  correction is largest.
+- **`n_seed_ensemble=4`** — overall deltas neutral in both modes (|Δspread| ≤ 0.02 pp) for ~75%
+  more runtime: replicate spread is dominated by weather sampling across windows, not seed noise.
+- **`model_factory="hgb"`** (sklearn HistGradientBoostingRegressor, capacity-matched) — prepost
+  worse (ALL Δscore +0.26), toggle marginally better: LightGBM's behaviour is family-level, not an
+  implementation quirk. Stays in the registry as the cross-implementation check.
+- **`model_factory="linear"`** (impute→scale→Ridge structured baseline) — far worse overall as
+  expected (prepost placebo bias +3.5/+2.5/+1.3 pp; misspecification dominates the hoped-for
+  "shrinkage-free" property), **but the cross-check paid off** (next section).
+
+### The toggle headline bias is small-fit tree shrinkage — three independent probes agree (Issue 13 hand-off)
+- **Calibration slopes scale with fit size**: ~1.0005–1.005 at n≈100k (2-year prepost baseline),
+  ~1.008–1.017 at n≈12–25k, **~1.013–1.027 at n≈6k** (3-month toggle off rows). The prepost
+  baseline is essentially slope-calibrated, so the −0.4 pp prepost headline bias is *not* a global
+  calibration artefact — consistent with Issue 13's covariate-shift mechanism for prepost.
+- **The linear model's toggle headline reads ~0** (3-month +0.39 → −0.01, better at every
+  campaign length): a learner with no tree-style shrinkage does not show the bias.
+- **More training data removes it**: `toggle_campaign_only=False` (the Issue 13 2×2's
+  {all-data, no-calibration} cell, measured) cuts the 3-month toggle headline bias to +0.07 —
+  but without the Issue 13 calibration/time-feature guards it imports drift everywhere else
+  (conditional 3-month ti Δscore +12.7; ≥6-month campaigns uniformly worse; cells 13 better / 58
+  worse). Campaign-only stays the default; revisit inside Issue 13's full 2×2.
+- Capacity is *not* the lever: the accepted `min_child_samples=50` barely moves the 3-month
+  toggle headline (+0.39 → +0.35). The shrinkage that matters is intrinsic to boosted trees on
+  ~6k rows, so Issue 13's data-side fixes (more rows, made safe by calibration) are the right
+  attack.
+
+### Method notes
+- The placebo screen again did all the discriminating; nothing needed the full sweep to be
+  rejected. One screen ≈ 13 min vs ≈ 55 min for a full sweep.
+- Post-hoc OOF calibration applied to a refit-on-100% model is structurally biased toward
+  overcorrection at small n (the OOF-vs-final shrinkage gap) — any future residual-calibration
+  design (Issue 13) must estimate the correction against the *final* model's predictions, e.g.
+  by calibrating on a window the final model genuinely never saw, not by recycling OOF folds.
+
+---
+
 ## F13 — removal ablation: dropping the availability feature + five ERA5 columns improves the benchmark; low importance ≠ removable
 
 *2026-07-04 — follow-up to the Issue 9–11 additions: the same A/B protocol run in reverse (remove each

--- a/tests/benchmarking/baselines/test_power_model_fitting.py
+++ b/tests/benchmarking/baselines/test_power_model_fitting.py
@@ -1,0 +1,110 @@
+"""Unit tests for the power model's fitting strategies (Issue 12): folds, calibration, capacity, factories."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from benchmarking.baselines.power_model.fitting import (
+    IDENTITY_CALIBRATION,
+    OUTCOME_MODEL_FACTORIES,
+    CalibrationLine,
+    early_stopped_n_estimators,
+    fit_calibration_line,
+    time_block_folds,
+)
+from benchmarking.baselines.rlearner.nuisance import make_outcome_model
+
+
+class TestTimeBlockFolds:
+    def test_round_robin_contiguous_blocks(self) -> None:
+        folds = time_block_folds(1000, n_folds=5, n_blocks=25)
+        assert folds.shape == (1000,)
+        assert set(folds) == {0, 1, 2, 3, 4}
+        # 25 equal blocks of 40 rows, block i -> fold i % 5
+        for i in range(25):
+            block = folds[i * 40 : (i + 1) * 40]
+            assert (block == i % 5).all()
+
+    def test_every_fold_is_a_fifth(self) -> None:
+        folds = time_block_folds(10_000, n_folds=5, n_blocks=25)
+        counts = np.bincount(folds)
+        assert (counts == 2000).all()
+
+    def test_uneven_n_still_covers_all_folds(self) -> None:
+        folds = time_block_folds(103, n_folds=5, n_blocks=25)
+        assert len(folds) == 103
+        assert set(folds) == {0, 1, 2, 3, 4}
+
+    def test_bad_args_raise(self) -> None:
+        with pytest.raises(ValueError, match="n_folds"):
+            time_block_folds(100, n_folds=1, n_blocks=25)
+        with pytest.raises(ValueError, match="n_folds"):
+            time_block_folds(100, n_folds=5, n_blocks=3)
+
+
+class TestCalibrationLine:
+    def test_recovers_known_line(self) -> None:
+        rng = np.random.default_rng(0)
+        pred = rng.uniform(0, 2000, 5000)
+        y = 50.0 + 1.25 * pred + rng.normal(0, 10, 5000)  # the model under-dispersed by 1/1.25
+        line = fit_calibration_line(y, pred)
+        assert line.slope == pytest.approx(1.25, abs=0.01)
+        assert line.intercept == pytest.approx(50.0, abs=5.0)
+        assert line.apply(np.array([1000.0]))[0] == pytest.approx(50.0 + 1250.0, rel=0.01)
+
+    def test_nan_pairs_ignored(self) -> None:
+        rng = np.random.default_rng(1)
+        pred = rng.uniform(0, 100, 1000)
+        y = 2.0 * pred
+        pred[:100] = np.nan
+        y[100:200] = np.nan
+        line = fit_calibration_line(y, pred)
+        assert line.slope == pytest.approx(2.0, abs=1e-6)
+
+    def test_too_few_rows_gives_identity(self) -> None:
+        assert fit_calibration_line(np.arange(10.0), np.arange(10.0)) == IDENTITY_CALIBRATION
+
+    def test_degenerate_predictions_give_identity(self) -> None:
+        y = np.random.default_rng(2).normal(0, 1, 500)
+        assert fit_calibration_line(y, np.full(500, 7.0)) == IDENTITY_CALIBRATION
+
+    def test_identity_apply_is_noop(self) -> None:
+        x = np.array([1.0, 2.0, 3.0])
+        np.testing.assert_array_equal(IDENTITY_CALIBRATION.apply(x), x)
+        assert CalibrationLine(intercept=1.0, slope=2.0).apply(np.array([3.0]))[0] == 7.0
+
+
+class TestEarlyStoppedNEstimators:
+    def test_simple_signal_stops_well_below_ceiling(self) -> None:
+        rng = np.random.default_rng(0)
+        n = 2000
+        x = pd.DataFrame({"a": rng.normal(0, 1, n), "b": rng.normal(0, 1, n)})
+        y = 3.0 * x["a"].to_numpy() + rng.normal(0, 0.1, n)
+        ceiling = 1500
+        valid = time_block_folds(n, n_folds=5, n_blocks=25) == 0
+        best = early_stopped_n_estimators(
+            lambda: make_outcome_model(n_estimators=ceiling, learning_rate=0.1, min_child_samples=20, random_state=0),
+            x,
+            y,
+            valid_mask=valid,
+            stopping_rounds=20,
+        )
+        assert 1 <= best < ceiling
+
+
+class TestFactories:
+    @pytest.mark.parametrize("name", sorted(OUTCOME_MODEL_FACTORIES))
+    def test_factory_fits_and_predicts(self, name: str) -> None:
+        rng = np.random.default_rng(0)
+        n = 1000
+        x = pd.DataFrame({"a": rng.normal(0, 1, n), "b": rng.normal(0, 1, n)})
+        x.loc[x.index[:20], "b"] = np.nan  # both factories must tolerate NaN features
+        y = 5.0 + 2.0 * x["a"].to_numpy() + rng.normal(0, 0.1, n)
+        model = OUTCOME_MODEL_FACTORIES[name](0)
+        model.fit(x, y)
+        pred = np.asarray(model.predict(x), dtype=float)
+        assert np.isfinite(pred).all()
+        # both learners should capture a clean linear signal well
+        assert float(np.corrcoef(pred, y)[0, 1]) > 0.95

--- a/tests/benchmarking/baselines/test_power_model_method.py
+++ b/tests/benchmarking/baselines/test_power_model_method.py
@@ -15,6 +15,7 @@ import pandas as pd
 import pytest
 
 from benchmarking.baselines.power_model import PowerModelMethod
+from benchmarking.baselines.rlearner.nuisance import make_outcome_model
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -151,6 +152,75 @@ class TestConfigGuards:
         mi = MethodInput(scada_df=scada, test_wtg="T1", upgrade_timing=pd.Timestamp(idx[n // 2]), turbine_col=_TURBINE)
         with pytest.raises(ValueError, match="not in scada_df"):
             method.estimate(mi)
+
+
+def _prepost_case(n: int = 4000, *, uplift: float = 0.05) -> tuple[MethodInput, pd.Timestamp]:
+    """A toy prepost MethodInput with a known uplift, for the model-fundamentals config trials."""
+    idx = pd.date_range("2019-01-01", periods=n, freq="10min", tz="UTC")
+    changeover = idx[n // 2]
+    treated = np.asarray(idx >= changeover)
+    scada = _toy_scada(n, uplift=uplift, treated=treated)
+    mi = MethodInput(scada_df=scada, test_wtg="T1", upgrade_timing=pd.Timestamp(changeover), turbine_col=_TURBINE)
+    return mi, changeover
+
+
+def _fundamentals_method(**overrides: object) -> PowerModelMethod:
+    return PowerModelMethod(
+        active_power_col=_POWER,
+        availability_col=_AVAIL,
+        baseline_rated_power_kw=2300.0,
+        wind_speed_col=_WS,
+        conditional_uplift=False,
+        **overrides,  # type: ignore[arg-type]
+    )
+
+
+class TestModelFundamentals:
+    """Issue 12 knobs: model factory, seed ensemble, early stopping, calibration slope."""
+
+    @pytest.mark.parametrize("factory", ["hgb", "linear"])
+    def test_registered_factories_recover_uplift(self, factory: str) -> None:
+        mi, _ = _prepost_case()
+        out = _fundamentals_method(model_factory=factory).estimate(mi)
+        assert out.p50_overall == pytest.approx(0.05, abs=0.02)
+
+    def test_callable_factory_recovers_uplift(self) -> None:
+        mi, _ = _prepost_case()
+        method = _fundamentals_method(model_factory=lambda seed: make_outcome_model(random_state=seed, **_FAST_PARAMS))
+        out = method.estimate(mi)
+        assert out.p50_overall == pytest.approx(0.05, abs=0.02)
+
+    def test_seed_ensemble_recovers_uplift(self) -> None:
+        mi, _ = _prepost_case()
+        out = _fundamentals_method(model_params=_FAST_PARAMS, n_seed_ensemble=3).estimate(mi)
+        assert out.p50_overall == pytest.approx(0.05, abs=0.02)
+
+    def test_early_stopping_recovers_uplift(self) -> None:
+        mi, _ = _prepost_case()
+        # n_estimators in model_params is the early-stopping ceiling (keeps the probe fit fast)
+        out = _fundamentals_method(model_params=dict(_FAST_PARAMS), early_stopping=True).estimate(mi)
+        assert out.p50_overall == pytest.approx(0.05, abs=0.02)
+
+    def test_calibrate_slope_recovers_uplift_and_placebo(self) -> None:
+        mi, _ = _prepost_case()
+        out = _fundamentals_method(model_params=_FAST_PARAMS, calibrate_slope=True).estimate(mi)
+        assert out.p50_overall == pytest.approx(0.05, abs=0.02)
+        mi0, _ = _prepost_case(uplift=0.0)
+        out0 = _fundamentals_method(model_params=_FAST_PARAMS, calibrate_slope=True).estimate(mi0)
+        assert out0.p50_overall == pytest.approx(0.0, abs=0.02)
+
+    def test_config_conflicts_raise(self) -> None:
+        mi, _ = _prepost_case(n=200)
+        with pytest.raises(ValueError, match="unknown model_factory"):
+            _fundamentals_method(model_factory="not_a_factory").estimate(mi)
+        with pytest.raises(ValueError, match="model_params"):
+            _fundamentals_method(model_factory="linear", model_params=_FAST_PARAMS).estimate(mi)
+        with pytest.raises(ValueError, match="early_stopping"):
+            _fundamentals_method(model_factory="linear", early_stopping=True).estimate(mi)
+        with pytest.raises(ValueError, match="n_seed_ensemble"):
+            _fundamentals_method(n_seed_ensemble=0).estimate(mi)
+        with pytest.raises(ValueError, match="random_state"):
+            _fundamentals_method(model_params={"random_state": 1}, n_seed_ensemble=2).estimate(mi)
 
 
 class TestReferenceOnly:

--- a/tests/benchmarking/baselines/test_power_model_method.py
+++ b/tests/benchmarking/baselines/test_power_model_method.py
@@ -221,6 +221,21 @@ class TestModelFundamentals:
             _fundamentals_method(n_seed_ensemble=0).estimate(mi)
         with pytest.raises(ValueError, match="random_state"):
             _fundamentals_method(model_params={"random_state": 1}, n_seed_ensemble=2).estimate(mi)
+        with pytest.raises(ValueError, match="calibrate_slope"):
+            _fundamentals_method(calibrate_slope=True, early_stopping=True).estimate(mi)
+        with pytest.raises(ValueError, match="calibrate_slope"):
+            _fundamentals_method(calibrate_slope=True, n_seed_ensemble=2).estimate(mi)
+
+    def test_model_factory_config_label_is_stable(self) -> None:
+        def label_for(**overrides: object) -> str | None:
+            return _fundamentals_method(**overrides)._config_params()["model_factory"]  # noqa: SLF001
+
+        assert label_for() is None
+        assert label_for(model_factory="hgb") == "hgb"
+        expected = f"{make_outcome_model.__module__}.{make_outcome_model.__qualname__}"
+        assert label_for(model_factory=make_outcome_model) == expected
+        # a lambda's repr embeds a memory address; the label must not (it goes in the run-config YAML)
+        assert "0x" not in str(label_for(model_factory=lambda s: s))
 
 
 class TestReferenceOnly:


### PR DESCRIPTION

## Issue 12 — Outcome-model fundamentals: objective, hyperparameters, calibration slope, alternative learners (WS2)

**Goal:** revisit the basics of the counterfactual model itself. Today it is a LightGBM
regressor with the L2 objective and fixed design-note hyperparameters (600 trees,
lr 0.03, 63 leaves, `min_child_samples=200`, subsample/colsample 0.8) — never tuned, no
early stopping, and identical whether the fit has ~13k training rows (3-month toggle) or
~250k (2-year prepost baseline).

**Two framing principles (record them in findings.md so they aren't relitigated):**
- **The objective must target the conditional mean.** The estimand is an energy ratio and
  energy is a sum of conditional means, so L2 stays the default (design note §2). Power
  conditional on features is skewed (near cut-in and around rated), so median-type
  objectives — MAE, Huber in its robust regime, quantile-0.5 — estimate the median and
  would bias the energy sum. The F5 shrinkage is a *regularisation* artefact, not a loss
  artefact; changing objective does not fix it. Legitimate within the mean family:
  **Tweedie** or variance-weighted L2 for the strong heteroscedasticity of power
  (an efficiency candidate, not a bias fix).
- **Tune on uplift metrics, never on prediction RMSE.** More regularisation can improve
  held-out RMSE while *worsening* shrinkage — the two objectives disagree exactly where
  it matters. Yardsticks: placebo bias on the harness, per-bin residual flatness and
  predicted-vs-actual **calibration slope** (target ≈ 1) on a time-blocked held-out
  baseline, and replicate spread. Guard against overfitting the benchmark: tune on the
  held-out-baseline proxies, confirm on the harness, ideally on turbines/windows not used
  for tuning.

**Scope (per the Issue 9 protocol, one candidate at a time)**
- **Data-size-adaptive capacity:** early stopping on a time-blocked validation split;
  scale `min_child_samples` / leaves with training size (the 3-month and 24-month fits
  differ ~10× in rows but share one capacity today).
- **`linear_tree=True`:** piecewise-linear leaves reduce the flat-leaf compression at the
  edges of the feature distribution — a direct attack on the F5 shrinkage (and it
  softens the Issue 10 boundary-clamping caveat, since linear leaves extrapolate).
- **Post-hoc calibration-slope correction:** fit actual-vs-predicted on time-blocked
  held-out baseline (linear, or isotonic), apply to the counterfactual predictions — the
  cheap de-shrinking cousin of Issue 13's residual calibration; measure how much each
  contributes when combined.
- **Seed ensembling:** average K seeds (subsample/colsample noise) for variance
  reduction; measure the replicate-spread gain vs run-time cost.
- **Alternative learners behind a model-factory seam** (make the outcome model injectable
  on `PowerModelMethod` rather than hard-coded to `make_outcome_model`): CatBoost /
  XGBoost as same-family sanity checks; a small tabular NN or TabPFN for the short-
  campaign regime; and a deliberately low-variance structured baseline (GAM / linear on
  hub-height ws + direction features from Issue 9) — lightly regularised so nearly
  shrinkage-free, valuable as a cross-check on the tree models' conditional bias even if
  its overall accuracy is worse.
- **Quantile objectives are out of scope for the point estimate** (median ≠ mean under
  skew → biased energy). Quantile models return in Issue 16 / WS4 for conformal OOD
  filtering and diagnostics — not as the uplift estimator.

**Done when:** a findings entry records the verdict per candidate against the uplift
yardsticks; defaults change only where those improve; the benchmark is regenerated if
defaults change.

## F14 — outcome-model fundamentals: `min_child_samples` 200→50 accepted; linear_tree, early stopping, calibration slope, seed ensembling and alternative learners rejected; the toggle headline bias localised to small-fit tree shrinkage (Issue 12)

*2026-07-04 — Issue 12 verdicts. New module `benchmarking/baselines/power_model/fitting.py`
(time-blocked folds, calibration line, early-stopped capacity pick, and the model-factory registry
`OUTCOME_MODEL_FACTORIES`) behind four new `PowerModelMethod` knobs — `model_factory` (str or
callable), `n_seed_ensemble`, `early_stopping`, `calibrate_slope` — all defaulting to today's
behaviour (a default-config re-run diffs the benchmark at ≤0.001 pp everywhere). The baseline
holdout *diagnostic* switched from a shuffled 20% split to a time-blocked fold (Issue 13's honest
display item; estimates unchanged). Candidates A/B'd per the Issue 9 protocol:
`study_power_model_compare.py --method-overrides` placebo screens (`cp_0pct`, both modes), full
7-profile sweep for the survivor, all diffed against the post-F13 benchmark.*

### Framing principles (recorded here so they aren't relitigated)
- **The objective targets the conditional mean.** The estimand is an energy ratio and energy is a
  sum of conditional means, so L2 stays (design note §2). Power conditional on features is skewed
  (near cut-in, around rated), so median-type objectives — MAE, Huber in its robust regime,
  quantile-0.5 — estimate the median and bias the energy sum. The F5 shrinkage is a
  *regularisation* artefact, not a loss artefact; changing objective does not fix it. Legitimate
  within the mean family: Tweedie / variance-weighted L2 (efficiency candidates, untried).
  Quantile objectives are out of scope for the point estimate (they return in Issue 16/WS4).
- **Tune on uplift metrics, never on prediction RMSE.** More regularisation can improve held-out
  RMSE while worsening shrinkage. Yardsticks: placebo bias on the harness, per-bin residual
  flatness, the predicted-vs-actual **calibration slope** (target ≈ 1) on a time-blocked held-out
  baseline, and replicate spread.

### ACCEPTED — `min_child_samples` 200→50 (now the driver default; benchmark regenerated)
- Placebo screen: prepost ALL Δscore **−0.62**, Δspread −0.75 (score cells 31 better / 9 worse);
  toggle overall better at every campaign. Dose-response check at `min_child_samples=20`
  overshoots (prepost ALL only −0.12, overall biases drift positive) — 50 is the sweet spot.
- Full 7-profile sweep: **prepost ALL Δscore −0.36, Δspread −0.41** (cells: score 216 better / 86
  worse of 469); overall P50 neutral-or-better at every campaign in both modes (prepost 3-month
  placebo |bias| 0.121 → 0.018). The accepted cost: a few large toggle ti cells at 9/12 months
  regress (9-month ti Δscore +3.2; toggle conditional mean +0.29 even though score cells split
  159 better / 145 worse) — accepted against the overall-P50/precision gains, the F13 precedent.
- Shipped as `TUNED_MODEL_PARAMS = {"min_child_samples": 50}` passed by the four HoT drivers;
  the design-note common params in `make_outcome_model` (shared with the R-learner) are unchanged.

### REJECTED — everything else, each with a one-screen placebo verdict
- **`linear_tree=True`** — mode-split (the F10 shear/veer pattern): toggle mildly better (ALL
  Δscore −0.36) but prepost overall bias worse at every campaign (+0.32/+0.28/+0.11 pp) and
  prepost conditional much worse (3-month ti Δscore +8.4). The hoped-for F5 edge-extrapolation fix
  adds bias/variance under the prepost weather shift instead.
- **`early_stopping`** (time-blocked valid split, refit at the picked capacity) — neutral overall
  in both modes *including the 3-month-toggle small-fit regime it was aimed at*; conditional
  slightly net-worse; +~15% runtime. The fixed design-note capacity is validated across the ~10×
  fit-size range.
- **`calibrate_slope`** — prepost neutral (nothing to correct), toggle **overcorrects**: bias
  flips sign (3-month +0.39 → −0.38) with a spread cost (Δspread +0.60) — the F7 short-campaign
  failure mode. Root cause: the line is fit on out-of-fold predictions from 80%-sized fits, which
  shrink more than the 100% fit it is applied to, and that gap is largest exactly where the
  correction is largest.
- **`n_seed_ensemble=4`** — overall deltas neutral in both modes (|Δspread| ≤ 0.02 pp) for ~75%
  more runtime: replicate spread is dominated by weather sampling across windows, not seed noise.
- **`model_factory="hgb"`** (sklearn HistGradientBoostingRegressor, capacity-matched) — prepost
  worse (ALL Δscore +0.26), toggle marginally better: LightGBM's behaviour is family-level, not an
  implementation quirk. Stays in the registry as the cross-implementation check.
- **`model_factory="linear"`** (impute→scale→Ridge structured baseline) — far worse overall as
  expected (prepost placebo bias +3.5/+2.5/+1.3 pp; misspecification dominates the hoped-for
  "shrinkage-free" property), **but the cross-check paid off** (next section).

### The toggle headline bias is small-fit tree shrinkage — three independent probes agree (Issue 13 hand-off)
- **Calibration slopes scale with fit size**: ~1.0005–1.005 at n≈100k (2-year prepost baseline),
  ~1.008–1.017 at n≈12–25k, **~1.013–1.027 at n≈6k** (3-month toggle off rows). The prepost
  baseline is essentially slope-calibrated, so the −0.4 pp prepost headline bias is *not* a global
  calibration artefact — consistent with Issue 13's covariate-shift mechanism for prepost.
- **The linear model's toggle headline reads ~0** (3-month +0.39 → −0.01, better at every
  campaign length): a learner with no tree-style shrinkage does not show the bias.
- **More training data removes it**: `toggle_campaign_only=False` (the Issue 13 2×2's
  {all-data, no-calibration} cell, measured) cuts the 3-month toggle headline bias to +0.07 —
  but without the Issue 13 calibration/time-feature guards it imports drift everywhere else
  (conditional 3-month ti Δscore +12.7; ≥6-month campaigns uniformly worse; cells 13 better / 58
  worse). Campaign-only stays the default; revisit inside Issue 13's full 2×2.
- Capacity is *not* the lever: the accepted `min_child_samples=50` barely moves the 3-month
  toggle headline (+0.39 → +0.35). The shrinkage that matters is intrinsic to boosted trees on
  ~6k rows, so Issue 13's data-side fixes (more rows, made safe by calibration) are the right
  attack.

### Method notes
- The placebo screen again did all the discriminating; nothing needed the full sweep to be
  rejected. One screen ≈ 13 min vs ≈ 55 min for a full sweep.
- Post-hoc OOF calibration applied to a refit-on-100% model is structurally biased toward
  overcorrection at small n (the OOF-vs-final shrinkage gap) — any future residual-calibration
  design (Issue 13) must estimate the correction against the *final* model's predictions, e.g.
  by calibrating on a window the final model genuinely never saw, not by recycling OOF folds.

---
