### PR TITLE
v1 issue 13

### DIFF
--- a/benchmarking/baselines/inspect_short_campaigns.py
+++ b/benchmarking/baselines/inspect_short_campaigns.py
@@ -1,0 +1,173 @@
+"""Short-campaign (1-2 month) exploration: check whether the Issue 9-13 accepted choices hold there.
+
+The committed benchmark sweeps 3-12 month campaigns; this driver scores 1- and 2-month campaigns
+(outside the benchmark grid, so no reference-run merge — oracle + naive anchor the numbers instead
+of v0, which is slow) and A/Bs the regime-dependent choices at those lengths.
+
+Which choices can even flip at short campaigns:
+
+* **prepost** — a shorter campaign shrinks only the *prediction* window; the training set (the
+  full pre-changeover baseline) is unchanged, so the fit-side choices (capacity, features) cannot
+  flip. Only the time-decay weights act on the training side, so prepost trials just those.
+* **toggle** — the campaign length scales the training data itself, so capacity
+  (``min_child_samples``), the training window (``toggle_campaign_only``), the decay weights and
+  the ``double_ratio`` estimator are all genuinely in play.
+
+Run from the repo root (defaults: both modes, all variants)::
+
+    uv run python -m benchmarking.baselines.inspect_short_campaigns
+
+Outputs one ``results_<mode>_<variant>_<profile>.csv`` per run plus a combined
+``short_campaign_summary.csv`` / log table of power_model bias/spread/score per
+``(mode, variant, campaign_months)`` under ``--output-dir``
+(default ``~/temp/wind-up-benchmarking/short_campaigns``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+from typing import Any, Literal, cast
+
+import pandas as pd
+
+from benchmarking.baselines.example_prepost_study import (
+    DEFAULT_END_DT_EXCL,
+    DEFAULT_START_DT,
+    DEFAULT_TREATMENT_START_RANGE,
+    DEFAULT_TURBINE_SUBSET,
+    DEFAULT_WTG_NUMBERS,
+    MIN_PRE_MONTHS,
+)
+from benchmarking.baselines.example_toggle_study import DEFAULT_TOGGLE_PERIOD
+from benchmarking.baselines.hot_context import build_hot_v0_context
+from benchmarking.baselines.naive_ratio import NaiveRatioMethod
+from benchmarking.baselines.overnight_profiles import overnight_profiles
+from benchmarking.baselines.study_power_model_compare import _make_power_model
+from benchmarking.harness import Method, StudyConfig, leaderboard, score_study
+from benchmarking.harness.example_hot_study import OracleMethod
+from benchmarking.synthetic import HOT_COLUMNS
+from benchmarking.synthetic.sources.hill_of_towie import load_hot_scada
+
+logger = logging.getLogger(__name__)
+
+CAMPAIGN_MONTHS = [1, 2]
+N_REPLICATES = 4
+SEED = 0
+PROFILES = ("cp_0pct", "cp_plus_3pct")  # placebo (bias/spread) + a plain recovery check
+_DEFAULT_OUTPUT_DIR = Path.home() / "temp" / "wind-up-benchmarking" / "short_campaigns"
+
+# Variant name -> (modes it is meaningful for, PowerModelMethod overrides). The "default" anchor
+# also scores oracle + naive for context. See the module docstring for why prepost trials only
+# the decay weights.
+VARIANTS: dict[str, tuple[tuple[str, ...], dict[str, Any]]] = {
+    "default": (("prepost", "toggle"), {}),
+    "hl90": (("prepost", "toggle"), {"time_decay_half_life_days": 90}),
+    "hl365": (("prepost", "toggle"), {"time_decay_half_life_days": 365}),
+    "mcs200": (("toggle",), {"model_params": {"min_child_samples": 200}}),
+    "tco_true": (("toggle",), {"toggle_campaign_only": True}),
+    "double_ratio": (("toggle",), {"toggle_estimator": "double_ratio"}),
+    "double_ratio_tco_true": (("toggle",), {"toggle_estimator": "double_ratio", "toggle_campaign_only": True}),
+}
+
+
+def _study(mode: str) -> StudyConfig:
+    return StudyConfig(
+        mode=cast("Literal['prepost', 'toggle']", mode),
+        turbine_subset=DEFAULT_TURBINE_SUBSET,
+        treatment_start_range=DEFAULT_TREATMENT_START_RANGE,
+        min_pre_months=MIN_PRE_MONTHS,
+        campaign_months=CAMPAIGN_MONTHS,
+        toggle_period=DEFAULT_TOGGLE_PERIOD if mode == "toggle" else None,
+        n_replicates=N_REPLICATES,
+        seed=SEED,
+    )
+
+
+def run_variant(
+    mode: str,
+    variant: str,
+    out_dir: Path,
+    *,
+    scada_df: pd.DataFrame,
+    era5_hourly_df: pd.DataFrame,
+    profiles: dict[str, list],
+) -> pd.DataFrame:
+    """Score one (mode, variant) over the short-campaign grid; anchor methods only on ``default``."""
+    overrides = VARIANTS[variant][1]
+    frames = []
+    for profile_name, profile in profiles.items():
+        methods: list[Method] = []
+        if variant == "default":
+            methods.append(OracleMethod(scada_df))
+            methods.append(
+                NaiveRatioMethod(
+                    active_power_col=HOT_COLUMNS.active_power,
+                    availability_col=HOT_COLUMNS.availability,
+                    out_dir=out_dir / "naive_runs",
+                )
+            )
+        methods.append(
+            _make_power_model(out_dir / variant / profile_name, era5_hourly_df=era5_hourly_df, overrides=overrides)
+        )
+        logger.info("Scoring %s / %s / %s", mode, variant, profile_name)
+        results = score_study(scada_df, profile=profile, methods=methods, study=_study(mode), profile_name=profile_name)
+        results.to_csv(out_dir / f"results_{mode}_{variant}_{profile_name}.csv", index=False)
+        frames.append(results.assign(variant=variant, mode=mode))
+    return pd.concat(frames, ignore_index=True)
+
+
+def summarise(all_results: pd.DataFrame, out_dir: Path) -> None:
+    """Write/log power_model bias/spread/score per (mode, variant, profile, campaign) + the anchors."""
+    rows = []
+    for (mode, variant), chunk in all_results.groupby(["mode", "variant"]):
+        lb = leaderboard(chunk)
+        lb = lb.assign(mode=mode, variant=variant)
+        rows.append(lb)
+    summary = pd.concat(rows, ignore_index=True)
+    cols = ["mode", "variant", "method", "profile", "campaign_months", "bias", "spread", "score"]
+    summary = summary[cols].sort_values(["mode", "profile", "campaign_months", "method", "variant"])
+    summary.to_csv(out_dir / "short_campaign_summary.csv", index=False)
+    show = summary.copy()
+    for col in ("bias", "spread", "score"):
+        show[col] = (100 * show[col]).round(3)
+    logger.info("Short-campaign summary [pp]:\n%s", show.to_string(index=False))
+
+
+def main() -> None:
+    """Run the short-campaign exploration for the requested modes/variants."""
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--modes", nargs="+", choices=["prepost", "toggle"], default=["prepost", "toggle"])
+    parser.add_argument("--variants", nargs="+", choices=sorted(VARIANTS), default=None)
+    parser.add_argument("--output-dir", type=Path, default=_DEFAULT_OUTPUT_DIR)
+    args = parser.parse_args()
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s", force=True)
+
+    out_dir = args.output_dir.expanduser()
+    out_dir.mkdir(parents=True, exist_ok=True)
+    scada_df, _ = load_hot_scada(
+        start_dt=DEFAULT_START_DT,
+        end_dt_excl=DEFAULT_END_DT_EXCL,
+        wtg_numbers=DEFAULT_WTG_NUMBERS,
+        wtg_names=DEFAULT_TURBINE_SUBSET,
+    )
+    context = build_hot_v0_context(wtg_names=DEFAULT_TURBINE_SUBSET)
+    era5 = context.reanalysis_datasets[0].data
+    profiles = {name: overnight_profiles()[name] for name in PROFILES}
+
+    all_results = []
+    for mode in args.modes:
+        for variant, (variant_modes, _) in VARIANTS.items():
+            if args.variants is not None and variant not in args.variants:
+                continue
+            if mode not in variant_modes:
+                continue
+            all_results.append(
+                run_variant(mode, variant, out_dir, scada_df=scada_df, era5_hourly_df=era5, profiles=profiles)
+            )
+    summarise(pd.concat(all_results, ignore_index=True), out_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarking/baselines/power_model/fitting.py
+++ b/benchmarking/baselines/power_model/fitting.py
@@ -89,6 +89,75 @@ def fit_calibration_line(y: np.ndarray, predicted: np.ndarray) -> CalibrationLin
     return CalibrationLine(intercept=float(intercept), slope=float(slope))
 
 
+@dataclass(frozen=True)
+class ResidualCellCalibration:
+    """Per-target-row residual corrections from **centred** cell-mean baseline residuals (Issue 13).
+
+    :param per_row_residual: one value per target row — its cell's mean baseline residual minus the
+        global mean residual (the mix-shift differential), or 0 where the cell was unseen in
+        baseline (or the row's cell is invalid)
+    :param global_mean_residual: mean residual over all finite baseline residuals (the centring
+        level; reported for diagnostics, deliberately **not** applied — see below)
+    :param n_target_unseen: target rows that fell back to 0 (no differential information)
+    :param n_cells: baseline cells with a residual estimate
+    """
+
+    per_row_residual: np.ndarray
+    global_mean_residual: float
+    n_target_unseen: int
+    n_cells: int
+
+
+def cell_residual_calibration(
+    *, codes_baseline: np.ndarray, residuals: np.ndarray, codes_target: np.ndarray
+) -> ResidualCellCalibration:
+    """Estimate each target row's expected model residual **differential** from baseline residuals.
+
+    The counterfactual model's conditional bias ``b(x)`` integrates to ~0 over the *training*
+    (baseline) covariate mix but the headline evaluates it over the *target* (upgraded) mix — any
+    shift between the two converts conditional bias into headline bias. This estimates that term on
+    untreated data: mean **out-of-fold** residual (``y - prediction``) per coarsened covariate cell
+    over the baseline rows, **centred by the global mean residual**, read out under the target
+    rows' cell occupancy. Adding the returned per-row values to the target predictions removes the
+    mix-shift headline bias.
+
+    The centring is the F14 lesson applied: the out-of-fold *level* (fold models see only ~80% of
+    an already-finite fit, so their residuals carry a small global offset the final 100% fit does
+    not have) is an artefact of the OOF basis and must not be transferred to the final model's
+    predictions; only the between-cell *differential* is the mix-shift term. A model that is
+    level-unbiased over its own training mix therefore gets a correction that integrates to ~0
+    under the baseline mix, exactly as ``b(x)`` does.
+
+    ``codes_baseline`` / ``codes_target`` are integer cell codes per (row, var) from
+    :func:`~benchmarking.baselines.power_model.matching.cell_codes`; a row with any ``-1`` (NaN /
+    out-of-range) belongs to no cell. Cells unseen in baseline — and invalid rows — get 0 (no
+    differential information), so the correction is always defined.
+    """
+    import pandas as pd  # noqa: PLC0415 - keep the module import-light like the factories
+
+    residuals = np.asarray(residuals, dtype=float)
+    finite = np.isfinite(residuals)
+    global_mean = float(residuals[finite].mean()) if finite.any() else 0.0
+
+    n_vars = codes_baseline.shape[1]
+    key_cols = list(range(n_vars))
+    valid_b = (codes_baseline >= 0).all(axis=1) & finite
+    base = pd.DataFrame(codes_baseline[valid_b], columns=key_cols)
+    base["residual"] = residuals[valid_b]
+    cell_means = base.groupby(key_cols, sort=False)["residual"].mean().rename("cell_mean").reset_index()
+
+    target = pd.DataFrame(codes_target, columns=key_cols)
+    mapped = target.merge(cell_means, on=key_cols, how="left")["cell_mean"].to_numpy(dtype=float)
+    mapped[~(codes_target >= 0).all(axis=1)] = np.nan
+    unseen = ~np.isfinite(mapped)
+    return ResidualCellCalibration(
+        per_row_residual=np.where(unseen, 0.0, mapped - global_mean),
+        global_mean_residual=global_mean,
+        n_target_unseen=int(unseen.sum()),
+        n_cells=len(cell_means),
+    )
+
+
 def early_stopped_n_estimators(
     make_model: Callable[[], Any],
     x: Any,  # noqa: ANN401 - pd.DataFrame

--- a/benchmarking/baselines/power_model/matching.py
+++ b/benchmarking/baselines/power_model/matching.py
@@ -110,7 +110,7 @@ def coarsened_exact_match(
             msg = f"{name} shape {np.asarray(sel).shape} does not align to matching_frame's {n_rows} rows"
             raise ValueError(msg)
 
-    codes = _cell_codes(matching_frame, bin_edges)
+    codes = cell_codes(matching_frame, bin_edges)
     valid_cell = np.all(codes >= 0, axis=1)  # -1 marks a NaN/out-of-range value in some var
     base = np.flatnonzero(np.asarray(baseline_sel, dtype=bool) & valid_cell)
     up = np.flatnonzero(np.asarray(upgraded_sel, dtype=bool) & valid_cell)
@@ -130,8 +130,12 @@ def coarsened_exact_match(
     return result
 
 
-def _cell_codes(matching_frame: pd.DataFrame, bin_edges: dict[str, list[float]]) -> np.ndarray:
-    """Integer cell code per (row, var); -1 where the value is NaN or outside the var's edges."""
+def cell_codes(matching_frame: pd.DataFrame, bin_edges: dict[str, list[float]]) -> np.ndarray:
+    """Integer cell code per (row, var); -1 where the value is NaN or outside the var's edges.
+
+    Public because the coarsening is shared: CEM matching here, and the residual calibration
+    (Issue 13), which estimates mean out-of-fold residuals over the same cells.
+    """
     columns = []
     for var, edges in bin_edges.items():
         # include_lowest so a value exactly on the lowest edge (e.g. 0° direction, calm wind) lands in

--- a/benchmarking/baselines/power_model/method.py
+++ b/benchmarking/baselines/power_model/method.py
@@ -265,12 +265,27 @@ class PowerModelMethod:
         Requires ``era5_hourly_df``; mutually exclusive with ``calibrate_slope`` and, like it, with
         ``early_stopping`` / ``n_seed_ensemble > 1`` (the out-of-fold basis must match the final
         model configuration).
-    :param time_decay_half_life_days: when set, training rows are sample-weighted by their
-        proximity in time to the campaign data: ``0.5 ** (days_outside_campaign / half_life)``.
-        Rows inside the campaign interval (for toggle, the interleaved on and off rows) weigh 1;
-        rows outside decay with their distance to it — so distant history informs the fit without
-        dominating it (Issue 13's recency weighting; the alternative to the rejected F11 drift
-        *feature*).
+    :param time_decay_half_life_days: training rows are sample-weighted by their proximity in
+        time to the campaign data: ``0.5 ** (days_outside_campaign / half_life)``. Rows inside
+        the campaign interval (for toggle, the interleaved on and off rows) weigh 1; rows outside
+        decay with their distance to it — so distant history informs the fit without dominating
+        it (Issue 13's recency weighting; the alternative to the rejected F11 drift *feature*).
+        Default **548 days (1.5 years)**: finite by design so an arbitrarily long SCADA history
+        cannot dominate the campaign era (year-old data still weighs ~63%, decade-old ~1%); on
+        the 2.5-year benchmark dataset it is neutral-to-slightly-better at every campaign length
+        (findings F16). Shorter half-lives (~90 days) measurably help 1-3-month campaigns at a
+        small long-prepost bias cost; ``None`` disables the weighting.
+    :param toggle_estimator: how a **toggle** headline is estimated (ignored for prepost).
+        ``"counterfactual"`` (default): ``Σactual/Σprediction - 1`` — needs the model to be
+        absolutely calibrated. ``"double_ratio"``: the naive-adoption hybrid — the model only
+        removes condition unfairness and the headline is a ratio of ratios,
+        ``(Σy_on/Σpred_on) / (Σy_off/Σpred_off) - 1``, where the off rows are predicted
+        out-of-fold and the on rows by the same fold-model ensemble (basis-consistent, the F15
+        rule), so the model's shrinkage/level bias cancels between the interleaved on and off
+        sides instead of needing to be zero. Implemented as
+        ``counterfactual = fold_ensemble_prediction * rho_off`` so every downstream sum and the
+        conditional re-level stay self-consistent. Cannot be combined with the calibrations
+        (it *is* one) or ``early_stopping`` / ``n_seed_ensemble > 1``.
     """
 
     active_power_col: str
@@ -303,7 +318,8 @@ class PowerModelMethod:
     early_stopping: bool = False
     calibrate_slope: bool = False
     calibrate_residuals: bool = False
-    time_decay_half_life_days: float | None = None
+    time_decay_half_life_days: float | None = 548.0
+    toggle_estimator: str = "counterfactual"
 
     def estimate(self, mi: MethodInput) -> MethodOutput:
         """Estimate the test turbine's P50 uplift for one campaign and write diagnostics."""
@@ -353,8 +369,14 @@ class PowerModelMethod:
         weights = self._time_decay_weights(
             index, campaign_start=_upgrade_start(mi.upgrade_timing, index), campaign_end=index.max()
         )
+        double_ratio = self.toggle_estimator == "double_ratio" and isinstance(mi.upgrade_timing, ToggleSchedule)
         fit = self._fit_predict(
-            features, y=y_arr, baseline_sel=baseline_sel, upgraded_sel=upgraded_sel, weights=weights
+            features,
+            y=y_arr,
+            baseline_sel=baseline_sel,
+            upgraded_sel=upgraded_sel,
+            weights=weights,
+            double_ratio=double_ratio,
         )
         sum_actual = float(fit["y_upgraded"].sum())
         sum_counter = float(fit["pred_upgraded"].sum())
@@ -409,6 +431,10 @@ class PowerModelMethod:
             # (toggle_campaign_only=False), only the interleaved campaign off rows qualify: matching
             # pre-campaign rows against campaign on rows would read reference/era drift as per-bin
             # uplift. The extra pre-campaign rows serve only the headline fit's training data.
+            # No time-decay weights here either (F16): the matched contrast is already
+            # era-insensitive (its common shrinkage cancels), and weighting the direction fits
+            # destabilises the sparse extreme-condition bins (a degenerate tail fit in one
+            # replicate can read three-digit per-bin uplift).
             by_condition = self._estimate_conditional(
                 scada,
                 mi=mi,
@@ -419,7 +445,6 @@ class PowerModelMethod:
                 fit=fit,
                 overall_ratio=uplift,
                 run_dir=run_dir,
-                weights=weights,
             )
         return MethodOutput(p50_overall=uplift, p50_by_condition=by_condition)
 
@@ -446,7 +471,6 @@ class PowerModelMethod:
         fit: dict[str, Any],
         overall_ratio: float,
         run_dir: Path,
-        weights: np.ndarray | None = None,
     ) -> pd.DataFrame | None:
         """Per-(ws, TI)-bin conditional uplift via a two-direction, ERA5-weather-matched cross-prediction.
 
@@ -474,11 +498,11 @@ class PowerModelMethod:
         )
         mb, mu = match.baseline_positions, match.upgraded_positions
         # Forward (train matched-baseline, predict matched-upgraded) gives ``1+r_fwd = (1+u)/s``.
-        pred_up = self._fit_direction(features, y, train=mb, predict=mu, weights=weights)
+        pred_up = self._fit_direction(features, y, train=mb, predict=mu)
         # Reverse (train matched-upgraded, predict matched-baseline): 1+r_rev = 1/(s(1+u)). Clip reuses
         # baseline_rated_power_kw — its upper bound max(rated, max(y_train)) already lifts the ceiling for an
         # uprate, so no separate upgraded-rating field is needed.
-        pred_base = self._fit_direction(features, y, train=mu, predict=mb, weights=weights)
+        pred_base = self._fit_direction(features, y, train=mu, predict=mb)
         r_fwd = _ratio(y[mu], pred_up)
         r_rev = _ratio(y[mb], pred_base)
 
@@ -511,22 +535,15 @@ class PowerModelMethod:
         return by_condition
 
     def _fit_direction(
-        self,
-        features: pd.DataFrame,
-        y: np.ndarray,
-        *,
-        train: np.ndarray,
-        predict: np.ndarray,
-        weights: np.ndarray | None = None,
+        self, features: pd.DataFrame, y: np.ndarray, *, train: np.ndarray, predict: np.ndarray
     ) -> np.ndarray:
         """Fit the outcome model(s) on ``train`` rows and return clipped predictions for ``predict`` rows.
 
-        No calibration here: the two-direction combine cancels the common per-bin shrinkage by
-        construction, so the calibration corrections are spent only on the overall headline.
+        No calibration and no time-decay weights here: the two-direction combine cancels the common
+        per-bin shrinkage by construction, and weighting the matched fits only destabilises sparse
+        extreme-condition bins (F16) — the corrections are spent on the overall headline instead.
         """
-        models = self._fit_models(
-            features.iloc[train], y[train], weights=weights[train] if weights is not None else None
-        )
+        models = self._fit_models(features.iloc[train], y[train])
         return _clip_predictions(
             self._predict_mean(models, features.iloc[predict]),
             y_train=y[train],
@@ -766,6 +783,7 @@ class PowerModelMethod:
         baseline_sel: np.ndarray,
         upgraded_sel: np.ndarray,
         weights: np.ndarray | None = None,
+        double_ratio: bool = False,
     ) -> dict[str, Any]:
         """Fit on baseline, predict the upgraded counterfactual; also a held-out baseline fit metric.
 
@@ -773,13 +791,18 @@ class PowerModelMethod:
         on a baseline train split predicts a held-out baseline slice, giving an honest fit-quality
         number that is not inflated by in-sample optimism. When ``calibrate_slope`` /
         ``calibrate_residuals`` is on, the counterfactual predictions pass through the out-of-fold
-        correction (line / per-cell residual means) before clipping.
+        correction (line / per-cell residual means) before clipping. ``double_ratio`` switches to the
+        toggle ratio-of-ratios estimator (see :attr:`toggle_estimator`).
         """
         x_base = features.iloc[baseline_sel]
         y_base = y[baseline_sel]
         x_up = features.iloc[upgraded_sel]
         y_up = y[upgraded_sel]
         w_base = weights[baseline_sel] if weights is not None else None
+        if double_ratio and len(y_base) >= _MIN_HOLDOUT_ROWS:
+            return self._fit_predict_double_ratio(
+                x_base, y_base=y_base, x_up=x_up, y_up=y_up, baseline_sel=baseline_sel, w_base=w_base
+            )
 
         y_valid, pred_valid, valid_local = self._holdout_fit(x_base, y_base, w_base=w_base)
         baseline_valid_pos = np.flatnonzero(baseline_sel)[valid_local]
@@ -803,6 +826,65 @@ class PowerModelMethod:
             "pred_baseline_valid": pred_valid,
             "baseline_valid_pos": baseline_valid_pos,  # positions over ``index`` of the held-out rows
             "calibration": calibration,
+        }
+
+    def _fit_predict_double_ratio(
+        self,
+        x_base: pd.DataFrame,
+        *,
+        y_base: np.ndarray,
+        x_up: pd.DataFrame,
+        y_up: np.ndarray,
+        baseline_sel: np.ndarray,
+        w_base: np.ndarray | None,
+    ) -> dict[str, Any]:
+        """Estimate via the toggle ratio-of-ratios: a model-normalised naive comparison (Issue 13 hybrid).
+
+        Fit one model per time-blocked fold on the off rows; each off row is predicted out-of-fold
+        and every on row by the mean of the fold models — both sides therefore share the ~80%-fit
+        basis (the F15 consistency rule), so the model's shrinkage/level bias cancels in
+        ``rho_on / rho_off``. The returned counterfactual is ``fold_ensemble_prediction * rho_off``
+        (``rho_off = Σy_off / Σpred_off``, the model's observed miscalibration on the off rows), which
+        makes ``Σactual / Σcounterfactual - 1`` equal the double ratio exactly — downstream sums,
+        diagnostics and the conditional re-level stay self-consistent. The full out-of-fold off-row
+        predictions double as the held-out fit-quality diagnostic.
+        """
+        n = len(y_base)
+        folds = time_block_folds(n, n_folds=_N_FOLDS, n_blocks=_N_BLOCKS)
+        oof = np.full(n, np.nan)
+        preds_on = []
+        models = []
+        for f in range(_N_FOLDS):
+            hold = folds == f
+            model = self._make_model()
+            model.fit(
+                x_base.iloc[~hold],
+                y_base[~hold],
+                **self._fit_kwargs(model, w_base[~hold] if w_base is not None else None),
+            )
+            oof[hold] = np.asarray(model.predict(x_base.iloc[hold]), dtype=float)
+            preds_on.append(np.asarray(model.predict(x_up), dtype=float))
+            models.append(model)
+        pred_off = _clip_predictions(oof, y_train=y_base, rated_power_kw=self.baseline_rated_power_kw)
+        rho_off = _ratio(y_base, pred_off) + 1.0
+        pred_up = _clip_predictions(
+            np.mean(preds_on, axis=0) * rho_off, y_train=y_base, rated_power_kw=self.baseline_rated_power_kw
+        )
+        logger.info(
+            "%s double-ratio toggle estimator: rho_off=%.5f over %d off rows (%d folds)",
+            self.name,
+            rho_off,
+            n,
+            _N_FOLDS,
+        )
+        return {
+            "model": models[0],
+            "pred_upgraded": pred_up,
+            "y_upgraded": y_up,
+            "y_baseline_valid": y_base,
+            "pred_baseline_valid": pred_off,
+            "baseline_valid_pos": np.flatnonzero(baseline_sel),
+            "calibration": IDENTITY_CALIBRATION,
         }
 
     def _validate_model_config(self) -> None:
@@ -838,6 +920,38 @@ class PowerModelMethod:
         if self.time_decay_half_life_days is not None and self.time_decay_half_life_days <= 0:
             msg = f"time_decay_half_life_days must be positive, got {self.time_decay_half_life_days}"
             raise ValueError(msg)
+        if self.toggle_estimator not in ("counterfactual", "double_ratio"):
+            msg = f"unknown toggle_estimator {self.toggle_estimator!r}; expected 'counterfactual' or 'double_ratio'"
+            raise ValueError(msg)
+        if self.toggle_estimator == "double_ratio" and (
+            self.calibrate_slope or self.calibrate_residuals or self.early_stopping or self.n_seed_ensemble > 1
+        ):
+            msg = (
+                "toggle_estimator='double_ratio' is itself a fold-basis calibration; it cannot be combined "
+                "with calibrate_slope, calibrate_residuals, early_stopping or n_seed_ensemble > 1."
+            )
+            raise ValueError(msg)
+
+    def _fit_kwargs(self, model: Any, weights: np.ndarray | None) -> dict[str, Any]:  # noqa: ANN401
+        """Return the fit kwargs for the time-decay ``weights``, empty for models that cannot take them.
+
+        A ``model_factory`` learner may not accept ``sample_weight`` (e.g. an sklearn ``Pipeline``);
+        with the weights on by default, such learners fit unweighted — warned once per run rather
+        than crashing the factory seam.
+        """
+        if weights is None:
+            return {}
+        from sklearn.utils.validation import has_fit_parameter  # noqa: PLC0415
+
+        if not has_fit_parameter(model, "sample_weight"):
+            logger.warning(
+                "%s: outcome model %s does not accept sample_weight; time-decay weights are ignored "
+                "for its fits (set time_decay_half_life_days=None to silence this).",
+                self.name,
+                type(model).__name__,
+            )
+            return {}
+        return {"sample_weight": weights}
 
     def _make_model(self, *, seed: int | None = None, extra_params: dict[str, Any] | None = None) -> Any:  # noqa: ANN401
         """One unfitted outcome model: the ``model_factory`` seam, or LightGBM with ``seed`` plumbed in.
@@ -873,11 +987,10 @@ class PowerModelMethod:
                 y_train,
                 valid_mask=time_block_folds(len(y_train), n_folds=_N_FOLDS, n_blocks=_N_BLOCKS) == 0,
             )
-        fit_kwargs: dict[str, Any] = {"sample_weight": weights} if weights is not None else {}
         models = []
         for k in range(self.n_seed_ensemble):
             model = self._make_model(seed=self.seed + k, extra_params=extra)
-            model.fit(x_train, y_train, **fit_kwargs)
+            model.fit(x_train, y_train, **self._fit_kwargs(model, weights))
             models.append(model)
         return models
 
@@ -901,8 +1014,11 @@ class PowerModelMethod:
         for f in range(_N_FOLDS):
             hold = folds == f
             model = self._make_model()
-            fit_kwargs: dict[str, Any] = {"sample_weight": w_base[~hold]} if w_base is not None else {}
-            model.fit(x_base.iloc[~hold], y_base[~hold], **fit_kwargs)
+            model.fit(
+                x_base.iloc[~hold],
+                y_base[~hold],
+                **self._fit_kwargs(model, w_base[~hold] if w_base is not None else None),
+            )
             oof[hold] = np.asarray(model.predict(x_base.iloc[hold]), dtype=float)
         return oof
 
@@ -1141,4 +1257,5 @@ class PowerModelMethod:
             "calibrate_slope": self.calibrate_slope,
             "calibrate_residuals": self.calibrate_residuals,
             "time_decay_half_life_days": self.time_decay_half_life_days,
+            "toggle_estimator": self.toggle_estimator,
         }

--- a/benchmarking/baselines/power_model/method.py
+++ b/benchmarking/baselines/power_model/method.py
@@ -44,11 +44,12 @@ from benchmarking.baselines.power_model.fitting import (
     IDENTITY_CALIBRATION,
     OUTCOME_MODEL_FACTORIES,
     CalibrationLine,
+    cell_residual_calibration,
     early_stopped_n_estimators,
     fit_calibration_line,
     time_block_folds,
 )
-from benchmarking.baselines.power_model.matching import coarsened_exact_match
+from benchmarking.baselines.power_model.matching import cell_codes, coarsened_exact_match
 from benchmarking.baselines.rlearner.nuisance import make_outcome_model
 from benchmarking.baselines.time_features import (
     TIME_FEATURE_NAMES,
@@ -211,7 +212,11 @@ class PowerModelMethod:
     :param model_params: LightGBM overrides passed to the outcome model
     :param timebase: analysis timebase; inferred from the data when ``None``
     :param toggle_campaign_only: for a toggle campaign, fit only on the interleaved on/off blocks
-        (drop the pre-campaign baseline) so on and off share a wind distribution; no-op for prepost
+        (drop the pre-campaign baseline); no-op for prepost. Default ``False`` since Issue 13
+        (findings F15): training on the pre-campaign baseline too removes most of the small-fit
+        shrinkage bias at short campaigns (3-month placebo +0.35 → +0.12 pp) — made safe for the
+        conditional step by matching within the campaign only (see ``estimate``). Set ``True`` to
+        restore the strict same-distribution training window.
     :param conditional_uplift: compute the per-(ws, TI)-bin conditional uplift distribution (default
         ``True``). The overall P50 is a single baseline→upgraded fit either way; when this is ``True``
         an extra two-direction, ERA5-weather-matched (CEM) cross-prediction runs **last** to estimate
@@ -250,6 +255,22 @@ class PowerModelMethod:
         Applies to the overall headline only — the conditional two-direction step cancels its
         per-bin shrinkage by construction. The line is fit with single-seed, non-early-stopped
         models, so it cannot be combined with ``early_stopping`` or ``n_seed_ensemble > 1``.
+    :param calibrate_residuals: ERA5-cell residual calibration (Issue 13): the model's conditional
+        bias integrates to ~0 over the *baseline* covariate mix but the headline evaluates it over
+        the *upgraded* mix. When on, estimate the mean out-of-fold baseline residual per coarsened
+        ERA5 cell (the ``matching_vars`` / F6 CEM coarsening), **centred by the global mean
+        residual** so only the mix-shift differential transfers (the OOF *level* is an artefact of
+        the fold basis — the F14 lesson), and add each upgraded row's centred cell mean (0 for
+        cells unseen in baseline) to its counterfactual prediction before the energy ratio.
+        Requires ``era5_hourly_df``; mutually exclusive with ``calibrate_slope`` and, like it, with
+        ``early_stopping`` / ``n_seed_ensemble > 1`` (the out-of-fold basis must match the final
+        model configuration).
+    :param time_decay_half_life_days: when set, training rows are sample-weighted by their
+        proximity in time to the campaign data: ``0.5 ** (days_outside_campaign / half_life)``.
+        Rows inside the campaign interval (for toggle, the interleaved on and off rows) weigh 1;
+        rows outside decay with their distance to it — so distant history informs the fit without
+        dominating it (Issue 13's recency weighting; the alternative to the rejected F11 drift
+        *feature*).
     """
 
     active_power_col: str
@@ -265,7 +286,7 @@ class PowerModelMethod:
     seed: int = 0
     model_params: dict[str, Any] = field(default_factory=dict)
     timebase: pd.Timedelta | None = None
-    toggle_campaign_only: bool = True
+    toggle_campaign_only: bool = False
     conditional_uplift: bool = True
     matching_vars: tuple[str, ...] = _DEFAULT_MATCHING_VARS
     matching_bin_edges: dict[str, list[float]] | None = None
@@ -281,6 +302,8 @@ class PowerModelMethod:
     n_seed_ensemble: int = 1
     early_stopping: bool = False
     calibrate_slope: bool = False
+    calibrate_residuals: bool = False
+    time_decay_half_life_days: float | None = None
 
     def estimate(self, mi: MethodInput) -> MethodOutput:
         """Estimate the test turbine's P50 uplift for one campaign and write diagnostics."""
@@ -327,7 +350,12 @@ class PowerModelMethod:
             raise ValueError(msg)
 
         y_arr = y.to_numpy(dtype=float)
-        fit = self._fit_predict(features, y=y_arr, baseline_sel=baseline_sel, upgraded_sel=upgraded_sel)
+        weights = self._time_decay_weights(
+            index, campaign_start=_upgrade_start(mi.upgrade_timing, index), campaign_end=index.max()
+        )
+        fit = self._fit_predict(
+            features, y=y_arr, baseline_sel=baseline_sel, upgraded_sel=upgraded_sel, weights=weights
+        )
         sum_actual = float(fit["y_upgraded"].sum())
         sum_counter = float(fit["pred_upgraded"].sum())
         uplift = sum_actual / sum_counter - 1.0 if np.isfinite(sum_counter) and sum_counter != 0 else float("nan")
@@ -376,18 +404,35 @@ class PowerModelMethod:
         # missing-ERA5 error).
         by_condition: pd.DataFrame | None = None
         if self.conditional_uplift and self.wind_speed_col is not None:
+            # The conditional two-direction step matches untreated against treated rows and relies on
+            # them sharing a distribution *and era* — for a toggle trained on pre-campaign data too
+            # (toggle_campaign_only=False), only the interleaved campaign off rows qualify: matching
+            # pre-campaign rows against campaign on rows would read reference/era drift as per-bin
+            # uplift. The extra pre-campaign rows serve only the headline fit's training data.
             by_condition = self._estimate_conditional(
                 scada,
                 mi=mi,
                 features=features,
                 y=y_arr,
-                baseline_sel=baseline_sel,
+                baseline_sel=baseline_sel & self._campaign_mask(index, upgrade_timing=mi.upgrade_timing),
                 upgraded_sel=upgraded_sel,
                 fit=fit,
                 overall_ratio=uplift,
                 run_dir=run_dir,
+                weights=weights,
             )
         return MethodOutput(p50_overall=uplift, p50_by_condition=by_condition)
+
+    @staticmethod
+    def _campaign_mask(index: pd.DatetimeIndex, *, upgrade_timing: pd.Timestamp | ToggleSchedule) -> np.ndarray:
+        """Boolean over ``index``: rows at/after the campaign start (all-True for prepost).
+
+        Prepost has no pre-campaign data beyond its baseline (which *is* the training era), so the
+        mask only bites for a toggle whose input still carries pre-campaign rows.
+        """
+        if isinstance(upgrade_timing, ToggleSchedule) and upgrade_timing.start is not None:
+            return np.asarray(index >= upgrade_timing.start)
+        return np.ones(len(index), dtype=bool)
 
     def _estimate_conditional(
         self,
@@ -401,6 +446,7 @@ class PowerModelMethod:
         fit: dict[str, Any],
         overall_ratio: float,
         run_dir: Path,
+        weights: np.ndarray | None = None,
     ) -> pd.DataFrame | None:
         """Per-(ws, TI)-bin conditional uplift via a two-direction, ERA5-weather-matched cross-prediction.
 
@@ -427,11 +473,12 @@ class PowerModelMethod:
             seed=self.seed,
         )
         mb, mu = match.baseline_positions, match.upgraded_positions
-        pred_up = self._fit_direction(features, y, train=mb, predict=mu)  # forward: 1+r_fwd = (1+u)/s
+        # Forward (train matched-baseline, predict matched-upgraded) gives ``1+r_fwd = (1+u)/s``.
+        pred_up = self._fit_direction(features, y, train=mb, predict=mu, weights=weights)
         # Reverse (train matched-upgraded, predict matched-baseline): 1+r_rev = 1/(s(1+u)). Clip reuses
         # baseline_rated_power_kw — its upper bound max(rated, max(y_train)) already lifts the ceiling for an
         # uprate, so no separate upgraded-rating field is needed.
-        pred_base = self._fit_direction(features, y, train=mu, predict=mb)
+        pred_base = self._fit_direction(features, y, train=mu, predict=mb, weights=weights)
         r_fwd = _ratio(y[mu], pred_up)
         r_rev = _ratio(y[mb], pred_base)
 
@@ -464,14 +511,22 @@ class PowerModelMethod:
         return by_condition
 
     def _fit_direction(
-        self, features: pd.DataFrame, y: np.ndarray, *, train: np.ndarray, predict: np.ndarray
+        self,
+        features: pd.DataFrame,
+        y: np.ndarray,
+        *,
+        train: np.ndarray,
+        predict: np.ndarray,
+        weights: np.ndarray | None = None,
     ) -> np.ndarray:
         """Fit the outcome model(s) on ``train`` rows and return clipped predictions for ``predict`` rows.
 
         No calibration here: the two-direction combine cancels the common per-bin shrinkage by
-        construction, so the slope correction is spent only on the overall headline.
+        construction, so the calibration corrections are spent only on the overall headline.
         """
-        models = self._fit_models(features.iloc[train], y[train])
+        models = self._fit_models(
+            features.iloc[train], y[train], weights=weights[train] if weights is not None else None
+        )
         return _clip_predictions(
             self._predict_mean(models, features.iloc[predict]),
             y_train=y[train],
@@ -628,11 +683,11 @@ class PowerModelMethod:
                 msg = f"era5_exclude names columns not in the ERA5 features: {missing}"
                 raise ValueError(msg)
             blocked = sorted(set(self.era5_exclude) & set(self.matching_vars))
-            if blocked and self.conditional_uplift:
+            if blocked and (self.conditional_uplift or self.calibrate_residuals):
                 msg = (
-                    f"era5_exclude {blocked} are conditional-uplift matching_vars; excluding them as model "
-                    f"features would break the CEM matching step. Turn conditional_uplift off or re-pick "
-                    f"matching_vars first."
+                    f"era5_exclude {blocked} are matching_vars; excluding them as model features would "
+                    f"break the CEM matching / residual-calibration cells. Turn conditional_uplift and "
+                    f"calibrate_residuals off or re-pick matching_vars first."
                 )
                 raise ValueError(msg)
             drop = [
@@ -672,6 +727,24 @@ class PowerModelMethod:
             frames.append(solar_altitude_azimuth(index, latitude=self.latitude, longitude=self.longitude))
         return pd.concat(frames, axis=1)
 
+    def _time_decay_weights(
+        self, index: pd.DatetimeIndex, *, campaign_start: pd.Timestamp, campaign_end: pd.Timestamp
+    ) -> np.ndarray | None:
+        """Exponential campaign-proximity sample weights over the analysis index (``None`` = knob off).
+
+        ``0.5 ** (days_outside_campaign / half_life)`` where the distance is to the campaign
+        *interval* ``[campaign_start, campaign_end]``: every row inside the campaign (for toggle,
+        the interleaved on **and** off rows) weighs exactly 1, and rows outside decay with their
+        distance to it — so distant history still informs the fit without dominating it. With
+        today's flows only pre-campaign rows exist outside the interval, but the definition is
+        two-sided on purpose.
+        """
+        if self.time_decay_half_life_days is None:
+            return None
+        seconds_outside = np.maximum((campaign_start - index).total_seconds(), (index - campaign_end).total_seconds())
+        days_outside = np.maximum(seconds_outside / 86400.0, 0.0)
+        return np.asarray(0.5 ** (days_outside / self.time_decay_half_life_days), dtype=float)
+
     def _select_rows(
         self, scada: pd.DataFrame, *, mi: MethodInput, index: pd.DatetimeIndex, y: pd.Series, timebase: pd.Timedelta
     ) -> np.ndarray:
@@ -686,30 +759,42 @@ class PowerModelMethod:
         return keep.to_numpy() & np.isfinite(y.to_numpy(dtype=float))
 
     def _fit_predict(
-        self, features: pd.DataFrame, *, y: np.ndarray, baseline_sel: np.ndarray, upgraded_sel: np.ndarray
+        self,
+        features: pd.DataFrame,
+        *,
+        y: np.ndarray,
+        baseline_sel: np.ndarray,
+        upgraded_sel: np.ndarray,
+        weights: np.ndarray | None = None,
     ) -> dict[str, Any]:
         """Fit on baseline, predict the upgraded counterfactual; also a held-out baseline fit metric.
 
         The final model(s) (for the counterfactual) are fit on **all** baseline rows. A separate model
         on a baseline train split predicts a held-out baseline slice, giving an honest fit-quality
-        number that is not inflated by in-sample optimism. When ``calibrate_slope`` is on, the
-        counterfactual predictions pass through the out-of-fold calibration line before clipping.
+        number that is not inflated by in-sample optimism. When ``calibrate_slope`` /
+        ``calibrate_residuals`` is on, the counterfactual predictions pass through the out-of-fold
+        correction (line / per-cell residual means) before clipping.
         """
         x_base = features.iloc[baseline_sel]
         y_base = y[baseline_sel]
         x_up = features.iloc[upgraded_sel]
         y_up = y[upgraded_sel]
+        w_base = weights[baseline_sel] if weights is not None else None
 
-        y_valid, pred_valid, valid_local = self._holdout_fit(x_base, y_base)
+        y_valid, pred_valid, valid_local = self._holdout_fit(x_base, y_base, w_base=w_base)
         baseline_valid_pos = np.flatnonzero(baseline_sel)[valid_local]
 
-        models = self._fit_models(x_base, y_base)
-        calibration = self._fit_calibration(x_base, y_base) if self.calibrate_slope else IDENTITY_CALIBRATION
-        pred_up = _clip_predictions(
-            calibration.apply(self._predict_mean(models, x_up)),
-            y_train=y_base,
-            rated_power_kw=self.baseline_rated_power_kw,
-        )
+        models = self._fit_models(x_base, y_base, weights=w_base)
+        pred_raw = self._predict_mean(models, x_up)
+        calibration = IDENTITY_CALIBRATION
+        if self.calibrate_slope:
+            calibration = self._fit_calibration(x_base, y_base, w_base=w_base)
+            pred_raw = calibration.apply(pred_raw)
+        elif self.calibrate_residuals:
+            pred_raw = pred_raw + self._residual_corrections(
+                features, y=y, baseline_sel=baseline_sel, upgraded_sel=upgraded_sel, w_base=w_base
+            )
+        pred_up = _clip_predictions(pred_raw, y_train=y_base, rated_power_kw=self.baseline_rated_power_kw)
         return {
             "model": models[0],
             "pred_upgraded": pred_up,
@@ -737,12 +822,21 @@ class PowerModelMethod:
         if self.n_seed_ensemble > 1 and "random_state" in self.model_params:
             msg = "a fixed random_state in model_params would make every ensemble member identical."
             raise ValueError(msg)
-        if self.calibrate_slope and (self.early_stopping or self.n_seed_ensemble > 1):
+        if self.calibrate_slope and self.calibrate_residuals:
+            msg = "calibrate_slope and calibrate_residuals are competing headline corrections; enable at most one."
+            raise ValueError(msg)
+        if (self.calibrate_slope or self.calibrate_residuals) and (self.early_stopping or self.n_seed_ensemble > 1):
             msg = (
-                "calibrate_slope fits its out-of-fold line with single-seed, non-early-stopped models, "
-                "so combining it with early_stopping or n_seed_ensemble > 1 would calibrate against a "
-                "different model configuration than the predictions it corrects."
+                "calibrate_slope / calibrate_residuals fit their out-of-fold basis with single-seed, "
+                "non-early-stopped models, so combining them with early_stopping or n_seed_ensemble > 1 "
+                "would calibrate against a different model configuration than the predictions they correct."
             )
+            raise ValueError(msg)
+        if self.calibrate_residuals and self.era5_hourly_df is None:
+            msg = "calibrate_residuals requires ERA5 (era5_hourly_df): the residual cells are the ERA5 matching_vars."
+            raise ValueError(msg)
+        if self.time_decay_half_life_days is not None and self.time_decay_half_life_days <= 0:
+            msg = f"time_decay_half_life_days must be positive, got {self.time_decay_half_life_days}"
             raise ValueError(msg)
 
     def _make_model(self, *, seed: int | None = None, extra_params: dict[str, Any] | None = None) -> Any:  # noqa: ANN401
@@ -761,11 +855,14 @@ class PowerModelMethod:
             return factory(s)
         return make_outcome_model(**{"random_state": s, **self.model_params, **(extra_params or {})})
 
-    def _fit_models(self, x_train: pd.DataFrame, y_train: np.ndarray) -> list[Any]:
+    def _fit_models(
+        self, x_train: pd.DataFrame, y_train: np.ndarray, *, weights: np.ndarray | None = None
+    ) -> list[Any]:
         """Fit the outcome model(s) on one training set, honouring ``early_stopping`` / ``n_seed_ensemble``.
 
         Early stopping runs once (a probe fit on a time-blocked split picks the tree count), then every
-        ensemble member is refit on **all** training rows at that capacity with its own seed.
+        ensemble member is refit on **all** training rows at that capacity with its own seed. ``weights``
+        (the time-decay sample weights, aligned to the training rows) are passed to every fit when given.
         """
         extra: dict[str, Any] = {}
         if self.early_stopping and len(y_train) >= _MIN_EARLY_STOPPING_ROWS:
@@ -776,10 +873,11 @@ class PowerModelMethod:
                 y_train,
                 valid_mask=time_block_folds(len(y_train), n_folds=_N_FOLDS, n_blocks=_N_BLOCKS) == 0,
             )
+        fit_kwargs: dict[str, Any] = {"sample_weight": weights} if weights is not None else {}
         models = []
         for k in range(self.n_seed_ensemble):
             model = self._make_model(seed=self.seed + k, extra_params=extra)
-            model.fit(x_train, y_train)
+            model.fit(x_train, y_train, **fit_kwargs)
             models.append(model)
         return models
 
@@ -788,27 +886,80 @@ class PowerModelMethod:
         """Seed-ensemble prediction: the mean over the fitted models (unclipped)."""
         return np.mean([np.asarray(m.predict(x), dtype=float) for m in models], axis=0)
 
-    def _fit_calibration(self, x_base: pd.DataFrame, y_base: np.ndarray) -> CalibrationLine:
-        """Fit the calibration line on time-blocked out-of-fold baseline predictions (single-seed fits).
+    def _oof_baseline_predictions(
+        self, x_base: pd.DataFrame, y_base: np.ndarray, *, w_base: np.ndarray | None = None
+    ) -> np.ndarray:
+        """Out-of-fold prediction for every baseline row via time-blocked folds (single-seed fits).
 
-        Every baseline row gets a prediction from a model not trained on its fold, so the slope is not
-        flattered by in-sample optimism (a shuffled or in-sample basis would read ~1 by construction).
+        Every baseline row gets a prediction from a model not trained on its fold, so residuals /
+        calibration fits on this basis are not flattered by in-sample optimism (a shuffled or
+        in-sample basis would read unbiased by construction).
         """
         n = len(y_base)
-        if n < _MIN_HOLDOUT_ROWS:
-            return IDENTITY_CALIBRATION
         folds = time_block_folds(n, n_folds=_N_FOLDS, n_blocks=_N_BLOCKS)
         oof = np.full(n, np.nan)
         for f in range(_N_FOLDS):
             hold = folds == f
             model = self._make_model()
-            model.fit(x_base.iloc[~hold], y_base[~hold])
+            fit_kwargs: dict[str, Any] = {"sample_weight": w_base[~hold]} if w_base is not None else {}
+            model.fit(x_base.iloc[~hold], y_base[~hold], **fit_kwargs)
             oof[hold] = np.asarray(model.predict(x_base.iloc[hold]), dtype=float)
-        line = fit_calibration_line(y_base, oof)
+        return oof
+
+    def _fit_calibration(
+        self, x_base: pd.DataFrame, y_base: np.ndarray, *, w_base: np.ndarray | None = None
+    ) -> CalibrationLine:
+        """Fit the calibration line on time-blocked out-of-fold baseline predictions."""
+        n = len(y_base)
+        if n < _MIN_HOLDOUT_ROWS:
+            return IDENTITY_CALIBRATION
+        line = fit_calibration_line(y_base, self._oof_baseline_predictions(x_base, y_base, w_base=w_base))
         logger.info("%s calibration line: slope=%.4f intercept=%.2f (n=%d)", self.name, line.slope, line.intercept, n)
         return line
 
-    def _holdout_fit(self, x_base: pd.DataFrame, y_base: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    def _residual_corrections(
+        self,
+        features: pd.DataFrame,
+        *,
+        y: np.ndarray,
+        baseline_sel: np.ndarray,
+        upgraded_sel: np.ndarray,
+        w_base: np.ndarray | None = None,
+    ) -> np.ndarray:
+        """Per-upgraded-row correction from centred cell-mean out-of-fold baseline residuals (Issue 13).
+
+        The cells are the F6 CEM coarsening of ``matching_vars``; adding each upgraded row's centred
+        cell-mean baseline residual to its prediction removes the headline bias that the
+        baseline→upgraded covariate-mix shift converts from the model's conditional bias (the global
+        OOF level is centred out — see :func:`~benchmarking.baselines.power_model.fitting.
+        cell_residual_calibration`). Returns zeros when the baseline is too small to split.
+        """
+        x_base = features.iloc[baseline_sel]
+        y_base = y[baseline_sel]
+        n_up = int(np.asarray(upgraded_sel).sum())
+        if len(y_base) < _MIN_HOLDOUT_ROWS:
+            return np.zeros(n_up)
+        residuals = y_base - self._oof_baseline_predictions(x_base, y_base, w_base=w_base)
+        edges = self.matching_bin_edges if self.matching_bin_edges is not None else self._default_bin_edges()
+        codes = cell_codes(features[list(self.matching_vars)], edges)
+        calib = cell_residual_calibration(
+            codes_baseline=codes[baseline_sel], residuals=residuals, codes_target=codes[upgraded_sel]
+        )
+        logger.info(
+            "%s residual calibration: mean centred correction %+.2f kW over %d upgraded rows "
+            "(%d cells; %d rows unseen -> 0; centred-out OOF level %+.2f kW)",
+            self.name,
+            float(calib.per_row_residual.mean()) if n_up else float("nan"),
+            n_up,
+            calib.n_cells,
+            calib.n_target_unseen,
+            calib.global_mean_residual,
+        )
+        return calib.per_row_residual
+
+    def _holdout_fit(
+        self, x_base: pd.DataFrame, y_base: np.ndarray, *, w_base: np.ndarray | None = None
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
         """Train on a baseline train split, predict a held-out baseline slice (honest fit quality).
 
         The held-out slice is **time-blocked** (fold 0 of the shared split shape), not shuffled — a
@@ -818,7 +969,7 @@ class PowerModelMethod:
         """
         n = len(y_base)
         if n < _MIN_HOLDOUT_ROWS:
-            models = self._fit_models(x_base, y_base)
+            models = self._fit_models(x_base, y_base, weights=w_base)
             pred = _clip_predictions(
                 self._predict_mean(models, x_base),
                 y_train=y_base,
@@ -826,7 +977,9 @@ class PowerModelMethod:
             )
             return y_base, pred, np.arange(n)
         valid = time_block_folds(n, n_folds=_N_FOLDS, n_blocks=_N_BLOCKS) == 0
-        models = self._fit_models(x_base.iloc[~valid], y_base[~valid])
+        models = self._fit_models(
+            x_base.iloc[~valid], y_base[~valid], weights=w_base[~valid] if w_base is not None else None
+        )
         pred_valid = _clip_predictions(
             self._predict_mean(models, x_base.iloc[valid]),
             y_train=y_base[~valid],
@@ -986,4 +1139,6 @@ class PowerModelMethod:
             "n_seed_ensemble": self.n_seed_ensemble,
             "early_stopping": self.early_stopping,
             "calibrate_slope": self.calibrate_slope,
+            "calibrate_residuals": self.calibrate_residuals,
+            "time_decay_half_life_days": self.time_decay_half_life_days,
         }

--- a/benchmarking/baselines/power_model/method.py
+++ b/benchmarking/baselines/power_model/method.py
@@ -249,20 +249,26 @@ class PowerModelMethod:
     :param early_stopping: pick the LightGBM tree count by early stopping on a time-blocked
         validation split, then refit on all training rows at that capacity — data-size-adaptive
         capacity instead of one fixed ``n_estimators`` for every fit size (default ``False``)
-    :param calibrate_slope: post-hoc calibration-slope correction (Issue 12): fit
-        ``actual ~ a + b * predicted`` on time-blocked out-of-fold baseline predictions and apply
-        the line to the counterfactual predictions before the energy ratio (default ``False``).
-        Applies to the overall headline only — the conditional two-direction step cancels its
-        per-bin shrinkage by construction. The line is fit with single-seed, non-early-stopped
-        models, so it cannot be combined with ``early_stopping`` or ``n_seed_ensemble > 1``.
-    :param calibrate_residuals: ERA5-cell residual calibration (Issue 13): the model's conditional
-        bias integrates to ~0 over the *baseline* covariate mix but the headline evaluates it over
-        the *upgraded* mix. When on, estimate the mean out-of-fold baseline residual per coarsened
-        ERA5 cell (the ``matching_vars`` / F6 CEM coarsening), **centred by the global mean
-        residual** so only the mix-shift differential transfers (the OOF *level* is an artefact of
-        the fold basis — the F14 lesson), and add each upgraded row's centred cell mean (0 for
-        cells unseen in baseline) to its counterfactual prediction before the energy ratio.
-        Requires ``era5_hourly_df``; mutually exclusive with ``calibrate_slope`` and, like it, with
+    :param calibrate_slope: post-hoc calibration-slope correction (Issue 12). **Measured and
+        rejected as a default (findings F14): the line is fit on out-of-fold predictions from
+        ~80%-sized fits, which shrink more than the final 100% fit it corrects, so it overcorrects
+        exactly where the correction is largest (small fits) — keep off unless researching that
+        mechanism.** When on: fit ``actual ~ a + b * predicted`` on time-blocked out-of-fold
+        baseline predictions and apply the line to the counterfactual predictions before the
+        energy ratio. Applies to the overall headline only — the conditional two-direction step
+        cancels its per-bin shrinkage by construction. The line is fit with single-seed,
+        non-early-stopped models, so it cannot be combined with ``early_stopping`` or
+        ``n_seed_ensemble > 1``.
+    :param calibrate_residuals: ERA5-cell residual calibration (Issue 13). **Measured and rejected
+        as a default (findings F15): out-of-fold residuals transfer to the final refit model in
+        neither level nor conditional shape — the estimated correction had the wrong sign vs the
+        observed placebo bias — so this knob is retained for research only.** When on: estimate
+        the mean out-of-fold baseline residual per coarsened ERA5 cell (the ``matching_vars`` / F6
+        CEM coarsening), **centred by the global mean residual** so only the mix-shift
+        differential transfers (the OOF *level* artefact, the F14 lesson — necessary but, per F15,
+        not sufficient), and add each upgraded row's centred cell mean (0 for cells unseen in
+        baseline) to its counterfactual prediction before the energy ratio. Requires
+        ``era5_hourly_df``; mutually exclusive with ``calibrate_slope`` and, like it, with
         ``early_stopping`` / ``n_seed_ensemble > 1`` (the out-of-fold basis must match the final
         model configuration).
     :param time_decay_half_life_days: training rows are sample-weighted by their proximity in

--- a/benchmarking/baselines/power_model/method.py
+++ b/benchmarking/baselines/power_model/method.py
@@ -326,6 +326,8 @@ class PowerModelMethod:
     calibrate_residuals: bool = False
     time_decay_half_life_days: float | None = 548.0
     toggle_estimator: str = "counterfactual"
+    # Not configuration: latches the missing-sample_weight warning so it fires once per instance.
+    _warned_no_sample_weight: bool = field(default=False, init=False, repr=False, compare=False)
 
     def estimate(self, mi: MethodInput) -> MethodOutput:
         """Estimate the test turbine's P50 uplift for one campaign and write diagnostics."""
@@ -805,7 +807,14 @@ class PowerModelMethod:
         x_up = features.iloc[upgraded_sel]
         y_up = y[upgraded_sel]
         w_base = weights[baseline_sel] if weights is not None else None
-        if double_ratio and len(y_base) >= _MIN_HOLDOUT_ROWS:
+        if double_ratio:
+            if len(y_base) < _MIN_HOLDOUT_ROWS:
+                # Fail loudly rather than silently estimating with a different estimator than requested.
+                msg = (
+                    f"toggle_estimator='double_ratio' needs at least {_MIN_HOLDOUT_ROWS} off rows for its "
+                    f"out-of-fold basis, got {len(y_base)}."
+                )
+                raise ValueError(msg)
             return self._fit_predict_double_ratio(
                 x_base, y_base=y_base, x_up=x_up, y_up=y_up, baseline_sel=baseline_sel, w_base=w_base
             )
@@ -849,11 +858,14 @@ class PowerModelMethod:
         Fit one model per time-blocked fold on the off rows; each off row is predicted out-of-fold
         and every on row by the mean of the fold models — both sides therefore share the ~80%-fit
         basis (the F15 consistency rule), so the model's shrinkage/level bias cancels in
-        ``rho_on / rho_off``. The returned counterfactual is ``fold_ensemble_prediction * rho_off``
-        (``rho_off = Σy_off / Σpred_off``, the model's observed miscalibration on the off rows), which
-        makes ``Σactual / Σcounterfactual - 1`` equal the double ratio exactly — downstream sums,
-        diagnostics and the conditional re-level stay self-consistent. The full out-of-fold off-row
-        predictions double as the held-out fit-quality diagnostic.
+        ``rho_on / rho_off``. The returned counterfactual is ``clip(fold_ensemble_prediction) *
+        rho_off`` (``rho_off = Σy_off / Σpred_off``, the model's observed miscalibration on the off
+        rows): the physical clip applies to the *prediction* and the calibration scale on top, so
+        ``Σactual / Σcounterfactual - 1`` equals the double ratio of the clipped predictions
+        exactly — downstream sums, diagnostics and the conditional re-level stay self-consistent.
+        (The scaled counterfactual may exceed the clip ceiling by the ~0-3 % calibration factor;
+        that is deliberate — re-clipping after scaling would break the identity.) The full
+        out-of-fold off-row predictions double as the held-out fit-quality diagnostic.
         """
         n = len(y_base)
         folds = time_block_folds(n, n_folds=_N_FOLDS, n_blocks=_N_BLOCKS)
@@ -873,8 +885,9 @@ class PowerModelMethod:
             models.append(model)
         pred_off = _clip_predictions(oof, y_train=y_base, rated_power_kw=self.baseline_rated_power_kw)
         rho_off = _ratio(y_base, pred_off) + 1.0
-        pred_up = _clip_predictions(
-            np.mean(preds_on, axis=0) * rho_off, y_train=y_base, rated_power_kw=self.baseline_rated_power_kw
+        pred_up = (
+            _clip_predictions(np.mean(preds_on, axis=0), y_train=y_base, rated_power_kw=self.baseline_rated_power_kw)
+            * rho_off
         )
         logger.info(
             "%s double-ratio toggle estimator: rho_off=%.5f over %d off rows (%d folds)",
@@ -942,20 +955,23 @@ class PowerModelMethod:
         """Return the fit kwargs for the time-decay ``weights``, empty for models that cannot take them.
 
         A ``model_factory`` learner may not accept ``sample_weight`` (e.g. an sklearn ``Pipeline``);
-        with the weights on by default, such learners fit unweighted — warned once per run rather
-        than crashing the factory seam.
+        with the weights on by default, such learners fit unweighted — warned once per method
+        instance (many fits happen per estimate: folds, holdout, ensemble) rather than crashing
+        the factory seam.
         """
         if weights is None:
             return {}
         from sklearn.utils.validation import has_fit_parameter  # noqa: PLC0415
 
         if not has_fit_parameter(model, "sample_weight"):
-            logger.warning(
-                "%s: outcome model %s does not accept sample_weight; time-decay weights are ignored "
-                "for its fits (set time_decay_half_life_days=None to silence this).",
-                self.name,
-                type(model).__name__,
-            )
+            if not self._warned_no_sample_weight:
+                self._warned_no_sample_weight = True
+                logger.warning(
+                    "%s: outcome model %s does not accept sample_weight; time-decay weights are ignored "
+                    "for its fits (set time_decay_half_life_days=None to silence this).",
+                    self.name,
+                    type(model).__name__,
+                )
             return {}
         return {"sample_weight": weights}
 

--- a/benchmarking/baselines/study_power_model_compare_baseline.json
+++ b/benchmarking/baselines/study_power_model_compare_baseline.json
@@ -2,8 +2,8 @@
   "schema": "power_model_compare_baseline_v2",
   "modes": {
     "prepost": {
-      "recorded_utc": "2026-07-04T15:12:20Z",
-      "git_commit": "47171a4-dirty",
+      "recorded_utc": "2026-07-04T19:42:37Z",
+      "git_commit": "f13a71d-dirty",
       "n_replicates": 4,
       "seed": 0,
       "campaign_months": [
@@ -26,171 +26,171 @@
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00016895,
-          "spread": 0.00301475,
-          "score": 0.00301948
+          "bias": -0.00017005,
+          "spread": 0.0030137,
+          "score": 0.00301849
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.06908335,
+          "bias": 0.06908138,
           "spread": 0.0,
-          "score": 0.06908335
+          "score": 0.06908138
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00912072,
-          "spread": 0.01147163,
-          "score": 0.01465557
+          "bias": -0.0091218,
+          "spread": 0.01147194,
+          "score": 0.01465649
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00223841,
-          "spread": 0.00420322,
-          "score": 0.00476209
+          "bias": 0.00223731,
+          "spread": 0.00420219,
+          "score": 0.00476067
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.0028987,
-          "spread": 0.00229472,
-          "score": 0.00369705
+          "bias": -0.00289979,
+          "spread": 0.00229367,
+          "score": 0.00369726
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00100239,
-          "spread": 0.01041473,
-          "score": 0.01046285
+          "bias": -0.00100349,
+          "spread": 0.01041468,
+          "score": 0.01046292
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.0029679,
-          "spread": 0.01845849,
-          "score": 0.01869557
+          "bias": 0.0029668,
+          "spread": 0.01845816,
+          "score": 0.01869507
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.02875143,
-          "spread": 0.04128892,
-          "score": 0.05031321
+          "bias": -0.02875249,
+          "spread": 0.04128891,
+          "score": 0.05031381
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.07989222,
-          "spread": 0.10806762,
-          "score": 0.13439263
+          "bias": 0.07989104,
+          "spread": 0.10806742,
+          "score": 0.13439176
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.2637524,
-          "spread": 0.43798076,
-          "score": 0.51126556
+          "bias": 0.26375172,
+          "spread": 0.43798147,
+          "score": 0.51126582
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.2659076,
-          "spread": 0.77885138,
-          "score": 0.8229923
+          "bias": 0.26590725,
+          "spread": 0.7788517,
+          "score": 0.82299249
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.0941778,
-          "spread": 0.07660007,
-          "score": 0.12139616
+          "bias": -0.09417876,
+          "spread": 0.07660031,
+          "score": 0.12139706
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -4.531e-05,
-          "spread": 0.00587507,
-          "score": 0.00587524
+          "bias": -4.64e-05,
+          "spread": 0.0058754,
+          "score": 0.00587559
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.0041206,
-          "spread": 0.00736971,
-          "score": 0.00844346
+          "bias": 0.00411951,
+          "spread": 0.00736979,
+          "score": 0.00844299
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00895196,
-          "spread": 0.01064625,
-          "score": 0.01390971
+          "bias": 0.00895086,
+          "spread": 0.01064637,
+          "score": 0.0139091
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.000362,
-          "spread": 0.00453073,
-          "score": 0.00454517
+          "bias": -0.00036309,
+          "spread": 0.00453125,
+          "score": 0.00454577
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.01017731,
-          "spread": 0.0154395,
-          "score": 0.01849205
+          "bias": 0.01017621,
+          "spread": 0.01543945,
+          "score": 0.0184914
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.10197168,
-          "spread": 0.10777949,
-          "score": 0.14837332
+          "bias": -0.10197263,
+          "spread": 0.10777959,
+          "score": 0.14837404
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00627086,
-          "spread": 0.02932543,
-          "score": 0.0299884
+          "bias": -0.00627169,
+          "spread": 0.02932598,
+          "score": 0.02998912
         },
         {
           "profile": "cp_0pct",
@@ -215,27 +215,27 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00157961,
-          "spread": 0.01519473,
-          "score": 0.01527662
+          "bias": -0.00158071,
+          "spread": 0.01519401,
+          "score": 0.01527601
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00421194,
-          "spread": 0.010672,
-          "score": 0.0114731
+          "bias": -0.00421304,
+          "spread": 0.01067124,
+          "score": 0.01147279
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00380189,
-          "spread": 0.00870777,
-          "score": 0.00950156
+          "bias": -0.00380299,
+          "spread": 0.00870698,
+          "score": 0.00950128
         },
         {
           "profile": "cp_0pct",
@@ -458,180 +458,180 @@
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00053585,
-          "spread": 0.00320815,
-          "score": 0.0032526
+          "bias": 0.00053603,
+          "spread": 0.003208,
+          "score": 0.00325247
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.13813931,
+          "bias": 0.13813852,
           "spread": 0.0,
-          "score": 0.13813931
+          "score": 0.13813852
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00288089,
-          "spread": 0.0032175,
-          "score": 0.00431877
+          "bias": -0.0028808,
+          "spread": 0.0032173,
+          "score": 0.00431857
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00043278,
-          "spread": 0.00233664,
-          "score": 0.00237638
+          "bias": -0.00043265,
+          "spread": 0.00233623,
+          "score": 0.00237595
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00045517,
-          "spread": 0.00400878,
-          "score": 0.00403454
+          "bias": -0.00045498,
+          "spread": 0.00400868,
+          "score": 0.00403442
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00336842,
-          "spread": 0.00436983,
-          "score": 0.00551739
+          "bias": 0.00336863,
+          "spread": 0.00436989,
+          "score": 0.00551757
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00922135,
-          "spread": 0.00641766,
-          "score": 0.01123475
+          "bias": 0.00922178,
+          "spread": 0.00641726,
+          "score": 0.01123488
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00058048,
-          "spread": 0.01232549,
-          "score": 0.01233915
+          "bias": 0.00058232,
+          "spread": 0.01232648,
+          "score": 0.01234022
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.05132899,
-          "spread": 0.04414552,
-          "score": 0.06770149
+          "bias": 0.05133769,
+          "spread": 0.04415664,
+          "score": 0.06771534
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.37368366,
-          "spread": 0.39407341,
-          "score": 0.54307764
+          "bias": 0.37368357,
+          "spread": 0.39407261,
+          "score": 0.543077
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.8742901,
-          "spread": 0.73872644,
-          "score": 1.14459597
+          "bias": 0.87429072,
+          "spread": 0.73872582,
+          "score": 1.14459604
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.10420271,
-          "spread": 0.09169912,
-          "score": 0.13880538
+          "bias": -0.10420448,
+          "spread": 0.09169726,
+          "score": 0.13880548
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00051167,
-          "spread": 0.00276714,
-          "score": 0.00281404
+          "bias": 0.00051177,
+          "spread": 0.00276718,
+          "score": 0.00281411
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00086443,
-          "spread": 0.00246008,
-          "score": 0.00260753
+          "bias": 0.00086453,
+          "spread": 0.00246063,
+          "score": 0.00260809
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00144594,
-          "spread": 0.00198458,
-          "score": 0.00245546
+          "bias": 0.00144604,
+          "spread": 0.00198503,
+          "score": 0.00245589
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -1.6e-07,
-          "spread": 0.0005908,
-          "score": 0.0005908
+          "bias": -6e-08,
+          "spread": 0.00059052,
+          "score": 0.00059052
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.0008949,
-          "spread": 0.00302055,
-          "score": 0.00315033
+          "bias": 0.000895,
+          "spread": 0.00302043,
+          "score": 0.00315024
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.12464721,
-          "spread": 0.0698015,
-          "score": 0.14286069
+          "bias": -0.12464562,
+          "spread": 0.06979938,
+          "score": 0.14285826
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00894075,
-          "spread": 0.01504116,
-          "score": 0.01749781
+          "bias": 0.00894086,
+          "spread": 0.01504156,
+          "score": 0.01749822
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.05339098,
-          "spread": 0.04155347,
-          "score": 0.06765565
+          "bias": 0.05339109,
+          "spread": 0.04155359,
+          "score": 0.06765582
         },
         {
           "profile": "cp_0pct",
@@ -647,27 +647,27 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00082169,
-          "spread": 0.0071036,
-          "score": 0.00715096
+          "bias": 0.00082225,
+          "spread": 0.00710368,
+          "score": 0.00715111
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00032125,
-          "spread": 0.00681354,
-          "score": 0.00682111
+          "bias": 0.00032173,
+          "spread": 0.00681331,
+          "score": 0.0068209
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00025681,
-          "spread": 0.00713496,
-          "score": 0.00713958
+          "bias": 0.00025698,
+          "spread": 0.00713468,
+          "score": 0.0071393
         },
         {
           "profile": "cp_minus_10pct",
@@ -890,9 +890,9 @@
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00328699,
-          "spread": 0.00203092,
-          "score": 0.00386379
+          "bias": 0.00328659,
+          "spread": 0.00203026,
+          "score": 0.00386311
         },
         {
           "profile": "cp_minus_10pct",
@@ -908,72 +908,72 @@
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00021613,
-          "spread": 0.00646895,
-          "score": 0.00647256
+          "bias": 0.00021574,
+          "spread": 0.00646951,
+          "score": 0.00647311
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00053886,
-          "spread": 0.0019241,
-          "score": 0.00199813
+          "bias": 0.00053845,
+          "spread": 0.0019236,
+          "score": 0.00199754
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00128805,
-          "spread": 0.00309272,
-          "score": 0.00335022
+          "bias": 0.00128765,
+          "spread": 0.00309229,
+          "score": 0.00334967
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00969937,
-          "spread": 0.00523976,
-          "score": 0.0110242
+          "bias": 0.00969898,
+          "spread": 0.00523954,
+          "score": 0.01102375
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.0151468,
-          "spread": 0.00525788,
-          "score": 0.01603343
+          "bias": 0.0151464,
+          "spread": 0.00525742,
+          "score": 0.0160329
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.01446786,
-          "spread": 0.01245717,
-          "score": 0.01909189
+          "bias": 0.01446747,
+          "spread": 0.01245664,
+          "score": 0.01909124
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.08205695,
-          "spread": 0.06795682,
-          "score": 0.10654329
+          "bias": 0.08205652,
+          "spread": 0.06795664,
+          "score": 0.10654285
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.24768873,
-          "spread": 0.0317112,
-          "score": 0.24971045
+          "bias": 0.24768815,
+          "spread": 0.03171178,
+          "score": 0.24970994
         },
         {
           "profile": "cp_minus_10pct",
@@ -989,72 +989,72 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.04077922,
-          "spread": 0.17268131,
-          "score": 0.17743105
+          "bias": -0.04077953,
+          "spread": 0.17268172,
+          "score": 0.17743152
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00375249,
-          "spread": 0.00421482,
-          "score": 0.00564322
+          "bias": 0.0037521,
+          "spread": 0.00421532,
+          "score": 0.00564333
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00179998,
-          "spread": 0.00444244,
-          "score": 0.00479325
+          "bias": -0.0018004,
+          "spread": 0.00444312,
+          "score": 0.00479404
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00246414,
-          "spread": 0.00296485,
-          "score": 0.00385517
+          "bias": 0.00246372,
+          "spread": 0.00296526,
+          "score": 0.00385521
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00101575,
-          "spread": 0.00075504,
-          "score": 0.00126564
+          "bias": 0.00101533,
+          "spread": 0.00075481,
+          "score": 0.00126516
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.01264818,
-          "spread": 0.01389676,
-          "score": 0.01879086
+          "bias": 0.01264775,
+          "spread": 0.01389658,
+          "score": 0.01879043
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.05622529,
-          "spread": 0.03015875,
-          "score": 0.06380309
+          "bias": -0.05622564,
+          "spread": 0.03015854,
+          "score": 0.06380329
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00195644,
-          "spread": 0.02954977,
-          "score": 0.02961447
+          "bias": -0.00195687,
+          "spread": 0.02954938,
+          "score": 0.02961411
         },
         {
           "profile": "cp_minus_10pct",
@@ -1079,207 +1079,207 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00788366,
-          "spread": 0.00731416,
-          "score": 0.01075402
+          "bias": 0.00788327,
+          "spread": 0.00731387,
+          "score": 0.01075354
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00183671,
-          "spread": 0.00526669,
-          "score": 0.00557778
+          "bias": 0.00183632,
+          "spread": 0.00526605,
+          "score": 0.00557704
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00454312,
-          "spread": 0.00634682,
-          "score": 0.00780526
+          "bias": 0.00454273,
+          "spread": 0.00634617,
+          "score": 0.0078045
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00057738,
+          "bias": 0.00057746,
           "spread": 0.00301884,
-          "score": 0.00307356
+          "score": 0.00307357
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.10737095,
+          "bias": 0.10737129,
           "spread": 0.0,
-          "score": 0.10737095
+          "score": 0.10737129
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00066511,
-          "spread": 0.00479391,
-          "score": 0.00483983
+          "bias": 0.00066566,
+          "spread": 0.00479353,
+          "score": 0.00483953
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00114045,
-          "spread": 0.00222391,
-          "score": 0.00249928
+          "bias": -0.00114039,
+          "spread": 0.00222409,
+          "score": 0.00249941
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00105168,
+          "bias": -0.00105173,
           "spread": 0.00391048,
-          "score": 0.00404943
+          "score": 0.00404945
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00543238,
-          "spread": 0.00375554,
-          "score": 0.00660415
+          "bias": 0.00543274,
+          "spread": 0.00375509,
+          "score": 0.00660419
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01191023,
-          "spread": 0.00542832,
-          "score": 0.01308893
+          "bias": 0.01191037,
+          "spread": 0.00542884,
+          "score": 0.01308928
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00663651,
-          "spread": 0.0112,
-          "score": 0.01301857
+          "bias": 0.00664002,
+          "spread": 0.01120104,
+          "score": 0.01302126
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.05448575,
-          "spread": 0.04031565,
-          "score": 0.06777941
+          "bias": 0.05448919,
+          "spread": 0.04031488,
+          "score": 0.06778172
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.34007876,
-          "spread": 0.32220075,
-          "score": 0.46847293
+          "bias": 0.34008004,
+          "spread": 0.32220059,
+          "score": 0.46847375
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.96175829,
-          "spread": 0.47400706,
-          "score": 1.07222278
+          "bias": 0.96174736,
+          "spread": 0.47399603,
+          "score": 1.07220811
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.08546013,
-          "spread": 0.08832582,
-          "score": 0.12290193
+          "bias": -0.08548442,
+          "spread": 0.08834515,
+          "score": 0.12293272
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.0040603,
-          "spread": 0.00231285,
-          "score": 0.00467282
+          "bias": 0.00406052,
+          "spread": 0.00231256,
+          "score": 0.00467288
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00320261,
-          "spread": 0.00299804,
-          "score": 0.00438691
+          "bias": -0.00320346,
+          "spread": 0.00299845,
+          "score": 0.00438781
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00037088,
-          "spread": 0.00175293,
-          "score": 0.00179174
+          "bias": -0.00037127,
+          "spread": 0.00175301,
+          "score": 0.00179189
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00115122,
-          "spread": 0.0013135,
-          "score": 0.00174659
+          "bias": -0.00115302,
+          "spread": 0.00131276,
+          "score": 0.00174723
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00116299,
-          "spread": 0.00492523,
-          "score": 0.00506068
+          "bias": 0.00116413,
+          "spread": 0.00492609,
+          "score": 0.00506177
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.06974034,
-          "spread": 0.03093198,
-          "score": 0.07629222
+          "bias": -0.06974394,
+          "spread": 0.03092999,
+          "score": 0.0762947
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.0127267,
-          "spread": 0.01913397,
-          "score": 0.02297994
+          "bias": 0.01272784,
+          "spread": 0.01913435,
+          "score": 0.02298089
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.06003979,
-          "spread": 0.04368593,
-          "score": 0.07425118
+          "bias": 0.06004102,
+          "spread": 0.04368664,
+          "score": 0.07425259
         },
         {
           "profile": "cp_minus_10pct",
@@ -1295,108 +1295,108 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00087915,
-          "spread": 0.00722597,
-          "score": 0.00727925
+          "bias": 0.00087976,
+          "spread": 0.00722433,
+          "score": 0.0072777
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00040846,
-          "spread": 0.00671208,
-          "score": 0.0067245
+          "bias": -0.00040728,
+          "spread": 0.00671268,
+          "score": 0.00672502
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00152426,
-          "spread": 0.00662782,
-          "score": 0.00680084
+          "bias": 0.00152446,
+          "spread": 0.00662767,
+          "score": 0.00680074
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00025655,
-          "spread": 0.00320688,
-          "score": 0.00321713
+          "bias": -0.00025606,
+          "spread": 0.00320697,
+          "score": 0.00321718
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.108133,
+          "bias": 0.10813522,
           "spread": 0.0,
-          "score": 0.108133
+          "score": 0.10813522
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00917278,
-          "spread": 0.0132942,
-          "score": 0.01615164
+          "bias": -0.00917229,
+          "spread": 0.01329497,
+          "score": 0.016152
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00551648,
-          "spread": 0.00479645,
-          "score": 0.0073101
+          "bias": 0.00551697,
+          "spread": 0.00479695,
+          "score": 0.00731079
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00406608,
-          "spread": 0.0020889,
-          "score": 0.00457127
+          "bias": -0.00406559,
+          "spread": 0.00208836,
+          "score": 0.00457059
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00396903,
-          "spread": 0.01182174,
-          "score": 0.01247023
+          "bias": -0.00396853,
+          "spread": 0.01182107,
+          "score": 0.01246944
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": -0.00205064,
-          "spread": 0.02466697,
-          "score": 0.02475206
+          "bias": -0.00205015,
+          "spread": 0.02466641,
+          "score": 0.02475146
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.03378816,
-          "spread": 0.04924606,
-          "score": 0.05972281
+          "bias": -0.03378769,
+          "spread": 0.04924539,
+          "score": 0.059722
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.08420959,
-          "spread": 0.12231169,
-          "score": 0.14849715
+          "bias": 0.08421024,
+          "spread": 0.12231277,
+          "score": 0.14849841
         },
         {
           "profile": "cp_plus_10pct",
@@ -1412,72 +1412,72 @@
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.15747284,
-          "spread": 0.93771082,
-          "score": 0.95084135
+          "bias": 0.15747309,
+          "spread": 0.93771062,
+          "score": 0.95084119
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.15381334,
-          "spread": 0.19470519,
-          "score": 0.24813032
+          "bias": -0.1538129,
+          "spread": 0.19470542,
+          "score": 0.24813023
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00345542,
-          "spread": 0.00429978,
-          "score": 0.00551616
+          "bias": -0.00345492,
+          "spread": 0.00430026,
+          "score": 0.00551622
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.0085149,
-          "spread": 0.0088842,
-          "score": 0.01230579
+          "bias": 0.00851538,
+          "spread": 0.00888492,
+          "score": 0.01230664
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00967722,
-          "spread": 0.01304265,
-          "score": 0.01624066
+          "bias": 0.00967769,
+          "spread": 0.01304328,
+          "score": 0.01624146
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00055968,
-          "spread": 0.00648665,
-          "score": 0.00651075
+          "bias": -0.00055922,
+          "spread": 0.00648652,
+          "score": 0.00651058
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00942854,
-          "spread": 0.0177043,
-          "score": 0.0200584
+          "bias": 0.00942901,
+          "spread": 0.0177049,
+          "score": 0.02005916
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.14161968,
-          "spread": 0.15727953,
-          "score": 0.21164353
+          "bias": -0.14161928,
+          "spread": 0.15727894,
+          "score": 0.21164282
         },
         {
           "profile": "cp_plus_10pct",
@@ -1511,27 +1511,27 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00093778,
-          "spread": 0.01876127,
-          "score": 0.01878469
+          "bias": -0.00093728,
+          "spread": 0.01876091,
+          "score": 0.01878431
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00431039,
-          "spread": 0.00990922,
-          "score": 0.01080611
+          "bias": -0.00430989,
+          "spread": 0.00990887,
+          "score": 0.0108056
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00572124,
-          "spread": 0.00839842,
-          "score": 0.01016199
+          "bias": -0.00572074,
+          "spread": 0.00839811,
+          "score": 0.01016145
         },
         {
           "profile": "cp_plus_10pct",
@@ -1556,72 +1556,72 @@
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00329654,
-          "spread": 0.00960114,
-          "score": 0.01015131
+          "bias": -0.00329659,
+          "spread": 0.00960122,
+          "score": 0.0101514
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00481024,
-          "spread": 0.00279081,
-          "score": 0.00556121
+          "bias": 0.00481019,
+          "spread": 0.00279075,
+          "score": 0.00556114
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00139581,
-          "spread": 0.0022662,
-          "score": 0.00266157
+          "bias": 0.00139578,
+          "spread": 0.00226615,
+          "score": 0.00266151
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00454016,
-          "spread": 0.00677732,
-          "score": 0.00815752
+          "bias": 0.00454015,
+          "spread": 0.00677731,
+          "score": 0.0081575
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00922987,
-          "spread": 0.00898452,
-          "score": 0.01288069
+          "bias": 0.00923047,
+          "spread": 0.00898547,
+          "score": 0.01288178
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00918127,
-          "spread": 0.01507674,
-          "score": 0.0176523
+          "bias": 0.0091826,
+          "spread": 0.0150787,
+          "score": 0.01765467
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.07444438,
-          "spread": 0.08496186,
-          "score": 0.1129623
+          "bias": 0.07444774,
+          "spread": 0.08496309,
+          "score": 0.11296545
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.17782859,
-          "spread": 0.14754405,
-          "score": 0.23106764
+          "bias": 0.17784053,
+          "spread": 0.147545,
+          "score": 0.23107743
         },
         {
           "profile": "cp_plus_10pct",
@@ -1637,72 +1637,72 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.1123031,
-          "spread": 0.15037927,
-          "score": 0.18768567
+          "bias": -0.11233112,
+          "spread": 0.15042127,
+          "score": 0.18773609
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00242465,
-          "spread": 0.00309933,
-          "score": 0.00393508
+          "bias": -0.0024248,
+          "spread": 0.00309927,
+          "score": 0.00393512
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00830147,
-          "spread": 0.00324099,
-          "score": 0.0089117
+          "bias": 0.00830132,
+          "spread": 0.00324121,
+          "score": 0.00891165
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.0069615,
-          "spread": 0.0039354,
-          "score": 0.00799687
+          "bias": 0.00696136,
+          "spread": 0.00393564,
+          "score": 0.00799686
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00331346,
-          "spread": 0.00374111,
-          "score": 0.00499749
+          "bias": 0.00331332,
+          "spread": 0.00374132,
+          "score": 0.00499756
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.01236245,
-          "spread": 0.01294514,
-          "score": 0.01789991
+          "bias": 0.01236231,
+          "spread": 0.01294518,
+          "score": 0.01789984
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.17707222,
-          "spread": 0.11778488,
-          "score": 0.2126684
+          "bias": -0.17707055,
+          "spread": 0.11778593,
+          "score": 0.21266759
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00977548,
-          "spread": 0.02275134,
-          "score": 0.02476254
+          "bias": -0.00977562,
+          "spread": 0.02275128,
+          "score": 0.02476255
         },
         {
           "profile": "cp_plus_10pct",
@@ -1727,7 +1727,7 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00877584,
+          "bias": 0.00877585,
           "spread": 0.00868639,
           "score": 0.01234783
         },
@@ -1736,108 +1736,108 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.002677,
-          "spread": 0.00468247,
-          "score": 0.00539369
+          "bias": 0.00267684,
+          "spread": 0.00468221,
+          "score": 0.00539339
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00160999,
-          "spread": 0.00770662,
-          "score": 0.007873
+          "bias": 0.00160984,
+          "spread": 0.00770638,
+          "score": 0.00787273
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00049447,
-          "spread": 0.00339741,
-          "score": 0.00343321
+          "bias": 0.00049448,
+          "spread": 0.00339743,
+          "score": 0.00343323
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.16084855,
+          "bias": 0.16084857,
           "spread": 0.0,
-          "score": 0.16084855
+          "score": 0.16084857
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00715256,
-          "spread": 0.00179146,
-          "score": 0.0073735
+          "bias": -0.00715255,
+          "spread": 0.00179147,
+          "score": 0.00737348
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00021264,
-          "spread": 0.0024553,
-          "score": 0.00246449
+          "bias": 0.00021266,
+          "spread": 0.00245532,
+          "score": 0.00246451
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 5.1e-07,
-          "spread": 0.00418431,
-          "score": 0.00418431
+          "bias": 5.3e-07,
+          "spread": 0.00418433,
+          "score": 0.00418433
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00158268,
-          "spread": 0.00506219,
-          "score": 0.00530383
+          "bias": 0.00158264,
+          "spread": 0.00506227,
+          "score": 0.00530389
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00668082,
-          "spread": 0.00744504,
-          "score": 0.0100031
+          "bias": 0.00668084,
+          "spread": 0.00744505,
+          "score": 0.01000312
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00349768,
-          "spread": 0.01527428,
-          "score": 0.01566964
+          "bias": -0.00349766,
+          "spread": 0.0152743,
+          "score": 0.01566965
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.05078987,
+          "bias": 0.05078989,
           "spread": 0.05249071,
-          "score": 0.0730403
+          "score": 0.07304032
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.41214523,
-          "spread": 0.46235825,
-          "score": 0.61938586
+          "bias": 0.41214526,
+          "spread": 0.46235826,
+          "score": 0.61938589
         },
         {
           "profile": "cp_plus_10pct",
@@ -1853,17 +1853,17 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.12731091,
-          "spread": 0.11626236,
-          "score": 0.17240941
+          "bias": -0.1273109,
+          "spread": 0.11626235,
+          "score": 0.17240939
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.0032016,
-          "spread": 0.00398459,
+          "bias": -0.00320158,
+          "spread": 0.0039846,
           "score": 0.00511148
         },
         {
@@ -1871,8 +1871,8 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00473674,
-          "spread": 0.00226507,
+          "bias": 0.00473676,
+          "spread": 0.00226505,
           "score": 0.00525046
         },
         {
@@ -1880,8 +1880,8 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00275821,
-          "spread": 0.00247124,
+          "bias": 0.00275822,
+          "spread": 0.00247122,
           "score": 0.00370334
         },
         {
@@ -1889,8 +1889,8 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00063185,
-          "spread": 0.0010934,
+          "bias": 0.00063186,
+          "spread": 0.00109339,
           "score": 0.00126283
         },
         {
@@ -1898,36 +1898,36 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": -2.311e-05,
-          "spread": 0.00167487,
-          "score": 0.00167503
+          "bias": -2.31e-05,
+          "spread": 0.00167488,
+          "score": 0.00167504
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.17680819,
+          "bias": -0.17680817,
           "spread": 0.11171677,
-          "score": 0.20914533
+          "score": 0.20914532
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00380486,
+          "bias": 0.00380487,
           "spread": 0.01172333,
-          "score": 0.01232531
+          "score": 0.01232532
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.04751507,
+          "bias": 0.04751509,
           "spread": 0.04060043,
-          "score": 0.06249862
+          "score": 0.06249863
         },
         {
           "profile": "cp_plus_10pct",
@@ -1943,16 +1943,16 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00155337,
-          "spread": 0.00767499,
-          "score": 0.00783061
+          "bias": 0.00155339,
+          "spread": 0.00767501,
+          "score": 0.00783063
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00069908,
+          "bias": 0.00069905,
           "spread": 0.00700916,
           "score": 0.00704393
         },
@@ -1961,180 +1961,180 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00092276,
-          "spread": 0.00754115,
-          "score": 0.00759739
+          "bias": -0.00092274,
+          "spread": 0.00754117,
+          "score": 0.00759741
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00019452,
-          "spread": 0.00307275,
-          "score": 0.00307891
+          "bias": -0.00019555,
+          "spread": 0.00307166,
+          "score": 0.00307788
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.06046989,
+          "bias": 0.06046841,
           "spread": 0.0,
-          "score": 0.06046989
+          "score": 0.06046841
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.0097195,
-          "spread": 0.01208851,
-          "score": 0.01551131
+          "bias": -0.00972051,
+          "spread": 0.01208888,
+          "score": 0.01551223
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00297597,
-          "spread": 0.00433629,
-          "score": 0.00525926
+          "bias": 0.00297494,
+          "spread": 0.00433542,
+          "score": 0.00525795
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00304261,
-          "spread": 0.00193617,
-          "score": 0.00360642
+          "bias": -0.00304364,
+          "spread": 0.0019351,
+          "score": 0.00360671
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00182615,
-          "spread": 0.01078783,
-          "score": 0.0109413
+          "bias": -0.00182718,
+          "spread": 0.01078752,
+          "score": 0.01094117
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00151893,
-          "spread": 0.02112426,
-          "score": 0.0211788
+          "bias": 0.00151788,
+          "spread": 0.02112366,
+          "score": 0.02117813
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.02992135,
-          "spread": 0.04828985,
-          "score": 0.05680842
+          "bias": -0.02992237,
+          "spread": 0.04828955,
+          "score": 0.0568087
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.08072446,
-          "spread": 0.10050931,
-          "score": 0.128913
+          "bias": 0.08072335,
+          "spread": 0.10050933,
+          "score": 0.12891231
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.25803575,
-          "spread": 0.43625752,
-          "score": 0.50685607
+          "bias": 0.25803498,
+          "spread": 0.43625829,
+          "score": 0.50685634
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.2227821,
-          "spread": 0.80966259,
-          "score": 0.83975317
+          "bias": 0.22278186,
+          "spread": 0.8096628,
+          "score": 0.8397533
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.14906775,
-          "spread": 0.18918124,
-          "score": 0.24085418
+          "bias": -0.14906844,
+          "spread": 0.18918162,
+          "score": 0.2408549
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00079742,
-          "spread": 0.0054878,
-          "score": 0.00554543
+          "bias": -0.00079844,
+          "spread": 0.0054884,
+          "score": 0.00554618
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00535453,
-          "spread": 0.00820187,
-          "score": 0.00979498
+          "bias": 0.00535352,
+          "spread": 0.00820211,
+          "score": 0.00979463
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00852678,
-          "spread": 0.0113344,
-          "score": 0.0141836
+          "bias": 0.00852577,
+          "spread": 0.01133471,
+          "score": 0.01418324
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00095162,
-          "spread": 0.00475661,
-          "score": 0.00485087
+          "bias": -0.00095262,
+          "spread": 0.00475707,
+          "score": 0.00485151
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00967763,
-          "spread": 0.01641662,
-          "score": 0.01905681
+          "bias": 0.00967661,
+          "spread": 0.01641682,
+          "score": 0.01905646
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.10881993,
-          "spread": 0.12978125,
-          "score": 0.16936632
+          "bias": -0.10882088,
+          "spread": 0.12978107,
+          "score": 0.16936679
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00728661,
-          "spread": 0.02927925,
-          "score": 0.03017232
+          "bias": -0.00728747,
+          "spread": 0.02927991,
+          "score": 0.03017317
         },
         {
           "profile": "cp_plus_3pct",
@@ -2159,36 +2159,36 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00161234,
-          "spread": 0.01722681,
-          "score": 0.0173021
+          "bias": -0.00161339,
+          "spread": 0.01722587,
+          "score": 0.01730126
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00498127,
-          "spread": 0.00961824,
-          "score": 0.01083161
+          "bias": -0.00498231,
+          "spread": 0.00961733,
+          "score": 0.01083127
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00411755,
-          "spread": 0.008217,
-          "score": 0.00919094
+          "bias": -0.00411859,
+          "spread": 0.00821607,
+          "score": 0.00919057
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00346054,
-          "spread": 0.00222461,
-          "score": 0.0041139
+          "bias": 0.0034603,
+          "spread": 0.00222469,
+          "score": 0.00411375
         },
         {
           "profile": "cp_plus_3pct",
@@ -2204,63 +2204,63 @@
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00223309,
-          "spread": 0.00852185,
-          "score": 0.00880958
+          "bias": -0.00223332,
+          "spread": 0.00852176,
+          "score": 0.00880955
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00345011,
-          "spread": 0.00212455,
-          "score": 0.00405179
+          "bias": 0.00344987,
+          "spread": 0.00212447,
+          "score": 0.00405155
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00139782,
-          "spread": 0.00251196,
-          "score": 0.00287469
+          "bias": 0.00139758,
+          "spread": 0.00251183,
+          "score": 0.00287446
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00614174,
-          "spread": 0.00617369,
-          "score": 0.00870836
+          "bias": 0.00614151,
+          "spread": 0.00617408,
+          "score": 0.00870847
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.0110096,
-          "spread": 0.00841101,
-          "score": 0.01385483
+          "bias": 0.01100936,
+          "spread": 0.00841129,
+          "score": 0.01385481
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.01089798,
-          "spread": 0.01392544,
-          "score": 0.01768287
+          "bias": 0.01089774,
+          "spread": 0.0139257,
+          "score": 0.01768293
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.07524562,
-          "spread": 0.07762175,
-          "score": 0.10810661
+          "bias": 0.07524534,
+          "spread": 0.07762136,
+          "score": 0.10810613
         },
         {
           "profile": "cp_plus_3pct",
@@ -2276,81 +2276,81 @@
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.0440264,
-          "spread": 0.53700413,
-          "score": 0.53880586
+          "bias": 0.04402617,
+          "spread": 0.53700436,
+          "score": 0.53880607
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.08656641,
-          "spread": 0.14042996,
-          "score": 0.16496763
+          "bias": -0.08656664,
+          "spread": 0.14042985,
+          "score": 0.16496765
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00027518,
-          "spread": 0.00307265,
-          "score": 0.00308495
+          "bias": -0.00027542,
+          "spread": 0.00307245,
+          "score": 0.00308477
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00498061,
-          "spread": 0.00389246,
-          "score": 0.00632121
+          "bias": 0.00498038,
+          "spread": 0.00389234,
+          "score": 0.00632096
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00577958,
-          "spread": 0.00344858,
-          "score": 0.00673025
+          "bias": 0.00577935,
+          "spread": 0.0034485,
+          "score": 0.00673001
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00271869,
-          "spread": 0.00251828,
-          "score": 0.0037058
+          "bias": 0.00271846,
+          "spread": 0.00251796,
+          "score": 0.00370542
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.01272146,
-          "spread": 0.01307251,
-          "score": 0.01824078
+          "bias": 0.01272123,
+          "spread": 0.01307271,
+          "score": 0.01824076
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.1361719,
-          "spread": 0.08284849,
-          "score": 0.15939466
+          "bias": -0.13617209,
+          "spread": 0.08284879,
+          "score": 0.15939498
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00735597,
-          "spread": 0.02459844,
-          "score": 0.02567477
+          "bias": -0.00735619,
+          "spread": 0.02459881,
+          "score": 0.02567518
         },
         {
           "profile": "cp_plus_3pct",
@@ -2375,89 +2375,89 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00768969,
-          "spread": 0.00752973,
-          "score": 0.01076235
+          "bias": 0.00768946,
+          "spread": 0.00753002,
+          "score": 0.01076239
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00242599,
-          "spread": 0.00499331,
-          "score": 0.00555144
+          "bias": 0.00242575,
+          "spread": 0.0049935,
+          "score": 0.00555152
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00306751,
-          "spread": 0.00736077,
-          "score": 0.00797437
+          "bias": 0.00306727,
+          "spread": 0.00736075,
+          "score": 0.00797426
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00052371,
-          "spread": 0.00326476,
-          "score": 0.0033065
+          "bias": 0.00052343,
+          "spread": 0.00326491,
+          "score": 0.0033066
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.14232805,
+          "bias": 0.14232803,
           "spread": 0.0,
-          "score": 0.14232805
+          "score": 0.14232803
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.0043495,
-          "spread": 0.00216245,
-          "score": 0.00485741
+          "bias": -0.00434981,
+          "spread": 0.00216278,
+          "score": 0.00485783
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00032856,
-          "spread": 0.00237676,
-          "score": 0.00239936
+          "bias": -0.00032886,
+          "spread": 0.00237718,
+          "score": 0.00239982
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00026262,
-          "spread": 0.00407977,
-          "score": 0.00408822
+          "bias": -0.00026291,
+          "spread": 0.00407984,
+          "score": 0.0040883
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00287613,
-          "spread": 0.0047264,
-          "score": 0.00553272
+          "bias": 0.00287588,
+          "spread": 0.00472632,
+          "score": 0.00553252
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00849072,
-          "spread": 0.00673173,
+          "bias": 0.00849086,
+          "spread": 0.00673155,
           "score": 0.01083552
         },
         {
@@ -2465,35 +2465,35 @@
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00012687,
-          "spread": 0.01320703,
-          "score": 0.01320763
+          "bias": 0.00012656,
+          "spread": 0.01320739,
+          "score": 0.013208
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.05262409,
-          "spread": 0.04654431,
-          "score": 0.07025431
+          "bias": 0.05262378,
+          "spread": 0.04654466,
+          "score": 0.0702543
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.38888075,
-          "spread": 0.41967018,
-          "score": 0.57214622
+          "bias": 0.38888044,
+          "spread": 0.41967046,
+          "score": 0.57214621
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.84200403,
-          "spread": 0.83770549,
+          "bias": 0.84200332,
+          "spread": 0.8377062,
           "score": 1.18773788
         },
         {
@@ -2501,81 +2501,81 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.1164932,
-          "spread": 0.09270044,
-          "score": 0.14887591
+          "bias": -0.11649349,
+          "spread": 0.09270013,
+          "score": 0.14887594
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00048309,
-          "spread": 0.00304511,
-          "score": 0.00308319
+          "bias": -0.00048339,
+          "spread": 0.00304501,
+          "score": 0.00308314
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00195704,
-          "spread": 0.00235358,
-          "score": 0.00306093
+          "bias": 0.00195674,
+          "spread": 0.00235312,
+          "score": 0.00306039
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00173082,
-          "spread": 0.00212271,
-          "score": 0.00273891
+          "bias": 0.00173052,
+          "spread": 0.00212242,
+          "score": 0.0027385
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 9.585e-05,
-          "spread": 0.0008362,
-          "score": 0.00084167
+          "bias": 9.555e-05,
+          "spread": 0.00083656,
+          "score": 0.000842
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00058079,
-          "spread": 0.00243932,
-          "score": 0.0025075
+          "bias": 0.00058049,
+          "spread": 0.00243961,
+          "score": 0.00250772
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.13933794,
-          "spread": 0.08134033,
-          "score": 0.16134221
+          "bias": -0.13933708,
+          "spread": 0.08134079,
+          "score": 0.1613417
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00687514,
-          "spread": 0.01468809,
-          "score": 0.01621751
+          "bias": 0.00687484,
+          "spread": 0.01468781,
+          "score": 0.01621713
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.0520188,
-          "spread": 0.04086756,
-          "score": 0.06615219
+          "bias": 0.05201849,
+          "spread": 0.04086768,
+          "score": 0.06615203
         },
         {
           "profile": "cp_plus_3pct",
@@ -2591,36 +2591,36 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00076455,
-          "spread": 0.00746535,
-          "score": 0.0075044
+          "bias": 0.00076438,
+          "spread": 0.00746533,
+          "score": 0.00750436
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00031206,
-          "spread": 0.00687414,
-          "score": 0.00688122
+          "bias": 0.00031184,
+          "spread": 0.00687444,
+          "score": 0.00688151
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 6.369e-05,
-          "spread": 0.00726577,
-          "score": 0.00726605
+          "bias": 6.339e-05,
+          "spread": 0.00726605,
+          "score": 0.00726633
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.0001631,
-          "spread": 0.00306819,
-          "score": 0.00307252
+          "bias": -0.00016314,
+          "spread": 0.00306814,
+          "score": 0.00307247
         },
         {
           "profile": "rated_plus_5pct",
@@ -2636,62 +2636,62 @@
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.01105196,
-          "spread": 0.01300433,
-          "score": 0.0170663
+          "bias": -0.011052,
+          "spread": 0.01300438,
+          "score": 0.01706636
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00028958,
-          "spread": 0.0042105,
-          "score": 0.00422044
+          "bias": 0.00028954,
+          "spread": 0.00421047,
+          "score": 0.00422042
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00259802,
-          "spread": 0.00253113,
-          "score": 0.00362717
+          "bias": -0.00259806,
+          "spread": 0.00253108,
+          "score": 0.00362716
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00138348,
-          "spread": 0.01035419,
-          "score": 0.01044621
+          "bias": 0.00138345,
+          "spread": 0.01035416,
+          "score": 0.01044617
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00698288,
-          "spread": 0.01878018,
-          "score": 0.02003636
+          "bias": 0.00698284,
+          "spread": 0.01878013,
+          "score": 0.0200363
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.02598117,
-          "spread": 0.04112222,
-          "score": 0.04864214
+          "bias": -0.0259812,
+          "spread": 0.04112218,
+          "score": 0.04864213
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.08534106,
-          "spread": 0.1096738,
+          "bias": 0.08534103,
+          "spread": 0.10967383,
           "score": 0.13896561
         },
         {
@@ -2699,9 +2699,9 @@
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.25240743,
-          "spread": 0.41627772,
-          "score": 0.48682302
+          "bias": 0.2524074,
+          "spread": 0.41627775,
+          "score": 0.48682303
         },
         {
           "profile": "rated_plus_5pct",
@@ -2717,72 +2717,72 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.06129618,
-          "spread": 0.14769098,
-          "score": 0.15990575
+          "bias": -0.06129621,
+          "spread": 0.14769102,
+          "score": 0.15990579
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00172272,
-          "spread": 0.00823771,
-          "score": 0.00841591
+          "bias": 0.00172269,
+          "spread": 0.00823776,
+          "score": 0.00841596
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00078378,
-          "spread": 0.00794256,
-          "score": 0.00798114
+          "bias": 0.00078374,
+          "spread": 0.00794261,
+          "score": 0.00798118
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00740431,
-          "spread": 0.01050433,
-          "score": 0.01285165
+          "bias": 0.00740428,
+          "spread": 0.01050438,
+          "score": 0.01285166
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00218493,
+          "bias": -0.00218496,
           "spread": 0.00385149,
-          "score": 0.00442808
+          "score": 0.0044281
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00914508,
-          "spread": 0.01458229,
-          "score": 0.01721266
+          "bias": 0.00914505,
+          "spread": 0.01458232,
+          "score": 0.01721267
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.09888408,
-          "spread": 0.10800958,
-          "score": 0.14643814
+          "bias": -0.09888411,
+          "spread": 0.10800955,
+          "score": 0.14643815
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00352569,
-          "spread": 0.03430483,
-          "score": 0.03448553
+          "bias": -0.00352573,
+          "spread": 0.03430486,
+          "score": 0.03448557
         },
         {
           "profile": "rated_plus_5pct",
@@ -2807,27 +2807,27 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00046466,
-          "spread": 0.01824497,
-          "score": 0.01825088
+          "bias": -0.00046469,
+          "spread": 0.01824491,
+          "score": 0.01825083
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00436853,
-          "spread": 0.01100383,
-          "score": 0.01183927
+          "bias": -0.00436856,
+          "spread": 0.01100377,
+          "score": 0.01183923
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00238442,
-          "spread": 0.00883608,
-          "score": 0.00915215
+          "bias": -0.00238446,
+          "spread": 0.00883603,
+          "score": 0.0091521
         },
         {
           "profile": "rated_plus_5pct",
@@ -3050,180 +3050,180 @@
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00056192,
-          "spread": 0.00326931,
-          "score": 0.00331725
+          "bias": 0.0005622,
+          "spread": 0.00326916,
+          "score": 0.00331715
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.13185605,
+          "bias": 0.13185608,
           "spread": 0.0,
-          "score": 0.13185605
+          "score": 0.13185608
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00130731,
-          "spread": 0.00431633,
-          "score": 0.00450997
+          "bias": -0.00130743,
+          "spread": 0.00431667,
+          "score": 0.00451032
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00089112,
-          "spread": 0.00249298,
-          "score": 0.00264746
+          "bias": -0.00089065,
+          "spread": 0.00249255,
+          "score": 0.00264689
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00075222,
-          "spread": 0.00408255,
-          "score": 0.00415127
+          "bias": -0.00075185,
+          "spread": 0.00408237,
+          "score": 0.00415102
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00465317,
-          "spread": 0.00435434,
-          "score": 0.00637277
+          "bias": 0.00465296,
+          "spread": 0.00435467,
+          "score": 0.00637285
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01109379,
-          "spread": 0.006267,
-          "score": 0.01274157
+          "bias": 0.01109355,
+          "spread": 0.0062667,
+          "score": 0.0127412
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00276302,
-          "spread": 0.01272683,
-          "score": 0.01302331
+          "bias": 0.00276164,
+          "spread": 0.01272802,
+          "score": 0.01302418
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.05485629,
-          "spread": 0.04687246,
-          "score": 0.07215428
+          "bias": 0.0548535,
+          "spread": 0.04687296,
+          "score": 0.07215248
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.37299287,
-          "spread": 0.38570965,
-          "score": 0.53655905
+          "bias": 0.37299258,
+          "spread": 0.38570933,
+          "score": 0.53655862
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.86761173,
-          "spread": 0.76141773,
-          "score": 1.1543427
+          "bias": 0.86762497,
+          "spread": 0.76142977,
+          "score": 1.15436059
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.11054606,
-          "spread": 0.10234208,
-          "score": 0.15064638
+          "bias": -0.11052905,
+          "spread": 0.10233137,
+          "score": 0.15062662
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00237674,
-          "spread": 0.00236643,
-          "score": 0.00335394
+          "bias": 0.00237673,
+          "spread": 0.00236709,
+          "score": 0.0033544
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.0010802,
-          "spread": 0.00285084,
-          "score": 0.00304862
+          "bias": -0.00107923,
+          "spread": 0.00285127,
+          "score": 0.00304869
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.0003611,
-          "spread": 0.00198115,
-          "score": 0.00201379
+          "bias": 0.00036156,
+          "spread": 0.00198162,
+          "score": 0.00201433
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00083792,
-          "spread": 0.00095423,
-          "score": 0.00126991
+          "bias": -0.00083548,
+          "spread": 0.00095508,
+          "score": 0.00126894
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00078786,
-          "spread": 0.00388999,
-          "score": 0.00396897
+          "bias": 0.00078772,
+          "spread": 0.00388987,
+          "score": 0.00396883
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.12484732,
-          "spread": 0.07024261,
-          "score": 0.1432511
+          "bias": -0.12484518,
+          "spread": 0.07024301,
+          "score": 0.14324943
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.01069351,
-          "spread": 0.01811955,
-          "score": 0.0210397
+          "bias": 0.01069338,
+          "spread": 0.01812015,
+          "score": 0.02104016
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.05883636,
-          "spread": 0.04345697,
-          "score": 0.07314524
+          "bias": 0.05883619,
+          "spread": 0.04345625,
+          "score": 0.07314467
         },
         {
           "profile": "rated_plus_5pct",
@@ -3239,27 +3239,27 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.0010922,
-          "spread": 0.00766929,
-          "score": 0.00774667
+          "bias": 0.00109141,
+          "spread": 0.00767097,
+          "score": 0.00774822
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 7.047e-05,
-          "spread": 0.00711952,
-          "score": 0.00711987
+          "bias": 7.016e-05,
+          "spread": 0.00711957,
+          "score": 0.00711992
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.0010147,
-          "spread": 0.00726283,
-          "score": 0.00733337
+          "bias": 0.00101483,
+          "spread": 0.00726267,
+          "score": 0.00733323
         },
         {
           "profile": "ti_dependent_cp",
@@ -3482,9 +3482,9 @@
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00350522,
-          "spread": 0.00227961,
-          "score": 0.00418129
+          "bias": 0.00350498,
+          "spread": 0.00227968,
+          "score": 0.00418113
         },
         {
           "profile": "ti_dependent_cp",
@@ -3500,45 +3500,45 @@
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00819245,
-          "spread": 0.01126598,
-          "score": 0.01392977
+          "bias": -0.00819448,
+          "spread": 0.01126622,
+          "score": 0.01393116
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00120503,
-          "spread": 0.00213787,
-          "score": 0.0024541
+          "bias": 0.00120456,
+          "spread": 0.00213783,
+          "score": 0.00245383
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00080652,
-          "spread": 0.00263363,
-          "score": 0.00275436
+          "bias": 0.00080634,
+          "spread": 0.00263337,
+          "score": 0.00275405
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.0107091,
-          "spread": 0.00511682,
-          "score": 0.01186872
+          "bias": 0.01070899,
+          "spread": 0.00511715,
+          "score": 0.01186877
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.02461826,
-          "spread": 0.00717787,
-          "score": 0.02564333
+          "bias": 0.02461899,
+          "spread": 0.00717754,
+          "score": 0.02564394
         },
         {
           "profile": "ti_dependent_cp",
@@ -3546,116 +3546,116 @@
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
           "bias": 0.03221439,
-          "spread": 0.01407122,
-          "score": 0.03515346
+          "spread": 0.01407149,
+          "score": 0.03515357
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.1016489,
-          "spread": 0.08301803,
-          "score": 0.13124211
+          "bias": 0.10164346,
+          "spread": 0.08302303,
+          "score": 0.13124106
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.27500281,
-          "spread": 0.04955415,
-          "score": 0.27943185
+          "bias": 0.27504034,
+          "spread": 0.04953869,
+          "score": 0.27946605
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.03728392,
-          "spread": 0.62521726,
-          "score": 0.62632796
+          "bias": -0.03728409,
+          "spread": 0.6252174,
+          "score": 0.62632811
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.08714736,
-          "spread": 0.15628718,
-          "score": 0.17894229
+          "bias": -0.08718422,
+          "spread": 0.15629693,
+          "score": 0.17896877
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00212396,
-          "spread": 0.00294181,
-          "score": 0.00362842
+          "bias": -0.00212561,
+          "spread": 0.00294053,
+          "score": 0.00362835
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00537445,
-          "spread": 0.00336081,
-          "score": 0.00633875
+          "bias": 0.00537328,
+          "spread": 0.00335966,
+          "score": 0.00633715
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00529387,
-          "spread": 0.0035316,
-          "score": 0.00636375
+          "bias": 0.00529294,
+          "spread": 0.00353084,
+          "score": 0.00636255
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00241054,
-          "spread": 0.00315469,
-          "score": 0.00397024
+          "bias": 0.0024095,
+          "spread": 0.00315456,
+          "score": 0.0039695
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.01209832,
-          "spread": 0.01261247,
-          "score": 0.01747695
+          "bias": 0.01209744,
+          "spread": 0.01261162,
+          "score": 0.01747572
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.13678707,
-          "spread": 0.0920196,
-          "score": 0.16485845
+          "bias": -0.13678312,
+          "spread": 0.09202357,
+          "score": 0.16485739
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00886862,
-          "spread": 0.02349835,
-          "score": 0.02511622
+          "bias": -0.00886977,
+          "spread": 0.02349788,
+          "score": 0.02511619
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.1771376,
+          "bias": 0.17713758,
           "spread": 0.0,
-          "score": 0.1771376
+          "score": 0.17713758
         },
         {
           "profile": "ti_dependent_cp",
@@ -3671,207 +3671,207 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00937461,
-          "spread": 0.00764075,
-          "score": 0.01209398
+          "bias": 0.00937984,
+          "spread": 0.00764871,
+          "score": 0.01210306
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00381249,
-          "spread": 0.00466789,
-          "score": 0.00602697
+          "bias": 0.00381318,
+          "spread": 0.00466746,
+          "score": 0.00602707
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00306364,
-          "spread": 0.00749303,
-          "score": 0.00809514
+          "bias": 0.00306237,
+          "spread": 0.00749405,
+          "score": 0.00809561
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00051428,
-          "spread": 0.0033297,
-          "score": 0.00336919
+          "bias": 0.00051421,
+          "spread": 0.00332943,
+          "score": 0.0033689
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.14742519,
+          "bias": 0.14742561,
           "spread": 0.0,
-          "score": 0.14742519
+          "score": 0.14742561
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.01009052,
-          "spread": 0.00239797,
-          "score": 0.01037154
+          "bias": -0.01009103,
+          "spread": 0.00239808,
+          "score": 0.01037206
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00233488,
-          "spread": 0.00267594,
-          "score": 0.00355138
+          "bias": -0.00233477,
+          "spread": 0.00267567,
+          "score": 0.00355111
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00068812,
-          "spread": 0.00410247,
-          "score": 0.00415978
+          "bias": -0.00068811,
+          "spread": 0.00410216,
+          "score": 0.00415947
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00668714,
-          "spread": 0.00408701,
-          "score": 0.00783719
+          "bias": 0.00668661,
+          "spread": 0.00408685,
+          "score": 0.00783666
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.02076038,
-          "spread": 0.00626011,
-          "score": 0.02168369
+          "bias": 0.02075976,
+          "spread": 0.00625975,
+          "score": 0.02168299
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.01969875,
-          "spread": 0.01310986,
-          "score": 0.0236624
+          "bias": 0.01969699,
+          "spread": 0.01311094,
+          "score": 0.02366154
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.07029836,
-          "spread": 0.0462499,
-          "score": 0.08414816
+          "bias": 0.07029517,
+          "spread": 0.04625087,
+          "score": 0.08414603
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.41026313,
-          "spread": 0.4132131,
-          "score": 0.58228936
+          "bias": 0.41026254,
+          "spread": 0.41321345,
+          "score": 0.5822892
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.90144576,
-          "spread": 0.77132686,
-          "score": 1.18640194
+          "bias": 0.90145861,
+          "spread": 0.77133971,
+          "score": 1.18642006
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.10502681,
-          "spread": 0.08894726,
-          "score": 0.13763084
+          "bias": -0.10500994,
+          "spread": 0.08893545,
+          "score": 0.13761032
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00222055,
-          "spread": 0.00357004,
-          "score": 0.00420429
+          "bias": -0.00222093,
+          "spread": 0.00357031,
+          "score": 0.00420472
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00286393,
-          "spread": 0.00203966,
-          "score": 0.003516
+          "bias": 0.0028645,
+          "spread": 0.00203978,
+          "score": 0.00351654
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00196043,
-          "spread": 0.00215633,
-          "score": 0.00291428
+          "bias": 0.00196051,
+          "spread": 0.00215664,
+          "score": 0.00291456
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00027218,
-          "spread": 0.00072845,
-          "score": 0.00077764
+          "bias": 0.00027416,
+          "spread": 0.00073159,
+          "score": 0.00078128
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00019046,
-          "spread": 0.0019773,
-          "score": 0.00198645
+          "bias": 0.00018997,
+          "spread": 0.00197705,
+          "score": 0.00198615
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.14168467,
-          "spread": 0.0878664,
-          "score": 0.16671848
+          "bias": -0.14168275,
+          "spread": 0.08786657,
+          "score": 0.16671693
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00512652,
-          "spread": 0.01405932,
-          "score": 0.01496482
+          "bias": 0.00512603,
+          "spread": 0.01405953,
+          "score": 0.01496484
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.04818731,
-          "spread": 0.03874595,
-          "score": 0.06183256
+          "bias": 0.04818677,
+          "spread": 0.03874513,
+          "score": 0.06183163
         },
         {
           "profile": "ti_dependent_cp",
@@ -3887,27 +3887,27 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00218866,
-          "spread": 0.00772541,
-          "score": 0.00802946
+          "bias": 0.00218744,
+          "spread": 0.00772713,
+          "score": 0.00803078
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00143064,
-          "spread": 0.00683361,
-          "score": 0.00698176
+          "bias": 0.00142998,
+          "spread": 0.00683377,
+          "score": 0.00698178
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00024173,
-          "spread": 0.00730351,
-          "score": 0.00730751
+          "bias": -0.00024196,
+          "spread": 0.00730338,
+          "score": 0.00730739
         },
         {
           "profile": "ws_dependent_cp",
@@ -4346,180 +4346,180 @@
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.0005551,
-          "spread": 0.00330798,
-          "score": 0.00335423
+          "bias": 0.00055509,
+          "spread": 0.00330796,
+          "score": 0.00335421
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.1686651,
+          "bias": 0.16866377,
           "spread": 0.0,
-          "score": 0.1686651
+          "score": 0.16866377
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00392362,
-          "spread": 0.00180257,
-          "score": 0.00431788
+          "bias": -0.00392519,
+          "spread": 0.00180371,
+          "score": 0.00431978
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00040442,
-          "spread": 0.00249109,
-          "score": 0.00252371
+          "bias": -0.00040426,
+          "spread": 0.00249104,
+          "score": 0.00252363
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00025979,
-          "spread": 0.00405681,
-          "score": 0.00406512
+          "bias": -0.00025962,
+          "spread": 0.0040567,
+          "score": 0.004065
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00304859,
-          "spread": 0.00511232,
-          "score": 0.00595229
+          "bias": 0.00304805,
+          "spread": 0.00511268,
+          "score": 0.00595232
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00967833,
+          "bias": 0.0096775,
           "spread": 0.00670514,
-          "score": 0.01177408
+          "score": 0.0117734
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00225083,
-          "spread": 0.01401554,
-          "score": 0.01419512
+          "bias": 0.00224879,
+          "spread": 0.01401651,
+          "score": 0.01419576
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.05347375,
-          "spread": 0.04883863,
-          "score": 0.07241998
+          "bias": 0.05347012,
+          "spread": 0.04883844,
+          "score": 0.07241718
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.4017357,
-          "spread": 0.44781866,
-          "score": 0.60160878
+          "bias": 0.40173446,
+          "spread": 0.44781759,
+          "score": 0.60160716
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.76613203,
-          "spread": 0.98930468,
-          "score": 1.25127217
+          "bias": 0.76614579,
+          "spread": 0.9893183,
+          "score": 1.25129136
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.13101628,
-          "spread": 0.10583398,
-          "score": 0.16842238
+          "bias": -0.13100044,
+          "spread": 0.10582151,
+          "score": 0.16840222
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00169958,
-          "spread": 0.00281801,
-          "score": 0.00329086
+          "bias": 0.00169909,
+          "spread": 0.00281844,
+          "score": 0.00329098
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00235833,
-          "spread": 0.00259461,
-          "score": 0.00350624
+          "bias": 0.00235878,
+          "spread": 0.0025949,
+          "score": 0.00350676
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00206215,
-          "spread": 0.00237198,
-          "score": 0.00314305
+          "bias": 0.00206211,
+          "spread": 0.00237225,
+          "score": 0.00314323
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00070089,
-          "spread": 0.00089743,
-          "score": 0.0011387
+          "bias": 0.00070275,
+          "spread": 0.0009008,
+          "score": 0.0011425
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00149031,
-          "spread": 0.0026483,
-          "score": 0.00303884
+          "bias": 0.00148971,
+          "spread": 0.00264831,
+          "score": 0.00303855
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.17927833,
-          "spread": 0.1114627,
-          "score": 0.21110342
+          "bias": -0.17924492,
+          "spread": 0.11141021,
+          "score": 0.21104733
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00907677,
-          "spread": 0.0147236,
-          "score": 0.0172966
+          "bias": 0.00907617,
+          "spread": 0.0147242,
+          "score": 0.01729678
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.05517742,
-          "spread": 0.041882,
-          "score": 0.06927229
+          "bias": 0.05517677,
+          "spread": 0.04188166,
+          "score": 0.06927156
         },
         {
           "profile": "ws_dependent_cp",
@@ -4535,33 +4535,33 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.0017967,
-          "spread": 0.00798206,
-          "score": 0.00818178
+          "bias": -0.00179295,
+          "spread": 0.0079843,
+          "score": 0.00818314
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00139607,
-          "spread": 0.00735356,
-          "score": 0.00748491
+          "bias": -0.00139693,
+          "spread": 0.00735397,
+          "score": 0.00748547
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00105179,
-          "spread": 0.00762844,
-          "score": 0.00770061
+          "bias": -0.00105216,
+          "spread": 0.00762855,
+          "score": 0.00770076
         }
       ]
     },
     "toggle": {
-      "recorded_utc": "2026-07-04T15:12:20Z",
-      "git_commit": "47171a4-dirty",
+      "recorded_utc": "2026-07-04T19:42:37Z",
+      "git_commit": "f13a71d-dirty",
       "n_replicates": 4,
       "seed": 0,
       "campaign_months": [
@@ -4585,9 +4585,9 @@
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00353355,
-          "spread": 0.00066358,
-          "score": 0.00359532
+          "bias": 0.00120201,
+          "spread": 0.00264262,
+          "score": 0.00290315
         },
         {
           "profile": "cp_0pct",
@@ -4603,162 +4603,162 @@
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00748047,
-          "spread": 0.01391508,
-          "score": 0.01579832
+          "bias": 0.00637684,
+          "spread": 0.01524718,
+          "score": 0.01652696
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00070593,
-          "spread": 0.00242268,
-          "score": 0.00252343
+          "bias": -0.00093667,
+          "spread": 0.00286283,
+          "score": 0.00301216
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00548091,
-          "spread": 0.00128676,
-          "score": 0.00562993
+          "bias": 0.00305754,
+          "spread": 0.00367043,
+          "score": 0.00477709
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00394722,
-          "spread": 0.0023675,
-          "score": 0.00460278
+          "bias": 0.00071358,
+          "spread": 0.00588916,
+          "score": 0.00593223
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00381493,
-          "spread": 0.00405233,
-          "score": 0.00556553
+          "bias": 0.00187449,
+          "spread": 0.00652564,
+          "score": 0.00678953
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00079581,
-          "spread": 0.03108862,
-          "score": 0.0310988
+          "bias": -0.00869374,
+          "spread": 0.03373402,
+          "score": 0.03483626
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.02759907,
-          "spread": 0.05538432,
-          "score": 0.06187998
+          "bias": 0.00539153,
+          "spread": 0.03431298,
+          "score": 0.03473398
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.06965265,
-          "spread": 0.4830821,
-          "score": 0.48807766
+          "bias": -0.00276187,
+          "spread": 0.39320117,
+          "score": 0.39321087
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.14096221,
+          "bias": -0.13858512,
           "spread": 0.0,
-          "score": 0.14096221
+          "score": 0.13858512
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.01355152,
-          "spread": 0.01636823,
-          "score": 0.02125
+          "bias": 0.00122631,
+          "spread": 0.02330555,
+          "score": 0.02333779
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00060208,
-          "spread": 0.0017339,
-          "score": 0.00183546
+          "bias": -0.00133404,
+          "spread": 0.00179846,
+          "score": 0.00223922
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00191051,
-          "spread": 0.00091223,
-          "score": 0.00211713
+          "bias": 0.00054029,
+          "spread": 0.00383005,
+          "score": 0.00386797
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00165304,
-          "spread": 0.00204547,
-          "score": 0.00262992
+          "bias": 4.212e-05,
+          "spread": 0.00481796,
+          "score": 0.00481814
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00215328,
-          "spread": 0.00155699,
-          "score": 0.00265722
+          "bias": 0.00018682,
+          "spread": 0.00291694,
+          "score": 0.00292292
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00370464,
-          "spread": 0.01909753,
-          "score": 0.01945354
+          "bias": 0.00637185,
+          "spread": 0.01993128,
+          "score": 0.02092502
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.01623147,
-          "spread": 0.03945832,
-          "score": 0.04266638
+          "bias": 0.00840889,
+          "spread": 0.03663473,
+          "score": 0.03758741
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.06356536,
-          "spread": 0.06364789,
-          "score": 0.08995337
+          "bias": 0.04094959,
+          "spread": 0.04550499,
+          "score": 0.06121742
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.0090114,
-          "spread": 0.00856435,
-          "score": 0.01243195
+          "bias": -0.00645216,
+          "spread": 0.00153387,
+          "score": 0.00663198
         },
         {
           "profile": "cp_0pct",
@@ -4774,207 +4774,207 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00426232,
-          "spread": 0.00932912,
-          "score": 0.0102567
+          "bias": -6.264e-05,
+          "spread": 0.01332214,
+          "score": 0.01332229
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00796638,
-          "spread": 0.00360988,
-          "score": 0.00874611
+          "bias": 0.00486058,
+          "spread": 0.0053534,
+          "score": 0.00723078
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00382501,
-          "spread": 0.00459222,
-          "score": 0.00597655
+          "bias": 0.00073912,
+          "spread": 0.00368378,
+          "score": 0.00375719
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00111382,
-          "spread": 0.00139904,
-          "score": 0.00178827
+          "bias": 0.0015952,
+          "spread": 0.00149575,
+          "score": 0.00218676
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.09199061,
-          "spread": 0.00436394,
-          "score": 0.09209406
+          "bias": 0.10036238,
+          "spread": 0.00210113,
+          "score": 0.10038437
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00014859,
-          "spread": 0.01053079,
-          "score": 0.01053184
+          "bias": 0.00044647,
+          "spread": 0.01153555,
+          "score": 0.01154418
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00031877,
-          "spread": 0.00164359,
-          "score": 0.00167422
+          "bias": 0.00040671,
+          "spread": 0.00177634,
+          "score": 0.0018223
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00260396,
-          "spread": 0.00153436,
-          "score": 0.0030224
+          "bias": 0.00304813,
+          "spread": 0.00125828,
+          "score": 0.00329763
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00072219,
-          "spread": 0.0019521,
-          "score": 0.00208141
+          "bias": -0.00052043,
+          "spread": 0.00227877,
+          "score": 0.00233744
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00357732,
-          "spread": 0.00667861,
-          "score": 0.00757634
+          "bias": 0.00145982,
+          "spread": 0.00987914,
+          "score": 0.00998641
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00469041,
-          "spread": 0.02190535,
-          "score": 0.02240188
+          "bias": 0.00355453,
+          "spread": 0.02097674,
+          "score": 0.02127577
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.02848612,
-          "spread": 0.03463453,
-          "score": 0.04484428
+          "bias": -0.03613915,
+          "spread": 0.0304459,
+          "score": 0.04725454
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.07167425,
-          "spread": 0.19567062,
-          "score": 0.20838472
+          "bias": 0.07167056,
+          "spread": 0.19711082,
+          "score": 0.20973637
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.39370194,
-          "spread": 0.44969101,
-          "score": 0.59768154
+          "bias": 0.41925886,
+          "spread": 0.42379021,
+          "score": 0.59613432
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.00202113,
-          "spread": 0.0174194,
-          "score": 0.01753627
+          "bias": 0.0035219,
+          "spread": 0.01463032,
+          "score": 0.01504826
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00011956,
-          "spread": 0.00299561,
-          "score": 0.00299799
+          "bias": 0.0012212,
+          "spread": 0.0014816,
+          "score": 0.00192002
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00014593,
-          "spread": 0.00162489,
-          "score": 0.00163143
+          "bias": 0.00070606,
+          "spread": 0.00280925,
+          "score": 0.00289662
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00030784,
-          "spread": 0.00205339,
-          "score": 0.00207634
+          "bias": 0.00031386,
+          "spread": 0.00332784,
+          "score": 0.0033426
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00021566,
-          "spread": 0.00132107,
-          "score": 0.00133855
+          "bias": 0.00063224,
+          "spread": 0.00279613,
+          "score": 0.00286672
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00244986,
-          "spread": 0.01054361,
-          "score": 0.01082449
+          "bias": 0.00235951,
+          "spread": 0.0119138,
+          "score": 0.0121452
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.00570082,
-          "spread": 0.0265959,
-          "score": 0.02720003
+          "bias": -0.0082556,
+          "spread": 0.02779045,
+          "score": 0.02899076
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00523091,
-          "spread": 0.00660029,
-          "score": 0.00842177
+          "bias": -0.00373567,
+          "spread": 0.00928082,
+          "score": 0.01000444
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.01369055,
-          "spread": 0.01409478,
-          "score": 0.01964927
+          "bias": 0.01238381,
+          "spread": 0.01520979,
+          "score": 0.01961368
         },
         {
           "profile": "cp_0pct",
@@ -4990,207 +4990,207 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00253323,
-          "spread": 0.00512995,
-          "score": 0.00572133
+          "bias": 0.00303631,
+          "spread": 0.00566381,
+          "score": 0.00642635
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00084402,
-          "spread": 0.00263243,
-          "score": 0.00276442
+          "bias": 0.00049836,
+          "spread": 0.0024874,
+          "score": 0.00253683
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.0027108,
-          "spread": 0.00429787,
-          "score": 0.00508135
+          "bias": 0.00280801,
+          "spread": 0.00470528,
+          "score": 0.00547947
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00100521,
-          "spread": 0.00169069,
-          "score": 0.00196695
+          "bias": 0.00083402,
+          "spread": 0.00290788,
+          "score": 0.00302511
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.08576204,
-          "spread": 0.01107903,
-          "score": 0.08647469
+          "bias": 0.0872176,
+          "spread": 0.01039399,
+          "score": 0.08783476
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00128811,
-          "spread": 0.00388221,
-          "score": 0.00409033
+          "bias": 0.00111621,
+          "spread": 0.00439507,
+          "score": 0.00453459
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.0017,
-          "spread": 0.00163701,
-          "score": 0.00236004
+          "bias": 0.00152872,
+          "spread": 0.00289264,
+          "score": 0.00327175
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.001087,
-          "spread": 0.00185746,
-          "score": 0.00215214
+          "bias": 0.00091479,
+          "spread": 0.00265752,
+          "score": 0.00281056
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00152444,
-          "spread": 0.00171278,
-          "score": 0.00229293
+          "bias": -0.00169499,
+          "spread": 0.00299033,
+          "score": 0.0034373
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00515748,
-          "spread": 0.00705418,
-          "score": 0.00873848
+          "bias": 0.00499439,
+          "spread": 0.00854338,
+          "score": 0.00989612
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00533376,
-          "spread": 0.02227027,
-          "score": 0.02290009
+          "bias": -0.00548679,
+          "spread": 0.02313815,
+          "score": 0.02377979
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.01130738,
-          "spread": 0.02425568,
-          "score": 0.02676181
+          "bias": 0.01115009,
+          "spread": 0.02498936,
+          "score": 0.02736407
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.0106919,
-          "spread": 0.27616556,
-          "score": 0.27637245
+          "bias": 0.01049977,
+          "spread": 0.27631662,
+          "score": 0.27651604
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.26835773,
-          "spread": 0.3630687,
-          "score": 0.45148062
+          "bias": 0.2684672,
+          "spread": 0.36410529,
+          "score": 0.4523796
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.01416058,
-          "spread": 0.03210956,
-          "score": 0.03509338
+          "bias": -0.01432426,
+          "spread": 0.03231854,
+          "score": 0.03535071
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.0010779,
-          "spread": 0.00236062,
-          "score": 0.00259507
+          "bias": -0.00124991,
+          "spread": 0.00296646,
+          "score": 0.00321903
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00095068,
-          "spread": 0.00121713,
-          "score": 0.00154441
+          "bias": 0.00077884,
+          "spread": 0.00239942,
+          "score": 0.00252266
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00034086,
-          "spread": 0.001426,
-          "score": 0.00146617
+          "bias": -0.00051299,
+          "spread": 0.00229992,
+          "score": 0.00235644
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 5.323e-05,
-          "spread": 0.00113122,
-          "score": 0.00113248
+          "bias": -0.00011875,
+          "spread": 0.00222805,
+          "score": 0.00223122
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00426124,
-          "spread": 0.00772058,
-          "score": 0.00881848
+          "bias": 0.00409819,
+          "spread": 0.00910249,
+          "score": 0.00998251
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.00402747,
-          "spread": 0.02244889,
-          "score": 0.02280731
+          "bias": 0.00388598,
+          "spread": 0.02389079,
+          "score": 0.02420477
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00407757,
-          "spread": 0.00602508,
-          "score": 0.00727518
+          "bias": 0.0039105,
+          "spread": 0.00716203,
+          "score": 0.00816007
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.0160287,
-          "spread": 0.02599727,
-          "score": 0.0305414
+          "bias": -0.01767627,
+          "spread": 0.02661051,
+          "score": 0.03194636
         },
         {
           "profile": "cp_0pct",
@@ -5206,252 +5206,252 @@
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 6.868e-05,
-          "spread": 0.00422753,
-          "score": 0.00422809
+          "bias": -0.00010523,
+          "spread": 0.00420368,
+          "score": 0.00420499
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00145401,
-          "spread": 0.00241409,
-          "score": 0.00281815
+          "bias": 0.00128206,
+          "spread": 0.00317781,
+          "score": 0.00342668
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00282164,
-          "spread": 0.00394825,
-          "score": 0.00485286
+          "bias": 0.00265198,
+          "spread": 0.00499346,
+          "score": 0.00565399
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00070517,
-          "spread": 0.00106978,
-          "score": 0.00128128
+          "bias": 0.00074636,
+          "spread": 0.00192919,
+          "score": 0.00206854
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.07702443,
-          "spread": 0.03012782,
-          "score": 0.082707
+          "bias": 0.07873567,
+          "spread": 0.03002629,
+          "score": 0.08426674
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00201337,
-          "spread": 0.00400958,
-          "score": 0.00448669
+          "bias": 0.00205494,
+          "spread": 0.00438638,
+          "score": 0.00484387
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00090964,
-          "spread": 0.00076172,
-          "score": 0.00118645
+          "bias": 0.00095093,
+          "spread": 0.0018287,
+          "score": 0.00206117
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00027703,
-          "spread": 0.00108234,
-          "score": 0.00111723
+          "bias": 0.00031737,
+          "spread": 0.00144228,
+          "score": 0.00147678
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00045052,
-          "spread": 0.00190323,
-          "score": 0.00195582
+          "bias": 0.00049299,
+          "spread": 0.00295948,
+          "score": 0.00300026
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00530534,
-          "spread": 0.00700544,
-          "score": 0.00878765
+          "bias": 0.00534874,
+          "spread": 0.00745539,
+          "score": 0.00917561
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00391404,
-          "spread": 0.02915303,
-          "score": 0.0294146
+          "bias": -0.00384002,
+          "spread": 0.03028346,
+          "score": 0.03052595
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.01349524,
-          "spread": 0.02007159,
-          "score": 0.02418657
+          "bias": -0.01345242,
+          "spread": 0.02026807,
+          "score": 0.02432616
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.03441911,
-          "spread": 0.23145234,
-          "score": 0.23399756
+          "bias": 0.03417374,
+          "spread": 0.2301375,
+          "score": 0.23266094
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.20243665,
-          "spread": 0.11375018,
-          "score": 0.23220616
+          "bias": -0.2026589,
+          "spread": 0.11253372,
+          "score": 0.23180696
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.00677135,
-          "spread": 0.0385606,
-          "score": 0.03915062
+          "bias": -0.00672605,
+          "spread": 0.03869698,
+          "score": 0.03927717
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.0001923,
-          "spread": 0.00198649,
-          "score": 0.00199578
+          "bias": -0.00015115,
+          "spread": 0.00255116,
+          "score": 0.00255564
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00120134,
-          "spread": 0.0006254,
-          "score": 0.00135438
+          "bias": 0.0012416,
+          "spread": 0.0010184,
+          "score": 0.00160583
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00060756,
-          "spread": 0.00124614,
-          "score": 0.00138636
+          "bias": -0.00056685,
+          "spread": 0.00179846,
+          "score": 0.00188568
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00042758,
-          "spread": 0.00043231,
-          "score": 0.00060804
+          "bias": 0.00046839,
+          "spread": 0.00141222,
+          "score": 0.00148787
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": -0.00035544,
-          "spread": 0.00230852,
-          "score": 0.00233572
+          "bias": -0.00031704,
+          "spread": 0.00154527,
+          "score": 0.00157746
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.00190677,
-          "spread": 0.02047409,
-          "score": 0.02056269
+          "bias": 0.00197779,
+          "spread": 0.02194232,
+          "score": 0.02203128
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00323821,
-          "spread": 0.00341508,
-          "score": 0.00470625
+          "bias": -0.00319274,
+          "spread": 0.00480046,
+          "score": 0.00576524
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.03205142,
-          "spread": 0.02597873,
-          "score": 0.04125758
+          "bias": -0.03201777,
+          "spread": 0.02583466,
+          "score": 0.04114082
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
-          "bias": 0.01950999,
+          "bias": 0.02099227,
           "spread": 0.0,
-          "score": 0.01950999
+          "score": 0.02099227
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00133102,
-          "spread": 0.00548241,
-          "score": 0.00564167
+          "bias": 0.00137697,
+          "spread": 0.00649893,
+          "score": 0.00664321
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00281354,
-          "spread": 0.00214334,
-          "score": 0.00353694
+          "bias": 0.00285713,
+          "spread": 0.00344512,
+          "score": 0.00447572
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00044893,
-          "spread": 0.00326151,
-          "score": 0.00329226
+          "bias": 0.00048793,
+          "spread": 0.00297024,
+          "score": 0.00301005
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00337371,
-          "spread": 0.00064035,
-          "score": 0.00343394
+          "bias": 0.00119341,
+          "spread": 0.00247774,
+          "score": 0.00275017
         },
         {
           "profile": "cp_minus_10pct",
@@ -5467,162 +5467,162 @@
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00731947,
-          "spread": 0.01495908,
-          "score": 0.01665379
+          "bias": 0.00631169,
+          "spread": 0.01588185,
+          "score": 0.01709007
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00055129,
-          "spread": 0.0021138,
-          "score": 0.0021845
+          "bias": -0.00229815,
+          "spread": 0.00237892,
+          "score": 0.00330768
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00516058,
-          "spread": 0.00171521,
-          "score": 0.00543815
+          "bias": 0.00286129,
+          "spread": 0.00403059,
+          "score": 0.00494293
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.0058683,
-          "spread": 0.00239494,
-          "score": 0.00633819
+          "bias": 0.00334303,
+          "spread": 0.00517045,
+          "score": 0.00615706
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00635238,
-          "spread": 0.00314742,
-          "score": 0.00708936
+          "bias": 0.00488462,
+          "spread": 0.00606042,
+          "score": 0.00778384
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00174521,
-          "spread": 0.02720435,
-          "score": 0.02726027
+          "bias": -0.00578654,
+          "spread": 0.03322491,
+          "score": 0.03372504
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.03469809,
-          "spread": 0.04813567,
-          "score": 0.05933801
+          "bias": 0.0167712,
+          "spread": 0.04135134,
+          "score": 0.04462294
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.35381325,
-          "spread": 0.27830953,
-          "score": 0.45015554
+          "bias": 0.25381224,
+          "spread": 0.23040524,
+          "score": 0.34279328
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.16293081,
+          "bias": -0.13463371,
           "spread": 0.0,
-          "score": 0.16293081
+          "score": 0.13463371
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.02156829,
-          "spread": 0.02113477,
-          "score": 0.03019718
+          "bias": 0.01377778,
+          "spread": 0.01916345,
+          "score": 0.02360222
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00340116,
-          "spread": 0.00271645,
-          "score": 0.00435281
+          "bias": 0.00174328,
+          "spread": 0.00251092,
+          "score": 0.00305675
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00273568,
-          "spread": 0.00100341,
-          "score": 0.0029139
+          "bias": -0.00422541,
+          "spread": 0.00350941,
+          "score": 0.00549272
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00026377,
-          "spread": 0.00163921,
-          "score": 0.0016603
+          "bias": -0.00129226,
+          "spread": 0.00413808,
+          "score": 0.00433516
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00160526,
-          "spread": 0.0015634,
-          "score": 0.00224078
+          "bias": -0.00036182,
+          "spread": 0.00247529,
+          "score": 0.00250159
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00343835,
-          "spread": 0.02334117,
-          "score": 0.02359306
+          "bias": 0.00660139,
+          "spread": 0.02312178,
+          "score": 0.02404569
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.02955646,
-          "spread": 0.04568628,
-          "score": 0.05441342
+          "bias": 0.02692841,
+          "spread": 0.04367402,
+          "score": 0.05130847
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.06913967,
-          "spread": 0.06965696,
-          "score": 0.09814472
+          "bias": 0.04954869,
+          "spread": 0.05453649,
+          "score": 0.07368379
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.00158259,
-          "spread": 0.01482082,
-          "score": 0.01490507
+          "bias": -0.00105763,
+          "spread": 0.00983095,
+          "score": 0.00988768
         },
         {
           "profile": "cp_minus_10pct",
@@ -5638,2154 +5638,426 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00438832,
-          "spread": 0.00898483,
-          "score": 0.00999923
+          "bias": 0.00037467,
+          "spread": 0.01235432,
+          "score": 0.01236
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00675529,
-          "spread": 0.00282692,
-          "score": 0.00732294
+          "bias": 0.00402207,
+          "spread": 0.00478275,
+          "score": 0.00624914
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.0046028,
-          "spread": 0.00457111,
-          "score": 0.00648697
+          "bias": 0.00170137,
+          "spread": 0.00377283,
+          "score": 0.00413871
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00114668,
-          "spread": 0.00131736,
-          "score": 0.00174652
+          "bias": 0.00159365,
+          "spread": 0.00139228,
+          "score": 0.00211617
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.0909291,
-          "spread": 0.01463739,
-          "score": 0.09209969
+          "bias": 0.10443539,
+          "spread": 0.00285198,
+          "score": 0.10447432
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00149712,
-          "spread": 0.01064364,
-          "score": 0.01074842
+          "bias": 0.00167059,
+          "spread": 0.01152692,
+          "score": 0.01164735
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00116228,
-          "spread": 0.00190238,
-          "score": 0.00222933
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": 0.002474,
-          "spread": 0.00073245,
-          "score": 0.00258015
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00104443,
-          "spread": 0.00154587,
-          "score": 0.00186562
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00676555,
-          "spread": 0.00630957,
-          "score": 0.00925112
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00553111,
-          "spread": 0.01718727,
-          "score": 0.01805535
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": -0.01652185,
-          "spread": 0.0353702,
-          "score": 0.03903873
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.14209619,
-          "spread": 0.07747577,
-          "score": 0.16184506
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": 0.37138161,
-          "spread": 0.40965151,
-          "score": 0.5529364
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": 0.00476487,
-          "spread": 0.01873144,
-          "score": 0.01932798
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00315469,
-          "spread": 0.00319287,
-          "score": 0.00448848
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00452089,
-          "spread": 0.00111087,
-          "score": 0.00465537
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00178729,
-          "spread": 0.00185807,
-          "score": 0.00257814
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": -8.334e-05,
-          "spread": 0.00101358,
-          "score": 0.001017
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.0032305,
-          "spread": 0.01241265,
-          "score": 0.01282614
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": 0.02930705,
-          "spread": 0.04649989,
-          "score": 0.05496492
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00061464,
-          "spread": 0.01201537,
-          "score": 0.01203108
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": 0.02675328,
-          "spread": 0.01445678,
-          "score": 0.03040948
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00276005,
-          "spread": 0.00475322,
-          "score": 0.00549645
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00029555,
-          "spread": 0.00266532,
-          "score": 0.00268166
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00344103,
-          "spread": 0.00430008,
-          "score": 0.0055074
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.00102229,
-          "spread": 0.00159111,
-          "score": 0.00189122
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": 0.06435767,
-          "spread": 0.00738156,
-          "score": 0.0647796
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00076481,
-          "spread": 0.00430588,
-          "score": 0.00437327
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00092227,
-          "spread": 0.00181583,
-          "score": 0.00203662
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00092268,
-          "spread": 0.00127943,
-          "score": 0.00157743
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00040951,
-          "spread": 0.00137083,
-          "score": 0.00143069
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00739054,
-          "spread": 0.00703601,
-          "score": 0.01020419
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00085819,
-          "spread": 0.01866382,
-          "score": 0.01868354
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": 0.02166467,
-          "spread": 0.02031926,
-          "score": 0.02970236
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.04934412,
-          "spread": 0.21778154,
-          "score": 0.22330168
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": -0.35563404,
-          "spread": 0.25971728,
-          "score": 0.44037329
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.00790295,
-          "spread": 0.03023524,
-          "score": 0.03125102
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00233461,
-          "spread": 0.00176584,
-          "score": 0.00292721
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00343644,
-          "spread": 0.00113213,
-          "score": 0.00361813
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00184393,
-          "spread": 0.00138307,
-          "score": 0.00230499
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00035602,
-          "spread": 0.00106566,
-          "score": 0.00112355
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00538822,
-          "spread": 0.00878387,
-          "score": 0.01030481
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": 0.03365676,
-          "spread": 0.03802135,
-          "score": 0.05077796
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00785913,
-          "spread": 0.00801526,
-          "score": 0.01122543
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": -0.00485003,
-          "spread": 0.02595472,
-          "score": 0.02640398
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": 9.032e-05,
-          "spread": 0.00384184,
-          "score": 0.00384291
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00120724,
-          "spread": 0.00211251,
-          "score": 0.00243313
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00347706,
-          "spread": 0.00384548,
-          "score": 0.00518437
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 12,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.00074323,
-          "spread": 0.00102498,
-          "score": 0.00126609
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": 0.07040581,
-          "spread": 0.00777631,
-          "score": 0.07083395
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00111718,
-          "spread": 0.00428096,
-          "score": 0.00442433
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": -5.146e-05,
-          "spread": 0.00099579,
-          "score": 0.00099712
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00030527,
-          "spread": 0.00074428,
-          "score": 0.00080445
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00237376,
-          "spread": 0.0016222,
-          "score": 0.00287512
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00891372,
-          "spread": 0.00708325,
-          "score": 0.01138538
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00027019,
-          "spread": 0.02411511,
-          "score": 0.02411662
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": -0.00512076,
-          "spread": 0.0204681,
-          "score": 0.02109894
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.03455414,
-          "spread": 0.20212441,
-          "score": 0.20505673
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": -0.06777103,
-          "spread": 0.0,
-          "score": 0.06777103
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.00187558,
-          "spread": 0.04324757,
-          "score": 0.04328822
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00305586,
-          "spread": 0.00144986,
-          "score": 0.00338236
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": -0.0028457,
-          "spread": 0.00048822,
-          "score": 0.00288728
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00206069,
-          "spread": 0.00121841,
-          "score": 0.00239394
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": -5.76e-05,
-          "spread": 0.00035876,
-          "score": 0.00036335
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00101086,
-          "spread": 0.00142258,
-          "score": 0.00174516
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": 0.02591585,
-          "spread": 0.03730928,
-          "score": 0.04542702
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00036532,
-          "spread": 0.00269831,
-          "score": 0.00272292
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": -0.02644025,
-          "spread": 0.02925618,
-          "score": 0.03943363
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": 0.02038977,
-          "spread": 0.0,
-          "score": 0.02038977
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": 0.0020259,
-          "spread": 0.00451514,
-          "score": 0.00494882
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00221669,
-          "spread": 0.00223986,
-          "score": 0.0031513
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00149298,
-          "spread": 0.00321343,
-          "score": 0.00354332
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.00369338,
-          "spread": 0.00068943,
-          "score": 0.00375718
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00680251,
-          "spread": 0.01241535,
-          "score": 0.0141568
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00223108,
-          "spread": 0.00295246,
-          "score": 0.00370064
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00582514,
-          "spread": 0.00146635,
-          "score": 0.00600686
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00136358,
-          "spread": 0.00264149,
-          "score": 0.00297268
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00183457,
-          "spread": 0.00505484,
-          "score": 0.00537745
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00298136,
-          "spread": 0.03481333,
-          "score": 0.03494075
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": 0.01699357,
-          "spread": 0.05905653,
-          "score": 0.06145287
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": -0.22330942,
-          "spread": 1.11172623,
-          "score": 1.13393223
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": 0.08292892,
-          "spread": 0.26297208,
-          "score": 0.27573813
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": 0.00842962,
-          "spread": 0.01310715,
-          "score": 0.01558384
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00172253,
-          "spread": 0.00149341,
-          "score": 0.00227978
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00630654,
-          "spread": 0.00149783,
-          "score": 0.00648197
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00281841,
-          "spread": 0.00238587,
-          "score": 0.00369267
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00278863,
-          "spread": 0.00211771,
-          "score": 0.00350159
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00421652,
-          "spread": 0.0143902,
-          "score": 0.01499522
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": 0.00070689,
-          "spread": 0.03634893,
-          "score": 0.03635581
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": 0.05494878,
-          "spread": 0.05398633,
-          "score": 0.07703176
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": -0.01289958,
-          "spread": 0.00272681,
-          "score": 0.01318463
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00506838,
-          "spread": 0.01002698,
-          "score": 0.01123516
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00914378,
-          "spread": 0.004234,
-          "score": 0.01007648
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00231569,
-          "spread": 0.00463095,
-          "score": 0.00517765
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.00108097,
-          "spread": 0.00148072,
-          "score": 0.00183331
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": 0.11754493,
-          "spread": 0.01026161,
-          "score": 0.11799199
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00092733,
-          "spread": 0.00993098,
-          "score": 0.00997418
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00076376,
-          "spread": 0.00156802,
-          "score": 0.00174413
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00258159,
-          "spread": 0.00249686,
-          "score": 0.0035915
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00250991,
-          "spread": 0.0021984,
-          "score": 0.00333656
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.0006543,
-          "spread": 0.00711804,
-          "score": 0.00714805
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00076294,
-          "spread": 0.02504472,
-          "score": 0.02505634
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": -0.04813812,
-          "spread": 0.02886311,
-          "score": 0.05612805
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": -0.01193198,
-          "spread": 0.31342482,
-          "score": 0.31365186
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": 0.50502003,
-          "spread": 0.55581116,
-          "score": 0.75098021
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.00025381,
-          "spread": 0.01802401,
-          "score": 0.0180258
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00301006,
-          "spread": 0.00305441,
-          "score": 0.00428834
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00438135,
-          "spread": 0.00171231,
-          "score": 0.00470406
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00109428,
-          "spread": 0.00231055,
-          "score": 0.00255657
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00039896,
-          "spread": 0.00157782,
-          "score": 0.00162748
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00181233,
-          "spread": 0.00866043,
-          "score": 0.00884803
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": -0.04232535,
-          "spread": 0.04690682,
-          "score": 0.06317978
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00961515,
-          "spread": 0.00501633,
-          "score": 0.01084503
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": -0.0007419,
-          "spread": 0.0137958,
-          "score": 0.01381573
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": 0.0021408,
-          "spread": 0.00599649,
-          "score": 0.00636717
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00150478,
-          "spread": 0.00264935,
-          "score": 0.00304687
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00153385,
-          "spread": 0.00468915,
-          "score": 0.00493364
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.00098813,
-          "spread": 0.00179034,
-          "score": 0.00204493
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": 0.0764484,
-          "spread": 0.00576954,
-          "score": 0.0766658
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": 0.0019135,
-          "spread": 0.00372176,
-          "score": 0.00418485
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00248103,
-          "spread": 0.0018007,
-          "score": 0.00306562
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": 0.0014082,
-          "spread": 0.00266442,
-          "score": 0.00301366
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00396788,
-          "spread": 0.00198125,
-          "score": 0.00443502
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00195476,
-          "spread": 0.00736234,
-          "score": 0.00761742
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": -0.01205117,
-          "spread": 0.02231875,
-          "score": 0.02536449
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": 0.00455112,
-          "spread": 0.02828559,
-          "score": 0.02864939
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": -0.01610572,
-          "spread": 0.33481061,
-          "score": 0.33519776
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": 0.2971093,
-          "spread": 0.42275724,
-          "score": 0.51671812
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.01279754,
-          "spread": 0.03893442,
-          "score": 0.04098373
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": -0.0044399,
-          "spread": 0.00285179,
-          "score": 0.00527688
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00508158,
-          "spread": 0.00154627,
-          "score": 0.00531162
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00071285,
-          "spread": 0.00145799,
-          "score": 0.00162292
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00037078,
-          "spread": 0.0012313,
-          "score": 0.00128591
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.0026625,
-          "spread": 0.00675594,
-          "score": 0.00726165
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": -0.02753296,
-          "spread": 0.03776565,
-          "score": 0.04673658
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00024423,
-          "spread": 0.00726398,
-          "score": 0.00726808
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": -0.02678332,
-          "spread": 0.0265178,
-          "score": 0.03769006
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00073976,
-          "spread": 0.00442099,
-          "score": 0.00448246
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00215039,
-          "spread": 0.00236787,
-          "score": 0.00319859
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00196597,
-          "spread": 0.00426288,
-          "score": 0.00469438
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.00066711,
-          "spread": 0.00111473,
-          "score": 0.0012991
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": 0.08905323,
-          "spread": 0.03743434,
-          "score": 0.09660128
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00218796,
-          "spread": 0.00390845,
-          "score": 0.00447919
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00179881,
-          "spread": 0.000539,
-          "score": 0.00187783
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00030407,
-          "spread": 0.00176743,
-          "score": 0.00179339
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00146009,
-          "spread": 0.00259057,
-          "score": 0.0029737
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00170492,
-          "spread": 0.00694778,
-          "score": 0.00715391
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": -0.01026733,
-          "spread": 0.03321877,
-          "score": 0.0347693
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": -0.02127983,
-          "spread": 0.02333751,
-          "score": 0.03158276
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.02162906,
-          "spread": 0.26423588,
-          "score": 0.26511962
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": 0.77348912,
-          "spread": 0.90512767,
-          "score": 1.19060553
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.01464604,
-          "spread": 0.04286384,
-          "score": 0.04529697
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00370342,
-          "spread": 0.00258488,
-          "score": 0.0045163
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00519966,
-          "spread": 0.0007984,
-          "score": 0.0052606
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": 0.0005644,
-          "spread": 0.00122672,
-          "score": 0.00135033
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00080484,
-          "spread": 0.0005275,
-          "score": 0.0009623
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": -0.0020563,
-          "spread": 0.00375288,
-          "score": 0.00427931
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": -0.02533422,
-          "spread": 0.02096606,
-          "score": 0.03288463
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00689045,
-          "spread": 0.00541315,
-          "score": 0.00876244
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": -0.03687513,
-          "spread": 0.02463179,
-          "score": 0.04434524
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": 0.01817093,
-          "spread": 0.0,
-          "score": 0.01817093
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00115837,
-          "spread": 0.00595899,
-          "score": 0.00607053
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00328656,
-          "spread": 0.00221798,
-          "score": 0.00396496
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00069999,
-          "spread": 0.00282222,
-          "score": 0.00290773
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.0035815,
-          "spread": 0.00067107,
-          "score": 0.00364383
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00722123,
-          "spread": 0.01336856,
-          "score": 0.01519423
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00121453,
-          "spread": 0.00257942,
-          "score": 0.00285105
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00557423,
-          "spread": 0.00121979,
-          "score": 0.00570613
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00308064,
-          "spread": 0.00263416,
-          "score": 0.00405329
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.003257,
-          "spread": 0.00352999,
-          "score": 0.00480301
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00100712,
-          "spread": 0.03037448,
-          "score": 0.03039117
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": 0.02712495,
-          "spread": 0.05958807,
-          "score": 0.06547137
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": -0.00680825,
-          "spread": 0.6814628,
-          "score": 0.68149681
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": -0.1581287,
-          "spread": 0.0,
-          "score": 0.1581287
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": 0.01528571,
-          "spread": 0.01987935,
-          "score": 0.02507671
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00015469,
-          "spread": 0.00199031,
-          "score": 0.00199631
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00324922,
-          "spread": 0.0011674,
-          "score": 0.00345257
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": 0.0019417,
-          "spread": 0.00237627,
-          "score": 0.00306869
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00262006,
-          "spread": 0.00192661,
-          "score": 0.00325215
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00419339,
-          "spread": 0.01694906,
-          "score": 0.0174601
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": 0.01217,
-          "spread": 0.03905425,
-          "score": 0.04090652
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": 0.0616323,
-          "spread": 0.06094281,
-          "score": 0.08667507
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": -0.01092281,
-          "spread": 0.00607802,
-          "score": 0.01250001
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00414851,
-          "spread": 0.00952603,
-          "score": 0.01039015
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00803385,
-          "spread": 0.00367609,
-          "score": 0.00883495
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00338326,
-          "spread": 0.00470911,
-          "score": 0.00579846
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.00110397,
-          "spread": 0.00142354,
-          "score": 0.00180145
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": 0.09866961,
-          "spread": 0.00681137,
-          "score": 0.09890443
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": 1.352e-05,
-          "spread": 0.00965361,
-          "score": 0.00965362
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": 1.113e-05,
-          "spread": 0.00153564,
-          "score": 0.00153568
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": 0.0025132,
-          "spread": 0.00188484,
-          "score": 0.00314146
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00107522,
-          "spread": 0.00196549,
-          "score": 0.00224037
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00283291,
-          "spread": 0.00659782,
-          "score": 0.0071803
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00180873,
-          "spread": 0.02099981,
-          "score": 0.02107756
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": -0.03559074,
-          "spread": 0.03247668,
-          "score": 0.04818128
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.04598061,
-          "spread": 0.22789235,
-          "score": 0.23248471
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": 0.43692824,
-          "spread": 0.49042449,
-          "score": 0.65682758
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.0039587,
-          "spread": 0.01666001,
-          "score": 0.01712388
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00081558,
-          "spread": 0.00301061,
-          "score": 0.00311913
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.001384,
-          "spread": 0.00141946,
-          "score": 0.00198251
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00013856,
-          "spread": 0.00215458,
-          "score": 0.00215903
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00029901,
-          "spread": 0.00143291,
-          "score": 0.00146378
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.0022954,
-          "spread": 0.01009907,
-          "score": 0.01035664
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": -0.01747039,
-          "spread": 0.03042646,
-          "score": 0.03508538
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00643228,
-          "spread": 0.00524436,
-          "score": 0.00829925
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": 0.00895162,
-          "spread": 0.01378066,
-          "score": 0.01643283
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00214778,
-          "spread": 0.00537958,
-          "score": 0.00579248
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00092735,
-          "spread": 0.00281547,
-          "score": 0.00296426
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00246255,
-          "spread": 0.00445014,
-          "score": 0.00508605
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.00100009,
-          "spread": 0.00172058,
-          "score": 0.00199012
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": 0.09313775,
-          "spread": 0.01756766,
-          "score": 0.09478008
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00138911,
-          "spread": 0.0039418,
-          "score": 0.0041794
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00192217,
-          "spread": 0.00170643,
-          "score": 0.00257034
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00122649,
-          "spread": 0.00205811,
-          "score": 0.00239585
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00224203,
-          "spread": 0.00165136,
-          "score": 0.00278455
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.0041235,
-          "spread": 0.00676135,
-          "score": 0.00791954
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00798233,
-          "spread": 0.02162552,
-          "score": 0.0230517
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": 0.00846698,
-          "spread": 0.02468443,
-          "score": 0.02609618
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.00645677,
-          "spread": 0.29250189,
-          "score": 0.29257314
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": 0.30079315,
-          "spread": 0.40670682,
-          "score": 0.5058527
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.01166599,
-          "spread": 0.03250925,
-          "score": 0.03453907
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": -0.0021061,
-          "spread": 0.00249182,
-          "score": 0.00326264
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00210471,
+          "bias": -0.0005615,
           "spread": 0.00144278,
-          "score": 0.00255175
+          "score": 0.00154819
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00290063,
+          "spread": 0.00141118,
+          "score": 0.00322569
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": 0.00141547,
+          "spread": 0.00212433,
+          "score": 0.00255271
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.00513435,
+          "spread": 0.00867155,
+          "score": 0.01007757
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": 0.00657753,
+          "spread": 0.01884419,
+          "score": 0.01995915
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.01797066,
+          "spread": 0.03410768,
+          "score": 0.03855228
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.14215195,
+          "spread": 0.07872728,
+          "score": 0.16249665
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": 0.3903411,
+          "spread": 0.39038385,
+          "score": 0.55205591
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.0075961,
+          "spread": 0.01449769,
+          "score": 0.01636716
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.00407151,
+          "spread": 0.00226202,
+          "score": 0.00465768
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": -0.00369409,
+          "spread": 0.00248344,
+          "score": 0.00445127
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": -0.00125665,
+          "spread": 0.00310516,
+          "score": 0.00334981
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00017216,
+          "spread": 0.00261128,
+          "score": 0.00261695
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00296613,
+          "spread": 0.01381634,
+          "score": 0.01413114
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": 0.02945639,
+          "spread": 0.04757968,
+          "score": 0.05595985
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.00062067,
+          "spread": 0.01354957,
+          "score": 0.01356378
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.0254496,
+          "spread": 0.01556904,
+          "score": 0.02983416
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": 0.00307904,
+          "spread": 0.00508611,
+          "score": 0.0059455
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.00011799,
+          "spread": 0.00241653,
+          "score": 0.00241941
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00358359,
+          "spread": 0.00457309,
+          "score": 0.00580993
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00085685,
+          "spread": 0.00271868,
+          "score": 0.00285051
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.06563593,
+          "spread": 0.00678594,
+          "score": 0.06598579
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.00060179,
+          "spread": 0.00481003,
+          "score": 0.00484753
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.0007526,
+          "spread": 0.00249277,
+          "score": 0.0026039
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00075517,
+          "spread": 0.00250794,
+          "score": 0.00261917
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": 0.00024906,
+          "spread": 0.00267932,
+          "score": 0.00269087
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.00723965,
+          "spread": 0.00837908,
+          "score": 0.01107346
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": 0.00071694,
+          "spread": 0.01946436,
+          "score": 0.01947756
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.02152209,
+          "spread": 0.02105097,
+          "score": 0.03010554
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.04917251,
+          "spread": 0.21795359,
+          "score": 0.22343165
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.35588817,
+          "spread": 0.25917613,
+          "score": 0.44025975
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.00807109,
+          "spread": 0.03035263,
+          "score": 0.0314074
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.00217231,
+          "spread": 0.00241501,
+          "score": 0.00324826
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": -0.0036064,
+          "spread": 0.00240328,
+          "score": 0.00433381
+        },
+        {
+          "profile": "cp_minus_10pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00018358,
-          "spread": 0.00148573,
-          "score": 0.00149703
+          "bias": -0.00201554,
+          "spread": 0.00233345,
+          "score": 0.00308341
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "cp_minus_10pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00018421,
-          "spread": 0.00116471,
-          "score": 0.00117918
+          "bias": -0.00052778,
+          "spread": 0.00244918,
+          "score": 0.0025054
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "cp_minus_10pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00384383,
-          "spread": 0.0075441,
-          "score": 0.00846691
+          "bias": 0.00522505,
+          "spread": 0.01007822,
+          "score": 0.01135216
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "cp_minus_10pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.0078808,
-          "spread": 0.02289693,
-          "score": 0.02421521
+          "bias": 0.03352557,
+          "spread": 0.03903254,
+          "score": 0.05145389
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "cp_minus_10pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00304077,
-          "spread": 0.00614101,
-          "score": 0.00685261
+          "bias": 0.00769332,
+          "spread": 0.00941408,
+          "score": 0.0121578
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "cp_minus_10pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.01919546,
-          "spread": 0.02638994,
-          "score": 0.03263272
+          "bias": -0.00649457,
+          "spread": 0.02656918,
+          "score": 0.02735143
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "cp_minus_10pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
@@ -7794,256 +6066,1984 @@
           "score": NaN
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "cp_minus_10pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 6.552e-05,
-          "spread": 0.00408989,
-          "score": 0.00409041
+          "bias": -6.549e-05,
+          "spread": 0.00401418,
+          "score": 0.00401471
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "cp_minus_10pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00178594,
-          "spread": 0.00248578,
-          "score": 0.00306084
+          "bias": 0.00105229,
+          "spread": 0.00276701,
+          "score": 0.00296035
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "cp_minus_10pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.0026502,
-          "spread": 0.00386136,
-          "score": 0.00468334
+          "bias": 0.00332326,
+          "spread": 0.00458428,
+          "score": 0.00566213
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00069375,
-          "spread": 0.00108325,
-          "score": 0.00128636
+          "bias": 0.00078126,
+          "spread": 0.00181811,
+          "score": 0.00197886
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.08027554,
-          "spread": 0.02050294,
-          "score": 0.08285248
+          "bias": 0.0719364,
+          "spread": 0.00766791,
+          "score": 0.07234392
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00161866,
-          "spread": 0.00399878,
-          "score": 0.00431396
+          "bias": 0.00116022,
+          "spread": 0.00494162,
+          "score": 0.005076
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00120684,
-          "spread": 0.00059914,
-          "score": 0.00134738
+          "bias": -1.368e-05,
+          "spread": 0.0016116,
+          "score": 0.00161165
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.0002716,
-          "spread": 0.00131087,
-          "score": 0.00133871
+          "bias": 0.00034032,
+          "spread": 0.00149424,
+          "score": 0.00153251
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00011247,
-          "spread": 0.00222618,
-          "score": 0.00222902
+          "bias": 0.00241135,
+          "spread": 0.00274027,
+          "score": 0.00365016
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.0042254,
-          "spread": 0.00694833,
-          "score": 0.00813224
+          "bias": 0.00895196,
+          "spread": 0.00756889,
+          "score": 0.01172287
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00596332,
-          "spread": 0.029936,
-          "score": 0.03052418
+          "bias": -0.00020575,
+          "spread": 0.02513307,
+          "score": 0.02513392
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.01404276,
-          "spread": 0.01979088,
-          "score": 0.02426681
+          "bias": -0.00508984,
+          "spread": 0.02028697,
+          "score": 0.02091573
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.0263759,
-          "spread": 0.24404182,
-          "score": 0.24546302
+          "bias": 0.03433874,
+          "spread": 0.20101925,
+          "score": 0.20393108
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.10109117,
-          "spread": 0.21007868,
-          "score": 0.23313617
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.01033364,
-          "spread": 0.04805108,
-          "score": 0.04914968
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00130051,
-          "spread": 0.00210059,
-          "score": 0.00247059
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00244984,
-          "spread": 0.00071499,
-          "score": 0.00255204
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00028436,
-          "spread": 0.00135436,
-          "score": 0.00138389
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00056112,
-          "spread": 0.00058382,
-          "score": 0.00080975
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": -0.00094692,
-          "spread": 0.00273808,
-          "score": 0.0028972
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": -0.00421772,
-          "spread": 0.01769555,
-          "score": 0.01819126
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00410416,
-          "spread": 0.00381435,
-          "score": 0.00560298
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": -0.03392907,
-          "spread": 0.0262782,
-          "score": 0.04291533
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": 0.02112563,
+          "bias": -0.06899187,
           "spread": 0.0,
-          "score": 0.02112563
+          "score": 0.06899187
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.00182463,
+          "spread": 0.04351619,
+          "score": 0.04355443
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.00309055,
+          "spread": 0.00206076,
+          "score": 0.0037146
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": -0.00280781,
+          "spread": 0.00106274,
+          "score": 0.0030022
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": -0.00202033,
+          "spread": 0.00168208,
+          "score": 0.0026289
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": -1.691e-05,
+          "spread": 0.00148971,
+          "score": 0.00148981
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00104907,
+          "spread": 0.00031767,
+          "score": 0.00109612
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": 0.0259556,
+          "spread": 0.03825693,
+          "score": 0.04623079
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.00041011,
+          "spread": 0.00384027,
+          "score": 0.00386211
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.02640772,
+          "spread": 0.0287307,
+          "score": 0.03902334
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": 0.0218609,
+          "spread": 0.0,
+          "score": 0.0218609
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": 0.00206693,
+          "spread": 0.00544805,
+          "score": 0.00582695
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.00225662,
+          "spread": 0.00350044,
+          "score": 0.00416478
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.0015277,
+          "spread": 0.00288611,
+          "score": 0.0032655
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00121061,
+          "spread": 0.00280854,
+          "score": 0.00305835
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.00473455,
+          "spread": 0.01275748,
+          "score": 0.01360769
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.00024544,
+          "spread": 0.00342854,
+          "score": 0.00343732
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00315547,
+          "spread": 0.00355455,
+          "score": 0.00475309
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.0013197,
+          "spread": 0.0063632,
+          "score": 0.00649861
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.00033325,
+          "spread": 0.00653759,
+          "score": 0.00654608
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.01034351,
+          "spread": 0.03451992,
+          "score": 0.03603628
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.00593816,
+          "spread": 0.03570934,
+          "score": 0.03619971
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": -0.29447265,
+          "spread": 1.02609238,
+          "score": 1.06751099
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": 0.11658013,
+          "spread": 0.22829912,
+          "score": 0.25634238
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.00401747,
+          "spread": 0.0311949,
+          "score": 0.03145253
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": -0.0042577,
+          "spread": 0.00189585,
+          "score": 0.00466072
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.0050849,
+          "spread": 0.00433343,
+          "score": 0.00668093
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.00170856,
+          "spread": 0.00467986,
+          "score": 0.004982
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00081098,
+          "spread": 0.00304655,
+          "score": 0.00315264
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00613208,
+          "spread": 0.01666068,
+          "score": 0.01775333
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.0093356,
+          "spread": 0.03970162,
+          "score": 0.04078446
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.0339031,
+          "spread": 0.03741861,
+          "score": 0.05049329
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.00344029,
+          "spread": 0.01665698,
+          "score": 0.01700854
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.00042259,
+          "spread": 0.01381494,
+          "score": 0.0138214
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.00599726,
+          "spread": 0.00586877,
+          "score": 0.00839104
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": -0.00103771,
+          "spread": 0.0039199,
+          "score": 0.00405493
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00159675,
+          "spread": 0.00159941,
+          "score": 0.00226003
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.11146397,
+          "spread": 0.0020531,
+          "score": 0.11148288
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": -0.00082087,
+          "spread": 0.01108258,
+          "score": 0.01111294
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.00158943,
+          "spread": 0.00210568,
+          "score": 0.00263821
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00297256,
+          "spread": 0.00167211,
+          "score": 0.00341058
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.00224811,
+          "spread": 0.00269107,
+          "score": 0.00350654
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.00058871,
+          "spread": 0.00912401,
+          "score": 0.00914298
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.00022661,
+          "spread": 0.02410778,
+          "score": 0.02410884
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.05291006,
+          "spread": 0.02872064,
+          "score": 0.06020257
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": -0.01198845,
+          "spread": 0.31514467,
+          "score": 0.31537262
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": 0.50217469,
+          "spread": 0.55824798,
+          "score": 0.75087963
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.00238077,
+          "spread": 0.01747055,
+          "score": 0.01763202
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": -0.00202809,
+          "spread": 0.00086406,
+          "score": 0.00220448
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00529708,
+          "spread": 0.0030194,
+          "score": 0.0060972
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.00171805,
+          "spread": 0.003543,
+          "score": 0.00393758
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00100208,
+          "spread": 0.00298841,
+          "score": 0.00315195
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00194213,
+          "spread": 0.0100076,
+          "score": 0.01019431
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.04097018,
+          "spread": 0.04553616,
+          "score": 0.06125437
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": -0.00799314,
+          "spread": 0.00848274,
+          "score": 0.01165535
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.00204985,
+          "spread": 0.01491195,
+          "score": 0.01505218
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": 0.00250202,
+          "spread": 0.00625161,
+          "score": 0.0067337
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.00111336,
+          "spread": 0.0023054,
+          "score": 0.00256017
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00179594,
+          "spread": 0.00505456,
+          "score": 0.00536414
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00081113,
+          "spread": 0.00309705,
+          "score": 0.00320151
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.07804558,
+          "spread": 0.00500285,
+          "score": 0.07820577
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.00173177,
+          "spread": 0.00395834,
+          "score": 0.00432059
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.00230765,
+          "spread": 0.00332251,
+          "score": 0.00404529
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00123142,
+          "spread": 0.00314702,
+          "score": 0.00337936
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.00414852,
+          "spread": 0.0032523,
+          "score": 0.0052714
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.00178066,
+          "spread": 0.00907519,
+          "score": 0.00924824
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.0122156,
+          "spread": 0.02341671,
+          "score": 0.02641142
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.00437877,
+          "spread": 0.02904062,
+          "score": 0.02936889
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": -0.01631189,
+          "spread": 0.33496535,
+          "score": 0.33536229
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": 0.29719196,
+          "spread": 0.42386597,
+          "score": 0.51767308
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.01297046,
+          "spread": 0.0388513,
+          "score": 0.0409592
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": -0.00462228,
+          "spread": 0.00326265,
+          "score": 0.00565778
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.0049083,
+          "spread": 0.00271268,
+          "score": 0.00560804
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.00054051,
+          "spread": 0.00237523,
+          "score": 0.00243595
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00019911,
+          "spread": 0.00227306,
+          "score": 0.00228177
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00249967,
+          "spread": 0.00823879,
+          "score": 0.00860965
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.02768406,
+          "spread": 0.0384108,
+          "score": 0.04734761
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 7.637e-05,
+          "spread": 0.00770278,
+          "score": 0.00770316
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.02843433,
+          "spread": 0.02712929,
+          "score": 0.03930025
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.00093025,
+          "spread": 0.00453853,
+          "score": 0.00463288
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.00196114,
+          "spread": 0.00326817,
+          "score": 0.00381143
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00178012,
+          "spread": 0.00551318,
+          "score": 0.00579344
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.0007114,
+          "spread": 0.00204054,
+          "score": 0.002161
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.09095575,
+          "spread": 0.03731502,
+          "score": 0.09831256
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.00222906,
+          "spread": 0.0041745,
+          "score": 0.00473235
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.00184345,
+          "spread": 0.002025,
+          "score": 0.00273842
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00034947,
+          "spread": 0.00165995,
+          "score": 0.00169634
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.0014123,
+          "spread": 0.00363389,
+          "score": 0.00389869
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.00175402,
+          "spread": 0.00743767,
+          "score": 0.00764169
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.01018467,
+          "spread": 0.03447203,
+          "score": 0.03594508
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.02123434,
+          "spread": 0.02349354,
+          "score": 0.03166771
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.02134755,
+          "spread": 0.26272593,
+          "score": 0.26359179
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": 0.77356969,
+          "spread": 0.90683004,
+          "score": 1.19195251
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.0145983,
+          "spread": 0.04307451,
+          "score": 0.04548103
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": -0.00365646,
+          "spread": 0.00291061,
+          "score": 0.00467347
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00524243,
+          "spread": 0.001222,
+          "score": 0.00538297
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.00060509,
+          "spread": 0.00173076,
+          "score": 0.00183349
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00084571,
+          "spread": 0.00136063,
+          "score": 0.00160204
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": -0.00201794,
+          "spread": 0.00314113,
+          "score": 0.00373346
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.02523813,
+          "spread": 0.02168216,
+          "score": 0.0332728
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": -0.00684495,
+          "spread": 0.0065901,
+          "score": 0.00950173
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.03684205,
+          "spread": 0.02488448,
+          "score": 0.04445868
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": 0.01966369,
+          "spread": 0.0,
+          "score": 0.01966369
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": 0.00120876,
+          "spread": 0.00703897,
+          "score": 0.007142
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.00333395,
+          "spread": 0.0035245,
+          "score": 0.00485153
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": -0.00065611,
+          "spread": 0.00281451,
+          "score": 0.00288998
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00120459,
+          "spread": 0.0026923,
+          "score": 0.00294949
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.00568382,
+          "spread": 0.01441884,
+          "score": 0.01549867
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": -0.00057672,
+          "spread": 0.00297294,
+          "score": 0.00302836
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00309244,
+          "spread": 0.00367893,
+          "score": 0.004806
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": 0.00020508,
+          "spread": 0.00562009,
+          "score": 0.00562383
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.00048317,
+          "spread": 0.00638995,
+          "score": 0.00640819
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.00830166,
+          "spread": 0.03317083,
+          "score": 0.03419388
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.00236563,
+          "spread": 0.04160784,
+          "score": 0.04167503
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": -0.06206971,
+          "spread": 0.59811644,
+          "score": 0.60132847
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.09928467,
+          "spread": 0.0,
+          "score": 0.09928467
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.00099107,
+          "spread": 0.02444008,
+          "score": 0.02446017
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": -0.0023681,
+          "spread": 0.00163075,
+          "score": 0.00287528
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00179592,
+          "spread": 0.00414975,
+          "score": 0.00452169
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.00050659,
+          "spread": 0.00484936,
+          "score": 0.00487575
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00064342,
+          "spread": 0.00323251,
+          "score": 0.00329593
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00643,
+          "spread": 0.01889766,
+          "score": 0.01996162
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": 0.00493295,
+          "spread": 0.03715663,
+          "score": 0.03748265
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.03641419,
+          "spread": 0.04020115,
+          "score": 0.05424136
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.00430212,
+          "spread": 0.0050145,
+          "score": 0.00660708
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": 0.00014122,
+          "spread": 0.01345156,
+          "score": 0.0134523
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.00529446,
+          "spread": 0.00550365,
+          "score": 0.00763685
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00031739,
+          "spread": 0.00406326,
+          "score": 0.00407563
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00159566,
+          "spread": 0.00152683,
+          "score": 0.00220847
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.10089175,
+          "spread": 0.00707408,
+          "score": 0.10113945
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 9.104e-05,
+          "spread": 0.01071659,
+          "score": 0.01071697
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.00073888,
+          "spread": 0.0018762,
+          "score": 0.00201644
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00295937,
+          "spread": 0.0013182,
+          "score": 0.00323968
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.00075832,
+          "spread": 0.00237365,
+          "score": 0.00249184
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.00096256,
+          "spread": 0.00942542,
+          "score": 0.00947444
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": 0.00239635,
+          "spread": 0.02230495,
+          "score": 0.0224333
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.04297487,
+          "spread": 0.02962661,
+          "score": 0.05219747
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.04595805,
+          "spread": 0.22942933,
+          "score": 0.23398709
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": 0.44628727,
+          "spread": 0.4806987,
+          "score": 0.65592954
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.00384118,
+          "spread": 0.0154718,
+          "score": 0.01594149
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.00028547,
+          "spread": 0.00125365,
+          "score": 0.00128574
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00227952,
+          "spread": 0.00276003,
+          "score": 0.00357966
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.00069349,
+          "spread": 0.00332666,
+          "score": 0.00339818
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00079716,
+          "spread": 0.00290677,
+          "score": 0.00301409
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00245472,
+          "spread": 0.01140957,
+          "score": 0.01167064
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.01888416,
+          "spread": 0.0322112,
+          "score": 0.03733862
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": -0.00493108,
+          "spread": 0.00834994,
+          "score": 0.00969727
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.0076448,
+          "spread": 0.01489584,
+          "score": 0.01674303
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": 0.00251358,
+          "spread": 0.00579438,
+          "score": 0.00631609
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.00081364,
+          "spread": 0.00224615,
+          "score": 0.00238898
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00243023,
+          "spread": 0.00508036,
+          "score": 0.0056317
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00082707,
+          "spread": 0.0029645,
+          "score": 0.00307771
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.09464412,
+          "spread": 0.01686263,
+          "score": 0.09613458
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.00121404,
+          "spread": 0.00433062,
+          "score": 0.00449757
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.0017502,
+          "spread": 0.00303828,
+          "score": 0.00350633
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00105293,
+          "spread": 0.00279625,
+          "score": 0.00298792
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.00241576,
+          "spread": 0.00296183,
+          "score": 0.00382209
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.00395646,
+          "spread": 0.00831741,
+          "score": 0.00921048
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.00813977,
+          "spread": 0.02254002,
+          "score": 0.02396473
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.00830361,
+          "spread": 0.0253812,
+          "score": 0.02670496
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.00626543,
+          "spread": 0.29268315,
+          "score": 0.29275021
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": 0.30091296,
+          "spread": 0.40778147,
+          "score": 0.50678826
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.01183186,
+          "spread": 0.03265736,
+          "score": 0.03473465
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": -0.00228108,
+          "spread": 0.0031096,
+          "score": 0.00385655
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00193254,
+          "spread": 0.00262076,
+          "score": 0.00325624
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": -0.00035568,
+          "spread": 0.00241458,
+          "score": 0.00244063
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 1.246e-05,
+          "spread": 0.0023392,
+          "score": 0.00233924
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00368092,
+          "spread": 0.00895541,
+          "score": 0.00968238
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.00802708,
+          "spread": 0.0241174,
+          "score": 0.02541817
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.00287368,
+          "spread": 0.00712776,
+          "score": 0.00768524
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.02084401,
+          "spread": 0.02700229,
+          "score": 0.03411153
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.0001135,
+          "spread": 0.00410371,
+          "score": 0.00410528
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.00160838,
+          "spread": 0.00316315,
+          "score": 0.00354858
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00247548,
+          "spread": 0.0049846,
+          "score": 0.00556545
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00073587,
+          "spread": 0.00196258,
+          "score": 0.002096
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.08204521,
+          "spread": 0.02037732,
+          "score": 0.08453787
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.00166052,
+          "spread": 0.00445172,
+          "score": 0.00475133
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.00124903,
+          "spread": 0.00179451,
+          "score": 0.0021864
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00031344,
+          "spread": 0.00148767,
+          "score": 0.00152033
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -6.83e-05,
+          "spread": 0.00327283,
+          "score": 0.00327355
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.00427103,
+          "spread": 0.00748742,
+          "score": 0.00861993
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.00588714,
+          "spread": 0.03110804,
+          "score": 0.03166021
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.01400173,
+          "spread": 0.01984795,
+          "score": 0.0242897
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.02611251,
+          "spread": 0.24265865,
+          "score": 0.24405959
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": 0.10098664,
+          "spread": 0.21145607,
+          "score": 0.23433304
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.01029401,
+          "spread": 0.04806528,
+          "score": 0.04915524
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": -0.00125759,
+          "spread": 0.00261358,
+          "score": 0.0029004
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00249085,
+          "spread": 0.00110643,
+          "score": 0.00272553
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": -0.0002438,
+          "spread": 0.00178835,
+          "score": 0.00180489
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00060186,
+          "spread": 0.00138527,
+          "score": 0.00151037
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": -0.00090857,
+          "spread": 0.00203373,
+          "score": 0.00222745
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.00413653,
+          "spread": 0.01930353,
+          "score": 0.01974176
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": -0.00405867,
+          "spread": 0.00517346,
+          "score": 0.00657552
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.03389721,
+          "spread": 0.02619407,
+          "score": 0.04283865
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": 0.02261398,
+          "spread": 0.0,
+          "score": 0.02261398
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.0012678,
-          "spread": 0.00542638,
-          "score": 0.00557251
+          "bias": 0.0013148,
+          "spread": 0.0064396,
+          "score": 0.00657246
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00314362,
-          "spread": 0.00212309,
-          "score": 0.00379339
+          "bias": 0.00318839,
+          "spread": 0.003452,
+          "score": 0.00469916
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 2.313e-05,
-          "spread": 0.00316259,
-          "score": 0.00316267
+          "bias": 6.366e-05,
+          "spread": 0.00297597,
+          "score": 0.00297665
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.0036029,
-          "spread": 0.00067607,
-          "score": 0.00366578
+          "bias": 0.0012303,
+          "spread": 0.002687,
+          "score": 0.00295527
         },
         {
           "profile": "rated_plus_5pct",
@@ -8059,162 +8059,162 @@
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.0071486,
-          "spread": 0.01579317,
-          "score": 0.01733571
+          "bias": 0.00613964,
+          "spread": 0.01691636,
+          "score": 0.01799607
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00024939,
-          "spread": 0.00225042,
-          "score": 0.0022642
+          "bias": -0.00159541,
+          "spread": 0.00263069,
+          "score": 0.00307666
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00569997,
-          "spread": 0.00134637,
-          "score": 0.00585682
+          "bias": 0.00302714,
+          "spread": 0.00393125,
+          "score": 0.00496168
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00490635,
-          "spread": 0.00270714,
-          "score": 0.00560365
+          "bias": 0.00212517,
+          "spread": 0.00590503,
+          "score": 0.0062758
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00475207,
-          "spread": 0.00396534,
-          "score": 0.00618919
+          "bias": 0.00454426,
+          "spread": 0.00720051,
+          "score": 0.00851455
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.0032848,
-          "spread": 0.03213677,
-          "score": 0.03230421
+          "bias": -0.00575299,
+          "spread": 0.03610477,
+          "score": 0.03656024
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.02308009,
-          "spread": 0.04877907,
-          "score": 0.05396377
+          "bias": 0.00946351,
+          "spread": 0.03522423,
+          "score": 0.03647333
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.11362029,
-          "spread": 0.5630428,
-          "score": 0.57439252
+          "bias": -0.00053258,
+          "spread": 0.39204871,
+          "score": 0.39204907
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.15468446,
+          "bias": -0.10828005,
           "spread": 0.0,
-          "score": 0.15468446
+          "score": 0.10828005
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.01279891,
-          "spread": 0.01378319,
-          "score": 0.01880926
+          "bias": 0.00551676,
+          "spread": 0.02172343,
+          "score": 0.02241299
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00213989,
-          "spread": 0.00228155,
-          "score": 0.00312804
+          "bias": 1.17e-05,
+          "spread": 0.00219428,
+          "score": 0.00219431
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00026219,
-          "spread": 0.00082123,
-          "score": 0.00086207
+          "bias": -0.00161371,
+          "spread": 0.00394566,
+          "score": 0.00426289
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00089742,
-          "spread": 0.00191161,
-          "score": 0.00211178
+          "bias": -0.00076736,
+          "spread": 0.00483709,
+          "score": 0.00489758
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00194409,
-          "spread": 0.00152688,
-          "score": 0.00247201
+          "bias": -9.226e-05,
+          "spread": 0.00295211,
+          "score": 0.00295355
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00462914,
-          "spread": 0.02077839,
-          "score": 0.0212878
+          "bias": 0.00689739,
+          "spread": 0.02187686,
+          "score": 0.02293842
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.01578187,
-          "spread": 0.03684477,
-          "score": 0.04008247
+          "bias": 0.01198408,
+          "spread": 0.03834997,
+          "score": 0.04017883
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.0707332,
-          "spread": 0.07172836,
-          "score": 0.100738
+          "bias": 0.04864124,
+          "spread": 0.05432731,
+          "score": 0.07292069
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.00891818,
-          "spread": 0.0150698,
-          "score": 0.01751093
+          "bias": -0.00191786,
+          "spread": 0.00337996,
+          "score": 0.00388617
         },
         {
           "profile": "rated_plus_5pct",
@@ -8230,207 +8230,207 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00447566,
-          "spread": 0.00902007,
-          "score": 0.01006942
+          "bias": -0.00020032,
+          "spread": 0.013886,
+          "score": 0.01388744
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00772525,
-          "spread": 0.00376801,
-          "score": 0.00859519
+          "bias": 0.0048885,
+          "spread": 0.00533548,
+          "score": 0.00723634
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00437401,
-          "spread": 0.00472589,
-          "score": 0.00643941
+          "bias": 0.0011976,
+          "spread": 0.00398907,
+          "score": 0.00416497
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00114936,
-          "spread": 0.00142739,
-          "score": 0.00183262
+          "bias": 0.00163763,
+          "spread": 0.00152069,
+          "score": 0.0022348
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.09899347,
-          "spread": 0.00298228,
-          "score": 0.09903838
+          "bias": 0.10209498,
+          "spread": 0.00179726,
+          "score": 0.1021108
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.0010332,
-          "spread": 0.01085735,
-          "score": 0.0109064
+          "bias": 0.00144095,
+          "spread": 0.01180194,
+          "score": 0.01188958
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00068341,
-          "spread": 0.00181952,
-          "score": 0.00194363
+          "bias": 2.862e-05,
+          "spread": 0.00155397,
+          "score": 0.00155423
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00269546,
-          "spread": 0.00127051,
-          "score": 0.00297989
+          "bias": 0.00312091,
+          "spread": 0.00129969,
+          "score": 0.00338072
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -4.051e-05,
-          "spread": 0.0018331,
-          "score": 0.00183354
+          "bias": 0.00024354,
+          "spread": 0.00239051,
+          "score": 0.00240289
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00541758,
-          "spread": 0.00719913,
-          "score": 0.00900986
+          "bias": 0.00342355,
+          "spread": 0.01011774,
+          "score": 0.01068126
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00281462,
-          "spread": 0.01904896,
-          "score": 0.01925578
+          "bias": 0.00296896,
+          "spread": 0.01965336,
+          "score": 0.01987635
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.02649286,
-          "spread": 0.03414651,
-          "score": 0.0432187
+          "bias": -0.03597145,
+          "spread": 0.02994047,
+          "score": 0.04680146
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.07634972,
-          "spread": 0.19149148,
-          "score": 0.20615108
+          "bias": 0.07633722,
+          "spread": 0.19293731,
+          "score": 0.20749018
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.4127347,
-          "spread": 0.4266298,
-          "score": 0.59360165
+          "bias": 0.41376096,
+          "spread": 0.42526041,
+          "score": 0.59333342
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.00560567,
-          "spread": 0.01622846,
-          "score": 0.01716935
+          "bias": 0.00458479,
+          "spread": 0.01530433,
+          "score": 0.01597632
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.0016346,
-          "spread": 0.00307652,
-          "score": 0.0034838
+          "bias": 0.00267053,
+          "spread": 0.00193623,
+          "score": 0.00329859
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00221194,
-          "spread": 0.00144375,
-          "score": 0.00264142
+          "bias": -0.00142163,
+          "spread": 0.00267756,
+          "score": 0.00303156
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00100813,
-          "spread": 0.00193666,
-          "score": 0.00218334
+          "bias": -0.00033037,
+          "spread": 0.00339094,
+          "score": 0.003407
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -6.676e-05,
-          "spread": 0.00094238,
-          "score": 0.00094474
+          "bias": 0.00056965,
+          "spread": 0.00294989,
+          "score": 0.00300439
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00266549,
-          "spread": 0.01196121,
-          "score": 0.01225461
+          "bias": 0.00251824,
+          "spread": 0.01339707,
+          "score": 0.0136317
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.00303815,
-          "spread": 0.02577282,
-          "score": 0.02595127
+          "bias": -0.00479478,
+          "spread": 0.02677063,
+          "score": 0.02719663
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00387547,
-          "spread": 0.00954827,
-          "score": 0.01030479
+          "bias": -0.00220916,
+          "spread": 0.01172252,
+          "score": 0.01192887
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.02074172,
-          "spread": 0.01433024,
-          "score": 0.02521061
+          "bias": 0.01937098,
+          "spread": 0.0155,
+          "score": 0.02480897
         },
         {
           "profile": "rated_plus_5pct",
@@ -8446,207 +8446,207 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00274471,
-          "spread": 0.00515089,
-          "score": 0.00583654
+          "bias": 0.00302993,
+          "spread": 0.00542285,
+          "score": 0.00621191
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00068893,
-          "spread": 0.00282264,
-          "score": 0.0029055
+          "bias": 0.00043449,
+          "spread": 0.00244954,
+          "score": 0.00248777
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00312196,
-          "spread": 0.00446801,
-          "score": 0.00545067
+          "bias": 0.00330229,
+          "spread": 0.00482894,
+          "score": 0.00585011
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00103646,
-          "spread": 0.0017218,
-          "score": 0.00200968
+          "bias": 0.00085924,
+          "spread": 0.00295323,
+          "score": 0.00307568
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.08293762,
-          "spread": 0.00869238,
-          "score": 0.08339188
+          "bias": 0.08439007,
+          "spread": 0.00800548,
+          "score": 0.08476893
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.0011088,
-          "spread": 0.00420478,
-          "score": 0.00434852
+          "bias": 0.00093233,
+          "spread": 0.0047296,
+          "score": 0.00482062
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00143916,
-          "spread": 0.00169173,
-          "score": 0.00222107
+          "bias": 0.00125973,
+          "spread": 0.00273224,
+          "score": 0.00300866
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00119311,
-          "spread": 0.00164098,
-          "score": 0.00202887
+          "bias": 0.00101427,
+          "spread": 0.00268948,
+          "score": 0.00287438
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00085776,
-          "spread": 0.00161737,
-          "score": 0.00183075
+          "bias": -0.00103194,
+          "spread": 0.00301763,
+          "score": 0.0031892
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00555284,
-          "spread": 0.00707597,
-          "score": 0.00899463
+          "bias": 0.0053873,
+          "spread": 0.00857751,
+          "score": 0.010129
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00312761,
-          "spread": 0.02198199,
-          "score": 0.02220338
+          "bias": -0.00328094,
+          "spread": 0.02290049,
+          "score": 0.02313432
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.01207662,
-          "spread": 0.02175073,
-          "score": 0.02487848
+          "bias": 0.01191189,
+          "spread": 0.02227956,
+          "score": 0.02526404
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.02483164,
-          "spread": 0.27296511,
-          "score": 0.27409225
+          "bias": 0.02463647,
+          "spread": 0.27310314,
+          "score": 0.27421211
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.34000828,
-          "spread": 0.44275786,
-          "score": 0.5582474
+          "bias": 0.34017394,
+          "spread": 0.44384245,
+          "score": 0.55920875
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.01668154,
-          "spread": 0.03254351,
-          "score": 0.03656985
+          "bias": -0.01685283,
+          "spread": 0.03250622,
+          "score": 0.03661519
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00066713,
-          "spread": 0.0021361,
-          "score": 0.00223785
+          "bias": 0.00049099,
+          "spread": 0.00279779,
+          "score": 0.00284055
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00116379,
-          "spread": 0.0011578,
-          "score": 0.00164162
+          "bias": -0.00134366,
+          "spread": 0.00248007,
+          "score": 0.00282067
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00110647,
-          "spread": 0.00154252,
-          "score": 0.00189832
+          "bias": -0.00128734,
+          "spread": 0.00243303,
+          "score": 0.00275261
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 3.127e-05,
-          "spread": 0.0012065,
-          "score": 0.0012069
+          "bias": -0.00014919,
+          "spread": 0.00261928,
+          "score": 0.00262352
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00487515,
-          "spread": 0.00864157,
-          "score": 0.00992188
+          "bias": 0.0047038,
+          "spread": 0.01006135,
+          "score": 0.0111066
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.00560242,
-          "spread": 0.02284528,
-          "score": 0.0235222
+          "bias": 0.00546175,
+          "spread": 0.02433036,
+          "score": 0.02493586
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.005961,
-          "spread": 0.00680963,
-          "score": 0.00905012
+          "bias": 0.0057854,
+          "spread": 0.00815707,
+          "score": 0.01000043
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.01195817,
-          "spread": 0.02692545,
-          "score": 0.02946146
+          "bias": -0.01368531,
+          "spread": 0.02756993,
+          "score": 0.03077968
         },
         {
           "profile": "rated_plus_5pct",
@@ -8662,252 +8662,252 @@
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00022167,
-          "spread": 0.00409139,
-          "score": 0.00409739
+          "bias": 4.716e-05,
+          "spread": 0.00402269,
+          "score": 0.00402297
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.0013892,
-          "spread": 0.00243008,
-          "score": 0.00279914
+          "bias": 0.00121698,
+          "spread": 0.00322126,
+          "score": 0.00344348
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.0032013,
-          "spread": 0.0041212,
-          "score": 0.00521849
+          "bias": 0.00303067,
+          "spread": 0.00504221,
+          "score": 0.00588293
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00073809,
-          "spread": 0.00109957,
-          "score": 0.00132432
+          "bias": 0.0007798,
+          "spread": 0.00196679,
+          "score": 0.00211574
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.08040743,
-          "spread": 0.01900135,
-          "score": 0.08262207
+          "bias": 0.08212557,
+          "spread": 0.01888166,
+          "score": 0.08426818
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00140933,
-          "spread": 0.00431096,
-          "score": 0.00453548
+          "bias": 0.00145392,
+          "spread": 0.00490347,
+          "score": 0.00511448
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00042395,
-          "spread": 0.00086685,
-          "score": 0.00096497
+          "bias": 0.00046556,
+          "spread": 0.00176154,
+          "score": 0.00182202
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00028067,
-          "spread": 0.00096039,
-          "score": 0.00100056
+          "bias": 0.00032039,
+          "spread": 0.00151176,
+          "score": 0.00154534
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00164751,
-          "spread": 0.00190365,
-          "score": 0.00251758
+          "bias": 0.00168986,
+          "spread": 0.00306427,
+          "score": 0.00349933
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00757962,
-          "spread": 0.00720035,
-          "score": 0.01045446
+          "bias": 0.0076231,
+          "spread": 0.00773214,
+          "score": 0.01085806
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00307202,
-          "spread": 0.02839799,
-          "score": 0.02856366
+          "bias": -0.00299903,
+          "spread": 0.0295204,
+          "score": 0.02967235
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.01017272,
-          "spread": 0.0209626,
-          "score": 0.02330053
+          "bias": -0.01013287,
+          "spread": 0.0210317,
+          "score": 0.0233454
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.03370273,
-          "spread": 0.23271487,
-          "score": 0.23514269
+          "bias": 0.03345576,
+          "spread": 0.231398,
+          "score": 0.23380403
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.17295861,
-          "spread": 0.07605068,
-          "score": 0.18894017
+          "bias": -0.17312558,
+          "spread": 0.07479184,
+          "score": 0.18859026
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.01248889,
-          "spread": 0.04058834,
-          "score": 0.04246629
+          "bias": -0.01245076,
+          "spread": 0.04057237,
+          "score": 0.04243982
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00136395,
-          "spread": 0.00185853,
-          "score": 0.00230532
+          "bias": 0.00140392,
+          "spread": 0.00244768,
+          "score": 0.00282173
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00073628,
-          "spread": 0.00050432,
-          "score": 0.00089244
+          "bias": -0.00069503,
+          "spread": 0.00117728,
+          "score": 0.00136714
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.0012977,
-          "spread": 0.00130579,
-          "score": 0.00184096
+          "bias": -0.001255,
+          "spread": 0.00189447,
+          "score": 0.00227245
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00021134,
-          "spread": 0.00045057,
-          "score": 0.00049768
+          "bias": 0.00025434,
+          "spread": 0.00165491,
+          "score": 0.00167434
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00018673,
-          "spread": 0.00183709,
-          "score": 0.00184656
+          "bias": 0.00022721,
+          "spread": 0.00103569,
+          "score": 0.00106032
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.00355508,
-          "spread": 0.01957797,
-          "score": 0.01989813
+          "bias": 0.00362554,
+          "spread": 0.02108109,
+          "score": 0.02139058
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00183231,
-          "spread": 0.00304883,
-          "score": 0.00355707
+          "bias": -0.00178469,
+          "spread": 0.00448285,
+          "score": 0.00482505
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.03097349,
-          "spread": 0.02920934,
-          "score": 0.04257397
+          "bias": -0.03093919,
+          "spread": 0.02884183,
+          "score": 0.04229758
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
-          "bias": 0.02170118,
+          "bias": 0.02325312,
           "spread": 0.0,
-          "score": 0.02170118
+          "score": 0.02325312
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.0016347,
-          "spread": 0.00511423,
-          "score": 0.00536913
+          "bias": 0.00168026,
+          "spread": 0.00611056,
+          "score": 0.00633737
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00286918,
-          "spread": 0.00218853,
-          "score": 0.00360859
+          "bias": 0.00291301,
+          "spread": 0.00353345,
+          "score": 0.0045794
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00090171,
-          "spread": 0.00344586,
-          "score": 0.00356188
+          "bias": 0.0009405,
+          "spread": 0.00311306,
+          "score": 0.00325202
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00363978,
-          "spread": 0.00066556,
-          "score": 0.00370013
+          "bias": 0.00122045,
+          "spread": 0.00275774,
+          "score": 0.00301573
         },
         {
           "profile": "ti_dependent_cp",
@@ -8923,162 +8923,162 @@
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00366757,
-          "spread": 0.01233397,
-          "score": 0.0128677
+          "bias": 0.00187813,
+          "spread": 0.01285611,
+          "score": 0.01299258
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00037565,
-          "spread": 0.00281742,
-          "score": 0.00284235
+          "bias": -0.00247275,
+          "spread": 0.00314501,
+          "score": 0.0040007
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00501286,
-          "spread": 0.00152132,
-          "score": 0.00523863
+          "bias": 0.00246429,
+          "spread": 0.00387779,
+          "score": 0.00459456
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00627364,
-          "spread": 0.00305591,
-          "score": 0.00697833
+          "bias": 0.00369595,
+          "spread": 0.00656919,
+          "score": 0.00753753
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01588502,
-          "spread": 0.00408924,
-          "score": 0.01640291
+          "bias": 0.01273498,
+          "spread": 0.00610347,
+          "score": 0.01412204
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.01658354,
-          "spread": 0.02928562,
-          "score": 0.03365504
+          "bias": 0.0076315,
+          "spread": 0.02985877,
+          "score": 0.0308186
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.04674347,
-          "spread": 0.06259371,
-          "score": 0.07812122
+          "bias": 0.02423643,
+          "spread": 0.04222742,
+          "score": 0.04868839
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.14735105,
-          "spread": 0.59027563,
-          "score": 0.60838939
+          "bias": 0.0603413,
+          "spread": 0.43575083,
+          "score": 0.43990892
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.16336723,
+          "bias": -0.11961518,
           "spread": 0.0,
-          "score": 0.16336723
+          "score": 0.11961518
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.01140363,
-          "spread": 0.01375527,
-          "score": 0.01786758
+          "bias": 0.00027117,
+          "spread": 0.02296886,
+          "score": 0.02297046
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00129853,
-          "spread": 0.00173028,
-          "score": 0.00216334
+          "bias": -0.00370311,
+          "spread": 0.00191249,
+          "score": 0.00416781
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00438535,
-          "spread": 0.00113884,
-          "score": 0.00453081
+          "bias": 0.00337162,
+          "spread": 0.00436782,
+          "score": 0.00551776
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.0023909,
-          "spread": 0.00264133,
-          "score": 0.00356273
+          "bias": 0.0010778,
+          "spread": 0.00481494,
+          "score": 0.0049341
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00292662,
-          "spread": 0.00205555,
-          "score": 0.00357636
+          "bias": 0.00086539,
+          "spread": 0.00322631,
+          "score": 0.00334035
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00488492,
-          "spread": 0.01628827,
-          "score": 0.01700501
+          "bias": 0.00705901,
+          "spread": 0.01848854,
+          "score": 0.0197903
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.01903327,
-          "spread": 0.04013033,
-          "score": 0.04441519
+          "bias": 0.00839481,
+          "spread": 0.03729743,
+          "score": 0.03823049
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.05574664,
-          "spread": 0.05388378,
-          "score": 0.07753161
+          "bias": 0.03572332,
+          "spread": 0.03834232,
+          "score": 0.05240505
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.01280956,
-          "spread": 0.00174622,
-          "score": 0.01292804
+          "bias": -0.00543786,
+          "spread": 0.01010305,
+          "score": 0.01147353
         },
         {
           "profile": "ti_dependent_cp",
@@ -9094,207 +9094,207 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00556406,
-          "spread": 0.00938034,
-          "score": 0.0109064
+          "bias": 0.00086006,
+          "spread": 0.0131914,
+          "score": 0.01321941
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00884016,
-          "spread": 0.00373449,
-          "score": 0.00959661
+          "bias": 0.00547776,
+          "spread": 0.00555992,
+          "score": 0.00780504
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00299941,
-          "spread": 0.00484759,
-          "score": 0.00570049
+          "bias": -0.00017414,
+          "spread": 0.00397383,
+          "score": 0.00397765
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00109261,
-          "spread": 0.0014559,
-          "score": 0.00182029
+          "bias": 0.00159932,
+          "spread": 0.00156926,
+          "score": 0.00224063
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.08827774,
-          "spread": 0.00840027,
-          "score": 0.08867651
+          "bias": 0.09269036,
+          "spread": 0.010733,
+          "score": 0.0933097
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00393302,
-          "spread": 0.01065345,
-          "score": 0.01135626
+          "bias": -0.00402936,
+          "spread": 0.01181393,
+          "score": 0.01248217
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00204594,
-          "spread": 0.00152544,
-          "score": 0.00255202
+          "bias": -0.00122873,
+          "spread": 0.00228812,
+          "score": 0.00259717
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00200169,
-          "spread": 0.00170446,
-          "score": 0.00262906
+          "bias": 0.0024145,
+          "spread": 0.00126437,
+          "score": 0.00272551
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00262023,
-          "spread": 0.00181137,
-          "score": 0.00318538
+          "bias": 0.00287457,
+          "spread": 0.00262243,
+          "score": 0.00389106
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01409662,
-          "spread": 0.00628938,
-          "score": 0.01543603
+          "bias": 0.01290354,
+          "spread": 0.00813604,
+          "score": 0.0152544
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.0219969,
-          "spread": 0.02420922,
-          "score": 0.03271009
+          "bias": 0.0205319,
+          "spread": 0.0225185,
+          "score": 0.03047362
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.01108995,
-          "spread": 0.03069239,
-          "score": 0.03263449
+          "bias": -0.01748412,
+          "spread": 0.02724376,
+          "score": 0.03237154
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.08203692,
-          "spread": 0.19257586,
-          "score": 0.20932156
+          "bias": 0.08202518,
+          "spread": 0.19403483,
+          "score": 0.21066002
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.45095289,
-          "spread": 0.48826882,
-          "score": 0.664654
+          "bias": 0.42277493,
+          "spread": 0.51608502,
+          "score": 0.66714495
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.00304666,
-          "spread": 0.01770408,
-          "score": 0.01796431
+          "bias": -0.00121671,
+          "spread": 0.01832729,
+          "score": 0.01836763
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00231478,
-          "spread": 0.00298008,
-          "score": 0.00377347
+          "bias": -0.00127139,
+          "spread": 0.00093914,
+          "score": 0.00158064
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.0024317,
-          "spread": 0.00154558,
-          "score": 0.00288132
+          "bias": 0.00333313,
+          "spread": 0.00305168,
+          "score": 0.00451913
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00064029,
-          "spread": 0.00241594,
-          "score": 0.00249935
+          "bias": 0.00107015,
+          "spread": 0.00335611,
+          "score": 0.00352259
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00038845,
-          "spread": 0.00164638,
-          "score": 0.00169158
+          "bias": 0.00081757,
+          "spread": 0.00282891,
+          "score": 0.00294469
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00226417,
-          "spread": 0.01018708,
-          "score": 0.01043566
+          "bias": 0.00209983,
+          "spread": 0.01157752,
+          "score": 0.01176641
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.01136741,
-          "spread": 0.02981023,
-          "score": 0.03190404
+          "bias": -0.01220541,
+          "spread": 0.03144846,
+          "score": 0.03373393
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00893693,
-          "spread": 0.00556757,
-          "score": 0.01052932
+          "bias": -0.00747142,
+          "spread": 0.00891264,
+          "score": 0.01163001
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.00195192,
-          "spread": 0.01372285,
-          "score": 0.01386098
+          "bias": 0.00064431,
+          "spread": 0.0148386,
+          "score": 0.01485258
         },
         {
           "profile": "ti_dependent_cp",
@@ -9310,207 +9310,207 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00304627,
-          "spread": 0.00564417,
-          "score": 0.00641377
+          "bias": 0.00326725,
+          "spread": 0.00580136,
+          "score": 0.00665813
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00136255,
-          "spread": 0.0025871,
-          "score": 0.00292398
+          "bias": 0.00102746,
+          "spread": 0.00236327,
+          "score": 0.00257696
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00221476,
-          "spread": 0.00475265,
-          "score": 0.00524336
+          "bias": 0.00249741,
+          "spread": 0.00501341,
+          "score": 0.00560101
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00099963,
-          "spread": 0.00176087,
-          "score": 0.00202483
+          "bias": 0.000826,
+          "spread": 0.00303087,
+          "score": 0.00314141
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.0825368,
-          "spread": 0.01044052,
-          "score": 0.08319452
+          "bias": 0.08413914,
+          "spread": 0.00967625,
+          "score": 0.08469371
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00111444,
-          "spread": 0.0037374,
-          "score": 0.00390002
+          "bias": -0.00129518,
+          "spread": 0.00409997,
+          "score": 0.00429968
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 5.733e-05,
-          "spread": 0.00163006,
-          "score": 0.00163107
+          "bias": -0.00011563,
+          "spread": 0.00310711,
+          "score": 0.00310926
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00067846,
-          "spread": 0.00190078,
-          "score": 0.00201824
+          "bias": 0.00050397,
+          "spread": 0.00270077,
+          "score": 0.00274739
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00124029,
-          "spread": 0.00142271,
-          "score": 0.00188744
+          "bias": 0.00106591,
+          "spread": 0.00307979,
+          "score": 0.00325903
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01564129,
-          "spread": 0.00811922,
-          "score": 0.01762304
+          "bias": 0.01547524,
+          "spread": 0.0096066,
+          "score": 0.01821455
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.01046737,
-          "spread": 0.02045732,
-          "score": 0.02297973
+          "bias": 0.01031209,
+          "spread": 0.02143816,
+          "score": 0.02378937
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.02862514,
-          "spread": 0.02462979,
-          "score": 0.03776275
+          "bias": 0.02846177,
+          "spread": 0.02523525,
+          "score": 0.03803801
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.02903013,
-          "spread": 0.28080166,
-          "score": 0.28229828
+          "bias": 0.02883146,
+          "spread": 0.28093759,
+          "score": 0.28241314
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.04751063,
-          "spread": 0.13203447,
-          "score": 0.14032235
+          "bias": 0.04745616,
+          "spread": 0.13291756,
+          "score": 0.14113528
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.01798337,
-          "spread": 0.0364784,
-          "score": 0.04067032
+          "bias": -0.0181461,
+          "spread": 0.03665445,
+          "score": 0.04090024
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00367183,
-          "spread": 0.00257114,
-          "score": 0.00448253
+          "bias": -0.00384865,
+          "spread": 0.00310601,
+          "score": 0.00494564
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00310985,
-          "spread": 0.0014437,
-          "score": 0.00342862
+          "bias": 0.00293751,
+          "spread": 0.00261875,
+          "score": 0.00393533
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 5.159e-05,
-          "spread": 0.00160338,
-          "score": 0.00160421
+          "bias": -0.00012042,
+          "spread": 0.00251841,
+          "score": 0.00252129
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00012521,
-          "spread": 0.00129603,
-          "score": 0.00130207
+          "bias": -4.666e-05,
+          "spread": 0.00230259,
+          "score": 0.00230306
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00341012,
-          "spread": 0.0074704,
-          "score": 0.00821193
+          "bias": 0.00324726,
+          "spread": 0.00892721,
+          "score": 0.00949947
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.00416722,
-          "spread": 0.02410842,
-          "score": 0.02446593
+          "bias": -0.0043128,
+          "spread": 0.02530655,
+          "score": 0.02567142
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00139649,
-          "spread": 0.00659496,
-          "score": 0.00674119
+          "bias": 0.00122874,
+          "spread": 0.00723177,
+          "score": 0.00733542
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.02522038,
-          "spread": 0.02712807,
-          "score": 0.03704051
+          "bias": -0.02686958,
+          "spread": 0.02773794,
+          "score": 0.03861823
         },
         {
           "profile": "ti_dependent_cp",
@@ -9526,252 +9526,252 @@
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00060731,
-          "spread": 0.00399776,
-          "score": 0.00404362
+          "bias": 0.00042516,
+          "spread": 0.00401098,
+          "score": 0.00403345
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00238153,
-          "spread": 0.00226263,
-          "score": 0.003285
+          "bias": 0.00220056,
+          "spread": 0.00305818,
+          "score": 0.00376762
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00263557,
-          "spread": 0.00416745,
-          "score": 0.00493091
+          "bias": 0.00245736,
+          "spread": 0.00532151,
+          "score": 0.00586149
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00068439,
-          "spread": 0.00110226,
-          "score": 0.00129745
+          "bias": 0.00072866,
+          "spread": 0.00200404,
+          "score": 0.0021324
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.07004853,
-          "spread": 0.01472308,
-          "score": 0.07157909
+          "bias": 0.07192394,
+          "spread": 0.01457023,
+          "score": 0.07338491
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00114898,
-          "spread": 0.00395162,
-          "score": 0.00411528
+          "bias": -0.00110792,
+          "spread": 0.00424903,
+          "score": 0.0043911
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00042458,
-          "spread": 0.00043249,
-          "score": 0.00060607
+          "bias": -0.00038049,
+          "spread": 0.00201224,
+          "score": 0.0020479
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00031275,
-          "spread": 0.00134312,
-          "score": 0.00137906
+          "bias": -0.0002689,
+          "spread": 0.00150885,
+          "score": 0.00153263
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00328782,
-          "spread": 0.00193914,
-          "score": 0.00381707
+          "bias": 0.00333324,
+          "spread": 0.00321445,
+          "score": 0.00463068
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01501978,
-          "spread": 0.00778789,
-          "score": 0.01691878
+          "bias": 0.01506503,
+          "spread": 0.00830582,
+          "score": 0.01720295
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.01091874,
-          "spread": 0.02912557,
-          "score": 0.03110494
+          "bias": 0.01099324,
+          "spread": 0.03027509,
+          "score": 0.0322092
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.00265888,
-          "spread": 0.02031973,
-          "score": 0.02049295
+          "bias": 0.00270023,
+          "spread": 0.02041329,
+          "score": 0.0205911
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.04013684,
-          "spread": 0.23370496,
-          "score": 0.23712649
+          "bias": 0.0398841,
+          "spread": 0.23236472,
+          "score": 0.23576281
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.1896474,
-          "spread": 0.10767137,
-          "score": 0.21808086
+          "bias": -0.18986124,
+          "spread": 0.1064359,
+          "score": 0.21766003
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.0076086,
-          "spread": 0.04059166,
-          "score": 0.0412986
+          "bias": -0.0075608,
+          "spread": 0.04077859,
+          "score": 0.0414736
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00281582,
-          "spread": 0.00226233,
-          "score": 0.00361206
+          "bias": -0.00276954,
+          "spread": 0.00266045,
+          "score": 0.00384036
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00354242,
-          "spread": 0.00068489,
-          "score": 0.00360802
+          "bias": 0.00358494,
+          "spread": 0.00135435,
+          "score": 0.00383224
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -5.9e-06,
-          "spread": 0.00124785,
-          "score": 0.00124787
+          "bias": 3.498e-05,
+          "spread": 0.00187847,
+          "score": 0.00187879
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00064246,
-          "spread": 0.00061111,
-          "score": 0.00088669
+          "bias": 0.00068326,
+          "spread": 0.00146395,
+          "score": 0.00161555
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": -0.00124238,
-          "spread": 0.00310465,
-          "score": 0.00334401
+          "bias": -0.00120404,
+          "spread": 0.00247008,
+          "score": 0.00274791
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.00086785,
-          "spread": 0.01901529,
-          "score": 0.01903508
+          "bias": -0.0007804,
+          "spread": 0.02061688,
+          "score": 0.02063165
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00600519,
-          "spread": 0.00441064,
-          "score": 0.00745091
+          "bias": -0.00596086,
+          "spread": 0.00558856,
+          "score": 0.00817091
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.03512766,
-          "spread": 0.02551048,
-          "score": 0.04341356
+          "bias": -0.03509673,
+          "spread": 0.02559304,
+          "score": 0.04343713
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
-          "bias": 0.01873546,
+          "bias": 0.02022686,
           "spread": 0.0,
-          "score": 0.01873546
+          "score": 0.02022686
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00192415,
-          "spread": 0.0054627,
-          "score": 0.00579167
+          "bias": 0.00197503,
+          "spread": 0.00651164,
+          "score": 0.00680457
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00348283,
-          "spread": 0.00211255,
-          "score": 0.00407344
+          "bias": 0.00353055,
+          "spread": 0.00346417,
+          "score": 0.00494624
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00010438,
-          "spread": 0.00303115,
-          "score": 0.00303295
+          "bias": -6.051e-05,
+          "spread": 0.00282089,
+          "score": 0.00282154
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00362961,
-          "spread": 0.00068049,
-          "score": 0.00369285
+          "bias": 0.0012247,
+          "spread": 0.00271694,
+          "score": 0.00298022
         },
         {
           "profile": "ws_dependent_cp",
@@ -9787,162 +9787,162 @@
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00869716,
-          "spread": 0.01320598,
-          "score": 0.0158126
+          "bias": 0.00630948,
+          "spread": 0.01315801,
+          "score": 0.01459256
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00140191,
-          "spread": 0.00275197,
-          "score": 0.00308848
+          "bias": -0.00032353,
+          "spread": 0.00296487,
+          "score": 0.00298247
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00600113,
-          "spread": 0.00134126,
-          "score": 0.0061492
+          "bias": 0.00340417,
+          "spread": 0.00372005,
+          "score": 0.00504254
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00208679,
-          "spread": 0.00222151,
-          "score": 0.00304792
+          "bias": -0.00099969,
+          "spread": 0.00557448,
+          "score": 0.00566341
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00218279,
-          "spread": 0.00509531,
-          "score": 0.00554318
+          "bias": -4.55e-05,
+          "spread": 0.00636031,
+          "score": 0.00636047
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00634239,
-          "spread": 0.0323985,
-          "score": 0.03301346
+          "bias": -0.01300143,
+          "spread": 0.03584837,
+          "score": 0.03813322
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.00385045,
-          "spread": 0.0585123,
-          "score": 0.05863885
+          "bias": -0.01964863,
+          "spread": 0.03965161,
+          "score": 0.0442529
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": -0.22979992,
-          "spread": 1.09816439,
-          "score": 1.12195055
+          "bias": -0.30514082,
+          "spread": 1.02500856,
+          "score": 1.0694641
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.05406184,
-          "spread": 0.25394169,
-          "score": 0.25963256
+          "bias": 0.09900704,
+          "spread": 0.20800891,
+          "score": 0.23036948
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.0070811,
-          "spread": 0.01284086,
-          "score": 0.01466389
+          "bias": 0.00193669,
+          "spread": 0.0313592,
+          "score": 0.03141895
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.0023388,
-          "spread": 0.00190277,
-          "score": 0.00301504
+          "bias": 8.892e-05,
+          "spread": 0.00182597,
+          "score": 0.00182813
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00301613,
-          "spread": 0.00113894,
-          "score": 0.00322401
+          "bias": 0.00180682,
+          "spread": 0.00413102,
+          "score": 0.00450887
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00207617,
-          "spread": 0.00228876,
-          "score": 0.00309013
+          "bias": 0.00066499,
+          "spread": 0.00496726,
+          "score": 0.00501158
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00299653,
-          "spread": 0.00178742,
-          "score": 0.00348914
+          "bias": 0.00117596,
+          "spread": 0.00307489,
+          "score": 0.00329209
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00579755,
-          "spread": 0.01719157,
-          "score": 0.01814281
+          "bias": 0.00694375,
+          "spread": 0.01972137,
+          "score": 0.02090809
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.0038476,
-          "spread": 0.0385015,
-          "score": 0.03869327
+          "bias": -0.00872773,
+          "spread": 0.0402743,
+          "score": 0.04120913
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.06609374,
-          "spread": 0.06530208,
-          "score": 0.09291256
+          "bias": 0.04211897,
+          "spread": 0.04580409,
+          "score": 0.06222558
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.00683944,
-          "spread": 0.00661462,
-          "score": 0.00951479
+          "bias": -0.00164309,
+          "spread": 0.00305397,
+          "score": 0.00346792
         },
         {
           "profile": "ws_dependent_cp",
@@ -9958,207 +9958,207 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00251827,
-          "spread": 0.01038761,
-          "score": 0.0106885
+          "bias": -0.00205126,
+          "spread": 0.01472588,
+          "score": 0.01486806
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00718837,
-          "spread": 0.00419259,
-          "score": 0.00832169
+          "bias": 0.00428841,
+          "spread": 0.00619143,
+          "score": 0.00753155
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00265786,
-          "spread": 0.00440822,
-          "score": 0.00514748
+          "bias": -0.00072114,
+          "spread": 0.00390694,
+          "score": 0.00397294
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00113478,
-          "spread": 0.00145555,
-          "score": 0.00184563
+          "bias": 0.0016294,
+          "spread": 0.00155781,
+          "score": 0.00225426
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.08494244,
-          "spread": 0.00499563,
-          "score": 0.08508921
+          "bias": 0.08290577,
+          "spread": 0.00912969,
+          "score": 0.08340694
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00030129,
-          "spread": 0.01002141,
-          "score": 0.01002594
+          "bias": 0.00051993,
+          "spread": 0.01110928,
+          "score": 0.01112144
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00020405,
-          "spread": 0.00168603,
-          "score": 0.00169833
+          "bias": 0.00099538,
+          "spread": 0.00184019,
+          "score": 0.00209215
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00282359,
-          "spread": 0.0019755,
-          "score": 0.00344605
+          "bias": 0.0032494,
+          "spread": 0.00132642,
+          "score": 0.0035097
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00171352,
-          "spread": 0.00214596,
-          "score": 0.00274615
+          "bias": -0.00167791,
+          "spread": 0.00263593,
+          "score": 0.00312467
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00079464,
-          "spread": 0.00698213,
-          "score": 0.0070272
+          "bias": -0.00074948,
+          "spread": 0.00939034,
+          "score": 0.0094202
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00040856,
-          "spread": 0.02810653,
-          "score": 0.0281095
+          "bias": -0.00017697,
+          "spread": 0.02765083,
+          "score": 0.0276514
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.05307734,
-          "spread": 0.02798846,
-          "score": 0.06000465
+          "bias": -0.06184161,
+          "spread": 0.03051571,
+          "score": 0.06896081
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": -0.00126203,
-          "spread": 0.31079807,
-          "score": 0.31080063
+          "bias": -0.00131219,
+          "spread": 0.31247787,
+          "score": 0.31248062
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.47959695,
-          "spread": 0.49392255,
-          "score": 0.68845677
+          "bias": 0.46756659,
+          "spread": 0.50557206,
+          "score": 0.68863752
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.00165475,
-          "spread": 0.01808285,
-          "score": 0.0181584
+          "bias": 0.00039258,
+          "spread": 0.0166209,
+          "score": 0.01662553
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00163945,
-          "spread": 0.00323007,
-          "score": 0.00362231
+          "bias": 0.00269384,
+          "spread": 0.00135798,
+          "score": 0.00301677
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00137004,
-          "spread": 0.00143353,
-          "score": 0.00198293
+          "bias": 0.0022338,
+          "spread": 0.00267725,
+          "score": 0.00348677
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.0003441,
-          "spread": 0.00222021,
-          "score": 0.00224671
+          "bias": 0.00079331,
+          "spread": 0.0032101,
+          "score": 0.00330668
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00067031,
-          "spread": 0.00125876,
-          "score": 0.00142611
+          "bias": 0.00126009,
+          "spread": 0.00296712,
+          "score": 0.0032236
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00319848,
-          "spread": 0.01055499,
-          "score": 0.01102897
+          "bias": 0.00305823,
+          "spread": 0.01191498,
+          "score": 0.0123012
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.0432923,
-          "spread": 0.04793829,
-          "score": 0.06459336
+          "bias": -0.04410977,
+          "spread": 0.04947588,
+          "score": 0.06628374
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00400006,
-          "spread": 0.00622655,
-          "score": 0.0074007
+          "bias": -0.00305178,
+          "spread": 0.00850906,
+          "score": 0.00903978
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.01521841,
-          "spread": 0.01443775,
-          "score": 0.02097734
+          "bias": 0.01391006,
+          "spread": 0.01555402,
+          "score": 0.02086665
         },
         {
           "profile": "ws_dependent_cp",
@@ -10174,207 +10174,207 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00012653,
-          "spread": 0.00565897,
-          "score": 0.00566039
+          "bias": 0.00058488,
+          "spread": 0.00605881,
+          "score": 0.00608697
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00028678,
-          "spread": 0.00289808,
-          "score": 0.00291224
+          "bias": -0.00063784,
+          "spread": 0.00269169,
+          "score": 0.00276623
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00156483,
-          "spread": 0.00475325,
-          "score": 0.00500421
+          "bias": 0.00176201,
+          "spread": 0.00514787,
+          "score": 0.00544107
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 9,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00102531,
-          "spread": 0.00175236,
-          "score": 0.00203028
+          "bias": 0.00085071,
+          "spread": 0.00300389,
+          "score": 0.00312203
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.05746352,
-          "spread": 0.00868898,
-          "score": 0.05811673
+          "bias": 0.05902569,
+          "spread": 0.0079314,
+          "score": 0.05955619
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00217943,
-          "spread": 0.00343273,
-          "score": 0.00406615
+          "bias": 0.00200239,
+          "spread": 0.00375098,
+          "score": 0.00425199
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00203794,
-          "spread": 0.00177686,
-          "score": 0.00270378
+          "bias": 0.00186521,
+          "spread": 0.00311605,
+          "score": 0.00363163
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00141927,
-          "spread": 0.00227509,
-          "score": 0.00268148
+          "bias": 0.00124437,
+          "spread": 0.00294566,
+          "score": 0.00319771
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00265873,
-          "spread": 0.00151775,
-          "score": 0.00306144
+          "bias": -0.00283472,
+          "spread": 0.00288505,
+          "score": 0.00404465
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.0026957,
-          "spread": 0.0068893,
-          "score": 0.00739793
+          "bias": 0.00252683,
+          "spread": 0.00852651,
+          "score": 0.00889304
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.01011212,
-          "spread": 0.02411004,
-          "score": 0.02614477
+          "bias": -0.01027118,
+          "spread": 0.02507574,
+          "score": 0.02709779
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.00201364,
-          "spread": 0.030514,
-          "score": 0.03058037
+          "bias": 0.00184755,
+          "spread": 0.03120875,
+          "score": 0.03126339
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": -0.01666415,
-          "spread": 0.31759297,
-          "score": 0.31802985
+          "bias": -0.01685733,
+          "spread": 0.31776771,
+          "score": 0.31821453
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.40574755,
-          "spread": 0.52575279,
-          "score": 0.66411375
+          "bias": 0.40592899,
+          "spread": 0.52690912,
+          "score": 0.66514026
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.00971793,
-          "spread": 0.02765946,
-          "score": 0.02931695
+          "bias": -0.00989481,
+          "spread": 0.02746772,
+          "score": 0.0291956
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00024686,
-          "spread": 0.0025335,
-          "score": 0.00254549
+          "bias": 7.234e-05,
+          "spread": 0.00306563,
+          "score": 0.00306649
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00204753,
-          "spread": 0.0013853,
-          "score": 0.00247213
+          "bias": 0.00187547,
+          "spread": 0.00262896,
+          "score": 0.00322936
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -5.043e-05,
-          "spread": 0.0014973,
-          "score": 0.00149815
+          "bias": -0.00022276,
+          "spread": 0.00244024,
+          "score": 0.00245039
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00056139,
-          "spread": 0.00121304,
-          "score": 0.00133665
+          "bias": 0.00038946,
+          "spread": 0.00249151,
+          "score": 0.00252177
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00462439,
-          "spread": 0.00783975,
-          "score": 0.00910201
+          "bias": 0.00446101,
+          "spread": 0.00921819,
+          "score": 0.01024088
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.02975565,
-          "spread": 0.03827139,
-          "score": 0.04847781
+          "bias": -0.02990564,
+          "spread": 0.03894326,
+          "score": 0.04910116
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00464267,
-          "spread": 0.0061312,
-          "score": 0.00769064
+          "bias": 0.00447467,
+          "spread": 0.00718998,
+          "score": 0.00846867
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.01492455,
-          "spread": 0.02657682,
-          "score": 0.03048064
+          "bias": -0.01657361,
+          "spread": 0.02718981,
+          "score": 0.0318429
         },
         {
           "profile": "ws_dependent_cp",
@@ -10390,243 +10390,243 @@
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00256574,
-          "spread": 0.00490567,
-          "score": 0.00553612
+          "bias": -0.00275506,
+          "spread": 0.00506453,
+          "score": 0.0057654
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00040006,
-          "spread": 0.00267742,
-          "score": 0.00270714
+          "bias": 0.00021594,
+          "spread": 0.00351135,
+          "score": 0.00351798
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00199089,
-          "spread": 0.00394815,
-          "score": 0.00442171
+          "bias": 0.00181335,
+          "spread": 0.0049852,
+          "score": 0.00530476
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00072863,
-          "spread": 0.00111537,
-          "score": 0.00133227
+          "bias": 0.00076995,
+          "spread": 0.00198829,
+          "score": 0.00213216
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.06552194,
-          "spread": 0.02109468,
-          "score": 0.06883393
+          "bias": 0.06737555,
+          "spread": 0.0209389,
+          "score": 0.07055425
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00215894,
-          "spread": 0.00359302,
-          "score": 0.00419176
+          "bias": 0.00220028,
+          "spread": 0.00380945,
+          "score": 0.00439922
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00131051,
-          "spread": 0.00066602,
-          "score": 0.00147004
+          "bias": 0.00135206,
+          "spread": 0.0017127,
+          "score": 0.00218206
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00052379,
-          "spread": 0.00138169,
-          "score": 0.00147764
+          "bias": 0.00056494,
+          "spread": 0.00159818,
+          "score": 0.00169509
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00046363,
-          "spread": 0.0022857,
-          "score": 0.00233225
+          "bias": -0.00041964,
+          "spread": 0.00343485,
+          "score": 0.00346039
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00266881,
-          "spread": 0.00650313,
-          "score": 0.00702945
+          "bias": 0.00271492,
+          "spread": 0.00700677,
+          "score": 0.00751436
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00947483,
-          "spread": 0.03231247,
-          "score": 0.03367295
+          "bias": -0.00939766,
+          "spread": 0.03354648,
+          "score": 0.03483794
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.02160247,
-          "spread": 0.02095046,
-          "score": 0.030093
+          "bias": -0.02155957,
+          "spread": 0.02112641,
+          "score": 0.0301851
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.01742396,
-          "spread": 0.2569254,
-          "score": 0.25751554
+          "bias": 0.01715809,
+          "spread": 0.25545323,
+          "score": 0.25602881
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.67480768,
-          "spread": 0.77999176,
-          "score": 1.03138381
+          "bias": 0.67483923,
+          "spread": 0.78159391,
+          "score": 1.0326166
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.00583662,
-          "spread": 0.04209304,
-          "score": 0.04249577
+          "bias": -0.00579163,
+          "spread": 0.04221405,
+          "score": 0.04260949
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00092449,
-          "spread": 0.0021895,
-          "score": 0.00237668
+          "bias": 0.000966,
+          "spread": 0.00254788,
+          "score": 0.00272486
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00240516,
-          "spread": 0.00060165,
-          "score": 0.00247927
+          "bias": 0.00244554,
+          "spread": 0.00108785,
+          "score": 0.00267658
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00014696,
-          "spread": 0.0012123,
-          "score": 0.00122117
+          "bias": -0.00010643,
+          "spread": 0.00167322,
+          "score": 0.0016766
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00089419,
-          "spread": 0.00054074,
-          "score": 0.00104498
+          "bias": 0.00093503,
+          "spread": 0.00146747,
+          "score": 0.00174004
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 1.588e-05,
-          "spread": 0.00242671,
-          "score": 0.00242676
+          "bias": 5.417e-05,
+          "spread": 0.00165229,
+          "score": 0.00165318
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.02626381,
-          "spread": 0.01944044,
-          "score": 0.03267596
+          "bias": -0.02616794,
+          "spread": 0.0201982,
+          "score": 0.03305645
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00267321,
-          "spread": 0.00328237,
-          "score": 0.0042332
+          "bias": -0.002628,
+          "spread": 0.00464857,
+          "score": 0.00534
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.03128215,
-          "spread": 0.02631204,
-          "score": 0.0408766
+          "bias": -0.03124949,
+          "spread": 0.02613349,
+          "score": 0.04073684
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
-          "bias": 0.02012885,
+          "bias": 0.02161203,
           "spread": 0.0,
-          "score": 0.02012885
+          "score": 0.02161203
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00103548,
-          "spread": 0.0061405,
-          "score": 0.00622719
+          "bias": -0.00098452,
+          "spread": 0.00732249,
+          "score": 0.00738838
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00165358,
-          "spread": 0.00226572,
-          "score": 0.00280496
+          "bias": 0.00169969,
+          "spread": 0.00359976,
+          "score": 0.00398086
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00059076,
-          "spread": 0.00333506,
-          "score": 0.00338698
+          "bias": -0.00055002,
+          "spread": 0.0031198,
+          "score": 0.00316791
         }
       ]
     }

--- a/benchmarking/baselines/study_power_model_compare_baseline.json
+++ b/benchmarking/baselines/study_power_model_compare_baseline.json
@@ -2,8 +2,8 @@
   "schema": "power_model_compare_baseline_v2",
   "modes": {
     "prepost": {
-      "recorded_utc": "2026-07-04T19:42:37Z",
-      "git_commit": "f13a71d-dirty",
+      "recorded_utc": "2026-07-05T08:20:02Z",
+      "git_commit": "33bfc23-dirty",
       "n_replicates": 4,
       "seed": 0,
       "campaign_months": [
@@ -26,171 +26,171 @@
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00017005,
-          "spread": 0.0030137,
-          "score": 0.00301849
+          "bias": 0.00135806,
+          "spread": 0.00227301,
+          "score": 0.00264781
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.06908138,
+          "bias": 0.07014485,
           "spread": 0.0,
-          "score": 0.06908138
+          "score": 0.07014485
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.0091218,
-          "spread": 0.01147194,
-          "score": 0.01465649
+          "bias": -0.00760448,
+          "spread": 0.01156328,
+          "score": 0.01383971
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00223731,
-          "spread": 0.00420219,
-          "score": 0.00476067
+          "bias": 0.00376899,
+          "spread": 0.00367953,
+          "score": 0.00526728
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00289979,
-          "spread": 0.00229367,
-          "score": 0.00369726
+          "bias": -0.00137496,
+          "spread": 0.00177076,
+          "score": 0.0022419
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00100349,
-          "spread": 0.01041468,
-          "score": 0.01046292
+          "bias": 0.00052424,
+          "spread": 0.01032104,
+          "score": 0.01033434
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.0029668,
-          "spread": 0.01845816,
-          "score": 0.01869507
+          "bias": 0.00449611,
+          "spread": 0.01817089,
+          "score": 0.01871888
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.02875249,
-          "spread": 0.04128891,
-          "score": 0.05031381
+          "bias": -0.02727116,
+          "spread": 0.04121358,
+          "score": 0.04941938
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.07989104,
-          "spread": 0.10806742,
-          "score": 0.13439176
+          "bias": 0.08153458,
+          "spread": 0.10807858,
+          "score": 0.13538414
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.26375172,
-          "spread": 0.43798147,
-          "score": 0.51126582
+          "bias": 0.26597007,
+          "spread": 0.43869291,
+          "score": 0.51302198
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.26590725,
-          "spread": 0.7788517,
-          "score": 0.82299249
+          "bias": 0.26813945,
+          "spread": 0.77987883,
+          "score": 0.82468767
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.09417876,
-          "spread": 0.07660031,
-          "score": 0.12139706
+          "bias": -0.09280846,
+          "spread": 0.0765284,
+          "score": 0.12029134
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -4.64e-05,
-          "spread": 0.0058754,
-          "score": 0.00587559
+          "bias": 0.00148546,
+          "spread": 0.0061467,
+          "score": 0.00632364
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00411951,
-          "spread": 0.00736979,
-          "score": 0.00844299
+          "bias": 0.0056555,
+          "spread": 0.00728829,
+          "score": 0.00922517
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00895086,
-          "spread": 0.01064637,
-          "score": 0.0139091
+          "bias": 0.01049421,
+          "spread": 0.0105915,
+          "score": 0.01491001
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00036309,
-          "spread": 0.00453125,
-          "score": 0.00454577
+          "bias": 0.00116663,
+          "spread": 0.00452595,
+          "score": 0.00467389
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.01017621,
-          "spread": 0.01543945,
-          "score": 0.0184914
+          "bias": 0.01171744,
+          "spread": 0.01515149,
+          "score": 0.01915375
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.10197263,
-          "spread": 0.10777959,
-          "score": 0.14837404
+          "bias": -0.10054736,
+          "spread": 0.10837825,
+          "score": 0.14783645
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00627169,
-          "spread": 0.02932598,
-          "score": 0.02998912
+          "bias": -0.00457834,
+          "spread": 0.02920829,
+          "score": 0.02956494
         },
         {
           "profile": "cp_0pct",
@@ -215,36 +215,36 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00158071,
-          "spread": 0.01519401,
-          "score": 0.01527601
+          "bias": -5.767e-05,
+          "spread": 0.01488226,
+          "score": 0.01488237
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00421304,
-          "spread": 0.01067124,
-          "score": 0.01147279
+          "bias": -0.00269237,
+          "spread": 0.01037496,
+          "score": 0.01071862
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00380299,
-          "spread": 0.00870698,
-          "score": 0.00950128
+          "bias": -0.00228259,
+          "spread": 0.00823018,
+          "score": 0.00854085
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.0034204,
-          "spread": 0.00217975,
-          "score": 0.00405591
+          "bias": 0.00437834,
+          "spread": 0.00191899,
+          "score": 0.00478042
         },
         {
           "profile": "cp_0pct",
@@ -260,162 +260,162 @@
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00265019,
-          "spread": 0.00717478,
-          "score": 0.00764859
+          "bias": -0.00169521,
+          "spread": 0.00749124,
+          "score": 0.00768065
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00266841,
-          "spread": 0.00212948,
-          "score": 0.00341395
+          "bias": 0.00362548,
+          "spread": 0.00177785,
+          "score": 0.00403793
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00140732,
-          "spread": 0.00254222,
-          "score": 0.00290576
+          "bias": 0.00236303,
+          "spread": 0.00218283,
+          "score": 0.00321693
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00737318,
-          "spread": 0.00571102,
-          "score": 0.00932628
+          "bias": 0.00833612,
+          "spread": 0.00583444,
+          "score": 0.01017505
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01194715,
-          "spread": 0.0069784,
-          "score": 0.01383592
+          "bias": 0.01291283,
+          "spread": 0.00684295,
+          "score": 0.01461394
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.01162629,
-          "spread": 0.01248746,
-          "score": 0.01706187
+          "bias": 0.01259167,
+          "spread": 0.01241933,
+          "score": 0.01768587
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.08069209,
-          "spread": 0.07869795,
-          "score": 0.1127146
+          "bias": 0.08169339,
+          "spread": 0.07834736,
+          "score": 0.11319063
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.25575882,
-          "spread": 0.05998212,
-          "score": 0.26269836
+          "bias": 0.25711471,
+          "spread": 0.06025504,
+          "score": 0.26408076
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.0273517,
-          "spread": 0.56666323,
-          "score": 0.56732295
+          "bias": 0.02844991,
+          "spread": 0.56748232,
+          "score": 0.56819502
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.11440496,
-          "spread": 0.10943213,
-          "score": 0.15831578
+          "bias": -0.11353768,
+          "spread": 0.10966636,
+          "score": 0.15785283
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00063006,
-          "spread": 0.00299925,
-          "score": 0.00306471
+          "bias": 0.00158617,
+          "spread": 0.003099,
+          "score": 0.00348134
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00358803,
-          "spread": 0.0041472,
-          "score": 0.0054839
+          "bias": 0.00454826,
+          "spread": 0.0045196,
+          "score": 0.00641198
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00519448,
-          "spread": 0.00336545,
-          "score": 0.00618941
+          "bias": 0.00615617,
+          "spread": 0.00379618,
+          "score": 0.00723252
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00281973,
-          "spread": 0.00215309,
-          "score": 0.00354777
+          "bias": 0.00377784,
+          "spread": 0.00224617,
+          "score": 0.00439515
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.01311291,
-          "spread": 0.0130995,
-          "score": 0.01853497
+          "bias": 0.01408456,
+          "spread": 0.01341591,
+          "score": 0.01945152
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.11464084,
-          "spread": 0.06607063,
-          "score": 0.13231723
+          "bias": -0.1137814,
+          "spread": 0.06630895,
+          "score": 0.13169314
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00476418,
-          "spread": 0.02536846,
-          "score": 0.02581194
+          "bias": -0.00380883,
+          "spread": 0.02557019,
+          "score": 0.02585231
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.18109937,
+          "bias": 0.18252001,
           "spread": 0.0,
-          "score": 0.18109937
+          "score": 0.18252001
         },
         {
           "profile": "cp_0pct",
@@ -431,207 +431,207 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00846941,
-          "spread": 0.0069988,
-          "score": 0.010987
+          "bias": 0.00943414,
+          "spread": 0.00721014,
+          "score": 0.01187389
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00194563,
-          "spread": 0.00532388,
-          "score": 0.00566826
+          "bias": 0.00290124,
+          "spread": 0.00504383,
+          "score": 0.00581871
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.0031503,
-          "spread": 0.00724321,
-          "score": 0.00789864
+          "bias": 0.00410559,
+          "spread": 0.00683023,
+          "score": 0.00796919
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00053603,
-          "spread": 0.003208,
-          "score": 0.00325247
+          "bias": 0.00114757,
+          "spread": 0.00334024,
+          "score": 0.00353187
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.13813852,
+          "bias": 0.138048,
           "spread": 0.0,
-          "score": 0.13813852
+          "score": 0.138048
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.0028808,
-          "spread": 0.0032173,
-          "score": 0.00431857
+          "bias": -0.00227157,
+          "spread": 0.00328414,
+          "score": 0.0039932
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00043265,
-          "spread": 0.00233623,
-          "score": 0.00237595
+          "bias": 0.00017802,
+          "spread": 0.00240822,
+          "score": 0.00241479
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00045498,
-          "spread": 0.00400868,
-          "score": 0.00403442
+          "bias": 0.00015568,
+          "spread": 0.00405469,
+          "score": 0.00405767
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00336863,
-          "spread": 0.00436989,
-          "score": 0.00551757
+          "bias": 0.00398299,
+          "spread": 0.00469621,
+          "score": 0.00615781
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00922178,
-          "spread": 0.00641726,
-          "score": 0.01123488
+          "bias": 0.00984061,
+          "spread": 0.00660377,
+          "score": 0.01185105
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00058232,
-          "spread": 0.01232648,
-          "score": 0.01234022
+          "bias": 0.00119096,
+          "spread": 0.01223081,
+          "score": 0.01228865
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.05133769,
-          "spread": 0.04415664,
-          "score": 0.06771534
+          "bias": 0.05196744,
+          "spread": 0.04380113,
+          "score": 0.06796436
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.37368357,
-          "spread": 0.39407261,
-          "score": 0.543077
+          "bias": 0.37437664,
+          "spread": 0.39366371,
+          "score": 0.54325775
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.87429072,
-          "spread": 0.73872582,
-          "score": 1.14459604
+          "bias": 0.8757448,
+          "spread": 0.73933271,
+          "score": 1.14609852
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.10420448,
-          "spread": 0.09169726,
-          "score": 0.13880548
+          "bias": -0.10367933,
+          "spread": 0.09153115,
+          "score": 0.13830168
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00051177,
-          "spread": 0.00276718,
-          "score": 0.00281411
+          "bias": 0.00112288,
+          "spread": 0.00277387,
+          "score": 0.00299252
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00086453,
-          "spread": 0.00246063,
-          "score": 0.00260809
+          "bias": 0.00147613,
+          "spread": 0.00257743,
+          "score": 0.0029702
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00144604,
-          "spread": 0.00198503,
-          "score": 0.00245589
+          "bias": 0.002058,
+          "spread": 0.00211829,
+          "score": 0.0029534
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -6e-08,
-          "spread": 0.00059052,
-          "score": 0.00059052
+          "bias": 0.0006109,
+          "spread": 0.00083652,
+          "score": 0.00103584
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.000895,
-          "spread": 0.00302043,
-          "score": 0.00315024
+          "bias": 0.00150718,
+          "spread": 0.00329042,
+          "score": 0.00361917
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.12464562,
-          "spread": 0.06979938,
-          "score": 0.14285826
+          "bias": -0.12407874,
+          "spread": 0.07016175,
+          "score": 0.14254194
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00894086,
-          "spread": 0.01504156,
-          "score": 0.01749822
+          "bias": 0.0095617,
+          "spread": 0.01535523,
+          "score": 0.01808892
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.05339109,
-          "spread": 0.04155359,
-          "score": 0.06765582
+          "bias": 0.05404805,
+          "spread": 0.04191147,
+          "score": 0.06839417
         },
         {
           "profile": "cp_0pct",
@@ -647,198 +647,198 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00082225,
-          "spread": 0.00710368,
-          "score": 0.00715111
+          "bias": 0.00143335,
+          "spread": 0.00714195,
+          "score": 0.00728436
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00032173,
-          "spread": 0.00681331,
-          "score": 0.0068209
+          "bias": 0.00093292,
+          "spread": 0.0068417,
+          "score": 0.00690501
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00025698,
-          "spread": 0.00713468,
-          "score": 0.0071393
+          "bias": 0.00086856,
+          "spread": 0.00722544,
+          "score": 0.00727746
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -8.319e-05,
-          "spread": 0.00282093,
-          "score": 0.00282216
+          "bias": 0.00134027,
+          "spread": 0.00213655,
+          "score": 0.00252214
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.07825479,
+          "bias": 0.07922471,
           "spread": 0.0,
-          "score": 0.07825479
+          "score": 0.07922471
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.01261494,
-          "spread": 0.01148004,
-          "score": 0.01705661
+          "bias": -0.01118848,
+          "spread": 0.01175001,
+          "score": 0.01622483
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.0015053,
-          "spread": 0.0040732,
-          "score": 0.00434245
+          "bias": -6.07e-05,
+          "spread": 0.0033935,
+          "score": 0.00339405
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00196589,
-          "spread": 0.00301779,
-          "score": 0.00360163
+          "bias": -0.00054689,
+          "spread": 0.00248387,
+          "score": 0.00254337
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00326579,
-          "spread": 0.00952025,
-          "score": 0.01006482
+          "bias": 0.00466659,
+          "spread": 0.00955969,
+          "score": 0.01063789
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00811631,
-          "spread": 0.01665766,
-          "score": 0.01852977
+          "bias": 0.00950343,
+          "spread": 0.01641777,
+          "score": 0.01896993
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.02018077,
-          "spread": 0.03863182,
-          "score": 0.04358533
+          "bias": -0.01884857,
+          "spread": 0.0385273,
+          "score": 0.04289081
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.08695532,
-          "spread": 0.08851129,
-          "score": 0.12407851
+          "bias": 0.08841442,
+          "spread": 0.08841616,
+          "score": 0.1250381
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.25695677,
-          "spread": 0.36421729,
-          "score": 0.44573649
+          "bias": 0.25885298,
+          "spread": 0.36478578,
+          "score": 0.4472958
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.29322666,
-          "spread": 0.65981012,
-          "score": 0.72203273
+          "bias": 0.29500699,
+          "spread": 0.66079521,
+          "score": 0.72365699
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.07374453,
-          "spread": 0.18769933,
-          "score": 0.2016663
+          "bias": -0.07223784,
+          "spread": 0.18832853,
+          "score": 0.20170756
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.0034155,
-          "spread": 0.00972465,
-          "score": 0.01030701
+          "bias": 0.00484427,
+          "spread": 0.00990789,
+          "score": 0.01102875
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00257377,
-          "spread": 0.00835413,
-          "score": 0.00874162
+          "bias": -0.00106259,
+          "spread": 0.00839275,
+          "score": 0.00845975
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00505902,
-          "spread": 0.01008945,
-          "score": 0.01128675
+          "bias": 0.00659428,
+          "spread": 0.01005477,
+          "score": 0.01202426
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00347498,
-          "spread": 0.00401143,
-          "score": 0.00530726
+          "bias": -0.00195204,
+          "spread": 0.00392767,
+          "score": 0.004386
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00870683,
-          "spread": 0.01325487,
-          "score": 0.01585876
+          "bias": 0.0102423,
+          "spread": 0.01288859,
+          "score": 0.01646269
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.05184434,
-          "spread": 0.07289313,
-          "score": 0.08944967
+          "bias": -0.05059259,
+          "spread": 0.07333189,
+          "score": 0.08909083
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00158041,
-          "spread": 0.03740353,
-          "score": 0.0374369
+          "bias": 0.00010424,
+          "spread": 0.03724922,
+          "score": 0.03724936
         },
         {
           "profile": "cp_minus_10pct",
@@ -863,36 +863,36 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00149543,
-          "spread": 0.0179489,
-          "score": 0.01801109
+          "bias": -0.00012815,
+          "spread": 0.01763245,
+          "score": 0.01763292
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00432262,
-          "spread": 0.01116218,
-          "score": 0.01196993
+          "bias": -0.00295572,
+          "spread": 0.0109533,
+          "score": 0.01134509
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00105158,
-          "spread": 0.00846354,
-          "score": 0.00852861
+          "bias": 0.00032089,
+          "spread": 0.00812739,
+          "score": 0.00813372
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00328659,
-          "spread": 0.00203026,
-          "score": 0.00386311
+          "bias": 0.00418202,
+          "spread": 0.00178584,
+          "score": 0.00454736
         },
         {
           "profile": "cp_minus_10pct",
@@ -908,162 +908,162 @@
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00021574,
-          "spread": 0.00646951,
-          "score": 0.00647311
+          "bias": 0.00110932,
+          "spread": 0.00687604,
+          "score": 0.00696495
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00053845,
-          "spread": 0.0019236,
-          "score": 0.00199754
+          "bias": 0.00144448,
+          "spread": 0.00147965,
+          "score": 0.00206782
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00128765,
-          "spread": 0.00309229,
-          "score": 0.00334967
+          "bias": 0.00218032,
+          "spread": 0.00271426,
+          "score": 0.00348152
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00969898,
-          "spread": 0.00523954,
-          "score": 0.01102375
+          "bias": 0.01058214,
+          "spread": 0.00544124,
+          "score": 0.01189911
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.0151464,
-          "spread": 0.00525742,
-          "score": 0.0160329
+          "bias": 0.01602368,
+          "spread": 0.00532355,
+          "score": 0.01688486
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.01446747,
-          "spread": 0.01245664,
-          "score": 0.01909124
+          "bias": 0.01533586,
+          "spread": 0.01243187,
+          "score": 0.01974183
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.08205652,
-          "spread": 0.06795664,
-          "score": 0.10654285
+          "bias": 0.08294349,
+          "spread": 0.0676397,
+          "score": 0.10702688
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.24768815,
-          "spread": 0.03171178,
-          "score": 0.24970994
+          "bias": 0.24885428,
+          "spread": 0.03200264,
+          "score": 0.25090361
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.07594973,
-          "spread": 0.4282179,
-          "score": 0.43490106
+          "bias": 0.07696708,
+          "spread": 0.42883409,
+          "score": 0.43568636
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.04077953,
-          "spread": 0.17268172,
-          "score": 0.17743152
+          "bias": -0.03982642,
+          "spread": 0.17303586,
+          "score": 0.17756
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.0037521,
-          "spread": 0.00421532,
-          "score": 0.00564333
+          "bias": 0.00464217,
+          "spread": 0.00429241,
+          "score": 0.00632254
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.0018004,
-          "spread": 0.00444312,
-          "score": 0.00479404
+          "bias": -0.00085521,
+          "spread": 0.00477439,
+          "score": 0.00485038
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00246372,
-          "spread": 0.00296526,
-          "score": 0.00385521
+          "bias": 0.00342183,
+          "spread": 0.0034355,
+          "score": 0.00484888
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00101533,
-          "spread": 0.00075481,
-          "score": 0.00126516
+          "bias": 0.0019709,
+          "spread": 0.0003814,
+          "score": 0.00200746
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.01264775,
-          "spread": 0.01389658,
-          "score": 0.01879043
+          "bias": 0.0136171,
+          "spread": 0.01415314,
+          "score": 0.01964018
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.05622564,
-          "spread": 0.03015854,
-          "score": 0.06380329
+          "bias": -0.05547734,
+          "spread": 0.0302997,
+          "score": 0.0632124
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00195687,
-          "spread": 0.02954938,
-          "score": 0.02961411
+          "bias": -0.00100486,
+          "spread": 0.02969569,
+          "score": 0.02971269
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.18877299,
+          "bias": 0.19019104,
           "spread": 0.0,
-          "score": 0.18877299
+          "score": 0.19019104
         },
         {
           "profile": "cp_minus_10pct",
@@ -1079,207 +1079,207 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00788327,
-          "spread": 0.00731387,
-          "score": 0.01075354
+          "bias": 0.00875164,
+          "spread": 0.00747465,
+          "score": 0.0115092
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00183632,
-          "spread": 0.00526605,
-          "score": 0.00557704
+          "bias": 0.00269645,
+          "spread": 0.0050432,
+          "score": 0.0057188
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00454273,
-          "spread": 0.00634617,
-          "score": 0.0078045
+          "bias": 0.0054049,
+          "spread": 0.00599819,
+          "score": 0.00807411
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00057746,
-          "spread": 0.00301884,
-          "score": 0.00307357
+          "bias": 0.00115183,
+          "spread": 0.00314345,
+          "score": 0.00334783
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.10737129,
+          "bias": 0.10729088,
           "spread": 0.0,
-          "score": 0.10737129
+          "score": 0.10729088
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00066566,
-          "spread": 0.00479353,
-          "score": 0.00483953
+          "bias": 0.00123358,
+          "spread": 0.00490321,
+          "score": 0.00505601
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00114039,
-          "spread": 0.00222409,
-          "score": 0.00249941
+          "bias": -0.000559,
+          "spread": 0.00225179,
+          "score": 0.00232013
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00105173,
-          "spread": 0.00391048,
-          "score": 0.00404945
+          "bias": -0.00047804,
+          "spread": 0.00395632,
+          "score": 0.0039851
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00543274,
-          "spread": 0.00375509,
-          "score": 0.00660419
+          "bias": 0.00599877,
+          "spread": 0.00407136,
+          "score": 0.00724992
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01191037,
-          "spread": 0.00542884,
-          "score": 0.01308928
+          "bias": 0.0124725,
+          "spread": 0.00558782,
+          "score": 0.013667
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00664002,
-          "spread": 0.01120104,
-          "score": 0.01302126
+          "bias": 0.00718757,
+          "spread": 0.01115163,
+          "score": 0.01326725
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.05448919,
-          "spread": 0.04031488,
-          "score": 0.06778172
+          "bias": 0.05504522,
+          "spread": 0.03999046,
+          "score": 0.06803832
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.34008004,
-          "spread": 0.32220059,
-          "score": 0.46847375
+          "bias": 0.34068513,
+          "spread": 0.32185705,
+          "score": 0.4686772
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.96174736,
-          "spread": 0.47399603,
-          "score": 1.07220811
+          "bias": 0.96297969,
+          "spread": 0.47458954,
+          "score": 1.07357586
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.08548442,
-          "spread": 0.08834515,
-          "score": 0.12293272
+          "bias": -0.08492257,
+          "spread": 0.08817036,
+          "score": 0.12241673
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00406052,
-          "spread": 0.00231256,
-          "score": 0.00467288
+          "bias": 0.00463037,
+          "spread": 0.00207319,
+          "score": 0.00507331
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00320346,
-          "spread": 0.00299845,
-          "score": 0.00438781
+          "bias": -0.00259881,
+          "spread": 0.00302123,
+          "score": 0.00398518
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00037127,
-          "spread": 0.00175301,
-          "score": 0.00179189
+          "bias": 0.00023985,
+          "spread": 0.00199491,
+          "score": 0.00200928
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00115302,
-          "spread": 0.00131276,
-          "score": 0.00174723
+          "bias": -0.00054074,
+          "spread": 0.00160552,
+          "score": 0.00169413
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00116413,
-          "spread": 0.00492609,
-          "score": 0.00506177
+          "bias": 0.00177452,
+          "spread": 0.00522151,
+          "score": 0.0055148
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.06974394,
-          "spread": 0.03092999,
-          "score": 0.0762947
+          "bias": -0.06924426,
+          "spread": 0.03123268,
+          "score": 0.07596215
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.01272784,
-          "spread": 0.01913435,
-          "score": 0.02298089
+          "bias": 0.01334703,
+          "spread": 0.01946872,
+          "score": 0.02360453
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.06004102,
-          "spread": 0.04368664,
-          "score": 0.07425259
+          "bias": 0.06069597,
+          "spread": 0.04405564,
+          "score": 0.07499933
         },
         {
           "profile": "cp_minus_10pct",
@@ -1295,198 +1295,198 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00087976,
-          "spread": 0.00722433,
-          "score": 0.0072777
+          "bias": 0.00142996,
+          "spread": 0.00727722,
+          "score": 0.00741639
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00040728,
-          "spread": 0.00671268,
-          "score": 0.00672502
+          "bias": 0.00014163,
+          "spread": 0.00676988,
+          "score": 0.00677136
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00152446,
-          "spread": 0.00662767,
-          "score": 0.00680074
+          "bias": 0.00207635,
+          "spread": 0.00674329,
+          "score": 0.00705572
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00025606,
-          "spread": 0.00320697,
-          "score": 0.00321718
+          "bias": 0.00138763,
+          "spread": 0.00241026,
+          "score": 0.00278116
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.10813522,
+          "bias": 0.10939043,
           "spread": 0.0,
-          "score": 0.10813522
+          "score": 0.10939043
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00917229,
-          "spread": 0.01329497,
-          "score": 0.016152
+          "bias": -0.00756063,
+          "spread": 0.01306884,
+          "score": 0.01509827
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00551697,
-          "spread": 0.00479695,
-          "score": 0.00731079
+          "bias": 0.00714657,
+          "spread": 0.00463591,
+          "score": 0.00851852
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00406559,
-          "spread": 0.00208836,
-          "score": 0.00457059
+          "bias": -0.00242408,
+          "spread": 0.00187717,
+          "score": 0.00306593
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00396853,
-          "spread": 0.01182107,
-          "score": 0.01246944
+          "bias": -0.00230135,
+          "spread": 0.01154606,
+          "score": 0.01177317
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": -0.00205015,
-          "spread": 0.02466641,
-          "score": 0.02475146
+          "bias": -0.00037089,
+          "spread": 0.02423234,
+          "score": 0.02423517
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.03378769,
-          "spread": 0.04924539,
-          "score": 0.059722
+          "bias": -0.03214808,
+          "spread": 0.04905435,
+          "score": 0.05865005
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.08421024,
-          "spread": 0.12231277,
-          "score": 0.14849841
+          "bias": 0.08605014,
+          "spread": 0.12225641,
+          "score": 0.14950336
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.2578908,
-          "spread": 0.47566701,
-          "score": 0.54107926
+          "bias": 0.26035988,
+          "spread": 0.47638924,
+          "score": 0.54289407
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.15747309,
-          "spread": 0.93771062,
-          "score": 0.95084119
+          "bias": 0.16005659,
+          "spread": 0.93873315,
+          "score": 0.95228044
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.1538129,
-          "spread": 0.19470542,
-          "score": 0.24813023
+          "bias": -0.15242804,
+          "spread": 0.19522801,
+          "score": 0.24768586
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00345492,
-          "spread": 0.00430026,
-          "score": 0.00551622
+          "bias": -0.00180737,
+          "spread": 0.00493209,
+          "score": 0.00525282
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00851538,
-          "spread": 0.00888492,
-          "score": 0.01230664
+          "bias": 0.01008346,
+          "spread": 0.00876578,
+          "score": 0.01336095
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00967769,
-          "spread": 0.01304328,
-          "score": 0.01624146
+          "bias": 0.01123414,
+          "spread": 0.01296106,
+          "score": 0.01715212
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00055922,
-          "spread": 0.00648652,
-          "score": 0.00651058
+          "bias": 0.00098201,
+          "spread": 0.00649239,
+          "score": 0.00656624
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00942901,
-          "spread": 0.0177049,
-          "score": 0.02005916
+          "bias": 0.01098316,
+          "spread": 0.01750178,
+          "score": 0.02066258
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.14161928,
-          "spread": 0.15727894,
-          "score": 0.21164282
+          "bias": -0.14001326,
+          "spread": 0.15780576,
+          "score": 0.21096533
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.01250248,
-          "spread": 0.02461511,
-          "score": 0.02760825
+          "bias": -0.01080114,
+          "spread": 0.02466299,
+          "score": 0.02692448
         },
         {
           "profile": "cp_plus_10pct",
@@ -1511,36 +1511,36 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00093728,
-          "spread": 0.01876091,
-          "score": 0.01878431
+          "bias": 0.00074979,
+          "spread": 0.01834302,
+          "score": 0.01835834
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00430989,
-          "spread": 0.00990887,
-          "score": 0.0108056
+          "bias": -0.00262389,
+          "spread": 0.00956809,
+          "score": 0.00992135
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00572074,
-          "spread": 0.00839811,
-          "score": 0.01016145
+          "bias": -0.00403882,
+          "spread": 0.00787047,
+          "score": 0.00884626
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00355396,
-          "spread": 0.0023294,
-          "score": 0.00424932
+          "bias": 0.00457516,
+          "spread": 0.0020525,
+          "score": 0.00501446
         },
         {
           "profile": "cp_plus_10pct",
@@ -1556,162 +1556,162 @@
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00329659,
-          "spread": 0.00960122,
-          "score": 0.0101514
+          "bias": -0.00227669,
+          "spread": 0.00986056,
+          "score": 0.01011998
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00481019,
-          "spread": 0.00279075,
-          "score": 0.00556114
+          "bias": 0.00581911,
+          "spread": 0.00259036,
+          "score": 0.00636961
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00139578,
-          "spread": 0.00226615,
-          "score": 0.00266151
+          "bias": 0.00241501,
+          "spread": 0.00193765,
+          "score": 0.00309625
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00454015,
-          "spread": 0.00677731,
-          "score": 0.0081575
+          "bias": 0.00558319,
+          "spread": 0.00682656,
+          "score": 0.00881896
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00923047,
-          "spread": 0.00898547,
-          "score": 0.01288178
+          "bias": 0.0102864,
+          "spread": 0.00878572,
+          "score": 0.0135277
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.0091826,
-          "spread": 0.0150787,
-          "score": 0.01765467
+          "bias": 0.01024638,
+          "spread": 0.01500011,
+          "score": 0.01816567
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.07444774,
-          "spread": 0.08496309,
-          "score": 0.11296545
+          "bias": 0.07556133,
+          "spread": 0.08457501,
+          "score": 0.11341273
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.17784053,
-          "spread": 0.147545,
-          "score": 0.23107743
+          "bias": 0.17906261,
+          "spread": 0.14815439,
+          "score": 0.23240728
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.10248773,
-          "spread": 0.56316086,
-          "score": 0.57241059
+          "bias": -0.10146656,
+          "spread": 0.56396458,
+          "score": 0.57301965
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.11233112,
-          "spread": 0.15042127,
-          "score": 0.18773609
+          "bias": -0.11145663,
+          "spread": 0.15068054,
+          "score": 0.18742253
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.0024248,
-          "spread": 0.00309927,
-          "score": 0.00393512
+          "bias": -0.00140209,
+          "spread": 0.00309919,
+          "score": 0.00340159
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00830132,
-          "spread": 0.00324121,
-          "score": 0.00891165
+          "bias": 0.0092762,
+          "spread": 0.00360045,
+          "score": 0.00995043
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00696136,
-          "spread": 0.00393564,
-          "score": 0.00799686
+          "bias": 0.00792622,
+          "spread": 0.00427275,
+          "score": 0.00900452
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00331332,
-          "spread": 0.00374132,
-          "score": 0.00499756
+          "bias": 0.00427333,
+          "spread": 0.00388288,
+          "score": 0.00577391
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.01236231,
-          "spread": 0.01294518,
-          "score": 0.01789984
+          "bias": 0.01333566,
+          "spread": 0.01329998,
+          "score": 0.01883426
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.17707055,
-          "spread": 0.11778593,
-          "score": 0.21266759
+          "bias": -0.17610209,
+          "spread": 0.11804766,
+          "score": 0.21200754
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00977562,
-          "spread": 0.02275128,
-          "score": 0.02476255
+          "bias": -0.00881756,
+          "spread": 0.02304719,
+          "score": 0.02467635
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.174475,
+          "bias": 0.1758995,
           "spread": 0.0,
-          "score": 0.174475
+          "score": 0.1758995
         },
         {
           "profile": "cp_plus_10pct",
@@ -1727,207 +1727,207 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00877585,
-          "spread": 0.00868639,
-          "score": 0.01234783
+          "bias": 0.00983778,
+          "spread": 0.00894254,
+          "score": 0.01329477
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00267684,
-          "spread": 0.00468221,
-          "score": 0.00539339
+          "bias": 0.00372966,
+          "spread": 0.00437553,
+          "score": 0.0057494
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00160984,
-          "spread": 0.00770638,
-          "score": 0.00787273
+          "bias": 0.00265908,
+          "spread": 0.00723457,
+          "score": 0.00770777
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00049448,
-          "spread": 0.00339743,
-          "score": 0.00343323
+          "bias": 0.00114411,
+          "spread": 0.00353643,
+          "score": 0.0037169
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.16084857,
+          "bias": 0.16074699,
           "spread": 0.0,
-          "score": 0.16084857
+          "score": 0.16074699
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00715255,
-          "spread": 0.00179147,
-          "score": 0.00737348
+          "bias": -0.00650249,
+          "spread": 0.00156448,
+          "score": 0.00668804
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00021266,
-          "spread": 0.00245532,
-          "score": 0.00246451
+          "bias": 0.00085351,
+          "spread": 0.00255223,
+          "score": 0.00269116
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 5.3e-07,
-          "spread": 0.00418433,
-          "score": 0.00418433
+          "bias": 0.00064925,
+          "spread": 0.00423268,
+          "score": 0.00428218
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00158264,
-          "spread": 0.00506227,
-          "score": 0.00530389
+          "bias": 0.00224599,
+          "spread": 0.00539843,
+          "score": 0.00584701
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00668084,
-          "spread": 0.00744505,
-          "score": 0.01000312
+          "bias": 0.00735454,
+          "spread": 0.00765629,
+          "score": 0.01061641
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00349766,
-          "spread": 0.0152743,
-          "score": 0.01566965
+          "bias": -0.00282702,
+          "spread": 0.01515549,
+          "score": 0.01541691
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.05078989,
-          "spread": 0.05249071,
-          "score": 0.07304032
+          "bias": 0.05148507,
+          "spread": 0.05210792,
+          "score": 0.07325263
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.41214526,
-          "spread": 0.46235826,
-          "score": 0.61938589
+          "bias": 0.41293213,
+          "spread": 0.46189054,
+          "score": 0.61956098
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.77093733,
-          "spread": 1.06356398,
-          "score": 1.31358772
+          "bias": 0.77261792,
+          "spread": 1.0642447,
+          "score": 1.31512556
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.1273109,
-          "spread": 0.11626235,
-          "score": 0.17240939
+          "bias": -0.12680542,
+          "spread": 0.11613579,
+          "score": 0.17195096
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00320158,
-          "spread": 0.0039846,
-          "score": 0.00511148
+          "bias": -0.00254882,
+          "spread": 0.00412592,
+          "score": 0.00484971
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00473676,
-          "spread": 0.00226505,
-          "score": 0.00525046
+          "bias": 0.00535681,
+          "spread": 0.00248021,
+          "score": 0.00590312
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00275822,
-          "spread": 0.00247122,
-          "score": 0.00370334
+          "bias": 0.00337183,
+          "spread": 0.00250427,
+          "score": 0.00420007
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00063186,
-          "spread": 0.00109339,
-          "score": 0.00126283
+          "bias": 0.00124375,
+          "spread": 0.00101369,
+          "score": 0.00160452
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": -2.31e-05,
-          "spread": 0.00167488,
-          "score": 0.00167504
+          "bias": 0.00059008,
+          "spread": 0.00177811,
+          "score": 0.00187347
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.17680817,
-          "spread": 0.11171677,
-          "score": 0.20914532
+          "bias": -0.17614422,
+          "spread": 0.11208083,
+          "score": 0.20877955
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00380487,
-          "spread": 0.01172333,
-          "score": 0.01232532
+          "bias": 0.00442618,
+          "spread": 0.01198209,
+          "score": 0.01277347
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.04751509,
-          "spread": 0.04060043,
-          "score": 0.06249863
+          "bias": 0.04817421,
+          "spread": 0.04093947,
+          "score": 0.06322021
         },
         {
           "profile": "cp_plus_10pct",
@@ -1943,198 +1943,198 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00155339,
-          "spread": 0.00767501,
-          "score": 0.00783063
+          "bias": 0.00223227,
+          "spread": 0.00772444,
+          "score": 0.00804052
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00069905,
-          "spread": 0.00700916,
-          "score": 0.00704393
+          "bias": 0.00137199,
+          "spread": 0.00702181,
+          "score": 0.00715459
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00092274,
-          "spread": 0.00754117,
-          "score": 0.00759741
+          "bias": -0.00025097,
+          "spread": 0.00759217,
+          "score": 0.00759632
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00019555,
-          "spread": 0.00307166,
-          "score": 0.00307788
+          "bias": 0.00137519,
+          "spread": 0.00231403,
+          "score": 0.00269182
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.06046841,
+          "bias": 0.06160172,
           "spread": 0.0,
-          "score": 0.06046841
+          "score": 0.06160172
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00972051,
-          "spread": 0.01208888,
-          "score": 0.01551223
+          "bias": -0.00816868,
+          "spread": 0.0121143,
+          "score": 0.01461108
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00297494,
-          "spread": 0.00433542,
-          "score": 0.00525795
+          "bias": 0.00454379,
+          "spread": 0.00396805,
+          "score": 0.00603253
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00304364,
-          "spread": 0.0019351,
-          "score": 0.00360671
+          "bias": -0.00147537,
+          "spread": 0.00148008,
+          "score": 0.00208981
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00182718,
-          "spread": 0.01078752,
-          "score": 0.01094117
+          "bias": -0.00024989,
+          "spread": 0.01060259,
+          "score": 0.01060553
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00151788,
-          "spread": 0.02112366,
-          "score": 0.02117813
+          "bias": 0.00309887,
+          "spread": 0.0207636,
+          "score": 0.02099357
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.02992237,
-          "spread": 0.04828955,
-          "score": 0.0568087
+          "bias": -0.02838872,
+          "spread": 0.04814701,
+          "score": 0.05589324
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.08072335,
-          "spread": 0.10050933,
-          "score": 0.12891231
+          "bias": 0.08242881,
+          "spread": 0.10046702,
+          "score": 0.12995434
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.25803498,
-          "spread": 0.43625829,
-          "score": 0.50685634
+          "bias": 0.26028814,
+          "spread": 0.43690788,
+          "score": 0.50856505
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.22278186,
-          "spread": 0.8096628,
-          "score": 0.8397533
+          "bias": 0.22509688,
+          "spread": 0.81065979,
+          "score": 0.84133103
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.14906844,
-          "spread": 0.18918162,
-          "score": 0.2408549
+          "bias": -0.14764521,
+          "spread": 0.18965438,
+          "score": 0.24034952
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00079844,
-          "spread": 0.0054884,
-          "score": 0.00554618
+          "bias": 0.0007768,
+          "spread": 0.00586249,
+          "score": 0.00591373
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00535352,
-          "spread": 0.00820211,
-          "score": 0.00979463
+          "bias": 0.00690707,
+          "spread": 0.00809927,
+          "score": 0.01064452
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00852577,
-          "spread": 0.01133471,
-          "score": 0.01418324
+          "bias": 0.01008005,
+          "spread": 0.01125107,
+          "score": 0.01510609
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00095262,
-          "spread": 0.00475707,
-          "score": 0.00485151
+          "bias": 0.00058766,
+          "spread": 0.00471047,
+          "score": 0.00474698
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00967661,
-          "spread": 0.01641682,
-          "score": 0.01905646
+          "bias": 0.01122968,
+          "spread": 0.01617271,
+          "score": 0.01968914
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.10882088,
-          "spread": 0.12978107,
-          "score": 0.16936679
+          "bias": -0.1073357,
+          "spread": 0.13030181,
+          "score": 0.168818
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00728747,
-          "spread": 0.02927991,
-          "score": 0.03017317
+          "bias": -0.0055892,
+          "spread": 0.02923514,
+          "score": 0.02976462
         },
         {
           "profile": "cp_plus_3pct",
@@ -2159,36 +2159,36 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00161339,
-          "spread": 0.01722587,
-          "score": 0.01730126
+          "bias": -3.553e-05,
+          "spread": 0.01684411,
+          "score": 0.01684415
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00498231,
-          "spread": 0.00961733,
-          "score": 0.01083127
+          "bias": -0.0034051,
+          "spread": 0.00932159,
+          "score": 0.00992405
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00411859,
-          "spread": 0.00821607,
-          "score": 0.00919057
+          "bias": -0.00254079,
+          "spread": 0.00775505,
+          "score": 0.00816066
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.0034603,
-          "spread": 0.00222469,
-          "score": 0.00411375
+          "bias": 0.00443749,
+          "spread": 0.00195882,
+          "score": 0.00485059
         },
         {
           "profile": "cp_plus_3pct",
@@ -2204,162 +2204,162 @@
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00223332,
-          "spread": 0.00852176,
-          "score": 0.00880955
+          "bias": -0.00125893,
+          "spread": 0.00882351,
+          "score": 0.00891287
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00344987,
-          "spread": 0.00212447,
-          "score": 0.00405155
+          "bias": 0.0044226,
+          "spread": 0.00182923,
+          "score": 0.00478596
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00139758,
-          "spread": 0.00251183,
-          "score": 0.00287446
+          "bias": 0.0023729,
+          "spread": 0.00218172,
+          "score": 0.00322344
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00614151,
-          "spread": 0.00617408,
-          "score": 0.00870847
+          "bias": 0.00712854,
+          "spread": 0.00625593,
+          "score": 0.00948435
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01100936,
-          "spread": 0.00841129,
-          "score": 0.01385481
+          "bias": 0.01200246,
+          "spread": 0.00824462,
+          "score": 0.01456134
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.01089774,
-          "spread": 0.0139257,
-          "score": 0.01768293
+          "bias": 0.01189303,
+          "spread": 0.01383608,
+          "score": 0.01824503
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.07524534,
-          "spread": 0.07762136,
-          "score": 0.10810613
+          "bias": 0.07627773,
+          "spread": 0.07724374,
+          "score": 0.10855822
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.25480312,
-          "spread": 0.06234877,
-          "score": 0.26232041
+          "bias": 0.25621289,
+          "spread": 0.06263174,
+          "score": 0.26375704
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.04402617,
-          "spread": 0.53700436,
-          "score": 0.53880607
+          "bias": 0.04515741,
+          "spread": 0.53783008,
+          "score": 0.53972251
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.08656664,
-          "spread": 0.14042985,
-          "score": 0.16496765
+          "bias": -0.08566212,
+          "spread": 0.14073101,
+          "score": 0.16475198
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00027542,
-          "spread": 0.00307245,
-          "score": 0.00308477
+          "bias": 0.00070133,
+          "spread": 0.00317264,
+          "score": 0.00324924
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00498038,
-          "spread": 0.00389234,
-          "score": 0.00632096
+          "bias": 0.00594514,
+          "spread": 0.00425374,
+          "score": 0.0073102
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00577935,
-          "spread": 0.0034485,
-          "score": 0.00673001
+          "bias": 0.00674198,
+          "spread": 0.00383894,
+          "score": 0.00775834
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00271846,
-          "spread": 0.00251796,
-          "score": 0.00370542
+          "bias": 0.00367588,
+          "spread": 0.00261789,
+          "score": 0.00451281
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.01272123,
-          "spread": 0.01307271,
-          "score": 0.01824076
+          "bias": 0.01369118,
+          "spread": 0.01339336,
+          "score": 0.01915282
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.13617209,
-          "spread": 0.08284879,
-          "score": 0.15939498
+          "bias": -0.1352824,
+          "spread": 0.08308691,
+          "score": 0.15876008
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00735619,
-          "spread": 0.02459881,
-          "score": 0.02567518
+          "bias": -0.00640041,
+          "spread": 0.02482486,
+          "score": 0.02563667
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.17768452,
+          "bias": 0.1791067,
           "spread": 0.0,
-          "score": 0.17768452
+          "score": 0.1791067
         },
         {
           "profile": "cp_plus_3pct",
@@ -2375,207 +2375,207 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00768946,
-          "spread": 0.00753002,
-          "score": 0.01076239
+          "bias": 0.00868317,
+          "spread": 0.0077442,
+          "score": 0.01163486
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00242575,
-          "spread": 0.0049935,
-          "score": 0.00555152
+          "bias": 0.00341159,
+          "spread": 0.00472805,
+          "score": 0.00583038
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00306727,
-          "spread": 0.00736075,
-          "score": 0.00797426
+          "bias": 0.00405158,
+          "spread": 0.00692649,
+          "score": 0.00802443
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00052343,
-          "spread": 0.00326491,
-          "score": 0.0033066
+          "bias": 0.00114635,
+          "spread": 0.00339926,
+          "score": 0.00358735
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.14232803,
+          "bias": 0.1422349,
           "spread": 0.0,
-          "score": 0.14232803
+          "score": 0.1422349
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00434981,
-          "spread": 0.00216278,
-          "score": 0.00485783
+          "bias": -0.00372839,
+          "spread": 0.00218911,
+          "score": 0.00432355
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00032886,
-          "spread": 0.00237718,
-          "score": 0.00239982
+          "bias": 0.00029076,
+          "spread": 0.0024555,
+          "score": 0.00247265
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00026291,
-          "spread": 0.00407984,
-          "score": 0.0040883
+          "bias": 0.00035912,
+          "spread": 0.0041211,
+          "score": 0.00413671
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00287588,
-          "spread": 0.00472632,
-          "score": 0.00553252
+          "bias": 0.00350495,
+          "spread": 0.00505702,
+          "score": 0.0061529
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00849086,
-          "spread": 0.00673155,
-          "score": 0.01083552
+          "bias": 0.00912526,
+          "spread": 0.00691414,
+          "score": 0.01144883
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00012656,
-          "spread": 0.01320739,
-          "score": 0.013208
+          "bias": 0.00075492,
+          "spread": 0.01308479,
+          "score": 0.01310655
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.05262378,
-          "spread": 0.04654466,
-          "score": 0.0702543
+          "bias": 0.05327207,
+          "spread": 0.04617997,
+          "score": 0.0705018
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.38888044,
-          "spread": 0.41967046,
-          "score": 0.57214621
+          "bias": 0.38960212,
+          "spread": 0.41924378,
+          "score": 0.57232434
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.84200332,
-          "spread": 0.8377062,
-          "score": 1.18773788
+          "bias": 0.84352372,
+          "spread": 0.83833531,
+          "score": 1.18925958
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.11649349,
-          "spread": 0.09270013,
-          "score": 0.14887594
+          "bias": -0.11597832,
+          "spread": 0.09252749,
+          "score": 0.14836545
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00048339,
-          "spread": 0.00304501,
-          "score": 0.00308314
+          "bias": 0.00014024,
+          "spread": 0.003083,
+          "score": 0.00308619
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00195674,
-          "spread": 0.00235312,
-          "score": 0.00306039
+          "bias": 0.0025708,
+          "spread": 0.00248001,
+          "score": 0.00357204
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00173052,
-          "spread": 0.00212242,
-          "score": 0.0027385
+          "bias": 0.00234292,
+          "spread": 0.00222434,
+          "score": 0.00323062
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 9.555e-05,
-          "spread": 0.00083656,
-          "score": 0.000842
+          "bias": 0.00070675,
+          "spread": 0.00094548,
+          "score": 0.00118044
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00058049,
-          "spread": 0.00243961,
-          "score": 0.00250772
+          "bias": 0.00119297,
+          "spread": 0.00269309,
+          "score": 0.00294549
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.13933708,
-          "spread": 0.08134079,
-          "score": 0.1613417
+          "bias": -0.13875315,
+          "spread": 0.08172503,
+          "score": 0.16103235
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00687484,
-          "spread": 0.01468781,
-          "score": 0.01621713
+          "bias": 0.00749543,
+          "spread": 0.01496999,
+          "score": 0.01674163
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.05201849,
-          "spread": 0.04086768,
-          "score": 0.06615203
+          "bias": 0.05267642,
+          "spread": 0.04122461,
+          "score": 0.06689001
         },
         {
           "profile": "cp_plus_3pct",
@@ -2591,198 +2591,198 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00076438,
-          "spread": 0.00746533,
-          "score": 0.00750436
+          "bias": 0.0013945,
+          "spread": 0.00752013,
+          "score": 0.00764833
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00031184,
-          "spread": 0.00687444,
-          "score": 0.00688151
+          "bias": 0.00094154,
+          "spread": 0.00691517,
+          "score": 0.00697897
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 6.339e-05,
-          "spread": 0.00726605,
-          "score": 0.00726633
+          "bias": 0.00069314,
+          "spread": 0.00734955,
+          "score": 0.00738216
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00016314,
-          "spread": 0.00306814,
-          "score": 0.00307247
+          "bias": 0.00138928,
+          "spread": 0.00231507,
+          "score": 0.00269993
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.11005497,
+          "bias": 0.11115727,
           "spread": 0.0,
-          "score": 0.11005497
+          "score": 0.11115727
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.011052,
-          "spread": 0.01300438,
-          "score": 0.01706636
+          "bias": -0.00950275,
+          "spread": 0.01325974,
+          "score": 0.01631327
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00028954,
-          "spread": 0.00421047,
-          "score": 0.00422042
+          "bias": 0.00185404,
+          "spread": 0.00357326,
+          "score": 0.00402562
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00259806,
-          "spread": 0.00253108,
-          "score": 0.00362716
+          "bias": -0.00104968,
+          "spread": 0.00193694,
+          "score": 0.00220308
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00138345,
-          "spread": 0.01035416,
-          "score": 0.01044617
+          "bias": 0.00292459,
+          "spread": 0.01028859,
+          "score": 0.01069619
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00698284,
-          "spread": 0.01878013,
-          "score": 0.0200363
+          "bias": 0.00852104,
+          "spread": 0.01851184,
+          "score": 0.02037882
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.0259812,
-          "spread": 0.04112218,
-          "score": 0.04864213
+          "bias": -0.02449787,
+          "spread": 0.04097839,
+          "score": 0.04774279
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.08534103,
-          "spread": 0.10967383,
-          "score": 0.13896561
+          "bias": 0.08698324,
+          "spread": 0.10960368,
+          "score": 0.13992516
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.2524074,
-          "spread": 0.41627775,
-          "score": 0.48682303
+          "bias": 0.25458949,
+          "spread": 0.41693327,
+          "score": 0.48851731
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.22162504,
-          "spread": 0.75298079,
-          "score": 0.78491893
+          "bias": 0.22379692,
+          "spread": 0.75398323,
+          "score": 0.78649589
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.06129621,
-          "spread": 0.14769102,
-          "score": 0.15990579
+          "bias": -0.05981845,
+          "spread": 0.14810748,
+          "score": 0.15973125
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00172269,
-          "spread": 0.00823776,
-          "score": 0.00841596
+          "bias": 0.00327995,
+          "spread": 0.00847891,
+          "score": 0.0090912
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00078374,
-          "spread": 0.00794261,
-          "score": 0.00798118
+          "bias": 0.00238399,
+          "spread": 0.00792123,
+          "score": 0.0082722
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00740428,
-          "spread": 0.01050438,
-          "score": 0.01285166
+          "bias": 0.00902056,
+          "spread": 0.01046749,
+          "score": 0.01381806
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00218496,
-          "spread": 0.00385149,
-          "score": 0.0044281
+          "bias": -0.00058269,
+          "spread": 0.00389613,
+          "score": 0.00393946
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00914505,
-          "spread": 0.01458232,
-          "score": 0.01721267
+          "bias": 0.01075871,
+          "spread": 0.01422225,
+          "score": 0.01783318
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.09888411,
-          "spread": 0.10800955,
-          "score": 0.14643815
+          "bias": -0.09746254,
+          "spread": 0.10853057,
+          "score": 0.14586922
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00352573,
-          "spread": 0.03430486,
-          "score": 0.03448557
+          "bias": -0.00175035,
+          "spread": 0.03416906,
+          "score": 0.03421386
         },
         {
           "profile": "rated_plus_5pct",
@@ -2807,36 +2807,36 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00046469,
-          "spread": 0.01824491,
-          "score": 0.01825083
+          "bias": 0.00105712,
+          "spread": 0.01784892,
+          "score": 0.01788019
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00436856,
-          "spread": 0.01100377,
-          "score": 0.01183923
+          "bias": -0.00284848,
+          "spread": 0.01072025,
+          "score": 0.01109223
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00238446,
-          "spread": 0.00883603,
-          "score": 0.0091521
+          "bias": -0.00086123,
+          "spread": 0.00842701,
+          "score": 0.0084709
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00348831,
-          "spread": 0.00220558,
-          "score": 0.00412709
+          "bias": 0.00446346,
+          "spread": 0.00193895,
+          "score": 0.00486642
         },
         {
           "profile": "rated_plus_5pct",
@@ -2852,162 +2852,162 @@
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00109535,
-          "spread": 0.00678535,
-          "score": 0.0068732
+          "bias": -0.00012248,
+          "spread": 0.00719487,
+          "score": 0.00719591
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00178909,
-          "spread": 0.00201226,
-          "score": 0.00269259
+          "bias": 0.00276897,
+          "spread": 0.00158002,
+          "score": 0.00318804
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00136469,
-          "spread": 0.00299308,
-          "score": 0.00328951
+          "bias": 0.0023371,
+          "spread": 0.00260979,
+          "score": 0.00350329
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00907235,
-          "spread": 0.00554328,
-          "score": 0.01063181
+          "bias": 0.01004438,
+          "spread": 0.00570743,
+          "score": 0.01155267
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01402929,
-          "spread": 0.00665075,
-          "score": 0.0155259
+          "bias": 0.01500057,
+          "spread": 0.00661002,
+          "score": 0.01639236
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.01291322,
-          "spread": 0.01485973,
-          "score": 0.01968661
+          "bias": 0.01388173,
+          "spread": 0.01484037,
+          "score": 0.0203209
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.07983896,
-          "spread": 0.07600521,
-          "score": 0.11023181
+          "bias": 0.08084036,
+          "spread": 0.07564139,
+          "score": 0.11071036
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.25567719,
-          "spread": 0.04874238,
-          "score": 0.26028186
+          "bias": 0.2570325,
+          "spread": 0.04902582,
+          "score": 0.26166627
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.03146144,
-          "spread": 0.5211242,
-          "score": 0.52207303
+          "bias": 0.0325502,
+          "spread": 0.52190327,
+          "score": 0.52291733
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.08768889,
-          "spread": 0.17562345,
-          "score": 0.19629808
+          "bias": -0.08678205,
+          "spread": 0.17593908,
+          "score": 0.19617769
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00245102,
-          "spread": 0.00362688,
-          "score": 0.00437741
+          "bias": 0.00342281,
+          "spread": 0.00376111,
+          "score": 0.00508542
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00090942,
-          "spread": 0.00483001,
-          "score": 0.00491488
+          "bias": 0.00191051,
+          "spread": 0.0051771,
+          "score": 0.00551837
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.0040657,
-          "spread": 0.00336532,
-          "score": 0.00527781
+          "bias": 0.00507401,
+          "spread": 0.00383998,
+          "score": 0.00636325
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00143407,
-          "spread": 0.00157855,
-          "score": 0.00213269
+          "bias": 0.0024383,
+          "spread": 0.00154529,
+          "score": 0.00288674
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.01318815,
-          "spread": 0.01399732,
-          "score": 0.01923155
+          "bias": 0.0142071,
+          "spread": 0.01430307,
+          "score": 0.02015985
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.11582286,
-          "spread": 0.06890401,
-          "score": 0.13476905
+          "bias": -0.11496423,
+          "spread": 0.06913629,
+          "score": 0.13415141
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00477817,
-          "spread": 0.02882741,
-          "score": 0.02922072
+          "bias": -0.00377726,
+          "spread": 0.02901926,
+          "score": 0.02926406
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.19386509,
+          "bias": 0.19535532,
           "spread": 0.0,
-          "score": 0.19386509
+          "score": 0.19535532
         },
         {
           "profile": "rated_plus_5pct",
@@ -3023,207 +3023,207 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00822943,
-          "spread": 0.0076138,
-          "score": 0.01121131
+          "bias": 0.00919442,
+          "spread": 0.00782841,
+          "score": 0.01207565
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00213836,
-          "spread": 0.00554957,
-          "score": 0.00594729
+          "bias": 0.00309438,
+          "spread": 0.00527837,
+          "score": 0.00611853
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00391696,
-          "spread": 0.00720577,
-          "score": 0.00820156
+          "bias": 0.00487388,
+          "spread": 0.0068054,
+          "score": 0.00837067
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.0005622,
-          "spread": 0.00326916,
-          "score": 0.00331715
+          "bias": 0.00118619,
+          "spread": 0.00340393,
+          "score": 0.00360469
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.13185608,
+          "bias": 0.13176651,
           "spread": 0.0,
-          "score": 0.13185608
+          "score": 0.13176651
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00130743,
-          "spread": 0.00431667,
-          "score": 0.00451032
+          "bias": -0.00068784,
+          "spread": 0.00440168,
+          "score": 0.0044551
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00089065,
-          "spread": 0.00249255,
-          "score": 0.00264689
+          "bias": -0.00026378,
+          "spread": 0.00253956,
+          "score": 0.00255322
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00075185,
-          "spread": 0.00408237,
-          "score": 0.00415102
+          "bias": -0.00012876,
+          "spread": 0.00413159,
+          "score": 0.00413359
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00465296,
-          "spread": 0.00435467,
-          "score": 0.00637285
+          "bias": 0.00527466,
+          "spread": 0.00469744,
+          "score": 0.00706314
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01109355,
-          "spread": 0.0062667,
-          "score": 0.0127412
+          "bias": 0.01171533,
+          "spread": 0.00646168,
+          "score": 0.01337918
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00276164,
-          "spread": 0.01272802,
-          "score": 0.01302418
+          "bias": 0.00337422,
+          "spread": 0.01265661,
+          "score": 0.01309866
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.0548535,
-          "spread": 0.04687296,
-          "score": 0.07215248
+          "bias": 0.05548199,
+          "spread": 0.04650934,
+          "score": 0.07239731
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.37299258,
-          "spread": 0.38570933,
-          "score": 0.53655862
+          "bias": 0.37369025,
+          "spread": 0.38530377,
+          "score": 0.53675265
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.86762497,
-          "spread": 0.76142977,
-          "score": 1.15436059
+          "bias": 0.86907665,
+          "spread": 0.76205615,
+          "score": 1.15586495
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.11052905,
-          "spread": 0.10233137,
-          "score": 0.15062662
+          "bias": -0.11001343,
+          "spread": 0.10215614,
+          "score": 0.15012938
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00237673,
-          "spread": 0.00236709,
-          "score": 0.0033544
+          "bias": 0.0029983,
+          "spread": 0.00224491,
+          "score": 0.00374559
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00107923,
-          "spread": 0.00285127,
-          "score": 0.00304869
+          "bias": -0.00044052,
+          "spread": 0.00292834,
+          "score": 0.00296128
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00036156,
-          "spread": 0.00198162,
-          "score": 0.00201433
+          "bias": 0.00100362,
+          "spread": 0.00218849,
+          "score": 0.00240765
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00083548,
-          "spread": 0.00095508,
-          "score": 0.00126894
+          "bias": -0.00019423,
+          "spread": 0.00124259,
+          "score": 0.00125768
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00078772,
-          "spread": 0.00388987,
-          "score": 0.00396883
+          "bias": 0.00143008,
+          "spread": 0.0041762,
+          "score": 0.00441427
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.12484518,
-          "spread": 0.07024301,
-          "score": 0.14324943
+          "bias": -0.12428185,
+          "spread": 0.07061252,
+          "score": 0.14294092
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.01069338,
-          "spread": 0.01812015,
-          "score": 0.02104016
+          "bias": 0.01134475,
+          "spread": 0.01844583,
+          "score": 0.0216553
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.05883619,
-          "spread": 0.04345625,
-          "score": 0.07314467
+          "bias": 0.05952528,
+          "spread": 0.04383949,
+          "score": 0.07392672
         },
         {
           "profile": "rated_plus_5pct",
@@ -3239,198 +3239,198 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00109141,
-          "spread": 0.00767097,
-          "score": 0.00774822
+          "bias": 0.00170369,
+          "spread": 0.00771997,
+          "score": 0.00790572
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 7.016e-05,
-          "spread": 0.00711957,
-          "score": 0.00711992
+          "bias": 0.00068179,
+          "spread": 0.00715959,
+          "score": 0.00719198
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00101483,
-          "spread": 0.00726267,
-          "score": 0.00733323
+          "bias": 0.00162763,
+          "spread": 0.00736442,
+          "score": 0.00754214
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00021061,
-          "spread": 0.0031395,
-          "score": 0.00314656
+          "bias": 0.00137962,
+          "spread": 0.00236677,
+          "score": 0.00273952
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.10253626,
+          "bias": 0.10372972,
           "spread": 0.0,
-          "score": 0.10253626
+          "score": 0.10372972
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.01469739,
-          "spread": 0.01482734,
-          "score": 0.02087734
+          "bias": -0.01310601,
+          "spread": 0.01464745,
+          "score": 0.0196549
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00127363,
-          "spread": 0.00517319,
-          "score": 0.00532767
+          "bias": 0.00287124,
+          "spread": 0.00492671,
+          "score": 0.00570232
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00427276,
-          "spread": 0.00182667,
-          "score": 0.00464685
+          "bias": -0.00268397,
+          "spread": 0.00121379,
+          "score": 0.00294567
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.0025637,
-          "spread": 0.01028459,
-          "score": 0.01059931
+          "bias": 0.00414815,
+          "spread": 0.00999245,
+          "score": 0.01081925
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01502161,
-          "spread": 0.02091197,
-          "score": 0.025748
+          "bias": 0.01658951,
+          "spread": 0.02047648,
+          "score": 0.02635333
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.01032624,
-          "spread": 0.0444181,
-          "score": 0.04560262
+          "bias": -0.00882154,
+          "spread": 0.04425591,
+          "score": 0.04512655
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.10029714,
-          "spread": 0.1087188,
-          "score": 0.14791651
+          "bias": 0.10196421,
+          "spread": 0.10866385,
+          "score": 0.14901186
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.2914696,
-          "spread": 0.46272407,
-          "score": 0.54687119
+          "bias": 0.29371741,
+          "spread": 0.46343346,
+          "score": 0.54867157
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.31007907,
-          "spread": 0.79213194,
-          "score": 0.85065976
+          "bias": 0.31237746,
+          "spread": 0.79316869,
+          "score": 0.8524648
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.16226848,
-          "spread": 0.12433569,
-          "score": 0.20442706
+          "bias": -0.1609386,
+          "spread": 0.12481819,
+          "score": 0.20366839
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00263134,
-          "spread": 0.00486248,
-          "score": 0.0055288
+          "bias": -0.00103533,
+          "spread": 0.00523487,
+          "score": 0.00533627
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.0056567,
-          "spread": 0.00807329,
-          "score": 0.0098578
+          "bias": 0.00720325,
+          "spread": 0.00785582,
+          "score": 0.01065836
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00839201,
-          "spread": 0.01160804,
-          "score": 0.01432384
+          "bias": 0.00993344,
+          "spread": 0.01144156,
+          "score": 0.01515198
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00113493,
-          "spread": 0.00513537,
-          "score": 0.00525929
+          "bias": 0.00039257,
+          "spread": 0.00495326,
+          "score": 0.0049688
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00905657,
-          "spread": 0.01608443,
-          "score": 0.01845888
+          "bias": 0.01059574,
+          "spread": 0.01575385,
+          "score": 0.01898561
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.11376003,
-          "spread": 0.13380106,
-          "score": 0.17562479
+          "bias": -0.11226496,
+          "spread": 0.13435889,
+          "score": 0.17508779
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.01304495,
-          "spread": 0.02384943,
-          "score": 0.02718393
+          "bias": -0.01135231,
+          "spread": 0.02374957,
+          "score": 0.02632332
         },
         {
           "profile": "ti_dependent_cp",
@@ -3455,36 +3455,36 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00075179,
-          "spread": 0.0195345,
-          "score": 0.01954896
+          "bias": 0.00236125,
+          "spread": 0.01921277,
+          "score": 0.01935733
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00333584,
-          "spread": 0.01034161,
-          "score": 0.01086632
+          "bias": -0.00172219,
+          "spread": 0.0101163,
+          "score": 0.01026184
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00440302,
-          "spread": 0.00780649,
-          "score": 0.00896258
+          "bias": -0.00279129,
+          "spread": 0.00728929,
+          "score": 0.00780545
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00350498,
-          "spread": 0.00227968,
-          "score": 0.00418113
+          "bias": 0.00450188,
+          "spread": 0.00200608,
+          "score": 0.00492862
         },
         {
           "profile": "ti_dependent_cp",
@@ -3500,162 +3500,162 @@
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00819448,
-          "spread": 0.01126622,
-          "score": 0.01393116
+          "bias": -0.00718022,
+          "spread": 0.01148858,
+          "score": 0.01354781
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00120456,
-          "spread": 0.00213783,
-          "score": 0.00245383
+          "bias": 0.0022014,
+          "spread": 0.00183995,
+          "score": 0.00286907
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00080634,
-          "spread": 0.00263337,
-          "score": 0.00275405
+          "bias": 0.00180095,
+          "spread": 0.00225621,
+          "score": 0.00288685
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.01070899,
-          "spread": 0.00511715,
-          "score": 0.01186877
+          "bias": 0.01170838,
+          "spread": 0.00514264,
+          "score": 0.012788
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.02461899,
-          "spread": 0.00717754,
-          "score": 0.02564394
+          "bias": 0.02561362,
+          "spread": 0.00694697,
+          "score": 0.02653899
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.03221439,
-          "spread": 0.01407149,
-          "score": 0.03515357
+          "bias": 0.03320676,
+          "spread": 0.01392726,
+          "score": 0.03600913
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.10164346,
-          "spread": 0.08302303,
-          "score": 0.13124106
+          "bias": 0.10266283,
+          "spread": 0.08266814,
+          "score": 0.13180925
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.27504034,
-          "spread": 0.04953869,
-          "score": 0.27946605
+          "bias": 0.27641737,
+          "spread": 0.04984578,
+          "score": 0.28087571
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.03728409,
-          "spread": 0.6252174,
-          "score": 0.62632811
+          "bias": -0.03831885,
+          "spread": 0.62816404,
+          "score": 0.6293317
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.08718422,
-          "spread": 0.15629693,
-          "score": 0.17896877
+          "bias": -0.08628223,
+          "spread": 0.15658952,
+          "score": 0.17878731
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00212561,
-          "spread": 0.00294053,
-          "score": 0.00362835
+          "bias": -0.00112807,
+          "spread": 0.0029266,
+          "score": 0.00313649
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00537328,
-          "spread": 0.00335966,
-          "score": 0.00633715
+          "bias": 0.00634171,
+          "spread": 0.00373666,
+          "score": 0.00736071
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00529294,
-          "spread": 0.00353084,
-          "score": 0.00636255
+          "bias": 0.00625543,
+          "spread": 0.00391653,
+          "score": 0.00738035
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.0024095,
-          "spread": 0.00315456,
-          "score": 0.0039695
+          "bias": 0.00336781,
+          "spread": 0.00325974,
+          "score": 0.00468701
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.01209744,
-          "spread": 0.01261162,
-          "score": 0.01747572
+          "bias": 0.01306908,
+          "spread": 0.01294389,
+          "score": 0.01839416
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.13678312,
-          "spread": 0.09202357,
-          "score": 0.16485739
+          "bias": -0.13587017,
+          "spread": 0.09224692,
+          "score": 0.16422605
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00886977,
-          "spread": 0.02349788,
-          "score": 0.02511619
+          "bias": -0.00791375,
+          "spread": 0.0237445,
+          "score": 0.02502856
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.17713758,
+          "bias": 0.17856492,
           "spread": 0.0,
-          "score": 0.17713758
+          "score": 0.17856492
         },
         {
           "profile": "ti_dependent_cp",
@@ -3671,207 +3671,207 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00937984,
-          "spread": 0.00764871,
-          "score": 0.01210306
+          "bias": 0.01040791,
+          "spread": 0.0079064,
+          "score": 0.01307042
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00381318,
-          "spread": 0.00466746,
-          "score": 0.00602707
+          "bias": 0.00482949,
+          "spread": 0.00442013,
+          "score": 0.00654688
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00306237,
-          "spread": 0.00749405,
-          "score": 0.00809561
+          "bias": 0.00407615,
+          "spread": 0.00703269,
+          "score": 0.00812857
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00051421,
-          "spread": 0.00332943,
-          "score": 0.0033689
+          "bias": 0.00114912,
+          "spread": 0.00346552,
+          "score": 0.00365107
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.14742561,
+          "bias": 0.14732603,
           "spread": 0.0,
-          "score": 0.14742561
+          "score": 0.14732603
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.01009103,
-          "spread": 0.00239808,
-          "score": 0.01037206
+          "bias": -0.00944284,
+          "spread": 0.00209959,
+          "score": 0.00967344
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00233477,
-          "spread": 0.00267567,
-          "score": 0.00355111
+          "bias": -0.00170036,
+          "spread": 0.00269795,
+          "score": 0.00318907
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00068811,
-          "spread": 0.00410216,
-          "score": 0.00415947
+          "bias": -5.38e-05,
+          "spread": 0.00412086,
+          "score": 0.00412121
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00668661,
-          "spread": 0.00408685,
-          "score": 0.00783666
+          "bias": 0.00732323,
+          "spread": 0.00442582,
+          "score": 0.00855673
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.02075976,
-          "spread": 0.00625975,
-          "score": 0.02168299
+          "bias": 0.02139376,
+          "spread": 0.00639851,
+          "score": 0.02233011
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.01969699,
-          "spread": 0.01311094,
-          "score": 0.02366154
+          "bias": 0.02031811,
+          "spread": 0.01293709,
+          "score": 0.02408721
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.07029517,
-          "spread": 0.04625087,
-          "score": 0.08414603
+          "bias": 0.07093332,
+          "spread": 0.04588397,
+          "score": 0.08448003
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.41026254,
-          "spread": 0.41321345,
-          "score": 0.5822892
+          "bias": 0.41097163,
+          "spread": 0.41279514,
+          "score": 0.5824925
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.90145861,
-          "spread": 0.77133971,
-          "score": 1.18642006
+          "bias": 0.90293703,
+          "spread": 0.77197378,
+          "score": 1.18795572
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.10500994,
-          "spread": 0.08893545,
-          "score": 0.13761032
+          "bias": -0.1044863,
+          "spread": 0.08875918,
+          "score": 0.13709697
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00222093,
-          "spread": 0.00357031,
-          "score": 0.00420472
+          "bias": -0.00158403,
+          "spread": 0.00365838,
+          "score": 0.00398659
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.0028645,
-          "spread": 0.00203978,
-          "score": 0.00351654
+          "bias": 0.00348132,
+          "spread": 0.00224476,
+          "score": 0.00414228
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00196051,
-          "spread": 0.00215664,
-          "score": 0.00291456
+          "bias": 0.00257357,
+          "spread": 0.00222461,
+          "score": 0.00340178
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00027416,
-          "spread": 0.00073159,
-          "score": 0.00078128
+          "bias": 0.00088592,
+          "spread": 0.00075698,
+          "score": 0.00116528
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00018997,
-          "spread": 0.00197705,
-          "score": 0.00198615
+          "bias": 0.00080293,
+          "spread": 0.00217117,
+          "score": 0.00231488
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.14168275,
-          "spread": 0.08786657,
-          "score": 0.16671693
+          "bias": -0.14108764,
+          "spread": 0.08825718,
+          "score": 0.1664183
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00512603,
-          "spread": 0.01405953,
-          "score": 0.01496484
+          "bias": 0.00574744,
+          "spread": 0.01431243,
+          "score": 0.01542332
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.04818677,
-          "spread": 0.03874513,
-          "score": 0.06183163
+          "bias": 0.04884508,
+          "spread": 0.03909368,
+          "score": 0.06256323
         },
         {
           "profile": "ti_dependent_cp",
@@ -3887,198 +3887,198 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00218744,
-          "spread": 0.00772713,
-          "score": 0.00803078
+          "bias": 0.00283658,
+          "spread": 0.00774355,
+          "score": 0.00824674
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00142998,
-          "spread": 0.00683377,
-          "score": 0.00698178
+          "bias": 0.00207953,
+          "spread": 0.00686208,
+          "score": 0.00717026
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00024196,
-          "spread": 0.00730338,
-          "score": 0.00730739
+          "bias": 0.00040686,
+          "spread": 0.00736765,
+          "score": 0.00737888
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.0001907,
-          "spread": 0.003135,
-          "score": 0.0031408
+          "bias": 0.00138744,
+          "spread": 0.00236675,
+          "score": 0.00274345
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.15377346,
+          "bias": 0.1549398,
           "spread": 0.0,
-          "score": 0.15377346
+          "score": 0.1549398
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00899187,
-          "spread": 0.01083921,
-          "score": 0.0140834
+          "bias": -0.00742468,
+          "spread": 0.01082196,
+          "score": 0.01312405
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.004027,
-          "spread": 0.00466306,
-          "score": 0.00616124
+          "bias": 0.00559798,
+          "spread": 0.00436483,
+          "score": 0.00709853
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00329965,
-          "spread": 0.00164475,
-          "score": 0.00368686
+          "bias": -0.0017261,
+          "spread": 0.00135119,
+          "score": 0.00219206
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.002517,
-          "spread": 0.01102389,
-          "score": 0.01130759
+          "bias": -0.00092391,
+          "spread": 0.01077924,
+          "score": 0.01081876
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00093,
-          "spread": 0.02343741,
-          "score": 0.02345586
+          "bias": 0.00254055,
+          "spread": 0.0230036,
+          "score": 0.02314347
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.02983829,
-          "spread": 0.04496933,
-          "score": 0.05396818
+          "bias": -0.02825304,
+          "spread": 0.0447957,
+          "score": 0.0529612
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.07745126,
-          "spread": 0.11921795,
-          "score": 0.14216757
+          "bias": 0.07923303,
+          "spread": 0.1191599,
+          "score": 0.14309771
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.2568556,
-          "spread": 0.46646101,
-          "score": 0.53250416
+          "bias": 0.2592838,
+          "spread": 0.46714828,
+          "score": 0.53428045
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.12765508,
-          "spread": 0.89751716,
-          "score": 0.90654998
+          "bias": 0.13013785,
+          "spread": 0.89845465,
+          "score": 0.90783073
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.12736315,
-          "spread": 0.23091563,
-          "score": 0.26371083
+          "bias": -0.12593502,
+          "spread": 0.23148578,
+          "score": 0.26352476
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00127979,
-          "spread": 0.00613656,
-          "score": 0.00626859
+          "bias": 0.00283276,
+          "spread": 0.0065267,
+          "score": 0.00711494
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00557858,
-          "spread": 0.00887199,
-          "score": 0.01048011
+          "bias": 0.0071165,
+          "spread": 0.00882263,
+          "score": 0.01133505
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00949963,
-          "spread": 0.01181231,
-          "score": 0.01515829
+          "bias": 0.0110432,
+          "spread": 0.01174921,
+          "score": 0.0161244
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00021539,
-          "spread": 0.00519596,
-          "score": 0.00520043
+          "bias": 0.00131398,
+          "spread": 0.00516429,
+          "score": 0.00532883
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.01089552,
-          "spread": 0.0159429,
-          "score": 0.01931032
+          "bias": 0.01243679,
+          "spread": 0.0156261,
+          "score": 0.0199712
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.14148281,
-          "spread": 0.15395616,
-          "score": 0.209093
+          "bias": -0.13988836,
+          "spread": 0.1544903,
+          "score": 0.20841306
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00469277,
-          "spread": 0.03164757,
-          "score": 0.0319936
+          "bias": -0.00299601,
+          "spread": 0.03156555,
+          "score": 0.03170741
         },
         {
           "profile": "ws_dependent_cp",
@@ -4103,36 +4103,36 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00435461,
-          "spread": 0.01889112,
-          "score": 0.01938652
+          "bias": -0.00269462,
+          "spread": 0.01844947,
+          "score": 0.01864521
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00659338,
-          "spread": 0.01114115,
-          "score": 0.01294596
+          "bias": -0.00496993,
+          "spread": 0.01086023,
+          "score": 0.0119434
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00506165,
-          "spread": 0.00874101,
-          "score": 0.01010077
+          "bias": -0.00347798,
+          "spread": 0.00831465,
+          "score": 0.00901276
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00352032,
-          "spread": 0.00225886,
-          "score": 0.00418271
+          "bias": 0.00450881,
+          "spread": 0.0019924,
+          "score": 0.0049294
         },
         {
           "profile": "ws_dependent_cp",
@@ -4148,162 +4148,162 @@
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00416996,
-          "spread": 0.01160001,
-          "score": 0.01232675
+          "bias": -0.00317451,
+          "spread": 0.01188696,
+          "score": 0.01230355
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00386081,
-          "spread": 0.00255467,
-          "score": 0.00462949
+          "bias": 0.00484221,
+          "spread": 0.00233077,
+          "score": 0.00537396
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00154438,
-          "spread": 0.00263669,
-          "score": 0.00305569
+          "bias": 0.00252924,
+          "spread": 0.00232321,
+          "score": 0.00343429
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00587269,
-          "spread": 0.00651478,
-          "score": 0.00877103
+          "bias": 0.0068761,
+          "spread": 0.00656909,
+          "score": 0.00950966
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01180497,
-          "spread": 0.00830273,
-          "score": 0.01443235
+          "bias": 0.01282253,
+          "spread": 0.00808343,
+          "score": 0.01515781
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.01253534,
-          "spread": 0.01473803,
-          "score": 0.01934798
+          "bias": 0.01356623,
+          "spread": 0.01469027,
+          "score": 0.01999616
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.07499664,
-          "spread": 0.08016367,
-          "score": 0.10977573
+          "bias": 0.07608965,
+          "spread": 0.07976696,
+          "score": 0.11023794
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.1376202,
-          "spread": 0.21393626,
-          "score": 0.25437775
+          "bias": 0.13879981,
+          "spread": 0.21453298,
+          "score": 0.25551866
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.05709027,
-          "spread": 0.50776975,
-          "score": 0.51096909
+          "bias": -0.05606311,
+          "spread": 0.50853144,
+          "score": 0.51161245
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.10542514,
-          "spread": 0.14272269,
-          "score": 0.17743795
+          "bias": -0.10454561,
+          "spread": 0.14297175,
+          "score": 0.17711777
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00229035,
-          "spread": 0.00270817,
-          "score": 0.00354681
+          "bias": 0.00325969,
+          "spread": 0.00275317,
+          "score": 0.00426679
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00543632,
-          "spread": 0.00447288,
-          "score": 0.0070399
+          "bias": 0.00639829,
+          "spread": 0.00481163,
+          "score": 0.00800561
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00590142,
-          "spread": 0.00363381,
-          "score": 0.00693046
+          "bias": 0.00686377,
+          "spread": 0.00402508,
+          "score": 0.00795692
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00352459,
-          "spread": 0.00278848,
-          "score": 0.00449426
+          "bias": 0.00448338,
+          "spread": 0.00285891,
+          "score": 0.00531734
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.01387594,
-          "spread": 0.01298847,
-          "score": 0.01900637
+          "bias": 0.01484839,
+          "spread": 0.01331141,
+          "score": 0.01994162
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.17898477,
-          "spread": 0.11787425,
-          "score": 0.2143126
+          "bias": -0.17801961,
+          "spread": 0.11812707,
+          "score": 0.21364687
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00502373,
-          "spread": 0.02663023,
-          "score": 0.02709995
+          "bias": -0.00406794,
+          "spread": 0.02684958,
+          "score": 0.02715599
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.18263025,
+          "bias": 0.18405273,
           "spread": 0.0,
-          "score": 0.18263025
+          "score": 0.18405273
         },
         {
           "profile": "ws_dependent_cp",
@@ -4319,207 +4319,207 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00529838,
-          "spread": 0.0084551,
-          "score": 0.00997805
+          "bias": 0.00635052,
+          "spread": 0.00866543,
+          "score": 0.01074331
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00039853,
-          "spread": 0.00530575,
-          "score": 0.0053207
+          "bias": 0.00141984,
+          "spread": 0.00506451,
+          "score": 0.00525977
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.0022424,
-          "spread": 0.00776709,
-          "score": 0.00808431
+          "bias": 0.0032373,
+          "spread": 0.00734598,
+          "score": 0.00802767
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00055509,
-          "spread": 0.00330796,
-          "score": 0.00335421
+          "bias": 0.00118508,
+          "spread": 0.0034466,
+          "score": 0.00364464
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.16866377,
+          "bias": 0.16856991,
           "spread": 0.0,
-          "score": 0.16866377
+          "score": 0.16856991
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00392519,
-          "spread": 0.00180371,
-          "score": 0.00431978
+          "bias": -0.00328935,
+          "spread": 0.00198419,
+          "score": 0.00384146
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00040426,
-          "spread": 0.00249104,
-          "score": 0.00252363
+          "bias": 0.00022091,
+          "spread": 0.00257779,
+          "score": 0.00258724
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00025962,
-          "spread": 0.0040567,
-          "score": 0.004065
+          "bias": 0.00036854,
+          "spread": 0.00408097,
+          "score": 0.00409757
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00304805,
-          "spread": 0.00511268,
-          "score": 0.00595232
+          "bias": 0.00368684,
+          "spread": 0.0054544,
+          "score": 0.00658356
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.0096775,
-          "spread": 0.00670514,
-          "score": 0.0117734
+          "bias": 0.01032711,
+          "spread": 0.00690045,
+          "score": 0.01242036
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00224879,
-          "spread": 0.01401651,
-          "score": 0.01419576
+          "bias": 0.00289994,
+          "spread": 0.01384924,
+          "score": 0.01414959
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.05347012,
-          "spread": 0.04883844,
-          "score": 0.07241718
+          "bias": 0.05415,
+          "spread": 0.04847006,
+          "score": 0.07267441
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.40173446,
-          "spread": 0.44781759,
-          "score": 0.60160716
+          "bias": 0.40250516,
+          "spread": 0.44736843,
+          "score": 0.6017881
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.76614579,
-          "spread": 0.9893183,
-          "score": 1.25129136
+          "bias": 0.76776281,
+          "spread": 0.98995053,
+          "score": 1.25278162
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.13100044,
-          "spread": 0.10582151,
-          "score": 0.16840222
+          "bias": -0.13049529,
+          "spread": 0.10568137,
+          "score": 0.16792132
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00169909,
-          "spread": 0.00281844,
-          "score": 0.00329098
+          "bias": 0.00231897,
+          "spread": 0.00287097,
+          "score": 0.00369054
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00235878,
-          "spread": 0.0025949,
-          "score": 0.00350676
+          "bias": 0.00297186,
+          "spread": 0.00269684,
+          "score": 0.00401309
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00206211,
-          "spread": 0.00237225,
-          "score": 0.00314323
+          "bias": 0.00267491,
+          "spread": 0.00244497,
+          "score": 0.00362395
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00070275,
-          "spread": 0.0009008,
-          "score": 0.0011425
+          "bias": 0.00131463,
+          "spread": 0.00098088,
+          "score": 0.00164023
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00148971,
-          "spread": 0.00264831,
-          "score": 0.00303855
+          "bias": 0.00210271,
+          "spread": 0.00291148,
+          "score": 0.00359139
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.17924492,
-          "spread": 0.11141021,
-          "score": 0.21104733
+          "bias": -0.17864555,
+          "spread": 0.11187867,
+          "score": 0.21078678
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00907617,
-          "spread": 0.0147242,
-          "score": 0.01729678
+          "bias": 0.0096974,
+          "spread": 0.01502468,
+          "score": 0.01788241
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.05517677,
-          "spread": 0.04188166,
-          "score": 0.06927156
+          "bias": 0.0558356,
+          "spread": 0.04224211,
+          "score": 0.07001436
         },
         {
           "profile": "ws_dependent_cp",
@@ -4535,33 +4535,33 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00179295,
-          "spread": 0.0079843,
-          "score": 0.00818314
+          "bias": -0.00112951,
+          "spread": 0.0080489,
+          "score": 0.00812777
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00139693,
-          "spread": 0.00735397,
-          "score": 0.00748547
+          "bias": -0.00074339,
+          "spread": 0.00740297,
+          "score": 0.0074402
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00105216,
-          "spread": 0.00762855,
-          "score": 0.00770076
+          "bias": -0.00041465,
+          "spread": 0.00773403,
+          "score": 0.00774514
         }
       ]
     },
     "toggle": {
-      "recorded_utc": "2026-07-04T19:42:37Z",
-      "git_commit": "f13a71d-dirty",
+      "recorded_utc": "2026-07-05T08:20:02Z",
+      "git_commit": "33bfc23-dirty",
       "n_replicates": 4,
       "seed": 0,
       "campaign_months": [
@@ -4585,9 +4585,9 @@
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00120201,
-          "spread": 0.00264262,
-          "score": 0.00290315
+          "bias": 0.00109247,
+          "spread": 0.00203933,
+          "score": 0.00231352
         },
         {
           "profile": "cp_0pct",
@@ -4603,162 +4603,162 @@
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00637684,
-          "spread": 0.01524718,
-          "score": 0.01652696
+          "bias": 0.00626549,
+          "spread": 0.01507388,
+          "score": 0.01632416
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00093667,
-          "spread": 0.00286283,
-          "score": 0.00301216
+          "bias": -0.00104529,
+          "spread": 0.00259834,
+          "score": 0.00280072
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00305754,
-          "spread": 0.00367043,
-          "score": 0.00477709
+          "bias": 0.00294701,
+          "spread": 0.00300944,
+          "score": 0.00421208
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00071358,
-          "spread": 0.00588916,
-          "score": 0.00593223
+          "bias": 0.00060275,
+          "spread": 0.00539895,
+          "score": 0.00543249
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00187449,
-          "spread": 0.00652564,
-          "score": 0.00678953
+          "bias": 0.00176562,
+          "spread": 0.00642177,
+          "score": 0.00666008
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00869374,
-          "spread": 0.03373402,
-          "score": 0.03483626
+          "bias": -0.00880981,
+          "spread": 0.03347998,
+          "score": 0.03461967
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.00539153,
-          "spread": 0.03431298,
-          "score": 0.03473398
+          "bias": 0.00525816,
+          "spread": 0.03355232,
+          "score": 0.03396184
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": -0.00276187,
-          "spread": 0.39320117,
-          "score": 0.39321087
+          "bias": -0.00309804,
+          "spread": 0.39262184,
+          "score": 0.39263407
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.13858512,
+          "bias": -0.13970076,
           "spread": 0.0,
-          "score": 0.13858512
+          "score": 0.13970076
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.00122631,
-          "spread": 0.02330555,
-          "score": 0.02333779
+          "bias": 0.00112799,
+          "spread": 0.0237243,
+          "score": 0.0237511
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00133404,
-          "spread": 0.00179846,
-          "score": 0.00223922
+          "bias": -0.00144293,
+          "spread": 0.00107359,
+          "score": 0.00179851
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00054029,
-          "spread": 0.00383005,
-          "score": 0.00386797
+          "bias": 0.00042966,
+          "spread": 0.00308348,
+          "score": 0.00311327
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 4.212e-05,
-          "spread": 0.00481796,
-          "score": 0.00481814
+          "bias": -6.872e-05,
+          "spread": 0.00418204,
+          "score": 0.00418261
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00018682,
-          "spread": 0.00291694,
-          "score": 0.00292292
+          "bias": 7.713e-05,
+          "spread": 0.00226979,
+          "score": 0.0022711
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00637185,
-          "spread": 0.01993128,
-          "score": 0.02092502
+          "bias": 0.00626161,
+          "spread": 0.01984828,
+          "score": 0.02081254
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.00840889,
-          "spread": 0.03663473,
-          "score": 0.03758741
+          "bias": 0.00827962,
+          "spread": 0.03606995,
+          "score": 0.03700802
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.04094959,
-          "spread": 0.04550499,
-          "score": 0.06121742
+          "bias": 0.04152811,
+          "spread": 0.04543682,
+          "score": 0.06155557
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.00645216,
-          "spread": 0.00153387,
-          "score": 0.00663198
+          "bias": -0.00589594,
+          "spread": 0.0016241,
+          "score": 0.00611554
         },
         {
           "profile": "cp_0pct",
@@ -4774,207 +4774,207 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -6.264e-05,
-          "spread": 0.01332214,
-          "score": 0.01332229
+          "bias": -0.00017567,
+          "spread": 0.01294009,
+          "score": 0.01294128
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00486058,
-          "spread": 0.0053534,
-          "score": 0.00723078
+          "bias": 0.00475042,
+          "spread": 0.00503898,
+          "score": 0.00692516
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00073912,
-          "spread": 0.00368378,
-          "score": 0.00375719
+          "bias": 0.00063143,
+          "spread": 0.00378763,
+          "score": 0.00383991
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.0015952,
-          "spread": 0.00149575,
-          "score": 0.00218676
+          "bias": 0.00153161,
+          "spread": 0.00154332,
+          "score": 0.00217432
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.10036238,
-          "spread": 0.00210113,
-          "score": 0.10038437
+          "bias": 0.09991353,
+          "spread": 0.00139605,
+          "score": 0.09992328
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00044647,
-          "spread": 0.01153555,
-          "score": 0.01154418
+          "bias": 0.00038136,
+          "spread": 0.01140599,
+          "score": 0.01141236
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00040671,
-          "spread": 0.00177634,
-          "score": 0.0018223
+          "bias": 0.00034296,
+          "spread": 0.00167901,
+          "score": 0.00171367
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00304813,
-          "spread": 0.00125828,
-          "score": 0.00329763
+          "bias": 0.00298447,
+          "spread": 0.00132447,
+          "score": 0.00326516
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00052043,
-          "spread": 0.00227877,
-          "score": 0.00233744
+          "bias": -0.00058405,
+          "spread": 0.00223748,
+          "score": 0.00231246
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00145982,
-          "spread": 0.00987914,
-          "score": 0.00998641
+          "bias": 0.00140003,
+          "spread": 0.01025746,
+          "score": 0.01035256
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00355453,
-          "spread": 0.02097674,
-          "score": 0.02127577
+          "bias": 0.0034845,
+          "spread": 0.02066779,
+          "score": 0.02095947
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.03613915,
-          "spread": 0.0304459,
-          "score": 0.04725454
+          "bias": -0.03619672,
+          "spread": 0.03056769,
+          "score": 0.04737707
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.07167056,
-          "spread": 0.19711082,
-          "score": 0.20973637
+          "bias": 0.07191635,
+          "spread": 0.19698838,
+          "score": 0.20970547
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.41925886,
-          "spread": 0.42379021,
-          "score": 0.59613432
+          "bias": 0.41875035,
+          "spread": 0.42432365,
+          "score": 0.59615637
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.0035219,
-          "spread": 0.01463032,
-          "score": 0.01504826
+          "bias": 0.00345974,
+          "spread": 0.01474473,
+          "score": 0.01514519
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.0012212,
-          "spread": 0.0014816,
-          "score": 0.00192002
+          "bias": 0.00115735,
+          "spread": 0.00132352,
+          "score": 0.00175817
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00070606,
-          "spread": 0.00280925,
-          "score": 0.00289662
+          "bias": 0.00064108,
+          "spread": 0.00226347,
+          "score": 0.00235251
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00031386,
-          "spread": 0.00332784,
-          "score": 0.0033426
+          "bias": 0.00024849,
+          "spread": 0.00273065,
+          "score": 0.00274194
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00063224,
-          "spread": 0.00279613,
-          "score": 0.00286672
+          "bias": 0.00056721,
+          "spread": 0.00222648,
+          "score": 0.00229759
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00235951,
-          "spread": 0.0119138,
-          "score": 0.0121452
+          "bias": 0.00229598,
+          "spread": 0.01193218,
+          "score": 0.01215107
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.0082556,
-          "spread": 0.02779045,
-          "score": 0.02899076
+          "bias": -0.00831764,
+          "spread": 0.02783203,
+          "score": 0.02904832
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00373567,
-          "spread": 0.00928082,
-          "score": 0.01000444
+          "bias": -0.00380259,
+          "spread": 0.0088869,
+          "score": 0.00966627
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.01238381,
-          "spread": 0.01520979,
-          "score": 0.01961368
+          "bias": 0.01266316,
+          "spread": 0.01494434,
+          "score": 0.01958798
         },
         {
           "profile": "cp_0pct",
@@ -4990,207 +4990,207 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00303631,
-          "spread": 0.00566381,
-          "score": 0.00642635
+          "bias": 0.0029708,
+          "spread": 0.00534069,
+          "score": 0.00611136
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00049836,
-          "spread": 0.0024874,
-          "score": 0.00253683
+          "bias": 0.00043602,
+          "spread": 0.00294669,
+          "score": 0.00297877
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00280801,
-          "spread": 0.00470528,
-          "score": 0.00547947
+          "bias": 0.00274591,
+          "spread": 0.00504028,
+          "score": 0.00573973
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00083402,
-          "spread": 0.00290788,
-          "score": 0.00302511
+          "bias": 0.00076519,
+          "spread": 0.00279324,
+          "score": 0.00289615
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.0872176,
-          "spread": 0.01039399,
-          "score": 0.08783476
+          "bias": 0.08700524,
+          "spread": 0.01037138,
+          "score": 0.08762121
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00111621,
-          "spread": 0.00439507,
-          "score": 0.00453459
+          "bias": 0.00104701,
+          "spread": 0.00423635,
+          "score": 0.00436381
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00152872,
-          "spread": 0.00289264,
-          "score": 0.00327175
+          "bias": 0.00145985,
+          "spread": 0.00277866,
+          "score": 0.00313881
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00091479,
-          "spread": 0.00265752,
-          "score": 0.00281056
+          "bias": 0.00084609,
+          "spread": 0.00257963,
+          "score": 0.00271484
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00169499,
-          "spread": 0.00299033,
-          "score": 0.0034373
+          "bias": -0.0017636,
+          "spread": 0.00289309,
+          "score": 0.00338825
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00499439,
-          "spread": 0.00854338,
-          "score": 0.00989612
+          "bias": 0.00492404,
+          "spread": 0.00835874,
+          "score": 0.00970128
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00548679,
-          "spread": 0.02313815,
-          "score": 0.02377979
+          "bias": -0.00555471,
+          "spread": 0.02314068,
+          "score": 0.02379802
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.01115009,
-          "spread": 0.02498936,
-          "score": 0.02736407
+          "bias": 0.01107666,
+          "spread": 0.02481938,
+          "score": 0.02717892
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.01049977,
-          "spread": 0.27631662,
-          "score": 0.27651604
+          "bias": 0.01043854,
+          "spread": 0.27629086,
+          "score": 0.27648798
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.2684672,
-          "spread": 0.36410529,
-          "score": 0.4523796
+          "bias": 0.26822577,
+          "spread": 0.36399723,
+          "score": 0.45214936
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.01432426,
-          "spread": 0.03231854,
-          "score": 0.03535071
+          "bias": -0.0143889,
+          "spread": 0.03240219,
+          "score": 0.03545338
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00124991,
-          "spread": 0.00296646,
-          "score": 0.00321903
+          "bias": -0.00131854,
+          "spread": 0.00287343,
+          "score": 0.00316151
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00077884,
-          "spread": 0.00239942,
-          "score": 0.00252266
+          "bias": 0.00070992,
+          "spread": 0.00221616,
+          "score": 0.00232709
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00051299,
-          "spread": 0.00229992,
-          "score": 0.00235644
+          "bias": -0.00058179,
+          "spread": 0.00212118,
+          "score": 0.00219952
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00011875,
-          "spread": 0.00222805,
-          "score": 0.00223122
+          "bias": -0.00018758,
+          "spread": 0.00204117,
+          "score": 0.00204977
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00409819,
-          "spread": 0.00910249,
-          "score": 0.00998251
+          "bias": 0.00402861,
+          "spread": 0.00900654,
+          "score": 0.00986648
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.00388598,
-          "spread": 0.02389079,
-          "score": 0.02420477
+          "bias": 0.00381543,
+          "spread": 0.02381025,
+          "score": 0.02411401
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.0039105,
-          "spread": 0.00716203,
-          "score": 0.00816007
+          "bias": 0.0038415,
+          "spread": 0.00711939,
+          "score": 0.00808968
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.01767627,
-          "spread": 0.02661051,
-          "score": 0.03194636
+          "bias": -0.01762448,
+          "spread": 0.02640993,
+          "score": 0.0317507
         },
         {
           "profile": "cp_0pct",
@@ -5206,252 +5206,252 @@
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00010523,
-          "spread": 0.00420368,
-          "score": 0.00420499
+          "bias": -0.00017347,
+          "spread": 0.00424901,
+          "score": 0.00425254
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00128206,
-          "spread": 0.00317781,
-          "score": 0.00342668
+          "bias": 0.00121349,
+          "spread": 0.00316232,
+          "score": 0.00338716
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00265198,
-          "spread": 0.00499346,
-          "score": 0.00565399
+          "bias": 0.00258283,
+          "spread": 0.00488749,
+          "score": 0.00552798
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00074636,
-          "spread": 0.00192919,
-          "score": 0.00206854
+          "bias": 0.00078617,
+          "spread": 0.00171221,
+          "score": 0.00188407
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.07873567,
-          "spread": 0.03002629,
-          "score": 0.08426674
+          "bias": 0.07831269,
+          "spread": 0.02979286,
+          "score": 0.08378837
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00205494,
-          "spread": 0.00438638,
-          "score": 0.00484387
+          "bias": 0.00209482,
+          "spread": 0.0043012,
+          "score": 0.0047842
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00095093,
-          "spread": 0.0018287,
-          "score": 0.00206117
+          "bias": 0.00099067,
+          "spread": 0.00155432,
+          "score": 0.00184319
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00031737,
-          "spread": 0.00144228,
-          "score": 0.00147678
+          "bias": 0.00035736,
+          "spread": 0.00130429,
+          "score": 0.00135236
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00049299,
-          "spread": 0.00295948,
-          "score": 0.00300026
+          "bias": 0.00053255,
+          "spread": 0.00273946,
+          "score": 0.00279074
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00534874,
-          "spread": 0.00745539,
-          "score": 0.00917561
+          "bias": 0.00538842,
+          "spread": 0.00736278,
+          "score": 0.00912391
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00384002,
-          "spread": 0.03028346,
-          "score": 0.03052595
+          "bias": -0.00380891,
+          "spread": 0.02999745,
+          "score": 0.0302383
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.01345242,
-          "spread": 0.02026807,
-          "score": 0.02432616
+          "bias": -0.0134172,
+          "spread": 0.02004434,
+          "score": 0.02412046
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.03417374,
-          "spread": 0.2301375,
-          "score": 0.23266094
+          "bias": 0.03431052,
+          "spread": 0.23056266,
+          "score": 0.2331016
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.2026589,
-          "spread": 0.11253372,
-          "score": 0.23180696
+          "bias": -0.20263182,
+          "spread": 0.11296621,
+          "score": 0.23199358
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.00672605,
-          "spread": 0.03869698,
-          "score": 0.03927717
+          "bias": -0.00668409,
+          "spread": 0.03875468,
+          "score": 0.03932687
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00015115,
-          "spread": 0.00255116,
-          "score": 0.00255564
+          "bias": -0.00011123,
+          "spread": 0.00244911,
+          "score": 0.00245163
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.0012416,
-          "spread": 0.0010184,
-          "score": 0.00160583
+          "bias": 0.00128149,
+          "spread": 0.00061767,
+          "score": 0.00142258
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00056685,
-          "spread": 0.00179846,
-          "score": 0.00188568
+          "bias": -0.00052731,
+          "spread": 0.00142074,
+          "score": 0.00151544
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00046839,
-          "spread": 0.00141222,
-          "score": 0.00148787
+          "bias": 0.00050808,
+          "spread": 0.00099167,
+          "score": 0.00111425
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": -0.00031704,
-          "spread": 0.00154527,
-          "score": 0.00157746
+          "bias": -0.00027697,
+          "spread": 0.00148437,
+          "score": 0.00150999
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.00197779,
-          "spread": 0.02194232,
-          "score": 0.02203128
+          "bias": 0.0020083,
+          "spread": 0.02149184,
+          "score": 0.02158547
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00319274,
-          "spread": 0.00480046,
-          "score": 0.00576524
+          "bias": -0.0031546,
+          "spread": 0.00438809,
+          "score": 0.00540433
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.03201777,
-          "spread": 0.02583466,
-          "score": 0.04114082
+          "bias": -0.03198219,
+          "spread": 0.02570082,
+          "score": 0.04102917
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
-          "bias": 0.02099227,
+          "bias": 0.02038782,
           "spread": 0.0,
-          "score": 0.02099227
+          "score": 0.02038782
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00137697,
-          "spread": 0.00649893,
-          "score": 0.00664321
+          "bias": 0.00141513,
+          "spread": 0.006173,
+          "score": 0.00633313
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00285713,
-          "spread": 0.00344512,
-          "score": 0.00447572
+          "bias": 0.00289648,
+          "spread": 0.00315903,
+          "score": 0.00428591
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00048793,
-          "spread": 0.00297024,
-          "score": 0.00301005
+          "bias": 0.00052857,
+          "spread": 0.00311891,
+          "score": 0.00316338
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00119341,
-          "spread": 0.00247774,
-          "score": 0.00275017
+          "bias": 0.00109301,
+          "spread": 0.00192617,
+          "score": 0.00221468
         },
         {
           "profile": "cp_minus_10pct",
@@ -5467,162 +5467,162 @@
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00631169,
-          "spread": 0.01588185,
-          "score": 0.01709007
+          "bias": 0.00620213,
+          "spread": 0.01575515,
+          "score": 0.01693196
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00229815,
-          "spread": 0.00237892,
-          "score": 0.00330768
+          "bias": -0.00239855,
+          "spread": 0.00221343,
+          "score": 0.00326379
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00286129,
-          "spread": 0.00403059,
-          "score": 0.00494293
+          "bias": 0.00276354,
+          "spread": 0.00336455,
+          "score": 0.004354
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00334303,
-          "spread": 0.00517045,
-          "score": 0.00615706
+          "bias": 0.00324433,
+          "spread": 0.0046821,
+          "score": 0.00569629
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00488462,
-          "spread": 0.00606042,
-          "score": 0.00778384
+          "bias": 0.00478809,
+          "spread": 0.00590133,
+          "score": 0.00759944
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00578654,
-          "spread": 0.03322491,
-          "score": 0.03372504
+          "bias": -0.00588776,
+          "spread": 0.03296949,
+          "score": 0.03349109
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.0167712,
-          "spread": 0.04135134,
-          "score": 0.04462294
+          "bias": 0.016652,
+          "spread": 0.04071155,
+          "score": 0.04398544
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.25381224,
-          "spread": 0.23040524,
-          "score": 0.34279328
+          "bias": 0.25345534,
+          "spread": 0.23035636,
+          "score": 0.34249623
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.13463371,
+          "bias": -0.13575446,
           "spread": 0.0,
-          "score": 0.13463371
+          "score": 0.13575446
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.01377778,
-          "spread": 0.01916345,
-          "score": 0.02360222
+          "bias": 0.01368057,
+          "spread": 0.01980035,
+          "score": 0.02406682
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00174328,
-          "spread": 0.00251092,
-          "score": 0.00305675
+          "bias": 0.00164609,
+          "spread": 0.00197628,
+          "score": 0.00257202
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00422541,
-          "spread": 0.00350941,
-          "score": 0.00549272
+          "bias": -0.00433223,
+          "spread": 0.00276973,
+          "score": 0.00514195
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00129226,
-          "spread": 0.00413808,
-          "score": 0.00433516
+          "bias": -0.00140239,
+          "spread": 0.00352411,
+          "score": 0.00379289
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00036182,
-          "spread": 0.00247529,
-          "score": 0.00250159
+          "bias": -0.00047104,
+          "spread": 0.00187939,
+          "score": 0.00193752
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00660139,
-          "spread": 0.02312178,
-          "score": 0.02404569
+          "bias": 0.00649219,
+          "spread": 0.02308871,
+          "score": 0.0239841
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.02692841,
-          "spread": 0.04367402,
-          "score": 0.05130847
+          "bias": 0.02682856,
+          "spread": 0.04304938,
+          "score": 0.05072495
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.04954869,
-          "spread": 0.05453649,
-          "score": 0.07368379
+          "bias": 0.05012588,
+          "spread": 0.05446733,
+          "score": 0.07402225
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.00105763,
-          "spread": 0.00983095,
-          "score": 0.00988768
+          "bias": -0.00050255,
+          "spread": 0.00992141,
+          "score": 0.00993413
         },
         {
           "profile": "cp_minus_10pct",
@@ -5638,684 +5638,684 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00037467,
-          "spread": 0.01235432,
-          "score": 0.01236
+          "bias": 0.00027304,
+          "spread": 0.0120311,
+          "score": 0.01203419
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00402207,
-          "spread": 0.00478275,
-          "score": 0.00624914
+          "bias": 0.00392286,
+          "spread": 0.00447588,
+          "score": 0.00595167
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00170137,
-          "spread": 0.00377283,
-          "score": 0.00413871
+          "bias": 0.00160461,
+          "spread": 0.0039046,
+          "score": 0.00422145
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00159365,
-          "spread": 0.00139228,
-          "score": 0.00211617
+          "bias": 0.00153465,
+          "spread": 0.00144272,
+          "score": 0.00210632
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.10443539,
-          "spread": 0.00285198,
-          "score": 0.10447432
+          "bias": 0.10402685,
+          "spread": 0.00349178,
+          "score": 0.10408543
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00167059,
-          "spread": 0.01152692,
-          "score": 0.01164735
+          "bias": 0.00160443,
+          "spread": 0.01149208,
+          "score": 0.01160354
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.0005615,
+          "bias": -0.00062045,
+          "spread": 0.00158835,
+          "score": 0.00170523
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00284365,
+          "spread": 0.00108833,
+          "score": 0.0030448
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": 0.00135869,
+          "spread": 0.00196758,
+          "score": 0.00239111
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.00508013,
+          "spread": 0.00893081,
+          "score": 0.01027459
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": 0.00651446,
+          "spread": 0.01854484,
+          "score": 0.01965577
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.01802192,
+          "spread": 0.03407175,
+          "score": 0.03854444
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.14234619,
+          "spread": 0.07866562,
+          "score": 0.16263676
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": 0.38981747,
+          "spread": 0.39092983,
+          "score": 0.55207227
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.00753842,
+          "spread": 0.01493608,
+          "score": 0.01673064
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.00401644,
+          "spread": 0.00205854,
+          "score": 0.00451324
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": -0.00375532,
+          "spread": 0.00194932,
+          "score": 0.00423111
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": -0.00132167,
+          "spread": 0.00251583,
+          "score": 0.00284186
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00010743,
+          "spread": 0.00213501,
+          "score": 0.00213771
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00290285,
+          "spread": 0.01387595,
+          "score": 0.01417634
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": 0.02941021,
+          "spread": 0.04717522,
+          "score": 0.05559192
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.00055395,
+          "spread": 0.01338655,
+          "score": 0.01339801
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.02572829,
+          "spread": 0.01530423,
+          "score": 0.02993601
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": 0.00302009,
+          "spread": 0.00479272,
+          "score": 0.0056649
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 6.183e-05,
+          "spread": 0.00277583,
+          "score": 0.00277652
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00352785,
+          "spread": 0.00487659,
+          "score": 0.00601888
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.0007924,
+          "spread": 0.00261258,
+          "score": 0.00273011
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.06544886,
+          "spread": 0.00676483,
+          "score": 0.06579754
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.0005364,
+          "spread": 0.00466851,
+          "score": 0.00469922
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.00068757,
+          "spread": 0.00243907,
+          "score": 0.00253414
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00069111,
+          "spread": 0.00238129,
+          "score": 0.00247955
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": 0.00018659,
+          "spread": 0.00257796,
+          "score": 0.0025847
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.00717613,
+          "spread": 0.00820852,
+          "score": 0.01090305
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": 0.00065595,
+          "spread": 0.01946331,
+          "score": 0.01947436
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.02145622,
+          "spread": 0.02090095,
+          "score": 0.02995362
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.0491184,
+          "spread": 0.21793187,
+          "score": 0.22339856
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.35598913,
+          "spread": 0.25916269,
+          "score": 0.44033347
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.00813598,
+          "spread": 0.03044753,
+          "score": 0.03151581
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.00210903,
+          "spread": 0.00229882,
+          "score": 0.00311971
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": -0.00367401,
+          "spread": 0.00222467,
+          "score": 0.00429506
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": -0.00208415,
+          "spread": 0.00215068,
+          "score": 0.00299484
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": -0.00059651,
+          "spread": 0.00226658,
+          "score": 0.00234376
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.0051556,
+          "spread": 0.00999449,
+          "score": 0.01124588
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": 0.03346643,
+          "spread": 0.0389391,
+          "score": 0.05134448
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.00762431,
+          "spread": 0.00933741,
+          "score": 0.01205476
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.00644257,
+          "spread": 0.02636901,
+          "score": 0.02714464
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.00012693,
+          "spread": 0.00403576,
+          "score": 0.00403776
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.00099063,
+          "spread": 0.00275645,
+          "score": 0.00292906
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 9,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00326102,
+          "spread": 0.00449867,
+          "score": 0.00555629
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00081861,
+          "spread": 0.00161825,
+          "score": 0.00181352
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.0715607,
+          "spread": 0.00746359,
+          "score": 0.07194887
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.00119452,
+          "spread": 0.00479995,
+          "score": 0.00494635
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 2.444e-05,
           "spread": 0.00144278,
-          "score": 0.00154819
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00290063,
-          "spread": 0.00141118,
-          "score": 0.00322569
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00141547,
-          "spread": 0.00212433,
-          "score": 0.00255271
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00513435,
-          "spread": 0.00867155,
-          "score": 0.01007757
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00657753,
-          "spread": 0.01884419,
-          "score": 0.01995915
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": -0.01797066,
-          "spread": 0.03410768,
-          "score": 0.03855228
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.14215195,
-          "spread": 0.07872728,
-          "score": 0.16249665
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": 0.3903411,
-          "spread": 0.39038385,
-          "score": 0.55205591
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": 0.0075961,
-          "spread": 0.01449769,
-          "score": 0.01636716
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00407151,
-          "spread": 0.00226202,
-          "score": 0.00465768
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00369409,
-          "spread": 0.00248344,
-          "score": 0.00445127
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00125665,
-          "spread": 0.00310516,
-          "score": 0.00334981
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00017216,
-          "spread": 0.00261128,
-          "score": 0.00261695
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00296613,
-          "spread": 0.01381634,
-          "score": 0.01413114
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": 0.02945639,
-          "spread": 0.04757968,
-          "score": 0.05595985
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00062067,
-          "spread": 0.01354957,
-          "score": 0.01356378
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": 0.0254496,
-          "spread": 0.01556904,
-          "score": 0.02983416
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00307904,
-          "spread": 0.00508611,
-          "score": 0.0059455
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00011799,
-          "spread": 0.00241653,
-          "score": 0.00241941
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00358359,
-          "spread": 0.00457309,
-          "score": 0.00580993
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.00085685,
-          "spread": 0.00271868,
-          "score": 0.00285051
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": 0.06563593,
-          "spread": 0.00678594,
-          "score": 0.06598579
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00060179,
-          "spread": 0.00481003,
-          "score": 0.00484753
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": 0.0007526,
-          "spread": 0.00249277,
-          "score": 0.0026039
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00075517,
-          "spread": 0.00250794,
-          "score": 0.00261917
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00024906,
-          "spread": 0.00267932,
-          "score": 0.00269087
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00723965,
-          "spread": 0.00837908,
-          "score": 0.01107346
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00071694,
-          "spread": 0.01946436,
-          "score": 0.01947756
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": 0.02152209,
-          "spread": 0.02105097,
-          "score": 0.03010554
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.04917251,
-          "spread": 0.21795359,
-          "score": 0.22343165
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": -0.35588817,
-          "spread": 0.25917613,
-          "score": 0.44025975
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.00807109,
-          "spread": 0.03035263,
-          "score": 0.0314074
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00217231,
-          "spread": 0.00241501,
-          "score": 0.00324826
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": -0.0036064,
-          "spread": 0.00240328,
-          "score": 0.00433381
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00201554,
-          "spread": 0.00233345,
-          "score": 0.00308341
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00052778,
-          "spread": 0.00244918,
-          "score": 0.0025054
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00522505,
-          "spread": 0.01007822,
-          "score": 0.01135216
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": 0.03352557,
-          "spread": 0.03903254,
-          "score": 0.05145389
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00769332,
-          "spread": 0.00941408,
-          "score": 0.0121578
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": -0.00649457,
-          "spread": 0.02656918,
-          "score": 0.02735143
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": -6.549e-05,
-          "spread": 0.00401418,
-          "score": 0.00401471
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00105229,
-          "spread": 0.00276701,
-          "score": 0.00296035
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00332326,
-          "spread": 0.00458428,
-          "score": 0.00566213
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 12,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.00078126,
-          "spread": 0.00181811,
-          "score": 0.00197886
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": 0.0719364,
-          "spread": 0.00766791,
-          "score": 0.07234392
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00116022,
-          "spread": 0.00494162,
-          "score": 0.005076
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": -1.368e-05,
-          "spread": 0.0016116,
-          "score": 0.00161165
+          "score": 0.00144299
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00034032,
-          "spread": 0.00149424,
-          "score": 0.00153251
+          "bias": 0.00037872,
+          "spread": 0.00123507,
+          "score": 0.00129183
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00241135,
-          "spread": 0.00274027,
-          "score": 0.00365016
+          "bias": 0.00244845,
+          "spread": 0.00249289,
+          "score": 0.0034942
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00895196,
-          "spread": 0.00756889,
-          "score": 0.01172287
+          "bias": 0.00898839,
+          "spread": 0.00744592,
+          "score": 0.01167189
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00020575,
-          "spread": 0.02513307,
-          "score": 0.02513392
+          "bias": -0.00017725,
+          "spread": 0.02487833,
+          "score": 0.02487896
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.00508984,
-          "spread": 0.02028697,
-          "score": 0.02091573
+          "bias": -0.00505692,
+          "spread": 0.02017899,
+          "score": 0.02080299
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.03433874,
-          "spread": 0.20101925,
-          "score": 0.20393108
+          "bias": 0.03445755,
+          "spread": 0.20138378,
+          "score": 0.20431043
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.06899187,
+          "bias": -0.06860186,
           "spread": 0.0,
-          "score": 0.06899187
+          "score": 0.06860186
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.00182463,
-          "spread": 0.04351619,
-          "score": 0.04355443
+          "bias": -0.00178255,
+          "spread": 0.04356006,
+          "score": 0.04359652
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00309055,
-          "spread": 0.00206076,
-          "score": 0.0037146
+          "bias": 0.00312947,
+          "spread": 0.00191108,
+          "score": 0.00366686
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00280781,
-          "spread": 0.00106274,
-          "score": 0.0030022
+          "bias": -0.00276741,
+          "spread": 0.00069762,
+          "score": 0.00285399
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00202033,
-          "spread": 0.00168208,
-          "score": 0.0026289
+          "bias": -0.00198071,
+          "spread": 0.00130935,
+          "score": 0.00237437
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -1.691e-05,
-          "spread": 0.00148971,
-          "score": 0.00148981
+          "bias": 2.284e-05,
+          "spread": 0.00109236,
+          "score": 0.0010926
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00104907,
-          "spread": 0.00031767,
-          "score": 0.00109612
+          "bias": 0.00108919,
+          "spread": 0.00036964,
+          "score": 0.0011502
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.0259556,
-          "spread": 0.03825693,
-          "score": 0.04623079
+          "bias": 0.02599076,
+          "spread": 0.03790023,
+          "score": 0.04595593
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00041011,
-          "spread": 0.00384027,
-          "score": 0.00386211
+          "bias": 0.00044834,
+          "spread": 0.00358476,
+          "score": 0.00361268
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.02640772,
-          "spread": 0.0287307,
-          "score": 0.03902334
+          "bias": -0.0263721,
+          "spread": 0.02871327,
+          "score": 0.0389864
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
-          "bias": 0.0218609,
+          "bias": 0.02126093,
           "spread": 0.0,
-          "score": 0.0218609
+          "score": 0.02126093
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00206693,
-          "spread": 0.00544805,
-          "score": 0.00582695
+          "bias": 0.00210144,
+          "spread": 0.00513798,
+          "score": 0.00555111
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00225662,
-          "spread": 0.00350044,
-          "score": 0.00416478
+          "bias": 0.00229187,
+          "spread": 0.00321284,
+          "score": 0.00394652
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.0015277,
-          "spread": 0.00288611,
-          "score": 0.0032655
+          "bias": 0.00156458,
+          "spread": 0.00304276,
+          "score": 0.00342145
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00121061,
-          "spread": 0.00280854,
-          "score": 0.00305835
+          "bias": 0.00109193,
+          "spread": 0.00215355,
+          "score": 0.00241456
         },
         {
           "profile": "cp_plus_10pct",
@@ -6331,162 +6331,162 @@
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00473455,
-          "spread": 0.01275748,
-          "score": 0.01360769
+          "bias": 0.00462201,
+          "spread": 0.01253401,
+          "score": 0.01335906
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00024544,
-          "spread": 0.00342854,
-          "score": 0.00343732
+          "bias": 0.00012874,
+          "spread": 0.00312991,
+          "score": 0.00313256
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00315547,
-          "spread": 0.00355455,
-          "score": 0.00475309
+          "bias": 0.00303212,
+          "spread": 0.00295513,
+          "score": 0.00423398
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.0013197,
-          "spread": 0.0063632,
-          "score": 0.00649861
+          "bias": -0.00144294,
+          "spread": 0.00580964,
+          "score": 0.00598614
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": -0.00033325,
-          "spread": 0.00653759,
-          "score": 0.00654608
+          "bias": -0.00045564,
+          "spread": 0.00629911,
+          "score": 0.00631557
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.01034351,
-          "spread": 0.03451992,
-          "score": 0.03603628
+          "bias": -0.01047368,
+          "spread": 0.0343042,
+          "score": 0.03586748
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.00593816,
-          "spread": 0.03570934,
-          "score": 0.03619971
+          "bias": -0.00609102,
+          "spread": 0.03484146,
+          "score": 0.03536987
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": -0.29447265,
-          "spread": 1.02609238,
-          "score": 1.06751099
+          "bias": -0.29478963,
+          "spread": 1.0255897,
+          "score": 1.06711534
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.11658013,
-          "spread": 0.22829912,
-          "score": 0.25634238
+          "bias": 0.11607878,
+          "spread": 0.22894819,
+          "score": 0.25669351
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.00401747,
-          "spread": 0.0311949,
-          "score": 0.03145253
+          "bias": -0.00411284,
+          "spread": 0.03158383,
+          "score": 0.03185049
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.0042577,
-          "spread": 0.00189585,
-          "score": 0.00466072
+          "bias": -0.00437843,
+          "spread": 0.00129452,
+          "score": 0.00456578
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.0050849,
-          "spread": 0.00433343,
-          "score": 0.00668093
+          "bias": 0.00497048,
+          "spread": 0.00361374,
+          "score": 0.00614531
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00170856,
-          "spread": 0.00467986,
-          "score": 0.004982
+          "bias": 0.00159759,
+          "spread": 0.00405169,
+          "score": 0.00435528
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00081098,
-          "spread": 0.00304655,
-          "score": 0.00315264
+          "bias": 0.00070121,
+          "spread": 0.0024377,
+          "score": 0.00253655
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00613208,
-          "spread": 0.01666068,
-          "score": 0.01775333
+          "bias": 0.00602112,
+          "spread": 0.01652665,
+          "score": 0.01758932
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.0093356,
-          "spread": 0.03970162,
-          "score": 0.04078446
+          "bias": -0.00949748,
+          "spread": 0.03935106,
+          "score": 0.04048096
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.0339031,
-          "spread": 0.03741861,
-          "score": 0.05049329
+          "bias": 0.03448373,
+          "spread": 0.03735182,
+          "score": 0.05083588
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.00344029,
-          "spread": 0.01665698,
-          "score": 0.01700854
+          "bias": -0.00287912,
+          "spread": 0.01657175,
+          "score": 0.01682
         },
         {
           "profile": "cp_plus_10pct",
@@ -6502,207 +6502,207 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00042259,
-          "spread": 0.01381494,
-          "score": 0.0138214
+          "bias": -0.00054626,
+          "spread": 0.01342159,
+          "score": 0.0134327
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00599726,
-          "spread": 0.00586877,
-          "score": 0.00839104
+          "bias": 0.00587609,
+          "spread": 0.00553481,
+          "score": 0.00807233
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00103771,
-          "spread": 0.0039199,
-          "score": 0.00405493
+          "bias": -0.00115645,
+          "spread": 0.00391798,
+          "score": 0.00408509
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00159675,
-          "spread": 0.00159941,
-          "score": 0.00226003
+          "bias": 0.00152858,
+          "spread": 0.00164407,
+          "score": 0.00224489
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.11146397,
-          "spread": 0.0020531,
-          "score": 0.11148288
+          "bias": 0.11097184,
+          "spread": 0.00127506,
+          "score": 0.11097916
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00082087,
-          "spread": 0.01108258,
-          "score": 0.01111294
+          "bias": -0.00088451,
+          "spread": 0.01087806,
+          "score": 0.01091396
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00158943,
-          "spread": 0.00210568,
-          "score": 0.00263821
+          "bias": 0.001521,
+          "spread": 0.00187424,
+          "score": 0.00241375
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00297256,
-          "spread": 0.00167211,
-          "score": 0.00341058
+          "bias": 0.00290232,
+          "spread": 0.0020719,
+          "score": 0.00356598
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00224811,
-          "spread": 0.00269107,
-          "score": 0.00350654
+          "bias": -0.00231884,
+          "spread": 0.00264673,
+          "score": 0.00351884
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": -0.00058871,
-          "spread": 0.00912401,
-          "score": 0.00914298
+          "bias": -0.00065631,
+          "spread": 0.00947881,
+          "score": 0.00950151
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00022661,
-          "spread": 0.02410778,
-          "score": 0.02410884
+          "bias": -0.00030573,
+          "spread": 0.02369738,
+          "score": 0.02369936
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.05291006,
-          "spread": 0.02872064,
-          "score": 0.06020257
+          "bias": -0.05297534,
+          "spread": 0.02901196,
+          "score": 0.06039934
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": -0.01198845,
-          "spread": 0.31514467,
-          "score": 0.31537262
+          "bias": -0.0116932,
+          "spread": 0.31498272,
+          "score": 0.31519969
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.50217469,
-          "spread": 0.55824798,
-          "score": 0.75087963
+          "bias": 0.50170699,
+          "spread": 0.5587453,
+          "score": 0.75093689
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.00238077,
-          "spread": 0.01747055,
-          "score": 0.01763202
+          "bias": -0.00243786,
+          "spread": 0.01783365,
+          "score": 0.0179995
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00202809,
-          "spread": 0.00086406,
-          "score": 0.00220448
+          "bias": -0.00210045,
+          "spread": 0.00115683,
+          "score": 0.00239795
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00529708,
-          "spread": 0.0030194,
-          "score": 0.0060972
+          "bias": 0.00522835,
+          "spread": 0.00244538,
+          "score": 0.00577197
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00171805,
-          "spread": 0.003543,
-          "score": 0.00393758
+          "bias": 0.00165234,
+          "spread": 0.00294366,
+          "score": 0.00337571
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00100208,
-          "spread": 0.00298841,
-          "score": 0.00315195
+          "bias": 0.0009369,
+          "spread": 0.00238967,
+          "score": 0.00256677
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00194213,
-          "spread": 0.0100076,
-          "score": 0.01019431
+          "bias": 0.00187852,
+          "spread": 0.00998692,
+          "score": 0.01016205
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.04097018,
-          "spread": 0.04553616,
-          "score": 0.06125437
+          "bias": -0.04105406,
+          "spread": 0.04603644,
+          "score": 0.06168298
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00799314,
-          "spread": 0.00848274,
-          "score": 0.01165535
+          "bias": -0.00806007,
+          "spread": 0.00789964,
+          "score": 0.01128579
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.00204985,
-          "spread": 0.01491195,
-          "score": 0.01505218
+          "bias": -0.00177022,
+          "spread": 0.01464623,
+          "score": 0.01475283
         },
         {
           "profile": "cp_plus_10pct",
@@ -6718,207 +6718,207 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00250202,
-          "spread": 0.00625161,
-          "score": 0.0067337
+          "bias": 0.00243025,
+          "spread": 0.00595023,
+          "score": 0.00642739
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00111336,
-          "spread": 0.0023054,
-          "score": 0.00256017
+          "bias": 0.00104472,
+          "spread": 0.00287479,
+          "score": 0.00305873
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00179594,
-          "spread": 0.00505456,
-          "score": 0.00536414
+          "bias": 0.00172737,
+          "spread": 0.00538048,
+          "score": 0.00565096
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 9,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00081113,
-          "spread": 0.00309705,
-          "score": 0.00320151
+          "bias": 0.00073792,
+          "spread": 0.00297386,
+          "score": 0.00306404
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.07804558,
-          "spread": 0.00500285,
-          "score": 0.07820577
+          "bias": 0.07781408,
+          "spread": 0.00498109,
+          "score": 0.07797334
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00173177,
-          "spread": 0.00395834,
-          "score": 0.00432059
+          "bias": 0.00165879,
+          "spread": 0.00379689,
+          "score": 0.00414343
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00230765,
-          "spread": 0.00332251,
-          "score": 0.00404529
+          "bias": 0.00223498,
+          "spread": 0.00317275,
+          "score": 0.00388092
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00123142,
-          "spread": 0.00314702,
-          "score": 0.00337936
+          "bias": 0.00115803,
+          "spread": 0.00311579,
+          "score": 0.00332403
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00414852,
-          "spread": 0.0032523,
-          "score": 0.0052714
+          "bias": -0.00422323,
+          "spread": 0.00316484,
+          "score": 0.00527749
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00178066,
-          "spread": 0.00907519,
-          "score": 0.00924824
+          "bias": 0.00170351,
+          "spread": 0.00888058,
+          "score": 0.00904249
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.0122156,
-          "spread": 0.02341671,
-          "score": 0.02641142
+          "bias": -0.01229099,
+          "spread": 0.02339809,
+          "score": 0.0264299
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.00437877,
-          "spread": 0.02904062,
-          "score": 0.02936889
+          "bias": 0.00429751,
+          "spread": 0.02885026,
+          "score": 0.02916858
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": -0.01631189,
-          "spread": 0.33496535,
-          "score": 0.33536229
+          "bias": -0.01638358,
+          "spread": 0.33492778,
+          "score": 0.33532826
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.29719196,
-          "spread": 0.42386597,
-          "score": 0.51767308
+          "bias": 0.2969365,
+          "spread": 0.4237581,
+          "score": 0.51743813
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.01297046,
-          "spread": 0.0388513,
-          "score": 0.0409592
+          "bias": -0.01303369,
+          "spread": 0.03896137,
+          "score": 0.04108364
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00462228,
-          "spread": 0.00326265,
-          "score": 0.00565778
+          "bias": -0.00469619,
+          "spread": 0.00320688,
+          "score": 0.00568668
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.0049083,
-          "spread": 0.00271268,
-          "score": 0.00560804
+          "bias": 0.00483803,
+          "spread": 0.00252381,
+          "score": 0.00545675
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00054051,
-          "spread": 0.00237523,
-          "score": 0.00243595
+          "bias": 0.00047151,
+          "spread": 0.0021991,
+          "score": 0.00224908
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00019911,
-          "spread": 0.00227306,
-          "score": 0.00228177
+          "bias": 0.00013014,
+          "spread": 0.00208495,
+          "score": 0.00208901
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00249967,
-          "spread": 0.00823879,
-          "score": 0.00860965
+          "bias": 0.00242997,
+          "spread": 0.00812585,
+          "score": 0.00848141
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.02768406,
-          "spread": 0.0384108,
-          "score": 0.04734761
+          "bias": -0.0277659,
+          "spread": 0.03842883,
+          "score": 0.04741013
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 7.637e-05,
-          "spread": 0.00770278,
-          "score": 0.00770316
+          "bias": 7.34e-06,
+          "spread": 0.00771328,
+          "score": 0.00771328
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.02843433,
-          "spread": 0.02712929,
-          "score": 0.03930025
+          "bias": -0.02838281,
+          "spread": 0.02692825,
+          "score": 0.03912435
         },
         {
           "profile": "cp_plus_10pct",
@@ -6934,252 +6934,252 @@
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00093025,
-          "spread": 0.00453853,
-          "score": 0.00463288
+          "bias": -0.00100537,
+          "spread": 0.00457801,
+          "score": 0.0046871
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00196114,
-          "spread": 0.00326817,
-          "score": 0.00381143
+          "bias": 0.00188558,
+          "spread": 0.00324053,
+          "score": 0.00374919
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00178012,
-          "spread": 0.00551318,
-          "score": 0.00579344
+          "bias": 0.00170412,
+          "spread": 0.00539967,
+          "score": 0.0056622
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.0007114,
-          "spread": 0.00204054,
-          "score": 0.002161
+          "bias": 0.00075373,
+          "spread": 0.00180637,
+          "score": 0.00195732
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.09095575,
-          "spread": 0.03731502,
-          "score": 0.09831256
+          "bias": 0.09048642,
+          "spread": 0.03705711,
+          "score": 0.09778048
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00222906,
-          "spread": 0.0041745,
-          "score": 0.00473235
+          "bias": 0.00227427,
+          "spread": 0.00409982,
+          "score": 0.00468837
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00184345,
-          "spread": 0.002025,
-          "score": 0.00273842
+          "bias": 0.0018849,
+          "spread": 0.00165108,
+          "score": 0.00250578
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00034947,
-          "spread": 0.00165995,
-          "score": 0.00169634
+          "bias": 0.0003912,
+          "spread": 0.00170094,
+          "score": 0.00174535
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.0014123,
-          "spread": 0.00363389,
-          "score": 0.00389869
+          "bias": -0.00137031,
+          "spread": 0.00343365,
+          "score": 0.00369699
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00175402,
-          "spread": 0.00743767,
-          "score": 0.00764169
+          "bias": 0.00179674,
+          "spread": 0.00734262,
+          "score": 0.00755925
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.01018467,
-          "spread": 0.03447203,
-          "score": 0.03594508
+          "bias": -0.01015078,
+          "spread": 0.03415321,
+          "score": 0.03562977
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.02123434,
-          "spread": 0.02349354,
-          "score": 0.03166771
+          "bias": -0.02119489,
+          "spread": 0.02326699,
+          "score": 0.03147342
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.02134755,
-          "spread": 0.26272593,
-          "score": 0.26359179
+          "bias": 0.02150366,
+          "spread": 0.26320636,
+          "score": 0.26408331
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.77356969,
-          "spread": 0.90683004,
-          "score": 1.19195251
+          "bias": 0.77346515,
+          "spread": 0.90620745,
+          "score": 1.19141104
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.0145983,
-          "spread": 0.04307451,
-          "score": 0.04548103
+          "bias": -0.01455584,
+          "spread": 0.04313903,
+          "score": 0.04552854
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00365646,
-          "spread": 0.00291061,
-          "score": 0.00467347
+          "bias": -0.00361535,
+          "spread": 0.00289619,
+          "score": 0.00463235
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00524243,
-          "spread": 0.001222,
-          "score": 0.00538297
+          "bias": 0.00528188,
+          "spread": 0.00088154,
+          "score": 0.00535493
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00060509,
-          "spread": 0.00173076,
-          "score": 0.00183349
+          "bias": 0.0006447,
+          "spread": 0.00135378,
+          "score": 0.00149945
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00084571,
-          "spread": 0.00136063,
-          "score": 0.00160204
+          "bias": 0.00088544,
+          "spread": 0.00096523,
+          "score": 0.00130984
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": -0.00201794,
-          "spread": 0.00314113,
-          "score": 0.00373346
+          "bias": -0.00197784,
+          "spread": 0.00308094,
+          "score": 0.00366115
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.02523813,
-          "spread": 0.02168216,
-          "score": 0.0332728
+          "bias": -0.0252097,
+          "spread": 0.02164986,
+          "score": 0.03323019
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00684495,
-          "spread": 0.0065901,
-          "score": 0.00950173
+          "bias": -0.00680667,
+          "spread": 0.00617068,
+          "score": 0.00918738
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.03684205,
-          "spread": 0.02488448,
-          "score": 0.04445868
+          "bias": -0.03680593,
+          "spread": 0.02464448,
+          "score": 0.04429477
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
-          "bias": 0.01966369,
+          "bias": 0.0190549,
           "spread": 0.0,
-          "score": 0.01966369
+          "score": 0.0190549
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00120876,
-          "spread": 0.00703897,
-          "score": 0.007142
+          "bias": 0.0012508,
+          "spread": 0.00669381,
+          "score": 0.00680967
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00333395,
-          "spread": 0.0035245,
-          "score": 0.00485153
+          "bias": 0.0033774,
+          "spread": 0.00324755,
+          "score": 0.00468545
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00065611,
-          "spread": 0.00281451,
-          "score": 0.00288998
+          "bias": -0.00061187,
+          "spread": 0.00287815,
+          "score": 0.00294247
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00120459,
-          "spread": 0.0026923,
-          "score": 0.00294949
+          "bias": 0.00109231,
+          "spread": 0.00207349,
+          "score": 0.00234361
         },
         {
           "profile": "cp_plus_3pct",
@@ -7195,162 +7195,162 @@
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00568382,
-          "spread": 0.01441884,
-          "score": 0.01549867
+          "bias": 0.00557187,
+          "spread": 0.01421215,
+          "score": 0.01526535
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00057672,
-          "spread": 0.00297294,
-          "score": 0.00302836
+          "bias": -0.00068776,
+          "spread": 0.00269132,
+          "score": 0.00277781
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00309244,
-          "spread": 0.00367893,
-          "score": 0.004806
+          "bias": 0.00297799,
+          "spread": 0.00301756,
+          "score": 0.00423959
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00020508,
-          "spread": 0.00562009,
-          "score": 0.00562383
+          "bias": 9.083e-05,
+          "spread": 0.00513351,
+          "score": 0.00513431
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00048317,
-          "spread": 0.00638995,
-          "score": 0.00640819
+          "bias": 0.00037013,
+          "spread": 0.00621353,
+          "score": 0.00622454
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00830166,
-          "spread": 0.03317083,
-          "score": 0.03419388
+          "bias": -0.00842065,
+          "spread": 0.03296512,
+          "score": 0.03402362
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.00236563,
-          "spread": 0.04160784,
-          "score": 0.04167503
+          "bias": 0.0022208,
+          "spread": 0.04079836,
+          "score": 0.04085876
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": -0.06206971,
-          "spread": 0.59811644,
-          "score": 0.60132847
+          "bias": -0.06242089,
+          "spread": 0.59753952,
+          "score": 0.60079102
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.09928467,
+          "bias": -0.10045121,
           "spread": 0.0,
-          "score": 0.09928467
+          "score": 0.10045121
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.00099107,
-          "spread": 0.02444008,
-          "score": 0.02446017
+          "bias": 0.00089303,
+          "spread": 0.02485,
+          "score": 0.02486604
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.0023681,
-          "spread": 0.00163075,
-          "score": 0.00287528
+          "bias": -0.00248037,
+          "spread": 0.00097879,
+          "score": 0.0026665
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00179592,
-          "spread": 0.00414975,
-          "score": 0.00452169
+          "bias": 0.00168399,
+          "spread": 0.00339745,
+          "score": 0.0037919
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00050659,
-          "spread": 0.00484936,
-          "score": 0.00487575
+          "bias": 0.00039572,
+          "spread": 0.00422927,
+          "score": 0.00424774
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00064342,
-          "spread": 0.00323251,
-          "score": 0.00329593
+          "bias": 0.00053356,
+          "spread": 0.00262165,
+          "score": 0.00267539
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00643,
-          "spread": 0.01889766,
-          "score": 0.01996162
+          "bias": 0.00631935,
+          "spread": 0.01879188,
+          "score": 0.01982597
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.00493295,
-          "spread": 0.03715663,
-          "score": 0.03748265
+          "bias": 0.00479341,
+          "spread": 0.03663691,
+          "score": 0.03694915
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.03641419,
-          "spread": 0.04020115,
-          "score": 0.05424136
+          "bias": 0.03699225,
+          "spread": 0.040132,
+          "score": 0.05458025
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.00430212,
-          "spread": 0.0050145,
-          "score": 0.00660708
+          "bias": -0.00374382,
+          "spread": 0.00492627,
+          "score": 0.00618743
         },
         {
           "profile": "cp_plus_3pct",
@@ -7366,207 +7366,207 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00014122,
-          "spread": 0.01345156,
-          "score": 0.0134523
+          "bias": 2.502e-05,
+          "spread": 0.01306915,
+          "score": 0.01306917
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00529446,
-          "spread": 0.00550365,
-          "score": 0.00763685
+          "bias": 0.00518104,
+          "spread": 0.00519413,
+          "score": 0.00733636
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00031739,
-          "spread": 0.00406326,
-          "score": 0.00407563
+          "bias": 0.00020629,
+          "spread": 0.00411198,
+          "score": 0.00411715
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00159566,
-          "spread": 0.00152683,
-          "score": 0.00220847
+          "bias": 0.0015307,
+          "spread": 0.00157353,
+          "score": 0.00219523
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.10089175,
-          "spread": 0.00707408,
-          "score": 0.10113945
+          "bias": 0.10042786,
+          "spread": 0.00634688,
+          "score": 0.10062822
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 9.104e-05,
-          "spread": 0.01071659,
-          "score": 0.01071697
+          "bias": 2.651e-05,
+          "spread": 0.01056869,
+          "score": 0.01056872
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00073888,
-          "spread": 0.0018762,
-          "score": 0.00201644
+          "bias": 0.00067371,
+          "spread": 0.00172481,
+          "score": 0.00185171
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00295937,
-          "spread": 0.0013182,
-          "score": 0.00323968
+          "bias": 0.00289377,
+          "spread": 0.00153442,
+          "score": 0.00327542
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00075832,
-          "spread": 0.00237365,
-          "score": 0.00249184
+          "bias": -0.00082413,
+          "spread": 0.00231124,
+          "score": 0.00245377
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00096256,
-          "spread": 0.00942542,
-          "score": 0.00947444
+          "bias": 0.00090026,
+          "spread": 0.00979039,
+          "score": 0.0098317
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00239635,
-          "spread": 0.02230495,
-          "score": 0.0224333
+          "bias": 0.00232253,
+          "spread": 0.02191979,
+          "score": 0.02204249
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.04297487,
-          "spread": 0.02962661,
-          "score": 0.05219747
+          "bias": -0.04303445,
+          "spread": 0.0298016,
+          "score": 0.05234595
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.04595805,
-          "spread": 0.22942933,
-          "score": 0.23398709
+          "bias": 0.04621937,
+          "spread": 0.22929515,
+          "score": 0.23390703
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.44628727,
-          "spread": 0.4806987,
-          "score": 0.65592954
+          "bias": 0.44579868,
+          "spread": 0.48121388,
+          "score": 0.65597505
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.00384118,
-          "spread": 0.0154718,
-          "score": 0.01594149
+          "bias": -0.00390251,
+          "spread": 0.01560467,
+          "score": 0.01608525
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00028547,
-          "spread": 0.00125365,
-          "score": 0.00128574
+          "bias": 0.00021901,
+          "spread": 0.0011489,
+          "score": 0.00116959
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00227952,
-          "spread": 0.00276003,
-          "score": 0.00357966
+          "bias": 0.00221343,
+          "spread": 0.00218762,
+          "score": 0.00311206
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00069349,
-          "spread": 0.00332666,
-          "score": 0.00339818
+          "bias": 0.00062805,
+          "spread": 0.00272739,
+          "score": 0.00279877
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00079716,
-          "spread": 0.00290677,
-          "score": 0.00301409
+          "bias": 0.00073204,
+          "spread": 0.00232095,
+          "score": 0.00243366
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00245472,
-          "spread": 0.01140957,
-          "score": 0.01167064
+          "bias": 0.00239106,
+          "spread": 0.01140899,
+          "score": 0.01165686
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.01888416,
-          "spread": 0.0322112,
-          "score": 0.03733862
+          "bias": -0.01895379,
+          "spread": 0.03239429,
+          "score": 0.0375318
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00493108,
-          "spread": 0.00834994,
-          "score": 0.00969727
+          "bias": -0.00499793,
+          "spread": 0.00787411,
+          "score": 0.00932636
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.0076448,
-          "spread": 0.01489584,
-          "score": 0.01674303
+          "bias": 0.00792418,
+          "spread": 0.01463036,
+          "score": 0.01663851
         },
         {
           "profile": "cp_plus_3pct",
@@ -7582,207 +7582,207 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00251358,
-          "spread": 0.00579438,
-          "score": 0.00631609
+          "bias": 0.0024462,
+          "spread": 0.00547274,
+          "score": 0.00599456
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00081364,
-          "spread": 0.00224615,
-          "score": 0.00238898
+          "bias": 0.00074927,
+          "spread": 0.00272289,
+          "score": 0.0028241
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00243023,
-          "spread": 0.00508036,
-          "score": 0.0056317
+          "bias": 0.00236633,
+          "spread": 0.0054216,
+          "score": 0.00591551
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 9,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00082707,
-          "spread": 0.0029645,
-          "score": 0.00307771
+          "bias": 0.00075699,
+          "spread": 0.00284739,
+          "score": 0.00294629
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.09464412,
-          "spread": 0.01686263,
-          "score": 0.09613458
+          "bias": 0.09442401,
+          "spread": 0.01683837,
+          "score": 0.09591363
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00121404,
-          "spread": 0.00433062,
-          "score": 0.00449757
+          "bias": 0.00114377,
+          "spread": 0.00417397,
+          "score": 0.00432785
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.0017502,
-          "spread": 0.00303828,
-          "score": 0.00350633
+          "bias": 0.00168025,
+          "spread": 0.0029147,
+          "score": 0.00336433
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00105293,
-          "spread": 0.00279625,
-          "score": 0.00298792
+          "bias": 0.00098287,
+          "spread": 0.00273102,
+          "score": 0.00290249
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00241576,
-          "spread": 0.00296183,
-          "score": 0.00382209
+          "bias": -0.00248616,
+          "spread": 0.00285948,
+          "score": 0.00378914
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00395646,
-          "spread": 0.00831741,
-          "score": 0.00921048
+          "bias": 0.00388422,
+          "spread": 0.00813049,
+          "score": 0.00901066
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00813977,
-          "spread": 0.02254002,
-          "score": 0.02396473
+          "bias": -0.00820976,
+          "spread": 0.02254009,
+          "score": 0.02398867
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.00830361,
-          "spread": 0.0253812,
-          "score": 0.02670496
+          "bias": 0.00822812,
+          "spread": 0.02520648,
+          "score": 0.02651544
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.00626543,
-          "spread": 0.29268315,
-          "score": 0.29275021
+          "bias": 0.00620087,
+          "spread": 0.29265407,
+          "score": 0.29271976
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.30091296,
-          "spread": 0.40778147,
-          "score": 0.50678826
+          "bias": 0.30066216,
+          "spread": 0.40766802,
+          "score": 0.50654807
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.01183186,
-          "spread": 0.03265736,
-          "score": 0.03473465
+          "bias": -0.01189656,
+          "spread": 0.03274276,
+          "score": 0.034837
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00228108,
-          "spread": 0.0031096,
-          "score": 0.00385655
+          "bias": -0.00235126,
+          "spread": 0.00302256,
+          "score": 0.0038294
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00193254,
-          "spread": 0.00262076,
-          "score": 0.00325624
+          "bias": 0.00186325,
+          "spread": 0.00243671,
+          "score": 0.00306745
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00035568,
-          "spread": 0.00241458,
-          "score": 0.00244063
+          "bias": -0.00042449,
+          "spread": 0.00223491,
+          "score": 0.00227487
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 1.246e-05,
-          "spread": 0.0023392,
-          "score": 0.00233924
+          "bias": -5.637e-05,
+          "spread": 0.00215356,
+          "score": 0.00215429
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00368092,
-          "spread": 0.00895541,
-          "score": 0.00968238
+          "bias": 0.00361136,
+          "spread": 0.00885531,
+          "score": 0.00956339
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.00802708,
-          "spread": 0.0241174,
-          "score": 0.02541817
+          "bias": -0.00810051,
+          "spread": 0.02407883,
+          "score": 0.02540489
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00287368,
-          "spread": 0.00712776,
-          "score": 0.00768524
+          "bias": 0.00280466,
+          "spread": 0.00709329,
+          "score": 0.00762764
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.02084401,
-          "spread": 0.02700229,
-          "score": 0.03411153
+          "bias": -0.02079234,
+          "spread": 0.02680157,
+          "score": 0.03392117
         },
         {
           "profile": "cp_plus_3pct",
@@ -7798,252 +7798,252 @@
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.0001135,
-          "spread": 0.00410371,
-          "score": 0.00410528
+          "bias": -0.00018376,
+          "spread": 0.0041503,
+          "score": 0.00415437
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00160838,
-          "spread": 0.00316315,
-          "score": 0.00354858
+          "bias": 0.0015378,
+          "spread": 0.00315782,
+          "score": 0.00351236
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00247548,
-          "spread": 0.0049846,
-          "score": 0.00556545
+          "bias": 0.00240433,
+          "spread": 0.00487367,
+          "score": 0.00543447
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00073587,
-          "spread": 0.00196258,
-          "score": 0.002096
+          "bias": 0.00077643,
+          "spread": 0.00174044,
+          "score": 0.00190578
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.08204521,
-          "spread": 0.02037732,
-          "score": 0.08453787
+          "bias": 0.08161088,
+          "spread": 0.02014117,
+          "score": 0.08405951
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00166052,
-          "spread": 0.00445172,
-          "score": 0.00475133
+          "bias": 0.00170183,
+          "spread": 0.00433604,
+          "score": 0.00465805
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00124903,
-          "spread": 0.00179451,
-          "score": 0.0021864
+          "bias": 0.00128931,
+          "spread": 0.00148056,
+          "score": 0.00196325
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00031344,
-          "spread": 0.00148767,
-          "score": 0.00152033
+          "bias": 0.00035396,
+          "spread": 0.00141629,
+          "score": 0.00145985
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -6.83e-05,
-          "spread": 0.00327283,
-          "score": 0.00327355
+          "bias": -2.802e-05,
+          "spread": 0.00306253,
+          "score": 0.00306266
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00427103,
-          "spread": 0.00748742,
-          "score": 0.00861993
+          "bias": 0.00431147,
+          "spread": 0.00737272,
+          "score": 0.00854083
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00588714,
-          "spread": 0.03110804,
-          "score": 0.03166021
+          "bias": -0.00585492,
+          "spread": 0.030817,
+          "score": 0.03136826
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.01400173,
-          "spread": 0.01984795,
-          "score": 0.0242897
+          "bias": -0.01396428,
+          "spread": 0.01965486,
+          "score": 0.02411047
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.02611251,
-          "spread": 0.24265865,
-          "score": 0.24405959
+          "bias": 0.02625666,
+          "spread": 0.24310129,
+          "score": 0.24451513
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.10098664,
-          "spread": 0.21145607,
-          "score": 0.23433304
+          "bias": 0.10096379,
+          "spread": 0.21095981,
+          "score": 0.23387546
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.01029401,
-          "spread": 0.04806528,
-          "score": 0.04915524
+          "bias": -0.01024876,
+          "spread": 0.04817705,
+          "score": 0.04925511
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00125759,
-          "spread": 0.00261358,
-          "score": 0.0029004
+          "bias": -0.00121734,
+          "spread": 0.00252937,
+          "score": 0.00280707
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00249085,
-          "spread": 0.00110643,
-          "score": 0.00272553
+          "bias": 0.00253061,
+          "spread": 0.00074216,
+          "score": 0.00263719
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.0002438,
-          "spread": 0.00178835,
-          "score": 0.00180489
+          "bias": -0.00020421,
+          "spread": 0.0014321,
+          "score": 0.00144659
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00060186,
-          "spread": 0.00138527,
-          "score": 0.00151037
+          "bias": 0.00064157,
+          "spread": 0.00097859,
+          "score": 0.00117015
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": -0.00090857,
-          "spread": 0.00203373,
-          "score": 0.00222745
+          "bias": -0.00086849,
+          "spread": 0.00197567,
+          "score": 0.00215814
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.00413653,
-          "spread": 0.01930353,
-          "score": 0.01974176
+          "bias": -0.00410751,
+          "spread": 0.01886469,
+          "score": 0.01930668
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00405867,
-          "spread": 0.00517346,
-          "score": 0.00657552
+          "bias": -0.00402044,
+          "spread": 0.00475333,
+          "score": 0.00622559
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.03389721,
-          "spread": 0.02619407,
-          "score": 0.04283865
+          "bias": -0.0338612,
+          "spread": 0.02604368,
+          "score": 0.04271832
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
-          "bias": 0.02261398,
+          "bias": 0.02200699,
           "spread": 0.0,
-          "score": 0.02261398
+          "score": 0.02200699
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.0013148,
-          "spread": 0.0064396,
-          "score": 0.00657246
+          "bias": 0.00135423,
+          "spread": 0.0061148,
+          "score": 0.00626296
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00318839,
-          "spread": 0.003452,
-          "score": 0.00469916
+          "bias": 0.00322895,
+          "spread": 0.00315872,
+          "score": 0.00451704
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 6.366e-05,
-          "spread": 0.00297597,
-          "score": 0.00297665
+          "bias": 0.00010538,
+          "spread": 0.00310046,
+          "score": 0.00310225
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.0012303,
-          "spread": 0.002687,
-          "score": 0.00295527
+          "bias": 0.00111984,
+          "spread": 0.0020758,
+          "score": 0.0023586
         },
         {
           "profile": "rated_plus_5pct",
@@ -8059,162 +8059,162 @@
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00613964,
-          "spread": 0.01691636,
-          "score": 0.01799607
+          "bias": 0.00602296,
+          "spread": 0.01672004,
+          "score": 0.01777177
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00159541,
-          "spread": 0.00263069,
-          "score": 0.00307666
+          "bias": -0.00170529,
+          "spread": 0.0024218,
+          "score": 0.00296195
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00302714,
-          "spread": 0.00393125,
-          "score": 0.00496168
+          "bias": 0.00291755,
+          "spread": 0.00323512,
+          "score": 0.00435639
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00212517,
-          "spread": 0.00590503,
-          "score": 0.0062758
+          "bias": 0.00201465,
+          "spread": 0.00537907,
+          "score": 0.00574397
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00454426,
-          "spread": 0.00720051,
-          "score": 0.00851455
+          "bias": 0.00443378,
+          "spread": 0.00687267,
+          "score": 0.00817875
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00575299,
-          "spread": 0.03610477,
-          "score": 0.03656024
+          "bias": -0.00587004,
+          "spread": 0.03583265,
+          "score": 0.03631028
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.00946351,
-          "spread": 0.03522423,
-          "score": 0.03647333
+          "bias": 0.00932902,
+          "spread": 0.03445855,
+          "score": 0.03569905
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": -0.00053258,
-          "spread": 0.39204871,
-          "score": 0.39204907
+          "bias": -0.0008645,
+          "spread": 0.3914892,
+          "score": 0.39149016
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.10828005,
+          "bias": -0.10943494,
           "spread": 0.0,
-          "score": 0.10828005
+          "score": 0.10943494
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.00551676,
-          "spread": 0.02172343,
-          "score": 0.02241299
+          "bias": 0.00542124,
+          "spread": 0.02231917,
+          "score": 0.02296813
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 1.17e-05,
-          "spread": 0.00219428,
-          "score": 0.00219431
+          "bias": -9.68e-05,
+          "spread": 0.00150447,
+          "score": 0.00150758
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00161371,
-          "spread": 0.00394566,
-          "score": 0.00426289
+          "bias": -0.00172808,
+          "spread": 0.00315398,
+          "score": 0.00359636
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00076736,
-          "spread": 0.00483709,
-          "score": 0.00489758
+          "bias": -0.00088345,
+          "spread": 0.00417624,
+          "score": 0.00426866
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -9.226e-05,
-          "spread": 0.00295211,
-          "score": 0.00295355
+          "bias": -0.0002073,
+          "spread": 0.00226362,
+          "score": 0.00227309
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00689739,
-          "spread": 0.02187686,
-          "score": 0.02293842
+          "bias": 0.0067822,
+          "spread": 0.02181575,
+          "score": 0.02284569
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.01198408,
-          "spread": 0.03834997,
-          "score": 0.04017883
+          "bias": 0.01185268,
+          "spread": 0.03776123,
+          "score": 0.03957773
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.04864124,
-          "spread": 0.05432731,
-          "score": 0.07292069
+          "bias": 0.04924854,
+          "spread": 0.05425639,
+          "score": 0.07327466
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.00191786,
-          "spread": 0.00337996,
-          "score": 0.00388617
+          "bias": -0.00133359,
+          "spread": 0.0034737,
+          "score": 0.00372089
         },
         {
           "profile": "rated_plus_5pct",
@@ -8230,207 +8230,207 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00020032,
-          "spread": 0.013886,
-          "score": 0.01388744
+          "bias": -0.00031381,
+          "spread": 0.01348472,
+          "score": 0.01348837
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.0048885,
-          "spread": 0.00533548,
-          "score": 0.00723634
+          "bias": 0.0047784,
+          "spread": 0.00503187,
+          "score": 0.00693922
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.0011976,
-          "spread": 0.00398907,
-          "score": 0.00416497
+          "bias": 0.0010901,
+          "spread": 0.00413611,
+          "score": 0.00427735
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00163763,
-          "spread": 0.00152069,
-          "score": 0.0022348
+          "bias": 0.00157317,
+          "spread": 0.00157137,
+          "score": 0.00222352
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.10209498,
-          "spread": 0.00179726,
-          "score": 0.1021108
+          "bias": 0.10164792,
+          "spread": 0.00250186,
+          "score": 0.1016787
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00144095,
-          "spread": 0.01180194,
-          "score": 0.01188958
+          "bias": 0.00137207,
+          "spread": 0.01171213,
+          "score": 0.01179222
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 2.862e-05,
-          "spread": 0.00155397,
-          "score": 0.00155423
+          "bias": -3.595e-05,
+          "spread": 0.0015597,
+          "score": 0.00156011
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00312091,
-          "spread": 0.00129969,
-          "score": 0.00338072
+          "bias": 0.00305746,
+          "spread": 0.00121236,
+          "score": 0.00328906
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00024354,
-          "spread": 0.00239051,
-          "score": 0.00240289
+          "bias": 0.00018015,
+          "spread": 0.00231083,
+          "score": 0.00231784
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00342355,
-          "spread": 0.01011774,
-          "score": 0.01068126
+          "bias": 0.00336328,
+          "spread": 0.0104468,
+          "score": 0.01097484
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00296896,
-          "spread": 0.01965336,
-          "score": 0.01987635
+          "bias": 0.00289919,
+          "spread": 0.01934283,
+          "score": 0.01955889
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.03597145,
-          "spread": 0.02994047,
-          "score": 0.04680146
+          "bias": -0.03602702,
+          "spread": 0.03012932,
+          "score": 0.04696512
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.07633722,
-          "spread": 0.19293731,
-          "score": 0.20749018
+          "bias": 0.0765849,
+          "spread": 0.19281135,
+          "score": 0.20746437
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.41376096,
-          "spread": 0.42526041,
-          "score": 0.59333342
+          "bias": 0.41325608,
+          "spread": 0.42579017,
+          "score": 0.59336149
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.00458479,
-          "spread": 0.01530433,
-          "score": 0.01597632
+          "bias": 0.00452616,
+          "spread": 0.01564593,
+          "score": 0.01628746
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00267053,
-          "spread": 0.00193623,
-          "score": 0.00329859
+          "bias": 0.00260782,
+          "spread": 0.00170352,
+          "score": 0.00311492
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00142163,
-          "spread": 0.00267756,
-          "score": 0.00303156
+          "bias": -0.00148795,
+          "spread": 0.0020974,
+          "score": 0.00257159
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00033037,
-          "spread": 0.00339094,
-          "score": 0.003407
+          "bias": -0.00039887,
+          "spread": 0.0027636,
+          "score": 0.00279224
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00056965,
-          "spread": 0.00294989,
-          "score": 0.00300439
+          "bias": 0.00050141,
+          "spread": 0.00237393,
+          "score": 0.00242631
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00251824,
-          "spread": 0.01339707,
-          "score": 0.0136317
+          "bias": 0.00245173,
+          "spread": 0.01344041,
+          "score": 0.01366219
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.00479478,
-          "spread": 0.02677063,
-          "score": 0.02719663
+          "bias": -0.00485938,
+          "spread": 0.02672749,
+          "score": 0.02716565
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00220916,
-          "spread": 0.01172252,
-          "score": 0.01192887
+          "bias": -0.00227943,
+          "spread": 0.01143223,
+          "score": 0.01165725
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.01937098,
-          "spread": 0.0155,
-          "score": 0.02480897
+          "bias": 0.01966403,
+          "spread": 0.01522153,
+          "score": 0.02486702
         },
         {
           "profile": "rated_plus_5pct",
@@ -8446,207 +8446,207 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00302993,
-          "spread": 0.00542285,
-          "score": 0.00621191
+          "bias": 0.00296481,
+          "spread": 0.00516055,
+          "score": 0.00595159
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00043449,
-          "spread": 0.00244954,
-          "score": 0.00248777
+          "bias": 0.00037223,
+          "spread": 0.00293996,
+          "score": 0.00296343
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00330229,
-          "spread": 0.00482894,
-          "score": 0.00585011
+          "bias": 0.00324014,
+          "spread": 0.00514212,
+          "score": 0.00607782
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00085924,
-          "spread": 0.00295323,
-          "score": 0.00307568
+          "bias": 0.0007895,
+          "spread": 0.00283665,
+          "score": 0.00294447
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.08439007,
-          "spread": 0.00800548,
-          "score": 0.08476893
+          "bias": 0.08417909,
+          "spread": 0.00798392,
+          "score": 0.08455686
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00093233,
-          "spread": 0.0047296,
-          "score": 0.00482062
+          "bias": 0.00086195,
+          "spread": 0.00457217,
+          "score": 0.00465271
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00125973,
-          "spread": 0.00273224,
-          "score": 0.00300866
+          "bias": 0.0011897,
+          "spread": 0.00264365,
+          "score": 0.00289901
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00101427,
-          "spread": 0.00268948,
-          "score": 0.00287438
+          "bias": 0.00094479,
+          "spread": 0.00258313,
+          "score": 0.00275049
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00103194,
-          "spread": 0.00301763,
-          "score": 0.0031892
+          "bias": -0.0011006,
+          "spread": 0.00290723,
+          "score": 0.00310859
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.0053873,
-          "spread": 0.00857751,
-          "score": 0.010129
+          "bias": 0.00531722,
+          "spread": 0.00838998,
+          "score": 0.009933
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00328094,
-          "spread": 0.02290049,
-          "score": 0.02313432
+          "bias": -0.00334889,
+          "spread": 0.02289583,
+          "score": 0.02313945
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.01191189,
-          "spread": 0.02227956,
-          "score": 0.02526404
+          "bias": 0.01183945,
+          "spread": 0.02212078,
+          "score": 0.02508987
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.02463647,
-          "spread": 0.27310314,
-          "score": 0.27421211
+          "bias": 0.02457369,
+          "spread": 0.27307549,
+          "score": 0.27417894
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.34017394,
-          "spread": 0.44384245,
-          "score": 0.55920875
+          "bias": 0.33991795,
+          "spread": 0.44371865,
+          "score": 0.55895479
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.01685283,
-          "spread": 0.03250622,
-          "score": 0.03661519
+          "bias": -0.01691618,
+          "spread": 0.03261349,
+          "score": 0.03673958
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00049099,
-          "spread": 0.00279779,
-          "score": 0.00284055
+          "bias": 0.00042193,
+          "spread": 0.00268214,
+          "score": 0.00271513
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00134366,
-          "spread": 0.00248007,
-          "score": 0.00282067
+          "bias": -0.001415,
+          "spread": 0.0022931,
+          "score": 0.00269454
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00128734,
-          "spread": 0.00243303,
-          "score": 0.00275261
+          "bias": -0.00135911,
+          "spread": 0.00224785,
+          "score": 0.00262678
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00014919,
-          "spread": 0.00261928,
-          "score": 0.00262352
+          "bias": -0.00022107,
+          "spread": 0.0024273,
+          "score": 0.00243735
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.0047038,
-          "spread": 0.01006135,
-          "score": 0.0111066
+          "bias": 0.00463117,
+          "spread": 0.00996463,
+          "score": 0.01098824
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.00546175,
-          "spread": 0.02433036,
-          "score": 0.02493586
+          "bias": 0.00539126,
+          "spread": 0.02424313,
+          "score": 0.02483536
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.0057854,
-          "spread": 0.00815707,
-          "score": 0.01000043
+          "bias": 0.00571339,
+          "spread": 0.0080968,
+          "score": 0.00990964
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.01368531,
-          "spread": 0.02756993,
-          "score": 0.03077968
+          "bias": -0.01363081,
+          "spread": 0.02735969,
+          "score": 0.03056716
         },
         {
           "profile": "rated_plus_5pct",
@@ -8662,252 +8662,252 @@
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 4.716e-05,
-          "spread": 0.00402269,
-          "score": 0.00402297
+          "bias": -2.073e-05,
+          "spread": 0.00406952,
+          "score": 0.00406957
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00121698,
-          "spread": 0.00322126,
-          "score": 0.00344348
+          "bias": 0.00114877,
+          "spread": 0.00320451,
+          "score": 0.0034042
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00303067,
-          "spread": 0.00504221,
-          "score": 0.00588293
+          "bias": 0.00296187,
+          "spread": 0.00494231,
+          "score": 0.00576187
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.0007798,
-          "spread": 0.00196679,
-          "score": 0.00211574
+          "bias": 0.00082033,
+          "spread": 0.00174765,
+          "score": 0.0019306
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.08212557,
-          "spread": 0.01888166,
-          "score": 0.08426818
+          "bias": 0.08170354,
+          "spread": 0.0186518,
+          "score": 0.08380548
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00145392,
-          "spread": 0.00490347,
-          "score": 0.00511448
+          "bias": 0.00149287,
+          "spread": 0.00476778,
+          "score": 0.00499604
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00046556,
-          "spread": 0.00176154,
-          "score": 0.00182202
+          "bias": 0.00050642,
+          "spread": 0.00151976,
+          "score": 0.00160192
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00032039,
-          "spread": 0.00151176,
-          "score": 0.00154534
+          "bias": 0.00036154,
+          "spread": 0.00130918,
+          "score": 0.00135819
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00168986,
-          "spread": 0.00306427,
-          "score": 0.00349933
+          "bias": 0.0017301,
+          "spread": 0.00281655,
+          "score": 0.00330548
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.0076231,
-          "spread": 0.00773214,
-          "score": 0.01085806
+          "bias": 0.00766295,
+          "spread": 0.00760188,
+          "score": 0.01079395
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00299903,
-          "spread": 0.0295204,
-          "score": 0.02967235
+          "bias": -0.00296762,
+          "spread": 0.02923635,
+          "score": 0.02938658
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.01013287,
-          "spread": 0.0210317,
-          "score": 0.0233454
+          "bias": -0.01009693,
+          "spread": 0.02083569,
+          "score": 0.02315327
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.03345576,
-          "spread": 0.231398,
-          "score": 0.23380403
+          "bias": 0.03359286,
+          "spread": 0.23182322,
+          "score": 0.2342445
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.17312558,
-          "spread": 0.07479184,
-          "score": 0.18859026
+          "bias": -0.17312048,
+          "spread": 0.07524223,
+          "score": 0.18876465
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.01245076,
-          "spread": 0.04057237,
-          "score": 0.04243982
+          "bias": -0.0124059,
+          "spread": 0.04069578,
+          "score": 0.04254471
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00140392,
-          "spread": 0.00244768,
-          "score": 0.00282173
+          "bias": 0.0014453,
+          "spread": 0.00232797,
+          "score": 0.00274014
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00069503,
-          "spread": 0.00117728,
-          "score": 0.00136714
+          "bias": -0.00065299,
+          "spread": 0.0007572,
+          "score": 0.00099987
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.001255,
-          "spread": 0.00189447,
-          "score": 0.00227245
+          "bias": -0.00121353,
+          "spread": 0.00150001,
+          "score": 0.00192943
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00025434,
-          "spread": 0.00165491,
-          "score": 0.00167434
+          "bias": 0.00029592,
+          "spread": 0.00123036,
+          "score": 0.00126544
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00022721,
-          "spread": 0.00103569,
-          "score": 0.00106032
+          "bias": 0.00026915,
+          "spread": 0.00091197,
+          "score": 0.00095086
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.00362554,
-          "spread": 0.02108109,
-          "score": 0.02139058
+          "bias": 0.00365653,
+          "spread": 0.02063219,
+          "score": 0.0209537
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00178469,
-          "spread": 0.00448285,
-          "score": 0.00482505
+          "bias": -0.00174473,
+          "spread": 0.00409785,
+          "score": 0.00445382
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.03093919,
-          "spread": 0.02884183,
-          "score": 0.04229758
+          "bias": -0.03090181,
+          "spread": 0.02876623,
+          "score": 0.04221869
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
-          "bias": 0.02325312,
+          "bias": 0.0226202,
           "spread": 0.0,
-          "score": 0.02325312
+          "score": 0.0226202
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00168026,
-          "spread": 0.00611056,
-          "score": 0.00633737
+          "bias": 0.00171855,
+          "spread": 0.00578526,
+          "score": 0.00603512
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00291301,
-          "spread": 0.00353345,
-          "score": 0.0045794
+          "bias": 0.00295227,
+          "spread": 0.00323032,
+          "score": 0.00437617
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.0009405,
-          "spread": 0.00311306,
-          "score": 0.00325202
+          "bias": 0.00098126,
+          "spread": 0.00327466,
+          "score": 0.00341852
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00122045,
-          "spread": 0.00275774,
-          "score": 0.00301573
+          "bias": 0.0011033,
+          "spread": 0.00212144,
+          "score": 0.00239119
         },
         {
           "profile": "ti_dependent_cp",
@@ -8923,162 +8923,162 @@
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00187813,
-          "spread": 0.01285611,
-          "score": 0.01299258
+          "bias": 0.0017654,
+          "spread": 0.0125938,
+          "score": 0.01271694
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00247275,
-          "spread": 0.00314501,
-          "score": 0.0040007
+          "bias": -0.00258819,
+          "spread": 0.00280386,
+          "score": 0.0038158
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00246429,
-          "spread": 0.00387779,
-          "score": 0.00459456
+          "bias": 0.00234516,
+          "spread": 0.00320471,
+          "score": 0.00397114
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00369595,
-          "spread": 0.00656919,
-          "score": 0.00753753
+          "bias": 0.00357849,
+          "spread": 0.00594441,
+          "score": 0.00693841
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01273498,
-          "spread": 0.00610347,
-          "score": 0.01412204
+          "bias": 0.01262039,
+          "spread": 0.00559863,
+          "score": 0.01380648
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.0076315,
-          "spread": 0.02985877,
-          "score": 0.0308186
+          "bias": 0.00751404,
+          "spread": 0.02957532,
+          "score": 0.03051492
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.02423643,
-          "spread": 0.04222742,
-          "score": 0.04868839
+          "bias": 0.02409448,
+          "spread": 0.04142929,
+          "score": 0.0479263
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.0603413,
-          "spread": 0.43575083,
-          "score": 0.43990892
+          "bias": 0.05998405,
+          "spread": 0.4351595,
+          "score": 0.43927426
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.11961518,
+          "bias": -0.12075539,
           "spread": 0.0,
-          "score": 0.11961518
+          "score": 0.12075539
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.00027117,
-          "spread": 0.02296886,
-          "score": 0.02297046
+          "bias": 0.00017354,
+          "spread": 0.02341826,
+          "score": 0.0234189
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00370311,
-          "spread": 0.00191249,
-          "score": 0.00416781
+          "bias": -0.00382132,
+          "spread": 0.00122748,
+          "score": 0.00401363
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00337162,
-          "spread": 0.00436782,
-          "score": 0.00551776
+          "bias": 0.00325766,
+          "spread": 0.00362044,
+          "score": 0.00487031
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.0010778,
-          "spread": 0.00481494,
-          "score": 0.0049341
+          "bias": 0.00096689,
+          "spread": 0.00421472,
+          "score": 0.0043242
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00086539,
-          "spread": 0.00322631,
-          "score": 0.00334035
+          "bias": 0.00075554,
+          "spread": 0.00262637,
+          "score": 0.00273288
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00705901,
-          "spread": 0.01848854,
-          "score": 0.0197903
+          "bias": 0.00694813,
+          "spread": 0.01836788,
+          "score": 0.01963812
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.00839481,
-          "spread": 0.03729743,
-          "score": 0.03823049
+          "bias": 0.00824648,
+          "spread": 0.03675142,
+          "score": 0.03766526
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.03572332,
-          "spread": 0.03834232,
-          "score": 0.05240505
+          "bias": 0.03630374,
+          "spread": 0.03827476,
+          "score": 0.05275338
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.00543786,
-          "spread": 0.01010305,
-          "score": 0.01147353
+          "bias": -0.00487821,
+          "spread": 0.01001534,
+          "score": 0.01114019
         },
         {
           "profile": "ti_dependent_cp",
@@ -9094,207 +9094,207 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00086006,
-          "spread": 0.0131914,
-          "score": 0.01321941
+          "bias": 0.00073842,
+          "spread": 0.0128231,
+          "score": 0.01284434
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00547776,
-          "spread": 0.00555992,
-          "score": 0.00780504
+          "bias": 0.00535876,
+          "spread": 0.00526726,
+          "score": 0.00751401
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00017414,
-          "spread": 0.00397383,
-          "score": 0.00397765
+          "bias": -0.00029182,
+          "spread": 0.00399343,
+          "score": 0.00400408
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00159932,
-          "spread": 0.00156926,
-          "score": 0.00224063
+          "bias": 0.00153122,
+          "spread": 0.00161557,
+          "score": 0.00222592
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.09269036,
-          "spread": 0.010733,
-          "score": 0.0933097
+          "bias": 0.09220031,
+          "spread": 0.00996345,
+          "score": 0.09273709
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00402936,
-          "spread": 0.01181393,
-          "score": 0.01248217
+          "bias": -0.00409293,
+          "spread": 0.01161022,
+          "score": 0.01231054
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00122873,
-          "spread": 0.00228812,
-          "score": 0.00259717
+          "bias": -0.00129664,
+          "spread": 0.00201232,
+          "score": 0.00239389
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.0024145,
-          "spread": 0.00126437,
-          "score": 0.00272551
+          "bias": 0.00234622,
+          "spread": 0.001423,
+          "score": 0.00274402
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00287457,
-          "spread": 0.00262243,
-          "score": 0.00389106
+          "bias": 0.00280707,
+          "spread": 0.00235841,
+          "score": 0.0036663
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01290354,
-          "spread": 0.00813604,
-          "score": 0.0152544
+          "bias": 0.01283981,
+          "spread": 0.00835734,
+          "score": 0.01532011
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.0205319,
-          "spread": 0.0225185,
-          "score": 0.03047362
+          "bias": 0.020458,
+          "spread": 0.02209266,
+          "score": 0.03011006
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.01748412,
-          "spread": 0.02724376,
-          "score": 0.03237154
+          "bias": -0.01754336,
+          "spread": 0.02736331,
+          "score": 0.03250415
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.08202518,
-          "spread": 0.19403483,
-          "score": 0.21066002
+          "bias": 0.08227427,
+          "spread": 0.19390897,
+          "score": 0.21064126
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.42277493,
-          "spread": 0.51608502,
-          "score": 0.66714495
+          "bias": 0.42231354,
+          "spread": 0.51657264,
+          "score": 0.66723011
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.00121671,
-          "spread": 0.01832729,
-          "score": 0.01836763
+          "bias": -0.00127243,
+          "spread": 0.01874918,
+          "score": 0.01879231
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00127139,
-          "spread": 0.00093914,
-          "score": 0.00158064
+          "bias": -0.00134209,
+          "spread": 0.000964,
+          "score": 0.00165242
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00333313,
-          "spread": 0.00305168,
-          "score": 0.00451913
+          "bias": 0.00326517,
+          "spread": 0.00247265,
+          "score": 0.00409577
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00107015,
-          "spread": 0.00335611,
-          "score": 0.00352259
+          "bias": 0.00100459,
+          "spread": 0.00275846,
+          "score": 0.0029357
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00081757,
-          "spread": 0.00282891,
-          "score": 0.00294469
+          "bias": 0.00075246,
+          "spread": 0.00223272,
+          "score": 0.0023561
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00209983,
-          "spread": 0.01157752,
-          "score": 0.01176641
+          "bias": 0.0020364,
+          "spread": 0.01159298,
+          "score": 0.01177047
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.01220541,
-          "spread": 0.03144846,
-          "score": 0.03373393
+          "bias": -0.01228161,
+          "spread": 0.03174856,
+          "score": 0.03404129
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00747142,
-          "spread": 0.00891264,
-          "score": 0.01163001
+          "bias": -0.00753871,
+          "spread": 0.00835462,
+          "score": 0.01125309
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.00064431,
-          "spread": 0.0148386,
-          "score": 0.01485258
+          "bias": 0.00092385,
+          "spread": 0.01457297,
+          "score": 0.01460223
         },
         {
           "profile": "ti_dependent_cp",
@@ -9310,207 +9310,207 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00326725,
-          "spread": 0.00580136,
-          "score": 0.00665813
+          "bias": 0.00319532,
+          "spread": 0.00547021,
+          "score": 0.00633508
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00102746,
-          "spread": 0.00236327,
-          "score": 0.00257696
+          "bias": 0.00095895,
+          "spread": 0.00291294,
+          "score": 0.00306672
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00249741,
-          "spread": 0.00501341,
-          "score": 0.00560101
+          "bias": 0.00242888,
+          "spread": 0.00534672,
+          "score": 0.00587256
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.000826,
-          "spread": 0.00303087,
-          "score": 0.00314141
+          "bias": 0.00075414,
+          "spread": 0.00291168,
+          "score": 0.00300776
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.08413914,
-          "spread": 0.00967625,
-          "score": 0.08469371
+          "bias": 0.0839064,
+          "spread": 0.00965342,
+          "score": 0.08445989
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00129518,
-          "spread": 0.00409997,
-          "score": 0.00429968
+          "bias": -0.00136799,
+          "spread": 0.00393026,
+          "score": 0.00416153
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00011563,
-          "spread": 0.00310711,
-          "score": 0.00310926
+          "bias": -0.00018756,
+          "spread": 0.00295999,
+          "score": 0.00296593
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00050397,
-          "spread": 0.00270077,
-          "score": 0.00274739
+          "bias": 0.00043224,
+          "spread": 0.00262355,
+          "score": 0.00265892
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00106591,
-          "spread": 0.00307979,
-          "score": 0.00325903
+          "bias": 0.00099441,
+          "spread": 0.002939,
+          "score": 0.00310267
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01547524,
-          "spread": 0.0096066,
-          "score": 0.01821455
+          "bias": 0.01540289,
+          "spread": 0.00941693,
+          "score": 0.01805347
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.01031209,
-          "spread": 0.02143816,
-          "score": 0.02378937
+          "bias": 0.01024272,
+          "spread": 0.02142547,
+          "score": 0.02374793
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.02846177,
-          "spread": 0.02523525,
-          "score": 0.03803801
+          "bias": 0.02838716,
+          "spread": 0.02506528,
+          "score": 0.0378695
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.02883146,
-          "spread": 0.28093759,
-          "score": 0.28241314
+          "bias": 0.02876894,
+          "spread": 0.28091096,
+          "score": 0.28238028
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.04745616,
-          "spread": 0.13291756,
-          "score": 0.14113528
+          "bias": 0.04726238,
+          "spread": 0.13285865,
+          "score": 0.14101473
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.0181461,
-          "spread": 0.03665445,
-          "score": 0.04090024
+          "bias": -0.01821031,
+          "spread": 0.03673256,
+          "score": 0.04099874
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00384865,
-          "spread": 0.00310601,
-          "score": 0.00494564
+          "bias": -0.00392094,
+          "spread": 0.00303917,
+          "score": 0.00496088
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00293751,
-          "spread": 0.00261875,
-          "score": 0.00393533
+          "bias": 0.00286766,
+          "spread": 0.00243131,
+          "score": 0.00375962
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00012042,
-          "spread": 0.00251841,
-          "score": 0.00252129
+          "bias": -0.00018937,
+          "spread": 0.00234147,
+          "score": 0.00234911
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -4.666e-05,
-          "spread": 0.00230259,
-          "score": 0.00230306
+          "bias": -0.00011557,
+          "spread": 0.00211562,
+          "score": 0.00211878
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00324726,
-          "spread": 0.00892721,
-          "score": 0.00949947
+          "bias": 0.00317759,
+          "spread": 0.00881885,
+          "score": 0.00937385
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.0043128,
-          "spread": 0.02530655,
-          "score": 0.02567142
+          "bias": -0.00438914,
+          "spread": 0.02526758,
+          "score": 0.02564595
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00122874,
-          "spread": 0.00723177,
-          "score": 0.00733542
+          "bias": 0.00115967,
+          "spread": 0.00722656,
+          "score": 0.00731902
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.02686958,
-          "spread": 0.02773794,
-          "score": 0.03861823
+          "bias": -0.02681824,
+          "spread": 0.0275371,
+          "score": 0.03843839
         },
         {
           "profile": "ti_dependent_cp",
@@ -9526,252 +9526,252 @@
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00042516,
-          "spread": 0.00401098,
-          "score": 0.00403345
+          "bias": 0.00035211,
+          "spread": 0.00404276,
+          "score": 0.00405807
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00220056,
-          "spread": 0.00305818,
-          "score": 0.00376762
+          "bias": 0.00212716,
+          "spread": 0.00303636,
+          "score": 0.00370733
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00245736,
-          "spread": 0.00532151,
-          "score": 0.00586149
+          "bias": 0.00238347,
+          "spread": 0.00521159,
+          "score": 0.00573076
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00072866,
-          "spread": 0.00200404,
-          "score": 0.0021324
+          "bias": 0.00076959,
+          "spread": 0.00177636,
+          "score": 0.0019359
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.07192394,
-          "spread": 0.01457023,
-          "score": 0.07338491
+          "bias": 0.07146664,
+          "spread": 0.01432502,
+          "score": 0.07288818
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00110792,
-          "spread": 0.00424903,
-          "score": 0.0043911
+          "bias": -0.00106296,
+          "spread": 0.00412022,
+          "score": 0.00425513
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00038049,
-          "spread": 0.00201224,
-          "score": 0.0020479
+          "bias": -0.00033942,
+          "spread": 0.00161259,
+          "score": 0.00164792
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.0002689,
-          "spread": 0.00150885,
-          "score": 0.00153263
+          "bias": -0.0002279,
+          "spread": 0.00143497,
+          "score": 0.00145295
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00333324,
-          "spread": 0.00321445,
-          "score": 0.00463068
+          "bias": 0.00337372,
+          "spread": 0.00293756,
+          "score": 0.00447339
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01506503,
-          "spread": 0.00830582,
-          "score": 0.01720295
+          "bias": 0.01510546,
+          "spread": 0.00818956,
+          "score": 0.01718266
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.01099324,
-          "spread": 0.03027509,
-          "score": 0.0322092
+          "bias": 0.01102531,
+          "spread": 0.02999368,
+          "score": 0.03195588
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.00270023,
-          "spread": 0.02041329,
-          "score": 0.0205911
+          "bias": 0.00273683,
+          "spread": 0.02022123,
+          "score": 0.0204056
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.0398841,
-          "spread": 0.23236472,
-          "score": 0.23576281
+          "bias": 0.04002302,
+          "spread": 0.23279553,
+          "score": 0.23621093
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.18986124,
-          "spread": 0.1064359,
-          "score": 0.21766003
+          "bias": -0.18983808,
+          "spread": 0.1068757,
+          "score": 0.21785526
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.0075608,
-          "spread": 0.04077859,
-          "score": 0.0414736
+          "bias": -0.00751956,
+          "spread": 0.04081701,
+          "score": 0.04150388
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00276954,
-          "spread": 0.00266045,
-          "score": 0.00384036
+          "bias": -0.0027295,
+          "spread": 0.00261765,
+          "score": 0.00378183
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00358494,
-          "spread": 0.00135435,
-          "score": 0.00383224
+          "bias": 0.00362435,
+          "spread": 0.00099455,
+          "score": 0.00375833
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 3.498e-05,
-          "spread": 0.00187847,
-          "score": 0.00187879
+          "bias": 7.458e-05,
+          "spread": 0.00149271,
+          "score": 0.00149458
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00068326,
-          "spread": 0.00146395,
-          "score": 0.00161555
+          "bias": 0.00072303,
+          "spread": 0.00105432,
+          "score": 0.00127842
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": -0.00120404,
-          "spread": 0.00247008,
-          "score": 0.00274791
+          "bias": -0.00116387,
+          "spread": 0.00240105,
+          "score": 0.00266826
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.0007804,
-          "spread": 0.02061688,
-          "score": 0.02063165
+          "bias": -0.00075226,
+          "spread": 0.02022216,
+          "score": 0.02023615
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00596086,
-          "spread": 0.00558856,
-          "score": 0.00817091
+          "bias": -0.00592225,
+          "spread": 0.00516465,
+          "score": 0.00785791
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.03509673,
-          "spread": 0.02559304,
-          "score": 0.04343713
+          "bias": -0.03506006,
+          "spread": 0.02539969,
+          "score": 0.04329379
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
-          "bias": 0.02022686,
+          "bias": 0.01961863,
           "spread": 0.0,
-          "score": 0.02022686
+          "score": 0.01961863
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00197503,
-          "spread": 0.00651164,
-          "score": 0.00680457
+          "bias": 0.00201471,
+          "spread": 0.00617601,
+          "score": 0.00649632
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00353055,
-          "spread": 0.00346417,
-          "score": 0.00494624
+          "bias": 0.00357175,
+          "spread": 0.00316836,
+          "score": 0.00477451
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -6.051e-05,
-          "spread": 0.00282089,
-          "score": 0.00282154
+          "bias": -1.839e-05,
+          "spread": 0.00294385,
+          "score": 0.0029439
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.0012247,
-          "spread": 0.00271694,
-          "score": 0.00298022
+          "bias": 0.00111163,
+          "spread": 0.0020918,
+          "score": 0.00236883
         },
         {
           "profile": "ws_dependent_cp",
@@ -9787,162 +9787,162 @@
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00630948,
-          "spread": 0.01315801,
-          "score": 0.01459256
+          "bias": 0.00619823,
+          "spread": 0.01295294,
+          "score": 0.01435956
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00032353,
-          "spread": 0.00296487,
-          "score": 0.00298247
+          "bias": -0.00043501,
+          "spread": 0.00272055,
+          "score": 0.00275511
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00340417,
-          "spread": 0.00372005,
-          "score": 0.00504254
+          "bias": 0.00328832,
+          "spread": 0.00306644,
+          "score": 0.00449623
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00099969,
-          "spread": 0.00557448,
-          "score": 0.00566341
+          "bias": -0.00111624,
+          "spread": 0.00508757,
+          "score": 0.00520859
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": -4.55e-05,
-          "spread": 0.00636031,
-          "score": 0.00636047
+          "bias": -0.00016317,
+          "spread": 0.00631757,
+          "score": 0.00631967
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.01300143,
-          "spread": 0.03584837,
-          "score": 0.03813322
+          "bias": -0.01312923,
+          "spread": 0.0355466,
+          "score": 0.03789377
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.01964863,
-          "spread": 0.03965161,
-          "score": 0.0442529
+          "bias": -0.01979892,
+          "spread": 0.03888474,
+          "score": 0.04363508
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": -0.30514082,
-          "spread": 1.02500856,
-          "score": 1.0694641
+          "bias": -0.30548084,
+          "spread": 1.02446175,
+          "score": 1.06903715
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.09900704,
-          "spread": 0.20800891,
-          "score": 0.23036948
+          "bias": 0.09850146,
+          "spread": 0.20865727,
+          "score": 0.2307388
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.00193669,
-          "spread": 0.0313592,
-          "score": 0.03141895
+          "bias": 0.00184029,
+          "spread": 0.03173601,
+          "score": 0.03178932
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 8.892e-05,
-          "spread": 0.00182597,
-          "score": 0.00182813
+          "bias": -2.209e-05,
+          "spread": 0.00110935,
+          "score": 0.00110957
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00180682,
-          "spread": 0.00413102,
-          "score": 0.00450887
+          "bias": 0.00169587,
+          "spread": 0.00339526,
+          "score": 0.00379523
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00066499,
-          "spread": 0.00496726,
-          "score": 0.00501158
+          "bias": 0.00055405,
+          "spread": 0.00434683,
+          "score": 0.004382
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00117596,
-          "spread": 0.00307489,
-          "score": 0.00329209
+          "bias": 0.00106609,
+          "spread": 0.00243525,
+          "score": 0.00265838
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00694375,
-          "spread": 0.01972137,
-          "score": 0.02090809
+          "bias": 0.00683389,
+          "spread": 0.01965939,
+          "score": 0.02081331
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.00872773,
-          "spread": 0.0402743,
-          "score": 0.04120913
+          "bias": -0.00889162,
+          "spread": 0.03987032,
+          "score": 0.04084976
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.04211897,
-          "spread": 0.04580409,
-          "score": 0.06222558
+          "bias": 0.04269812,
+          "spread": 0.04573599,
+          "score": 0.06256924
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.00164309,
-          "spread": 0.00305397,
-          "score": 0.00346792
+          "bias": -0.00108458,
+          "spread": 0.00296588,
+          "score": 0.00315797
         },
         {
           "profile": "ws_dependent_cp",
@@ -9958,207 +9958,207 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00205126,
-          "spread": 0.01472588,
-          "score": 0.01486806
+          "bias": -0.00217476,
+          "spread": 0.01432198,
+          "score": 0.01448616
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00428841,
-          "spread": 0.00619143,
-          "score": 0.00753155
+          "bias": 0.00417069,
+          "spread": 0.00589848,
+          "score": 0.00722404
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00072114,
-          "spread": 0.00390694,
-          "score": 0.00397294
+          "bias": -0.00083339,
+          "spread": 0.00400587,
+          "score": 0.00409164
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.0016294,
-          "spread": 0.00155781,
-          "score": 0.00225426
+          "bias": 0.00156512,
+          "spread": 0.00160974,
+          "score": 0.00224519
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.08290577,
-          "spread": 0.00912969,
-          "score": 0.08340694
+          "bias": 0.08244228,
+          "spread": 0.00987504,
+          "score": 0.08303159
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00051993,
-          "spread": 0.01110928,
-          "score": 0.01112144
+          "bias": 0.00045843,
+          "spread": 0.0109291,
+          "score": 0.01093871
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00099538,
-          "spread": 0.00184019,
-          "score": 0.00209215
+          "bias": 0.00093071,
+          "spread": 0.00170265,
+          "score": 0.00194042
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.0032494,
-          "spread": 0.00132642,
-          "score": 0.0035097
+          "bias": 0.00318412,
+          "spread": 0.00159781,
+          "score": 0.00356253
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00167791,
-          "spread": 0.00263593,
-          "score": 0.00312467
+          "bias": -0.00174366,
+          "spread": 0.00266288,
+          "score": 0.00318297
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": -0.00074948,
-          "spread": 0.00939034,
-          "score": 0.0094202
+          "bias": -0.00081146,
+          "spread": 0.00979919,
+          "score": 0.00983273
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00017697,
-          "spread": 0.02765083,
-          "score": 0.0276514
+          "bias": -0.00025058,
+          "spread": 0.02722257,
+          "score": 0.02722373
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.06184161,
-          "spread": 0.03051571,
-          "score": 0.06896081
+          "bias": -0.06190185,
+          "spread": 0.03094796,
+          "score": 0.06920704
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": -0.00131219,
-          "spread": 0.31247787,
-          "score": 0.31248062
+          "bias": -0.00102284,
+          "spread": 0.31231902,
+          "score": 0.31232069
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.46756659,
-          "spread": 0.50557206,
-          "score": 0.68863752
+          "bias": 0.46708843,
+          "spread": 0.50607784,
+          "score": 0.68868453
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.00039258,
-          "spread": 0.0166209,
-          "score": 0.01662553
+          "bias": 0.00033106,
+          "spread": 0.01675099,
+          "score": 0.01675426
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00269384,
-          "spread": 0.00135798,
-          "score": 0.00301677
+          "bias": 0.00262884,
+          "spread": 0.0013521,
+          "score": 0.00295618
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.0022338,
-          "spread": 0.00267725,
-          "score": 0.00348677
+          "bias": 0.00216875,
+          "spread": 0.00210913,
+          "score": 0.00302522
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00079331,
-          "spread": 0.0032101,
-          "score": 0.00330668
+          "bias": 0.00072798,
+          "spread": 0.00261586,
+          "score": 0.00271527
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00126009,
-          "spread": 0.00296712,
-          "score": 0.0032236
+          "bias": 0.00119491,
+          "spread": 0.00238836,
+          "score": 0.00267059
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00305823,
-          "spread": 0.01191498,
-          "score": 0.0123012
+          "bias": 0.00299498,
+          "spread": 0.0119596,
+          "score": 0.0123289
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.04410977,
-          "spread": 0.04947588,
-          "score": 0.06628374
+          "bias": -0.04419039,
+          "spread": 0.0500032,
+          "score": 0.06673163
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00305178,
-          "spread": 0.00850906,
-          "score": 0.00903978
+          "bias": -0.00311832,
+          "spread": 0.00812964,
+          "score": 0.00870718
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.01391006,
-          "spread": 0.01555402,
-          "score": 0.02086665
+          "bias": 0.01418975,
+          "spread": 0.01528826,
+          "score": 0.02085857
         },
         {
           "profile": "ws_dependent_cp",
@@ -10174,207 +10174,207 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00058488,
-          "spread": 0.00605881,
-          "score": 0.00608697
+          "bias": 0.00051355,
+          "spread": 0.00573834,
+          "score": 0.00576127
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00063784,
-          "spread": 0.00269169,
-          "score": 0.00276623
+          "bias": -0.00070437,
+          "spread": 0.0031724,
+          "score": 0.00324965
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00176201,
-          "spread": 0.00514787,
-          "score": 0.00544107
+          "bias": 0.00169731,
+          "spread": 0.00546905,
+          "score": 0.00572637
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 9,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00085071,
-          "spread": 0.00300389,
-          "score": 0.00312203
+          "bias": 0.00078046,
+          "spread": 0.00288519,
+          "score": 0.00298889
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.05902569,
-          "spread": 0.0079314,
-          "score": 0.05955619
+          "bias": 0.0588008,
+          "spread": 0.00791188,
+          "score": 0.0593307
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00200239,
-          "spread": 0.00375098,
-          "score": 0.00425199
+          "bias": 0.00193178,
+          "spread": 0.00359263,
+          "score": 0.00407906
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00186521,
-          "spread": 0.00311605,
-          "score": 0.00363163
+          "bias": 0.00179515,
+          "spread": 0.00298561,
+          "score": 0.00348374
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00124437,
-          "spread": 0.00294566,
-          "score": 0.00319771
+          "bias": 0.00117417,
+          "spread": 0.00289035,
+          "score": 0.00311975
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00283472,
-          "spread": 0.00288505,
-          "score": 0.00404465
+          "bias": -0.00290568,
+          "spread": 0.0027815,
+          "score": 0.0040224
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00252683,
-          "spread": 0.00852651,
-          "score": 0.00889304
+          "bias": 0.00245353,
+          "spread": 0.00833831,
+          "score": 0.00869179
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.01027118,
-          "spread": 0.02507574,
-          "score": 0.02709779
+          "bias": -0.01034311,
+          "spread": 0.02506677,
+          "score": 0.02711684
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.00184755,
-          "spread": 0.03120875,
-          "score": 0.03126339
+          "bias": 0.0017693,
+          "spread": 0.03102579,
+          "score": 0.03107619
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": -0.01685733,
-          "spread": 0.31776771,
-          "score": 0.31821453
+          "bias": -0.01692588,
+          "spread": 0.31773524,
+          "score": 0.31818575
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 9,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.40592899,
-          "spread": 0.52690912,
-          "score": 0.66514026
+          "bias": 0.40565569,
+          "spread": 0.52677606,
+          "score": 0.66486807
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.00989481,
-          "spread": 0.02746772,
-          "score": 0.0291956
+          "bias": -0.00995875,
+          "spread": 0.02759236,
+          "score": 0.02933453
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 7.234e-05,
-          "spread": 0.00306563,
-          "score": 0.00306649
+          "bias": 3.1e-06,
+          "spread": 0.00298088,
+          "score": 0.00298088
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00187547,
-          "spread": 0.00262896,
-          "score": 0.00322936
+          "bias": 0.00180679,
+          "spread": 0.00244631,
+          "score": 0.00304121
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00022276,
-          "spread": 0.00244024,
-          "score": 0.00245039
+          "bias": -0.00029125,
+          "spread": 0.00225848,
+          "score": 0.00227718
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00038946,
-          "spread": 0.00249151,
-          "score": 0.00252177
+          "bias": 0.0003209,
+          "spread": 0.0023048,
+          "score": 0.00232704
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00446101,
-          "spread": 0.00921819,
-          "score": 0.01024088
+          "bias": 0.00439175,
+          "spread": 0.00912185,
+          "score": 0.01012402
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.02990564,
-          "spread": 0.03894326,
-          "score": 0.04910116
+          "bias": -0.02998687,
+          "spread": 0.03895994,
+          "score": 0.0491639
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00447467,
-          "spread": 0.00718998,
-          "score": 0.00846867
+          "bias": 0.00440608,
+          "spread": 0.00716005,
+          "score": 0.00840713
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.01657361,
-          "spread": 0.02718981,
-          "score": 0.0318429
+          "bias": -0.01652187,
+          "spread": 0.02698904,
+          "score": 0.0316446
         },
         {
           "profile": "ws_dependent_cp",
@@ -10390,243 +10390,243 @@
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00275506,
-          "spread": 0.00506453,
-          "score": 0.0057654
+          "bias": -0.0028292,
+          "spread": 0.00510663,
+          "score": 0.00583798
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00021594,
-          "spread": 0.00351135,
-          "score": 0.00351798
+          "bias": 0.00014307,
+          "spread": 0.00349535,
+          "score": 0.00349828
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 9,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00181335,
-          "spread": 0.0049852,
-          "score": 0.00530476
+          "bias": 0.0017418,
+          "spread": 0.00488628,
+          "score": 0.00518745
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00076995,
-          "spread": 0.00198829,
-          "score": 0.00213216
+          "bias": 0.00081161,
+          "spread": 0.00176902,
+          "score": 0.00194632
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.06737555,
-          "spread": 0.0209389,
-          "score": 0.07055425
+          "bias": 0.06692428,
+          "spread": 0.02069775,
+          "score": 0.07005181
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00220028,
-          "spread": 0.00380945,
-          "score": 0.00439922
+          "bias": 0.00224362,
+          "spread": 0.00374166,
+          "score": 0.00436278
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00135206,
-          "spread": 0.0017127,
-          "score": 0.00218206
+          "bias": 0.00139324,
+          "spread": 0.00142285,
+          "score": 0.00199139
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00056494,
-          "spread": 0.00159818,
-          "score": 0.00169509
+          "bias": 0.00060646,
+          "spread": 0.00152914,
+          "score": 0.00164501
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00041964,
-          "spread": 0.00343485,
-          "score": 0.00346039
+          "bias": -0.00037841,
+          "spread": 0.0031953,
+          "score": 0.00321763
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00271492,
-          "spread": 0.00700677,
-          "score": 0.00751436
+          "bias": 0.00275664,
+          "spread": 0.00690563,
+          "score": 0.00743551
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00939766,
-          "spread": 0.03354648,
-          "score": 0.03483794
+          "bias": -0.00936343,
+          "spread": 0.03322548,
+          "score": 0.03451966
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.02155957,
-          "spread": 0.02112641,
-          "score": 0.0301851
+          "bias": -0.02152047,
+          "spread": 0.0209175,
+          "score": 0.0300112
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.01715809,
-          "spread": 0.25545323,
-          "score": 0.25602881
+          "bias": 0.01730751,
+          "spread": 0.25591926,
+          "score": 0.25650383
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.67483923,
-          "spread": 0.78159391,
-          "score": 1.0326166
+          "bias": 0.67475697,
+          "spread": 0.78100991,
+          "score": 1.03212085
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.00579163,
-          "spread": 0.04221405,
-          "score": 0.04260949
+          "bias": -0.00574894,
+          "spread": 0.04228275,
+          "score": 0.04267179
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.000966,
-          "spread": 0.00254788,
-          "score": 0.00272486
+          "bias": 0.00100645,
+          "spread": 0.00250034,
+          "score": 0.0026953
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00244554,
-          "spread": 0.00108785,
-          "score": 0.00267658
+          "bias": 0.00248546,
+          "spread": 0.00069711,
+          "score": 0.00258137
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00010643,
-          "spread": 0.00167322,
-          "score": 0.0016766
+          "bias": -6.681e-05,
+          "spread": 0.00130756,
+          "score": 0.00130927
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00093503,
-          "spread": 0.00146747,
-          "score": 0.00174004
+          "bias": 0.00097475,
+          "spread": 0.00108415,
+          "score": 0.00145791
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 5.417e-05,
-          "spread": 0.00165229,
-          "score": 0.00165318
+          "bias": 9.426e-05,
+          "spread": 0.00160329,
+          "score": 0.00160606
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.02616794,
-          "spread": 0.0201982,
-          "score": 0.03305645
+          "bias": -0.02613985,
+          "spread": 0.02014609,
+          "score": 0.03300237
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.002628,
-          "spread": 0.00464857,
-          "score": 0.00534
+          "bias": -0.00258973,
+          "spread": 0.0042484,
+          "score": 0.0049755
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.03124949,
-          "spread": 0.02613349,
-          "score": 0.04073684
+          "bias": -0.03121366,
+          "spread": 0.0260096,
+          "score": 0.04062994
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
-          "bias": 0.02161203,
+          "bias": 0.02100715,
           "spread": 0.0,
-          "score": 0.02161203
+          "score": 0.02100715
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00098452,
-          "spread": 0.00732249,
-          "score": 0.00738838
+          "bias": -0.000943,
+          "spread": 0.00695575,
+          "score": 0.00701938
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00169969,
-          "spread": 0.00359976,
-          "score": 0.00398086
+          "bias": 0.00174189,
+          "spread": 0.00330975,
+          "score": 0.00374014
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00055002,
-          "spread": 0.0031198,
-          "score": 0.00316791
+          "bias": -0.00050767,
+          "spread": 0.00325881,
+          "score": 0.00329811
         }
       ]
     }

--- a/docs/v1/findings.md
+++ b/docs/v1/findings.md
@@ -7,6 +7,74 @@ from, not just conclusions.
 
 ---
 
+## F16 — a finite time-decay half-life (548 d) is the default, applied to the headline fit only; the double-ratio toggle estimator validated as opt-in; the 1–2-month regime flips the training-window verdict (Issue 13 extension)
+
+*2026-07-04/05 — three user-directed follow-ups to F15, A/B'd against the post-F15 benchmark.
+New: `toggle_estimator="double_ratio"` on `PowerModelMethod` (the naive-adoption hybrid) and
+`benchmarking/baselines/inspect_short_campaigns.py` (1–2-month campaigns are outside the committed
+benchmark grid; oracle + naive anchor them — the oracle scores exactly 0 there, so the harness
+itself is sound at those lengths).*
+
+### ACCEPTED — `time_decay_half_life_days = 548` (1.5 years), headline fit only; benchmark regenerated
+- **Why finite at all:** the method must work on any dataset; with 20 years of SCADA an unbounded
+  training window would let ancient eras dominate the campaign era. `0.5^(days outside the
+  campaign interval / 548)`: rows in the campaign weigh exactly 1, year-old data ~63%,
+  decade-old ~1%.
+- **Dose curve (cp_0pct, both modes):** 90/180/365/548/1096 days all leave the toggle overall
+  neutral-or-better; prepost overall bias nudges up slightly (+0.1–0.2 pp at 3 months) and
+  everything ≥365 d is indistinguishable on this 2.5-year dataset — the specific choice of 548
+  rests on the bounding argument, not a HoT win. Short half-lives (90 d) measurably help
+  1–3-month campaigns in **both** modes (prepost 2-month score 0.21 vs 0.59 unweighted; toggle
+  best-or-near-best at 1/2/3 months) at a small long-prepost bias cost — the documented
+  short-campaign tuning.
+- **Headline fit only.** Weighting the conditional two-direction fits destabilises the sparse
+  extreme-TI tail bins (a degenerate matched fit in one replicate read +1039 % in one bin; it
+  appeared at hl365/548 and not at 180/1096 — replicate chance, the F7/F8 tail fragility that
+  Issue 14's count floor addresses). The matched contrast is already era-insensitive (its common
+  shrinkage cancels), so the weights buy nothing there. With weights confined to the headline
+  path the full sweep is clean: prepost conditional ALL Δscore +5.4 (weighted) → **+0.03**
+  (headline-only); every overall row in both modes inside the ±0.1 pp neutrality band, toggle
+  slightly better everywhere.
+
+### Validated opt-in — `toggle_estimator="double_ratio"` (the naive-adoption hybrid)
+- The model is demoted to removing condition unfairness; the headline is a ratio of ratios,
+  ``(Σy_on/Σpred_on) / (Σy_off/Σpred_off) − 1``. Off rows are predicted out-of-fold and on rows
+  by the same fold-model ensemble (basis-consistent, the F15 rule), so the model's shrinkage /
+  level bias cancels between the interleaved sides instead of needing to be zero.
+- **On the benchmark grid it does exactly what it promises:** toggle placebo headline bias ≈ 0 at
+  every campaign length (−0.00/+0.08/−0.06/−0.05 pp vs +0.12/+0.16/+0.08/+0.08 for the default),
+  score neutral. The logged ρ_off (0.9995–1.0006 on ~100k-row fits) is precisely the residual OOF
+  shrinkage, cancelled by construction.
+- **Not the default, for two measured reasons:** (i) with campaign-only training it overcorrects
+  and the 3-month spread balloons (0.26 → 0.80 — five fold models on ~6k rows are noise); (ii) at
+  1–2-month campaigns it is *worse* than the default (score 1.05/0.59 vs 0.90/0.38): with
+  all-data training, ρ_off is measured across two years of eras while the ON window is a
+  one-month sliver, so the "cancellation" subtracts the wrong era's miscalibration. Right tool
+  for ≥3-month toggle campaigns where headline-bias purity matters.
+
+### The 1–2-month regime check (the reason the user asked for it)
+- **The Issue 13 training-window verdict flips below ~3 months:** campaign-only training wins at
+  1–2 months (toggle 1-month score 0.334 vs 0.895 for all-data; bias +0.02 vs −0.64) because the
+  campaign is <5 % of the all-data training set and drift dominates; all-data wins at ≥3 months
+  where shrinkage dominates. The decay weights interpolate between the regimes: hl90 is
+  best-or-near-best at 1, 2 *and* 3 months. A campaign-length-adaptive training window (or
+  half-life) is the natural future refinement — noted for the later-work list, not implemented.
+- The 3–12-month verdicts (the committed benchmark grid) all stand: mcs=50, tco=False, and the
+  F12/F13 feature set were re-checked where they can flip and none reversed on that grid.
+- power_model beats the naive anchor at 1–2-month toggle only in its campaign-only configuration
+  (0.334 vs 0.518 at 1 month); in the default all-data configuration naive wins there — worth
+  remembering when quoting short-campaign capability.
+
+### Method notes
+- The weights default surfaced a seam conflict: sklearn ``Pipeline`` factories take no
+  ``sample_weight``. ``_fit_kwargs`` now probes support (``has_fit_parameter``) and fits
+  unweighted with a warning instead of crashing the factory seam.
+- 1–2-month campaigns are deliberately **not** added to the committed benchmark grid (the frozen
+  v0/naive reference runs don't cover them); `inspect_short_campaigns.py` is the reproducible
+  driver for that regime.
+
+---
+
 ## F15 — residual calibration rejected with a sharpened OOF-transfer rule; `toggle_campaign_only=False` accepted (all-data headline training + campaign-restricted conditional); time-decay weights validated as opt-in (Issue 13)
 
 *2026-07-04 — Issue 13 verdicts. New `PowerModelMethod` knobs (default off): `calibrate_residuals`
@@ -101,7 +169,7 @@ display item; estimates unchanged). Candidates A/B'd per the Issue 9 protocol:
   quantile-0.5 — estimate the median and bias the energy sum. The F5 shrinkage is a
   *regularisation* artefact, not a loss artefact; changing objective does not fix it. Legitimate
   within the mean family: Tweedie / variance-weighted L2 (efficiency candidates, untried).
-  Quantile objectives are out of scope for the point estimate (they return in Issue 16/WS4).
+  Quantile objectives are out of scope for the point estimate (they return in Issue 17/WS4).
 - **Tune on uplift metrics, never on prediction RMSE.** More regularisation can improve held-out
   RMSE while worsening shrinkage. Yardsticks: placebo bias on the harness, per-bin residual
   flatness, the predicted-vs-actual **calibration slope** (target ≈ 1) on a time-blocked held-out

--- a/docs/v1/findings.md
+++ b/docs/v1/findings.md
@@ -7,6 +7,81 @@ from, not just conclusions.
 
 ---
 
+## F15 — residual calibration rejected with a sharpened OOF-transfer rule; `toggle_campaign_only=False` accepted (all-data headline training + campaign-restricted conditional); time-decay weights validated as opt-in (Issue 13)
+
+*2026-07-04 — Issue 13 verdicts. New `PowerModelMethod` knobs (default off): `calibrate_residuals`
+(ERA5-cell residual calibration: full-baseline out-of-fold predictions via the shared time-blocked
+folds, mean residual per F6 CEM cell — `matching.cell_codes` is now public — read out under the
+upgraded window's occupancy) and `time_decay_half_life_days` (campaign-proximity sample weights
+`0.5^(days outside the campaign interval / half-life)`: interleaved campaign rows weigh exactly 1,
+pre-campaign rows decay; threaded through every fit). One structural change: with
+`toggle_campaign_only=False` the conditional two-direction step now **matches within the campaign
+only** — pre-campaign rows serve only the headline fit's training data. A/B'd on the placebo
+(`cp_0pct`) against the post-F14 benchmark; acceptance via a full 7-profile sweep. Entering
+Issue 13, the prepost placebo headline bias was already −0.02/+0.35/+0.05 pp at 3/6/12 months
+(the F3-era uniform −0.4 pp is gone since F13/F14) and toggle +0.36 pp at 3 months (F14: small-fit
+tree shrinkage).*
+
+### REJECTED — ERA5-cell residual calibration, twice; the F14 OOF-transfer rule now covers *shape*
+- **v1 (raw cell means)**: prepost bias up nearly uniformly (+0.32/+0.21/+0.13 pp) — the global OOF
+  residual level (≈ −1 kW: fold models fit on 80% of the rows over-predict relative to the final
+  100% fit) leaks into every cell mean and swamps the mix-shift signal. Toggle: right direction but
+  a short-campaign spread cost (3-month Δspread +0.72 — the F7 failure mode; the level term is
+  noise at small n).
+- **v2 (centred: `cell_mean − global_mean`, the pure mix-shift differential; unseen cells → 0)**:
+  prepost deltas nearly identical to v1 (+0.33/+0.20/+0.15). The logged corrections under the
+  upgraded mix are systematically *negative* (−0.05…−4.9 kW) while the observed placebo bias is
+  *positive* — **the estimated correction has the wrong sign vs the actual bias**. The fold
+  models' conditional residual *structure* differs from the final refit model's, not just its
+  level. Toggle adds a sparse-cell artifact: ~450 F6 cells over ~6k off rows ≈ 13 rows/cell of
+  noise (uniform positive bias shifts decaying ~1/n).
+- **The sharpened rule (extends the F14 method note): out-of-fold residuals cannot be transferred
+  to a refit model — neither their level nor their conditional shape.** Any future residual
+  calibration must be basis-consistent: estimate corrections for the model actually deployed
+  (e.g. predict with the fold ensemble itself, or calibrate on a held-out era the final model
+  never saw).
+- **Corollary**: the remaining prepost 6-month +0.35 pp placebo bias is measurably *not* an
+  ERA5-weather-mix-shift effect (the purpose-built correction moves it the wrong way). 3- and
+  12-month prepost already meet the issue's ≲0.1–0.2 pp target; the 6-month anomaly stays open
+  (candidate mechanism: a seasonal/drift interaction specific to half-year windows).
+
+### ACCEPTED — `toggle_campaign_only=False` (all-data headline training; benchmark regenerated)
+- **Where the all-data damage actually lives.** Every naive all-data arm wrecked the toggle
+  conditional identically (3-month ti Δscore ≈ +14) regardless of decay weights or calibration —
+  because the drift enters through the conditional CEM **matching** (pre-campaign rows matched
+  against campaign on-rows at full weight in the two-direction contrast), not through the fits.
+  Weighting cannot fix a matching problem; the structural fix (conditional matches within the
+  campaign only, where its shared-distribution assumption holds) resolves it completely — the
+  3-month conditional comes out *better* than the campaign-only benchmark (ti Δscore −1.7).
+- **Full-sweep verdict (7 profiles)**: prepost bit-identical (the flip is toggle-only; 0.0 across
+  all 469 cells). Toggle: 3-month headline bias +0.358 → **+0.121** (Δscore −0.070), pooled ALL
+  Δscore −0.144, |bias| cells 144 better / 86 worse. Accepted cost: mild spread at 9/12 months
+  (overall Δscore +0.11/+0.08) — the extra rows only add drift variance once the campaign is
+  data-rich. Three-method picture: power_model now ties v0/naive at 3-month toggle (0.294 vs
+  0.296/0.297), closing its last deficit vs v0 (F4); naive keeps the 9/12-month toggle lead.
+- `naive_ratio` keeps campaign-only, per the issue — there the restriction *is* the method's
+  distribution matching.
+
+### Validated opt-in — `time_decay_half_life_days` (campaign-proximity training weights)
+- On top of all-data + the conditional fix, 90-day half-life trades headline bias for spread:
+  3-month bias +0.19 (vs +0.12 unweighted) but the best 3-month overall score of any arm (0.239
+  vs 0.290 unweighted, 0.359 benchmark), and pooled ALL −0.142. The 45-day dose is flat vs 90
+  (ALL 4.038 vs 4.045) — the response is insensitive in this range.
+- **Not defaulted** because the weights are shared-path: in prepost they nudge the placebo
+  headline bias *up* at all three campaign lengths (+0.09/+0.09/+0.02; score is a wash — 3-month
+  −0.14 better, 6-month +0.12 worse) — the wrong direction for the issue's own target metric.
+  Remains available where short-campaign spread matters more than bias purity.
+
+### Method notes
+- The refactor no-op was verified against the benchmark before any A/B (all deltas 0.0), and the
+  uncentered→centred iteration was driven by the per-run correction logs — keep logging the
+  mean correction and the centred-out level; they made the wrong-sign diagnosis possible.
+- Issue 13's "time-blocked baseline cross-validation" item shipped across F14/F15: the holdout
+  display is time-blocked (F14) and `_oof_baseline_predictions` gives every baseline row an
+  out-of-fold prediction (F15), shared by both calibration paths.
+
+---
+
 ## F14 — outcome-model fundamentals: `min_child_samples` 200→50 accepted; linear_tree, early stopping, calibration slope, seed ensembling and alternative learners rejected; the toggle headline bias localised to small-fit tree shrinkage (Issue 12)
 
 *2026-07-04 — Issue 12 verdicts. New module `benchmarking/baselines/power_model/fitting.py`

--- a/docs/v1/issues.md
+++ b/docs/v1/issues.md
@@ -10,10 +10,11 @@ conditional P50, then extending the measurement to AEP uplift and starting the
 uncertainty (Phase 3 / WS4) work.
 
 Suggested order of execution: #1 → #2 → #3 → #4 → #5 (done), then
-#9 → #10 → #11 → #12 → #13 → #14 → #15 → #16. (#9–#12 are independent input-data and
-model trials sharing one evaluation protocol — many ideas, each tested one by one;
-#14 is small and independent, so it can be pulled earlier; #16 builds on #15's AEP
-machinery, so it goes last.) (Issue 4 was originally a data contract +
+#9 → #10 → #11 → #12 → #13 (done) → #14 → #15 → #16 → #17. (#9–#12 are independent
+input-data and model trials sharing one evaluation protocol — many ideas, each tested
+one by one; #14 is small and independent, so it can be pulled earlier — and #15's
+adaptive rule wants #14's hardened conditional scoring in place; #17 builds on #16's
+AEP machinery, so it goes last.) (Issue 4 was originally a data contract +
 method-selector issue; it has been re-scoped to a naive energy-ratio method — see
 Issue 4 below for why.)
 
@@ -389,7 +390,7 @@ early stopping, and identical whether the fit has ~13k training rows (3-month to
   shrinkage-free, valuable as a cross-check on the tree models' conditional bias even if
   its overall accuracy is worse.
 - **Quantile objectives are out of scope for the point estimate** (median ≠ mean under
-  skew → biased energy). Quantile models return in Issue 16 / WS4 for conformal OOD
+  skew → biased energy). Quantile models return in Issue 17 / WS4 for conformal OOD
   filtering and diagnostics — not as the uplift estimator.
 
 **Done when:** a findings entry records the verdict per candidate against the uplift
@@ -469,6 +470,18 @@ default changes.
 estimate, so every reported per-bin number is either trustworthy or an explicitly
 flagged, physics-informed fallback — and keep the scoring honest about the difference.
 
+**Motivation strengthened by Issues 12–13 (F14–F16):** three further independent hits on
+the un-floored sparse tail. (a) F15's residual calibration was partly sunk by sparse-cell
+noise (~13 rows/cell on a 3-month toggle). (b) F16: merely *sample-weighting* the matched
+direction fits flipped degenerate extreme-TI bins to three-digit per-bin uplift (+1039 %
+in one replicate) at some decay half-lives and not others — replicate chance, i.e. the
+tail bins sit on a knife edge; the time-decay weights had to be confined to the headline
+fit as a workaround, and the floor should make the conditional path robust enough to lift
+that restriction. (c) Throughout the F14–F16 A/B screens the conditional *mean* deltas
+were dominated by the same few exploding tail cells, forcing verdicts to be read from
+overall rows and cell tallies — the floor is also what makes the conditional benchmark
+signal itself trustworthy.
+
 **Scope**
 - **Per-reporting-bin matched-count floor** (the F7/F9 follow-up): below a minimum
   matched count per side in a reporting bin, replace the overshooting two-direction
@@ -511,6 +524,25 @@ flagged, physics-informed fallback — and keep the scoring honest about the dif
   and compare A/B variants on commonly-covered bins as well as overall — imputed bins
   are scored like any other (the flag distinguishes them), so the imputation prior is
   itself benchmarked.
+**Scope addition (2026-07-05) — make `study_power_model_compare.py` measure the out-of-the-box
+method on the full campaign range.** The committed benchmark must reflect performance with **no
+specialist tuning**: today the driver passes four accepted-by-findings behaviour settings that are
+not `PowerModelMethod` class defaults, and the campaign grid stops at 3 months.
+- **Promote the accepted behaviour defaults onto the class** so a bare `PowerModelMethod`
+  behaves like the benchmarked method: `TUNED_MODEL_PARAMS` (`min_child_samples=50`, F14) as the
+  `model_params` default and `availability_feature=False` (F13) directly; make
+  `CURATED_ERA5_EXCLUDE` defaultable by softening the exclusion to drop-if-present (it currently
+  raises on non-Open-Meteo frames, which is why F13 left it driver-level). `reference_stat_cols`
+  stays driver-level — it names a source-specific SCADA tag, i.e. data-schema description, not
+  tuning; document that distinction where the drivers configure it. After promotion the driver
+  should pass **only** schema description (columns, rated power, ERA5 frame, stat-col names).
+- **Extend the scored campaign grid to 1/2/3/6/12 months in both modes** (toggle drops 9): relax
+  the alignment guard to check truth equality on *intersecting* cases only (still failing loudly
+  on any truth mismatch); **compute `naive_ratio` fresh** for campaign lengths the frozen
+  reference run does not cover (it is cheap — v0 stays reference-only and is simply absent at
+  1–2 months, where comparing to naive suffices); regenerate the committed benchmark JSON on the
+  new grid. The F16 short-campaign regime evidence (`inspect_short_campaigns.py`) then becomes
+  part of every future A/B automatically — which Issue 15's adaptive rule needs.
 - **Sequencing:** the three fixes interact (balance changes effective counts → floor;
   floor changes coverage → re-level), so land and measure them incrementally in the
   order re-level fix (a pure bug) → floor + imputation → balance, per the Issue 9
@@ -521,10 +553,63 @@ flagged, physics-informed fallback — and keep the scoring honest about the dif
 (fixed, or flagged-and-imputed by the floor); conditional |bias| no worse on
 commonly-covered bins; coverage visible in the leaderboard; the decomposition —
 measured plus pinned imputed bins — still energy-aggregates exactly to the headline.
+Additionally (the 2026-07-05 scope addition): a bare `PowerModelMethod` given only data-schema
+config behaves identically to the benchmarked configuration; `study_power_model_compare.py`
+scores 1/2/3/6/12-month campaigns in both modes with naive computed fresh where the reference
+lacks it; the benchmark JSON is regenerated on the new grid.
 
 ---
 
-## Issue 15 — AEP uplift: long-term extrapolation design + harness scoring (WS1/WS4)
+## Issue 15 — The headline estimator configures itself: regime-adaptive training window and estimator (WS2)
+
+**Goal:** the method must "just work" on any campaign with **no manual configuration** —
+a user should not need to know when to flip `toggle_campaign_only`, pick a
+`toggle_estimator` or tune a decay half-life. F16 measured why this matters: the best
+configuration is regime-dependent, with a crossover near ~3 months.
+
+**The measured regime map (F16, `inspect_short_campaigns.py` + the benchmark grid):**
+- Toggle training window: campaign-only wins at 1–2 months (the campaign is <5 % of the
+  all-data training set, so drift dominates; 1-month score 0.334 vs 0.895), all-data wins
+  at ≥3 months (shrinkage dominates; 3-month 0.294 vs 0.359).
+- `double_ratio` (the model-normalised naive comparison): toggle placebo headline bias
+  ≈ 0 at every 3–12-month length, but *worse* than the default at 1–2 months — its
+  `rho_off` is currently measured over all off rows (two years of eras) while the ON
+  window is a sliver, so the cancellation subtracts the wrong era's miscalibration.
+- Decay half-life: ~90 days is best-or-near-best at 1/2/3 months in both modes; ≥1 year
+  is the safe long-campaign default (548 d accepted in F16).
+
+**Scope (in preference order — a dominating single configuration beats selection logic)**
+- **Era-local `rho_off` first.** Fix `double_ratio` itself: measure `rho_off` on
+  campaign-window off rows only (out-of-fold), predicted by the same all-data-trained
+  fold models. If that removes the 1–2-month failure while keeping the ≥3-month bias ≈ 0,
+  one estimator may dominate everywhere and become the toggle default outright — no
+  selection machinery needed. Test at 1, 2, 3, 6, 12 months in both framings.
+- **Adaptive training window / half-life as fallback.** If no single configuration
+  dominates: derive the switch (or a blended weight) from the campaign's own observables
+  — campaign length, campaign-row count vs pre-campaign-row count — never from the
+  benchmark truth. Prefer a smooth blend (e.g. weight the campaign-only and all-data
+  estimates by a logistic in log(campaign rows)) over a hard threshold, so estimates
+  don't jump discontinuously at a boundary; hard-validate whatever rule is chosen at the
+  boundary lengths (2–4 months).
+- **Guard against benchmark overfitting** (the Issue 12 framing rule): the rule's
+  parameters must be justified by the mechanism (drift-vs-shrinkage trade-off), tuned at
+  most coarsely, and confirmed on profiles/turbines not used to pick them.
+- **Evaluation surface:** extend the scored campaign grid to include 1- and 2-month
+  campaigns for the adaptive-rule validation (either promote them into the committed
+  benchmark — needs fresh naive/v0 reference runs — or keep `inspect_short_campaigns.py`
+  as the reproducible driver for that regime, citing it in the findings entry).
+- Remove the user-facing knobs this makes redundant (or demote them to expert overrides
+  with the automatic behaviour as the default).
+
+**Done when:** the out-of-the-box configuration is best-or-tied (within the materiality
+band) at every campaign length 1–12 months in both modes on the placebo and standard
+profiles; no scenario requires the user to choose a training window, estimator or
+half-life; the findings entry records the mechanism-based justification for the rule (or
+the dominance of the single configuration); benchmark regenerated.
+
+---
+
+## Issue 16 — AEP uplift: long-term extrapolation design + harness scoring (WS1/WS4)
 
 **Goal:** turn the campaign conditional uplift into an **AEP uplift** — the long-term
 annual energy benefit, PR #100's third metric — and score it in the harness against known
@@ -572,7 +657,7 @@ beats the naive extrapolation baseline on condition-dependent profiles.
 
 ---
 
-## Issue 16 — Uncertainty: campaign & AEP P50 uncertainty with harness coverage scoring (WS4)
+## Issue 17 — Uncertainty: campaign & AEP P50 uncertainty with harness coverage scoring (WS4)
 
 **Goal:** start Phase 3 — report an uncertainty (σ / P95) on the campaign overall P50 and
 the AEP P50, and verify it in the harness per PR #100: the campaign-uplift P95 should sit
@@ -615,7 +700,7 @@ agreed tolerance of nominal on the placebo and the standard profiles.
 
 ## Not in the first wave (tracked for later phases)
 
-- Uncertainty / P95 model beyond Issue 16's first cut: conformal OOD filtering,
+- Uncertainty / P95 model beyond Issue 17's first cut: conformal OOD filtering,
   density-ratio long-term weighting in place of hard CEM subsampling (WS4, Phase 3).
   Density-ratio weighting also reclaims the short-campaign matched-set size the CEM
   subsample throws away (F7 follow-up).

--- a/tests/benchmarking/baselines/test_power_model_fitting.py
+++ b/tests/benchmarking/baselines/test_power_model_fitting.py
@@ -10,10 +10,12 @@ from benchmarking.baselines.power_model.fitting import (
     IDENTITY_CALIBRATION,
     OUTCOME_MODEL_FACTORIES,
     CalibrationLine,
+    cell_residual_calibration,
     early_stopped_n_estimators,
     fit_calibration_line,
     time_block_folds,
 )
+from benchmarking.baselines.power_model.matching import cell_codes
 from benchmarking.baselines.rlearner.nuisance import make_outcome_model
 
 
@@ -74,6 +76,65 @@ class TestCalibrationLine:
         x = np.array([1.0, 2.0, 3.0])
         np.testing.assert_array_equal(IDENTITY_CALIBRATION.apply(x), x)
         assert CalibrationLine(intercept=1.0, slope=2.0).apply(np.array([3.0]))[0] == 7.0
+
+
+class TestCellResidualCalibration:
+    def test_reads_out_centred_cell_means_under_target_mix(self) -> None:
+        # two cells: cell 0 residual mean +10, cell 1 residual mean -10 (global mean 0);
+        # the target sits mostly in cell 1, so the correction reads out the differential there
+        codes_base = np.array([[0]] * 50 + [[1]] * 50)
+        residuals = np.array([10.0] * 50 + [-10.0] * 50)
+        codes_target = np.array([[0]] * 2 + [[1]] * 8)
+        calib = cell_residual_calibration(codes_baseline=codes_base, residuals=residuals, codes_target=codes_target)
+        np.testing.assert_allclose(calib.per_row_residual, [10.0] * 2 + [-10.0] * 8)
+        assert calib.global_mean_residual == pytest.approx(0.0)
+        assert calib.n_target_unseen == 0
+        assert calib.n_cells == 2
+
+    def test_global_level_offset_is_centred_out(self) -> None:
+        # the F14 lesson: a uniform OOF level offset (here +5 everywhere) is an artefact of the
+        # out-of-fold basis and must not transfer to the correction
+        codes_base = np.array([[0]] * 50 + [[1]] * 50)
+        residuals = np.array([15.0] * 50 + [-5.0] * 50)  # cell means +15/-5, global +5
+        codes_target = np.array([[0], [1]])
+        calib = cell_residual_calibration(codes_baseline=codes_base, residuals=residuals, codes_target=codes_target)
+        np.testing.assert_allclose(calib.per_row_residual, [10.0, -10.0])
+        assert calib.global_mean_residual == pytest.approx(5.0)
+
+    def test_unseen_cell_and_invalid_row_get_zero(self) -> None:
+        codes_base = np.array([[0]] * 10)
+        residuals = np.full(10, 3.0)
+        codes_target = np.array([[0], [5], [-1]])  # seen, unseen, invalid
+        calib = cell_residual_calibration(codes_baseline=codes_base, residuals=residuals, codes_target=codes_target)
+        np.testing.assert_allclose(calib.per_row_residual, [0.0, 0.0, 0.0])  # single cell = global mean
+        assert calib.n_target_unseen == 2
+
+    def test_nan_and_invalid_baseline_rows_only_count_toward_global_mean(self) -> None:
+        codes_base = np.array([[0], [0], [-1], [0]])
+        residuals = np.array([2.0, 4.0, 100.0, np.nan])  # invalid-cell row only enters the global mean
+        codes_target = np.array([[0], [7]])
+        calib = cell_residual_calibration(codes_baseline=codes_base, residuals=residuals, codes_target=codes_target)
+        global_mean = (2.0 + 4.0 + 100.0) / 3
+        assert calib.per_row_residual[0] == pytest.approx(3.0 - global_mean)  # centred cell mean
+        assert calib.per_row_residual[1] == pytest.approx(0.0)  # unseen -> no differential info
+        assert calib.n_cells == 1
+
+    def test_multi_var_cells_via_cell_codes(self) -> None:
+        frame = pd.DataFrame({"a": [0.5, 0.5, 1.5, 1.5], "b": [0.5, 0.5, 0.5, 1.5]})
+        edges = {"a": [0.0, 1.0, 2.0], "b": [0.0, 1.0, 2.0]}
+        codes = cell_codes(frame, edges)
+        residuals = np.array([1.0, 3.0, 5.0, 7.0])
+        calib = cell_residual_calibration(codes_baseline=codes, residuals=residuals, codes_target=codes)
+        global_mean = 4.0
+        np.testing.assert_allclose(calib.per_row_residual, np.array([2.0, 2.0, 5.0, 7.0]) - global_mean)
+        assert calib.n_cells == 3
+
+    def test_correction_integrates_to_zero_under_baseline_mix(self) -> None:
+        rng = np.random.default_rng(3)
+        codes = rng.integers(0, 4, size=(500, 1))
+        residuals = rng.normal(2.0, 1.0, 500) + 3.0 * codes[:, 0]
+        calib = cell_residual_calibration(codes_baseline=codes, residuals=residuals, codes_target=codes)
+        assert float(calib.per_row_residual.mean()) == pytest.approx(0.0, abs=1e-9)
 
 
 class TestEarlyStoppedNEstimators:

--- a/tests/benchmarking/baselines/test_power_model_method.py
+++ b/tests/benchmarking/baselines/test_power_model_method.py
@@ -165,14 +165,15 @@ def _prepost_case(n: int = 4000, *, uplift: float = 0.05) -> tuple[MethodInput, 
 
 
 def _fundamentals_method(**overrides: object) -> PowerModelMethod:
-    return PowerModelMethod(
-        active_power_col=_POWER,
-        availability_col=_AVAIL,
-        baseline_rated_power_kw=2300.0,
-        wind_speed_col=_WS,
-        conditional_uplift=False,
-        **overrides,  # type: ignore[arg-type]
-    )
+    kwargs: dict[str, object] = {
+        "active_power_col": _POWER,
+        "availability_col": _AVAIL,
+        "baseline_rated_power_kw": 2300.0,
+        "wind_speed_col": _WS,
+        "conditional_uplift": False,
+        **overrides,
+    }
+    return PowerModelMethod(**kwargs)  # type: ignore[arg-type]
 
 
 class TestModelFundamentals:
@@ -225,6 +226,72 @@ class TestModelFundamentals:
             _fundamentals_method(calibrate_slope=True, early_stopping=True).estimate(mi)
         with pytest.raises(ValueError, match="calibrate_slope"):
             _fundamentals_method(calibrate_slope=True, n_seed_ensemble=2).estimate(mi)
+
+    def test_calibrate_residuals_recovers_uplift_and_placebo(self) -> None:
+        for uplift in (0.05, 0.0):
+            mi, _ = _prepost_case(uplift=uplift)
+            method = _fundamentals_method(
+                model_params=_FAST_PARAMS,
+                calibrate_residuals=True,
+                era5_hourly_df=_toy_era5(pd.DatetimeIndex(pd.unique(mi.scada_df.index))),
+            )
+            out = method.estimate(mi)
+            assert out.p50_overall == pytest.approx(uplift, abs=0.02)
+
+    def test_time_decay_weights_recover_uplift(self) -> None:
+        mi, _ = _prepost_case()
+        out = _fundamentals_method(model_params=_FAST_PARAMS, time_decay_half_life_days=30.0).estimate(mi)
+        assert out.p50_overall == pytest.approx(0.05, abs=0.02)
+
+    def test_time_decay_weight_values(self) -> None:
+        method = _fundamentals_method(time_decay_half_life_days=10.0)
+        index = pd.date_range("2019-01-01", periods=5, freq="10D", tz="UTC")
+        # campaign interval [index[2], index[3]]: inside weighs 1, outside decays both ways
+        weights = method._time_decay_weights(index, campaign_start=index[2], campaign_end=index[3])  # noqa: SLF001
+        np.testing.assert_allclose(weights, [0.25, 0.5, 1.0, 1.0, 0.5])
+        off = _fundamentals_method()._time_decay_weights(index, campaign_start=index[2], campaign_end=index[3])  # noqa: SLF001
+        assert off is None
+
+    def test_issue13_config_conflicts_raise(self) -> None:
+        mi, _ = _prepost_case(n=200)
+        era5 = _toy_era5(pd.DatetimeIndex(pd.unique(mi.scada_df.index)))
+        with pytest.raises(ValueError, match="requires ERA5"):
+            _fundamentals_method(calibrate_residuals=True).estimate(mi)
+        with pytest.raises(ValueError, match="competing headline corrections"):
+            _fundamentals_method(calibrate_residuals=True, calibrate_slope=True, era5_hourly_df=era5).estimate(mi)
+        with pytest.raises(ValueError, match="out-of-fold basis"):
+            _fundamentals_method(calibrate_residuals=True, n_seed_ensemble=2, era5_hourly_df=era5).estimate(mi)
+        with pytest.raises(ValueError, match="must be positive"):
+            _fundamentals_method(time_decay_half_life_days=0.0).estimate(mi)
+
+    def test_campaign_mask_bites_only_for_started_toggle(self) -> None:
+        index = pd.date_range("2019-01-01", periods=4, freq="10D", tz="UTC")
+        mask = PowerModelMethod._campaign_mask  # noqa: SLF001
+        np.testing.assert_array_equal(
+            mask(index, upgrade_timing=ToggleSchedule(period=pd.Timedelta(hours=4), start=index[2])),
+            [False, False, True, True],
+        )
+        assert mask(index, upgrade_timing=pd.Timestamp(index[2])).all()  # prepost: all-True
+        assert mask(index, upgrade_timing=ToggleSchedule(period=pd.Timedelta(hours=4))).all()  # no start
+
+    def test_toggle_all_data_with_conditional_recovers_uplift(self) -> None:
+        n = 4000
+        idx = pd.date_range("2019-01-01", periods=n, freq="10min", tz="UTC")
+        start = idx[n // 2]  # first half pre-campaign baseline, second half interleaved toggle
+        schedule = ToggleSchedule(period=pd.Timedelta(hours=4), start=start)
+        within = (((idx - start) // (schedule.period / 2)).astype(int) % 2) == 1
+        treated = np.asarray((idx >= start) & within)
+        scada = _toy_scada(n, uplift=0.04, treated=treated)
+        method = _fundamentals_method(
+            model_params=_FAST_PARAMS,
+            toggle_campaign_only=False,
+            conditional_uplift=True,
+            era5_hourly_df=_toy_era5(idx),
+        )
+        mi = MethodInput(scada_df=scada, test_wtg="T1", upgrade_timing=schedule, turbine_col=_TURBINE)
+        out = method.estimate(mi)
+        assert out.p50_overall == pytest.approx(0.04, abs=0.02)
+        assert out.p50_by_condition is not None
 
     def test_model_factory_config_label_is_stable(self) -> None:
         def label_for(**overrides: object) -> str | None:

--- a/tests/benchmarking/baselines/test_power_model_method.py
+++ b/tests/benchmarking/baselines/test_power_model_method.py
@@ -249,8 +249,8 @@ class TestModelFundamentals:
         # campaign interval [index[2], index[3]]: inside weighs 1, outside decays both ways
         weights = method._time_decay_weights(index, campaign_start=index[2], campaign_end=index[3])  # noqa: SLF001
         np.testing.assert_allclose(weights, [0.25, 0.5, 1.0, 1.0, 0.5])
-        off = _fundamentals_method()._time_decay_weights(index, campaign_start=index[2], campaign_end=index[3])  # noqa: SLF001
-        assert off is None
+        no_decay = _fundamentals_method(time_decay_half_life_days=None)
+        assert no_decay._time_decay_weights(index, campaign_start=index[2], campaign_end=index[3]) is None  # noqa: SLF001
 
     def test_issue13_config_conflicts_raise(self) -> None:
         mi, _ = _prepost_case(n=200)
@@ -273,6 +273,32 @@ class TestModelFundamentals:
         )
         assert mask(index, upgrade_timing=pd.Timestamp(index[2])).all()  # prepost: all-True
         assert mask(index, upgrade_timing=ToggleSchedule(period=pd.Timedelta(hours=4))).all()  # no start
+
+    @pytest.mark.parametrize("uplift", [0.04, 0.0])
+    def test_double_ratio_toggle_recovers_uplift(self, uplift: float) -> None:
+        n = 4000
+        idx = pd.date_range("2019-01-01", periods=n, freq="10min", tz="UTC")
+        schedule = ToggleSchedule(period=pd.Timedelta(hours=4))
+        treated = np.asarray((((idx - idx.min()) // (schedule.period / 2)).astype(int) % 2) == 1)
+        scada = _toy_scada(n, uplift=uplift, treated=treated)
+        method = _fundamentals_method(model_params=_FAST_PARAMS, toggle_estimator="double_ratio")
+        mi = MethodInput(scada_df=scada, test_wtg="T1", upgrade_timing=schedule, turbine_col=_TURBINE)
+        out = method.estimate(mi)
+        assert out.p50_overall == pytest.approx(uplift, abs=0.02)
+
+    def test_double_ratio_ignored_for_prepost(self) -> None:
+        mi, _ = _prepost_case()
+        out = _fundamentals_method(model_params=_FAST_PARAMS, toggle_estimator="double_ratio").estimate(mi)
+        assert out.p50_overall == pytest.approx(0.05, abs=0.02)
+
+    def test_toggle_estimator_guards(self) -> None:
+        mi, _ = _prepost_case(n=200)
+        with pytest.raises(ValueError, match="unknown toggle_estimator"):
+            _fundamentals_method(toggle_estimator="nope").estimate(mi)
+        with pytest.raises(ValueError, match="fold-basis calibration"):
+            _fundamentals_method(toggle_estimator="double_ratio", calibrate_slope=True).estimate(mi)
+        with pytest.raises(ValueError, match="fold-basis calibration"):
+            _fundamentals_method(toggle_estimator="double_ratio", n_seed_ensemble=2).estimate(mi)
 
     def test_toggle_all_data_with_conditional_recovers_uplift(self) -> None:
         n = 4000

--- a/tests/benchmarking/baselines/test_power_model_method.py
+++ b/tests/benchmarking/baselines/test_power_model_method.py
@@ -300,6 +300,19 @@ class TestModelFundamentals:
         with pytest.raises(ValueError, match="fold-basis calibration"):
             _fundamentals_method(toggle_estimator="double_ratio", n_seed_ensemble=2).estimate(mi)
 
+    def test_double_ratio_too_few_off_rows_raises(self) -> None:
+        # 36 rows, half toggled on -> ~18 off rows after filtering, below the fold-basis minimum;
+        # the requested estimator must fail loudly, not silently fall back to the counterfactual.
+        n = 36
+        idx = pd.date_range("2019-01-01", periods=n, freq="10min", tz="UTC")
+        schedule = ToggleSchedule(period=pd.Timedelta(minutes=20))
+        treated = np.asarray((((idx - idx.min()) // (schedule.period / 2)).astype(int) % 2) == 1)
+        scada = _toy_scada(n, uplift=0.0, treated=treated)
+        method = _fundamentals_method(model_params=_FAST_PARAMS, toggle_estimator="double_ratio")
+        mi = MethodInput(scada_df=scada, test_wtg="T1", upgrade_timing=schedule, turbine_col=_TURBINE)
+        with pytest.raises(ValueError, match=r"double_ratio.*off rows"):
+            method.estimate(mi)
+
     def test_toggle_all_data_with_conditional_recovers_uplift(self) -> None:
         n = 4000
         idx = pd.date_range("2019-01-01", periods=n, freq="10min", tz="UTC")

--- a/tests/benchmarking/baselines/test_rlearner_end_to_end.py
+++ b/tests/benchmarking/baselines/test_rlearner_end_to_end.py
@@ -37,6 +37,7 @@ def _rlearner(tmp_path) -> RLearnerMethod:  # noqa: ANN001
     )
 
 
+@pytest.mark.skip(reason="Rlearner method abandoned")
 @pytest.mark.slow
 def test_rlearner_recovers_prepost_uplift(tmp_path) -> None:  # noqa: ANN001
     scada_df, _ = load_hot_scada(
@@ -69,6 +70,7 @@ def test_rlearner_recovers_prepost_uplift(tmp_path) -> None:  # noqa: ANN001
     assert abs(rlearner_row["signed_error"]) < 0.03
 
 
+@pytest.mark.skip(reason="Rlearner method abandoned")
 @pytest.mark.slow
 def test_rlearner_recovers_toggle_uplift(tmp_path) -> None:  # noqa: ANN001
     scada_df, _ = load_hot_scada(


### PR DESCRIPTION

## Issue 13 — Calibrate out the structural headline bias; revisit toggle's campaign-only training (WS2)

**Goal:** remove the persistent overall-P50 bias: prepost ≈ **−0.4 pp on every profile**
(F3/F4) and toggle ≈ +0.4 pp at 3 months. The flatness across profiles says it is a model
artefact, not effect-dependent — but the two modes get there by different mechanisms, and
this issue addresses both. **Prepost:** the model's conditional bias `b(x)` integrates to
≈ 0 over the *training* (baseline) covariate mix, but the headline evaluates it over the
*upgraded* window's mix — any weather/seasonal shift between the windows converts
conditional bias into headline bias. Estimate that term on untreated data and subtract it
(this is F5's implication #1, baseline-residual calibration, never actioned — aimed at
the headline rather than the bins, which Issue 8 already fixed). **Toggle:** under
`toggle_campaign_only=True` the train (off) and predict (on) rows interleave through the
same weeks, so train/predict covariate shift is minimal by construction — the 3-month
bias is more plausibly small-sample shrinkage from the tiny fit (~6–7k off rows vs ~250k
for a 2-year prepost baseline). The candidate fix is more training data: the pre-campaign
baseline that `toggle_campaign_only` currently drops, made safe by exactly this issue's
calibration plus Issue 10's time features.

**Scope**
- **Time-blocked baseline cross-validation.** Replace the random 20% holdout in
  `_holdout_fit` with contiguous time blocks (out-of-fold prediction for every baseline
  row). The current shuffled split leaks autocorrelation (holdout rows sit minutes from
  training rows), so its residuals are optimistic — fine as a display, unusable as a
  calibration basis. This also makes the step-5 fit-quality diagnostics honest.
- **The calibration.** From the out-of-fold baseline residuals, estimate the mean residual
  per ERA5 cell (reuse the CEM coarsening); weight cells by the *upgraded* window's
  occupancy to get the expected headline bias under the upgraded mix; subtract it from
  `Σcounterfactual` (guard cells unseen in baseline — fall back to the global mean
  residual). For toggle, the campaign's off rows are untreated data under (almost
  exactly) the on rows' covariate mix, so their out-of-fold residuals estimate the
  headline bias more directly than the ERA5-cell reweighting prepost needs.
- **Toggle training-window revisit.** Today `toggle_campaign_only=True` drops every
  pre-campaign row, so a 3-month toggle fits on the campaign's off rows only. Trial
  including the pre-campaign baseline as a 2×2 on the placebo sweep — {campaign-only,
  all-data} × {calibration off, on} — with the Issue 10 time features in place.
  `time_since_campaign_start` is *not* treatment-collinear in toggle (on and off
  interleave), so the model can learn baseline→campaign drift and interpolate within the
  campaign, largely voiding the Issue 10 boundary-clamping caveat. Win condition: the
  extra rows cut shrinkage/spread without importing drift bias. Decide the
  `toggle_campaign_only` default from that evidence (`naive_ratio` keeps campaign-only
  regardless — there the restriction *is* the method's distribution matching).
- **Time-decay weights are a contingency, not a deliverable.** If the placebo with
  pre-campaign data shows drift-driven bias that the time features and the calibration do
  not absorb, trial exponential time-decay sample weights before rejecting pre-campaign
  data outright; otherwise the age-of-data feature carries the recency signal and keeps
  full effective sample size.
- **A/B behind a flag** (the Issue 8 playbook): placebo-centred evaluation across the
  campaign sweep in **both modes** — the win condition is placebo bias → ≈ 0 **without**
  a spread cost at short campaigns (the F7 failure mode to avoid).
- **Sequencing with Issues 9–12:** run after (or with) the feature and model trials —
  better features and a better-calibrated model shrink `b(x)` and therefore the
  correction (Issue 12's calibration-slope fix is the closest cousin); report how much
  bias remains for this calibration once those land.
- Keep the Issue 8 conditional path consistent: the re-level target becomes the
  calibrated headline.

**Done when:** pooled prepost |bias| materially reduced (target ≲ 0.1–0.2 pp on the
placebo) at no spread cost at any campaign length; the 3-month toggle bias explained, and
either materially reduced or the campaign-only default re-confirmed with placebo
evidence; a recorded decision on the `toggle_campaign_only` default; findings entry
quantifying both mechanisms; benchmark regenerated if the calibration or the toggle
default changes.

---
## F15 — residual calibration rejected with a sharpened OOF-transfer rule; `toggle_campaign_only=False` accepted (all-data headline training + campaign-restricted conditional); time-decay weights validated as opt-in (Issue 13)

*2026-07-04 — Issue 13 verdicts. New `PowerModelMethod` knobs (default off): `calibrate_residuals`
(ERA5-cell residual calibration: full-baseline out-of-fold predictions via the shared time-blocked
folds, mean residual per F6 CEM cell — `matching.cell_codes` is now public — read out under the
upgraded window's occupancy) and `time_decay_half_life_days` (campaign-proximity sample weights
`0.5^(days outside the campaign interval / half-life)`: interleaved campaign rows weigh exactly 1,
pre-campaign rows decay; threaded through every fit). One structural change: with
`toggle_campaign_only=False` the conditional two-direction step now **matches within the campaign
only** — pre-campaign rows serve only the headline fit's training data. A/B'd on the placebo
(`cp_0pct`) against the post-F14 benchmark; acceptance via a full 7-profile sweep. Entering
Issue 13, the prepost placebo headline bias was already −0.02/+0.35/+0.05 pp at 3/6/12 months
(the F3-era uniform −0.4 pp is gone since F13/F14) and toggle +0.36 pp at 3 months (F14: small-fit
tree shrinkage).*

### REJECTED — ERA5-cell residual calibration, twice; the F14 OOF-transfer rule now covers *shape*
- **v1 (raw cell means)**: prepost bias up nearly uniformly (+0.32/+0.21/+0.13 pp) — the global OOF
  residual level (≈ −1 kW: fold models fit on 80% of the rows over-predict relative to the final
  100% fit) leaks into every cell mean and swamps the mix-shift signal. Toggle: right direction but
  a short-campaign spread cost (3-month Δspread +0.72 — the F7 failure mode; the level term is
  noise at small n).
- **v2 (centred: `cell_mean − global_mean`, the pure mix-shift differential; unseen cells → 0)**:
  prepost deltas nearly identical to v1 (+0.33/+0.20/+0.15). The logged corrections under the
  upgraded mix are systematically *negative* (−0.05…−4.9 kW) while the observed placebo bias is
  *positive* — **the estimated correction has the wrong sign vs the actual bias**. The fold
  models' conditional residual *structure* differs from the final refit model's, not just its
  level. Toggle adds a sparse-cell artifact: ~450 F6 cells over ~6k off rows ≈ 13 rows/cell of
  noise (uniform positive bias shifts decaying ~1/n).
- **The sharpened rule (extends the F14 method note): out-of-fold residuals cannot be transferred
  to a refit model — neither their level nor their conditional shape.** Any future residual
  calibration must be basis-consistent: estimate corrections for the model actually deployed
  (e.g. predict with the fold ensemble itself, or calibrate on a held-out era the final model
  never saw).
- **Corollary**: the remaining prepost 6-month +0.35 pp placebo bias is measurably *not* an
  ERA5-weather-mix-shift effect (the purpose-built correction moves it the wrong way). 3- and
  12-month prepost already meet the issue's ≲0.1–0.2 pp target; the 6-month anomaly stays open
  (candidate mechanism: a seasonal/drift interaction specific to half-year windows).

### ACCEPTED — `toggle_campaign_only=False` (all-data headline training; benchmark regenerated)
- **Where the all-data damage actually lives.** Every naive all-data arm wrecked the toggle
  conditional identically (3-month ti Δscore ≈ +14) regardless of decay weights or calibration —
  because the drift enters through the conditional CEM **matching** (pre-campaign rows matched
  against campaign on-rows at full weight in the two-direction contrast), not through the fits.
  Weighting cannot fix a matching problem; the structural fix (conditional matches within the
  campaign only, where its shared-distribution assumption holds) resolves it completely — the
  3-month conditional comes out *better* than the campaign-only benchmark (ti Δscore −1.7).
- **Full-sweep verdict (7 profiles)**: prepost bit-identical (the flip is toggle-only; 0.0 across
  all 469 cells). Toggle: 3-month headline bias +0.358 → **+0.121** (Δscore −0.070), pooled ALL
  Δscore −0.144, |bias| cells 144 better / 86 worse. Accepted cost: mild spread at 9/12 months
  (overall Δscore +0.11/+0.08) — the extra rows only add drift variance once the campaign is
  data-rich. Three-method picture: power_model now ties v0/naive at 3-month toggle (0.294 vs
  0.296/0.297), closing its last deficit vs v0 (F4); naive keeps the 9/12-month toggle lead.
- `naive_ratio` keeps campaign-only, per the issue — there the restriction *is* the method's
  distribution matching.

### Validated opt-in — `time_decay_half_life_days` (campaign-proximity training weights)
- On top of all-data + the conditional fix, 90-day half-life trades headline bias for spread:
  3-month bias +0.19 (vs +0.12 unweighted) but the best 3-month overall score of any arm (0.239
  vs 0.290 unweighted, 0.359 benchmark), and pooled ALL −0.142. The 45-day dose is flat vs 90
  (ALL 4.038 vs 4.045) — the response is insensitive in this range.
- **Not defaulted** because the weights are shared-path: in prepost they nudge the placebo
  headline bias *up* at all three campaign lengths (+0.09/+0.09/+0.02; score is a wash — 3-month
  −0.14 better, 6-month +0.12 worse) — the wrong direction for the issue's own target metric.
  Remains available where short-campaign spread matters more than bias purity.

### Method notes
- The refactor no-op was verified against the benchmark before any A/B (all deltas 0.0), and the
  uncentered→centred iteration was driven by the per-run correction logs — keep logging the
  mean correction and the centred-out level; they made the wrong-sign diagnosis possible.
- Issue 13's "time-blocked baseline cross-validation" item shipped across F14/F15: the holdout
  display is time-blocked (F14) and `_oof_baseline_predictions` gives every baseline row an
  out-of-fold prediction (F15), shared by both calibration paths.
