### PR TITLE
v1 issue14

### DIFF
--- a/benchmarking/baselines/power_model/conditional.py
+++ b/benchmarking/baselines/power_model/conditional.py
@@ -13,23 +13,6 @@ import numpy as np
 import pandas as pd
 
 
-def intersect_cell_support(fwd_cell_ids: np.ndarray, rev_cell_ids: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
-    """Masks keeping only rows whose ERA5 cell is present on *both* directions (Issue 14 per-bin balance).
-
-    Within one reporting bin the forward (matched-upgraded) and reverse (matched-baseline) row sets can
-    still carry different ERA5-weather mixes — the shrinkage-cancellation premise is per bin, but CEM only
-    equalises the cell mix globally. Post-stratifying both sides to the **intersection** of their ERA5-cell
-    supports removes that residual within-bin imbalance without any new model fit; it thins sparse bins
-    (which the count floor then catches). ``*_cell_ids`` are 1-D integer cell keys (the caller collapses
-    the multi-variable cell codes to a single id per row). Returns ``(fwd_mask, rev_mask)`` over the two
-    inputs; both are all-False when the two supports do not overlap at all.
-    """
-    fwd = np.asarray(fwd_cell_ids)
-    rev = np.asarray(rev_cell_ids)
-    common = np.intersect1d(fwd, rev)
-    return np.isin(fwd, common), np.isin(rev, common)
-
-
 def impute_uncovered_bins(
     one_plus_u: np.ndarray,
     *,

--- a/benchmarking/baselines/power_model/conditional.py
+++ b/benchmarking/baselines/power_model/conditional.py
@@ -31,9 +31,13 @@ def impute_uncovered_bins(
       prior is wrong for uprating / power-boost upgrades; it is a documented, replaceable default.
     - ``ti``: no ordering physics, so uncovered bins take the overall uplift (``one_plus_overall``).
 
-    Returns an all-finite array provided at least one bin is measured (ws) / ``one_plus_overall`` is
-    finite (ti).
+    The result is always all-finite: ws falls back to ``1.0`` (even with no measured bins), ti to
+    ``one_plus_overall``. Raises for a ``condition`` other than ``"ws"`` / ``"ti"`` so a mistyped axis
+    fails loudly rather than silently taking the ti branch.
     """
+    if condition not in ("ws", "ti"):
+        msg = f"unknown condition {condition!r}; expected 'ws' or 'ti'"
+        raise ValueError(msg)
     s = pd.Series(np.asarray(one_plus_u, dtype=float))
     s[~np.asarray(measured, dtype=bool)] = np.nan
     s = s.bfill().fillna(1.0) if condition == "ws" else s.fillna(float(one_plus_overall))

--- a/benchmarking/baselines/power_model/conditional.py
+++ b/benchmarking/baselines/power_model/conditional.py
@@ -1,0 +1,93 @@
+"""Pure conditional-decomposition helpers (imputation + energy-identity re-level).
+
+Extracted from ``method.py`` so they are unit-testable without a fit and keep the method file
+focused. The imputation fills the per-bin uplift *shape* for bins the two-direction combine could
+not measure (a degenerate non-positive ratio, or too few matched rows once the count floor is on);
+the re-level pins those imputed bins and rescales only the measured bins so the whole decomposition
+energy-aggregates back to the headline exactly.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+
+def intersect_cell_support(fwd_cell_ids: np.ndarray, rev_cell_ids: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """Masks keeping only rows whose ERA5 cell is present on *both* directions (Issue 14 per-bin balance).
+
+    Within one reporting bin the forward (matched-upgraded) and reverse (matched-baseline) row sets can
+    still carry different ERA5-weather mixes — the shrinkage-cancellation premise is per bin, but CEM only
+    equalises the cell mix globally. Post-stratifying both sides to the **intersection** of their ERA5-cell
+    supports removes that residual within-bin imbalance without any new model fit; it thins sparse bins
+    (which the count floor then catches). ``*_cell_ids`` are 1-D integer cell keys (the caller collapses
+    the multi-variable cell codes to a single id per row). Returns ``(fwd_mask, rev_mask)`` over the two
+    inputs; both are all-False when the two supports do not overlap at all.
+    """
+    fwd = np.asarray(fwd_cell_ids)
+    rev = np.asarray(rev_cell_ids)
+    common = np.intersect1d(fwd, rev)
+    return np.isin(fwd, common), np.isin(rev, common)
+
+
+def impute_uncovered_bins(
+    one_plus_u: np.ndarray,
+    *,
+    condition: str,
+    measured: np.ndarray,
+    one_plus_overall: float,
+) -> np.ndarray:
+    """Fill the per-bin ``1+u`` shape for uncovered bins; measured bins pass through unchanged.
+
+    Bins **must** be in ascending bin order (low ws / low TI first). ``measured`` is the trust mask
+    (``True`` = keep the two-direction shape). Uncovered bins:
+
+    - ``ws``: backward-fill from the nearest covered bin above (uplift-vs-ws is Cp-shaped, so a low
+      gap looks most like the next covered bin up), then any bins above the last covered one take
+      ``1.0`` — 0 uplift, since at rated both baseline and upgraded hit rated power. This 0-at-rated
+      prior is wrong for uprating / power-boost upgrades; it is a documented, replaceable default.
+    - ``ti``: no ordering physics, so uncovered bins take the overall uplift (``one_plus_overall``).
+
+    Returns an all-finite array provided at least one bin is measured (ws) / ``one_plus_overall`` is
+    finite (ti).
+    """
+    s = pd.Series(np.asarray(one_plus_u, dtype=float))
+    s[~np.asarray(measured, dtype=bool)] = np.nan
+    s = s.bfill().fillna(1.0) if condition == "ws" else s.fillna(float(one_plus_overall))
+    return s.to_numpy()
+
+
+def relevel_conditional(
+    sum_actual_b: np.ndarray,
+    one_plus_u_b: np.ndarray,
+    *,
+    measured: np.ndarray,
+    one_plus_overall: float,
+) -> np.ndarray:
+    """Rescale measured bins by one λ (imputed bins pinned) so the decomposition aggregates to overall.
+
+    The aggregation is the ratio-of-sums ``Σactual / Σ(actual/(1+u))`` and must equal
+    ``one_plus_overall``. Imputed bins (``~measured``)
+    contribute a fixed counterfactual energy ``C_i = Σ_imp actual/(1+u_imp)``; measured bins scale as
+    ``1+u -> λ(1+u)`` so their counterfactual energy is ``S_m/λ`` with ``S_m = Σ_meas actual/(1+u)``.
+    Setting ``S_m/λ + C_i = Σactual / one_plus_overall`` gives
+    ``λ = S_m / (Σactual/one_plus_overall - C_i)``. If there are no measured bins or the denominator is
+    non-positive (imputed energy already exceeds the headline total), λ cannot be solved for a positive
+    scale — fall back to reporting ``one_plus_overall`` in every bin.
+    """
+    a = np.asarray(sum_actual_b, dtype=float)
+    u1 = np.asarray(one_plus_u_b, dtype=float)
+    is_measured = np.asarray(measured, dtype=bool)
+    usable = np.isfinite(u1) & (u1 != 0) & np.isfinite(a)
+    m = is_measured & usable
+    imp = (~is_measured) & usable
+    total_actual = float(a[np.isfinite(a)].sum())
+    s_m = float((a[m] / u1[m]).sum()) if m.any() else 0.0
+    c_i = float((a[imp] / u1[imp]).sum()) if imp.any() else 0.0
+    denom = total_actual / one_plus_overall - c_i
+    if not m.any() or denom <= 0:
+        return np.full_like(u1, float(one_plus_overall))
+    lam = s_m / denom
+    out = u1.copy()
+    out[m] = lam * u1[m]
+    return out

--- a/benchmarking/baselines/power_model/method.py
+++ b/benchmarking/baselines/power_model/method.py
@@ -32,6 +32,7 @@ from benchmarking.baselines.era5_sync import sync_era5
 from benchmarking.baselines.filtering import NormalOperationFilter
 from benchmarking.baselines.naive_ratio import restrict_to_campaign
 from benchmarking.baselines.power_model import diagnostics as diag
+from benchmarking.baselines.power_model.conditional import impute_uncovered_bins, relevel_conditional
 from benchmarking.baselines.power_model.features import (
     build_reference_features,
     check_reference_only,
@@ -98,6 +99,15 @@ CURATED_ERA5_EXCLUDE: tuple[str, ...] = (
 # ``make_outcome_model`` (shared with the R-learner) are unchanged; drivers pass this instead.
 TUNED_MODEL_PARAMS: dict[str, Any] = {"min_child_samples": 50}
 
+# Per-reporting-bin matched-count floor for the two-direction conditional combine (Issue 14). Below this
+# many matched rows *per side* in a ws/TI reporting bin, the combine overshoots — the F7/F9 sparse-extreme
+# tail (e.g. TI (0.45,0.50] swinging -77 to +93 pp between replicates) — so the bin is marked uncovered and
+# filled by the physics-informed imputer instead of trusting its noisy shape. Compared against the raw
+# per-side matched count today; if the per-bin balance reweighting (A5) is adopted it becomes the Kish
+# ESS. The value is chosen on placebo/benchmark evidence across many bins (findings F17), not tuned to the
+# one known bad TI bin.
+_MIN_BIN_MATCHED_COUNT = 50
+
 # F6 matching set + bin widths for the bias-cancellation correction, verified on real HoT by the CEM
 # coverage sweep (docs/v1/findings.md F6). wind_speed_100m (dominant) is binned finest, wind_gusts_10m
 # coarser, and wind_direction_100m in 20° sectors (a reanalysis direction — finer is finer than the
@@ -128,25 +138,6 @@ def _combine_uplift(r_fwd: np.ndarray, r_rev: np.ndarray) -> np.ndarray:
     valid = (a > 0) & (b > 0)
     frac = np.divide(a, b, out=np.full(np.broadcast(a, b).shape, np.nan), where=valid)
     return np.sqrt(frac, out=np.full_like(frac, np.nan), where=np.isfinite(frac)) - 1.0
-
-
-def _relevel_conditional(sum_actual_b: np.ndarray, one_plus_u_b: np.ndarray, *, one_plus_overall: float) -> np.ndarray:
-    """Rescale a per-bin corrected shape by one factor so its energy aggregation equals the overall.
-
-    The per-bin two-direction combine gives the *shape* of the uplift across bins but not a level tied
-    to the headline. This scales every bin's ``(1+u_b)`` by ``λ = one_plus_overall / (1+u_agg)``, where
-    ``1+u_agg = Σactual / Σ(actual/(1+u_b))`` is the ratio-of-sums the shape currently aggregates to, so
-    the re-leveled bins' total MWh uplift equals ``one_plus_overall`` exactly (the "overall = aggregation"
-    self-consistency target). Bins with non-finite ``(1+u_b)`` are left NaN and excluded from the sums.
-    """
-    a = np.asarray(sum_actual_b, dtype=float)
-    u1 = np.asarray(one_plus_u_b, dtype=float)
-    finite = np.isfinite(a) & np.isfinite(u1) & (u1 != 0)
-    cf = np.divide(a, u1, out=np.full(a.shape, np.nan), where=finite)
-    denom = float(cf[finite].sum()) if finite.any() else 0.0
-    one_plus_u_agg = float(a[finite].sum()) / denom if denom != 0 else float("nan")
-    lam = one_plus_overall / one_plus_u_agg if np.isfinite(one_plus_u_agg) and one_plus_u_agg != 0 else float("nan")
-    return lam * u1
 
 
 def _implied_shrinkage(r_fwd: np.ndarray, r_rev: np.ndarray) -> np.ndarray:
@@ -209,7 +200,10 @@ class PowerModelMethod:
     :param save_plots: also write the diagnostic plots
     :param seed: seed for the baseline holdout split and the LightGBM ``random_state`` (a caller-supplied
         ``random_state`` in ``model_params`` still wins)
-    :param model_params: LightGBM overrides passed to the outcome model
+    :param model_params: LightGBM overrides passed to the outcome model; merged **over** the tuned
+        default ``TUNED_MODEL_PARAMS`` (``min_child_samples=50``, F14), so a bare method already carries
+        the accepted capacity and any key here wins. Left empty by default so the ``model_factory`` vs
+        ``model_params`` guard still distinguishes "user set params" from "default"
     :param timebase: analysis timebase; inferred from the data when ``None``
     :param toggle_campaign_only: for a toggle campaign, fit only on the interleaved on/off blocks
         (drop the pre-campaign baseline); no-op for prepost. Default ``False`` since Issue 13
@@ -236,9 +230,12 @@ class PowerModelMethod:
         active-power max/min/SD companion statistics)
     :param era5_exclude: raw ERA5 columns to drop from the model features (removal-ablation knob;
         a dropped direction column also loses its sin/cos companions). Columns used as
-        ``matching_vars`` cannot be excluded while ``conditional_uplift`` is on.
-    :param availability_feature: when ``False``, drop the per-reference availability *feature*
-        (removal-ablation knob); ``availability_col`` itself stays required for the downtime filter
+        ``matching_vars`` cannot be excluded while ``conditional_uplift`` is on. Defaults to the
+        accepted ``CURATED_ERA5_EXCLUDE`` set (F13); the **untouched default** is drop-if-present (so a
+        non-Open-Meteo ERA5 frame lacking those columns is not broken), while an **explicitly-set**
+        value keeps the strict raise-on-unknown-column typo guard.
+    :param availability_feature: when ``False`` (the accepted default, F13), drop the per-reference
+        availability *feature*; ``availability_col`` itself stays required for the downtime filter
     :param model_factory: the outcome-model seam (Issue 12): a registered factory name (see
         :data:`~benchmarking.baselines.power_model.fitting.OUTCOME_MODEL_FACTORIES`) or a callable
         ``seed -> unfitted sklearn-style regressor``. ``None`` (default) keeps the design-note
@@ -317,8 +314,8 @@ class PowerModelMethod:
     latitude: float | None = None
     longitude: float | None = None
     reference_stat_cols: tuple[str, ...] = ()
-    era5_exclude: tuple[str, ...] = ()
-    availability_feature: bool = True
+    era5_exclude: tuple[str, ...] = CURATED_ERA5_EXCLUDE
+    availability_feature: bool = False
     model_factory: str | Callable[[int], Any] | None = None
     n_seed_ensemble: int = 1
     early_stopping: bool = False
@@ -572,14 +569,18 @@ class PowerModelMethod:
         actual_full: np.ndarray,
         overall_ratio: float,
     ) -> pd.DataFrame | None:
-        """Per-(ws, TI)-bin two-direction uplift *shape*, re-leveled so each marginal aggregates to overall.
+        """Per-(ws, TI)-bin two-direction uplift, imputed where uncovered and re-leveled onto the headline.
 
-        The **shape** ``1+u_b = sqrt((1+r_fwd_b)/(1+r_rev_b))`` comes from the matched forward/reverse fits
-        (NaN for a degenerate non-positive-ratio bin). The re-level **weights** are the *full-upgraded* actual
-        energy per bin (``actual_full`` over ``upgraded_pos``), so a single per-condition factor pins the
-        decomposition's energy aggregation to ``1 + overall_ratio`` — the reported per-bin MWh then partitions
-        the full-data headline (F8). Matched forward/reverse stay in-distribution; the full-upgraded energy
-        makes the decomposition add up to the full-data overall.
+        The measured **shape** ``1+u_b = sqrt((1+r_fwd_b)/(1+r_rev_b))`` comes from the matched
+        forward/reverse fits; a bin is ``covered`` (trusted) only when that shape is finite (Issue 14 adds
+        the per-bin matched-count floor to this test). Uncovered bins are filled by
+        :func:`~benchmarking.baselines.power_model.conditional.impute_uncovered_bins` (ws: bfill then 0 at
+        rated; ti: the overall uplift) so every bin carries a best estimate rather than a bare NaN. The
+        re-level **weights** are the *full-upgraded* actual energy per bin (``actual_full`` over
+        ``upgraded_pos``): imputed bins are pinned and one λ scales the measured bins so measured + imputed
+        together energy-aggregate to ``1 + overall_ratio`` exactly (F8, corrected for uncovered-bin energy).
+        The returned frame carries a ``covered`` flag (a per-run diagnostic — the harness seam only sees
+        ``p50_uplift``).
         """
         if self.wind_speed_col is None:
             return None
@@ -593,6 +594,7 @@ class PowerModelMethod:
         cond_up = conditions.iloc[mu].reset_index(drop=True)  # matched-upgraded (forward binning)
         cond_base = conditions.iloc[mb].reset_index(drop=True)  # matched-baseline (reverse binning)
         cond_full = conditions.iloc[upgraded_pos].reset_index(drop=True)  # all upgraded (re-level weights)
+        one_plus_overall = 1.0 + overall_ratio
         frames = []
         for name in [c for c in ("ws", "ti") if c in conditions.columns]:
             fwd = energy_ratio_by_bin(cond_up[name].to_numpy(), y[mu], pred_up, bins=CONDITION_BINS[name])
@@ -603,26 +605,40 @@ class PowerModelMethod:
                 full[["condition_bin", "sum_actual"]].rename(columns={"sum_actual": "sum_actual_full"}),
                 on="condition_bin",
             )
+            # impute_uncovered_bins needs ascending bin order (low ws/TI first); the merges above do not
+            # guarantee it, so pin the canonical CONDITION_BINS order before imputing / re-leveling.
+            order = pd.cut([], bins=CONDITION_BINS[name]).categories.astype(str)
+            merged["condition_bin"] = pd.Categorical(merged["condition_bin"], categories=order, ordered=True)
+            merged = merged.sort_values("condition_bin").reset_index(drop=True)
+
             r_fwd = merged["p50_uplift_fwd"].to_numpy()  # per-bin energy ratio IS the per-bin r
             r_rev = merged["p50_uplift_rev"].to_numpy()
-            one_plus_u = 1.0 + _combine_uplift(r_fwd, r_rev)  # shrinkage-free shape (NaN if degenerate)
+            shape = 1.0 + _combine_uplift(r_fwd, r_rev)  # shrinkage-free shape (NaN if degenerate)
             sum_actual_full = merged["sum_actual_full"].to_numpy()
-            releveled = _relevel_conditional(sum_actual_full, one_plus_u, one_plus_overall=1.0 + overall_ratio)
-            lam = np.divide(releveled, one_plus_u, out=np.full(one_plus_u.shape, np.nan), where=np.isfinite(one_plus_u))
+            # A bin is covered only if its shape is finite AND both directions have enough matched rows;
+            # below the floor the two-direction combine overshoots, so the bin is imputed instead (F7/F9).
+            per_side = np.minimum(merged["n_records_fwd"].to_numpy(), merged["n_records_rev"].to_numpy())
+            measured = np.isfinite(shape) & (per_side >= _MIN_BIN_MATCHED_COUNT)
+            imputed_shape = impute_uncovered_bins(
+                shape, condition=name, measured=measured, one_plus_overall=one_plus_overall
+            )
+            releveled = relevel_conditional(
+                sum_actual_full, imputed_shape, measured=measured, one_plus_overall=one_plus_overall
+            )
             frames.append(
                 pd.DataFrame(
                     {
                         "condition": name,
-                        "condition_bin": merged["condition_bin"],
+                        "condition_bin": merged["condition_bin"].astype(str),
                         "n_records_fwd": merged["n_records_fwd"],
                         "n_records_rev": merged["n_records_rev"],
                         "sum_actual": sum_actual_full,  # full-upgraded energy per bin (the MWh re-level weight)
                         "r_fwd": r_fwd,
                         "r_rev": r_rev,
                         "implied_shrinkage": _implied_shrinkage(r_fwd, r_rev),
-                        "u_b": one_plus_u - 1.0,  # per-bin corrected shape, before re-leveling
-                        "lambda": lam,  # the condition's re-level factor (constant within a condition)
-                        "p50_uplift": releveled - 1.0,  # re-leveled per-bin uplift (aggregates to overall)
+                        "u_b": shape - 1.0,  # measured two-direction shape (NaN where uncovered)
+                        "covered": measured,  # per-run diagnostic: measured vs imputed
+                        "p50_uplift": releveled - 1.0,  # measured-or-imputed, re-leveled to the headline
                     }
                 )
             )
@@ -704,7 +720,10 @@ class PowerModelMethod:
         era5_features = era5_feature_frame(result.aligned)
         if self.era5_exclude:
             missing = sorted(set(self.era5_exclude) - set(era5_features.columns))
-            if missing:
+            # An explicitly-set era5_exclude keeps the strict typo guard; the promoted class default
+            # (CURATED_ERA5_EXCLUDE) is drop-if-present, so a non-Open-Meteo ERA5 frame lacking those
+            # columns is not broken by an exclusion it never had. Identity check = "untouched default".
+            if missing and self.era5_exclude is not CURATED_ERA5_EXCLUDE:
                 msg = f"era5_exclude names columns not in the ERA5 features: {missing}"
                 raise ValueError(msg)
             blocked = sorted(set(self.era5_exclude) & set(self.matching_vars))
@@ -989,7 +1008,9 @@ class PowerModelMethod:
                 else self.model_factory
             )
             return factory(s)
-        return make_outcome_model(**{"random_state": s, **self.model_params, **(extra_params or {})})
+        return make_outcome_model(
+            **{"random_state": s, **TUNED_MODEL_PARAMS, **self.model_params, **(extra_params or {})}
+        )
 
     def _fit_models(
         self, x_train: pd.DataFrame, y_train: np.ndarray, *, weights: np.ndarray | None = None
@@ -1272,7 +1293,7 @@ class PowerModelMethod:
             "reference_stat_cols": list(self.reference_stat_cols),
             "era5_exclude": list(self.era5_exclude),
             "availability_feature": self.availability_feature,
-            "model_params": self.model_params,
+            "model_params": {**TUNED_MODEL_PARAMS, **self.model_params} if self.model_factory is None else {},
             "model_factory": self._model_factory_label(),
             "n_seed_ensemble": self.n_seed_ensemble,
             "early_stopping": self.early_stopping,

--- a/benchmarking/baselines/study_power_model_compare.py
+++ b/benchmarking/baselines/study_power_model_compare.py
@@ -3,24 +3,25 @@
 Iterative-development helper. The overnight v0 runs are very slow, so they are computed once
 (:mod:`benchmarking.baselines.study_overnight_prepost` / ``study_overnight_toggle`` with
 ``include_v0=True``) and kept on disk. As ``power_model`` is improved you only want to re-run the
-cheap method and re-draw the comparison plots, reusing the frozen v0 (and naive) numbers. That is
-what this script does:
+cheap methods and re-draw the comparison plots, reusing the frozen v0 numbers. That is what this
+script does:
 
-1. **Run** ``power_model`` **only** over the *exact* current overnight prepost + toggle configs —
-   same seven :func:`~benchmarking.baselines.overnight_profiles.overnight_profiles`, same campaign
-   grids, ``n_replicates=4``, ``seed=0`` — so every ``(profile, turbine, treatment-start, campaign)``
-   case matches the frozen overnight run. v0 and naive are *not* recomputed (v0 is very slow and
-   both are already frozen in the reference run).
-2. **Merge** each fresh ``power_model`` result with the ``v0_binned`` and ``naive_ratio`` rows
-   pulled from the reference overnight directory.
+1. **Run** ``power_model`` **and** ``naive_ratio`` over the *exact* current overnight prepost + toggle
+   configs — same seven :func:`~benchmarking.baselines.overnight_profiles.overnight_profiles`, same
+   campaign grids (Issue 14: 1/2/3/6/12 months both modes), ``n_replicates=4``, ``seed=0``. naive is
+   very cheap (no wind_up pipeline) so it is recomputed fresh here rather than pulled from the reference
+   run — which is what lets the grid extend to 1/2 months, where the frozen reference has no naive
+   either. Only v0 is *not* recomputed (it is very slow and already frozen in the reference run; it is
+   simply absent below 3 months).
+2. **Merge** each fresh ``power_model`` + ``naive_ratio`` result with the ``v0_binned`` rows pulled
+   from the reference overnight directory.
 3. **Plot** a three-method campaign-length comparison (``naive_ratio``, ``v0_binned``,
    ``power_model``) per profile, and write merged per-profile + all-profiles leaderboards.
 
-An alignment guard checks that the method-independent ground ``truth`` of every fresh case equals
-the reference run's truth for the same key; a mismatch means the configs have drifted and the
-merge would be comparing different cases, so it fails loudly rather than plotting nonsense. (The
-``truth`` column the harness attaches to every ``power_model`` row is itself the cross-check, so
-re-running the oracle/naive anchors purely to validate the line-up is unnecessary.)
+An alignment guard checks that the method-independent ground ``truth`` of the fresh cases equals the
+reference run's truth on the campaign lengths they share; a mismatch there means the configs have
+drifted and the merge would be comparing different cases, so it fails loudly. Fresh cases the
+reference never covered (1/2 months) are expected and skipped by the guard.
 
 **Benchmark regression tracking.** ``power_model``'s bias/spread/score per
 ``(mode, profile, campaign_months)`` at a known-good commit is frozen in a committed JSON benchmark
@@ -86,8 +87,9 @@ from benchmarking.baselines.example_prepost_study import (
 )
 from benchmarking.baselines.example_toggle_study import DEFAULT_TOGGLE_PERIOD
 from benchmarking.baselines.hot_context import build_hot_v0_context
+from benchmarking.baselines.naive_ratio import NaiveRatioMethod
 from benchmarking.baselines.overnight_profiles import overnight_profiles
-from benchmarking.baselines.power_model import CURATED_ERA5_EXCLUDE, TUNED_MODEL_PARAMS, PowerModelMethod
+from benchmarking.baselines.power_model import PowerModelMethod
 from benchmarking.harness import (
     StudyConfig,
     conditional_leaderboard,
@@ -103,11 +105,13 @@ logger = logging.getLogger(__name__)
 
 # The three methods compared in the merged plots (oracle is dropped: it is only a truth anchor).
 COMPARE_METHODS = ["naive_ratio", "v0_binned", "power_model"]
-REUSED_METHODS = ["naive_ratio", "v0_binned"]  # taken from the reference run, not recomputed
+REUSED_METHODS = ["v0_binned"]  # only v0 is reused from the reference run; naive is recomputed fresh
 
-# Match study_overnight_prepost.py / study_overnight_toggle.py exactly.
-PREPOST_CAMPAIGN_MONTHS = [3, 6, 12]
-TOGGLE_CAMPAIGN_MONTHS = [3, 6, 9, 12]
+# Issue 14: the out-of-the-box method is scored across the full 1-12-month range in both modes, so the
+# short-campaign regime (F16) is part of every A/B. v0 is only frozen in the reference run at 3/6/(9)/12,
+# so it is simply absent below 3 months — naive (recomputed fresh here) is the bar to beat there.
+PREPOST_CAMPAIGN_MONTHS = [1, 2, 3, 6, 12]
+TOGGLE_CAMPAIGN_MONTHS = [1, 2, 3, 6, 12]
 N_REPLICATES = 4
 SEED = 0
 
@@ -187,6 +191,11 @@ def _make_power_model(
     protocol), e.g. ``{"era5_derivations": ["gust_ratio"]}``; unknown field names fail loudly and
     JSON lists are coerced to the tuples the dataclass fields expect.
     """
+    # Only data-schema description is passed here now: the accepted behaviour defaults (F13
+    # availability_feature/era5_exclude, F14 min_child_samples) live on the PowerModelMethod class
+    # (Issue 14), so a bare method already *is* the benchmarked config. reference_stat_cols stays
+    # driver-level because it names a source-specific SCADA tag (wtc_ActPower_min) — schema
+    # description, not tuning — so it belongs with the other HoT column names, not on the class.
     kwargs: dict[str, Any] = {
         "active_power_col": HOT_COLUMNS.active_power,
         "wind_speed_col": HOT_COLUMNS.wind_speed,
@@ -194,15 +203,7 @@ def _make_power_model(
         "wind_speed_sd_col": HOT_COLUMNS.wind_speed_sd,
         "baseline_rated_power_kw": HOT_RATED_POWER_KW,
         "era5_hourly_df": era5_hourly_df,
-        # Issue 11 accepted default (findings F12): each reference's within-period active-power
-        # minimum. Better on every benchmark gate in both modes; max/SD were rejected.
-        "reference_stat_cols": ("wtc_ActPower_min",),
-        # Removal-ablation accepted defaults (findings F13): drop the availability feature and the
-        # redundant thermodynamic/precipitation ERA5 columns.
-        "availability_feature": False,
-        "era5_exclude": CURATED_ERA5_EXCLUDE,
-        # Issue 12 accepted default (findings F14): looser leaf capacity.
-        "model_params": dict(TUNED_MODEL_PARAMS),
+        "reference_stat_cols": ("wtc_ActPower_min",),  # Issue 11 accepted feature (F12); a HoT SCADA tag
         "out_dir": out_dir / "power_model_runs",
     }
     if overrides:
@@ -222,14 +223,16 @@ def run_power_model(
     profiles: list[str] | None = None,
     method_overrides: dict[str, Any] | None = None,
 ) -> pd.DataFrame:
-    """Score **only** ``power_model`` over the overnight cases for one mode (no v0/naive/oracle).
+    """Score ``power_model`` **and** ``naive_ratio`` over the overnight cases for one mode (no v0/oracle).
 
     ``profiles`` restricts to a subset of :func:`overnight_profiles` (default: all) for fast feedback on
     a power_model change. power_model runs at its default (conditional uplift on), so every case also
-    emits the per-bin conditional cells the benchmark tracks. Each fresh row still carries the harness's
-    method-independent ground ``truth`` (so the merge's alignment guard has its cross-check without
-    recomputing any anchor). Writes a per-profile ``results_*.csv`` and per-profile ``power_model`` curve
-    under ``out_dir``, and returns the concatenated tidy results.
+    emits the per-bin conditional cells the benchmark tracks. naive is recomputed fresh here (it is very
+    cheap and has no wind_up pipeline) so the merge no longer depends on the reference run's naive rows —
+    which matters at 1/2 months, where the frozen reference run has no naive either. Each fresh row still
+    carries the harness's method-independent ground ``truth`` (so the merge's alignment guard has its
+    cross-check against v0). Writes a per-profile ``results_*.csv`` and per-profile method curves under
+    ``out_dir``, and returns the concatenated tidy results.
     """
     out_dir.mkdir(parents=True, exist_ok=True)
     scada_df, _ = load_hot_scada(
@@ -250,11 +253,16 @@ def run_power_model(
             era5_hourly_df=context.reanalysis_datasets[0].data,
             overrides=method_overrides,
         )
-        logger.info("Scoring %s profile %s with power_model", mode, profile_name)
+        naive = NaiveRatioMethod(
+            active_power_col=HOT_COLUMNS.active_power,
+            availability_col=HOT_COLUMNS.availability,
+            out_dir=out_dir / profile_name / "naive_runs",
+        )
+        logger.info("Scoring %s profile %s with power_model + naive_ratio", mode, profile_name)
         results = score_study(
             scada_df,
             profile=profile,
-            methods=[method],
+            methods=[naive, method],
             study=study,
             profile_name=profile_name,
             on_method_complete=partial(save_per_method_curve, out_dir, profile_name),
@@ -301,20 +309,19 @@ def _case_key(df: pd.DataFrame) -> pd.Series:
 
 
 def _check_alignment(fresh: pd.DataFrame, reference: pd.DataFrame) -> None:
-    """Fail loudly if the fresh cases do not line up case-for-case with the reference run.
+    """Fail loudly if the fresh and reference runs disagree on ground truth where they overlap.
 
     Ground ``truth`` is method-independent and deterministic in the study config + seed, so equal
-    keys must carry equal truth. Mismatched keys or truths mean the configs drifted.
+    keys must carry equal truth. Since Issue 14 the fresh grid (1-12 months) extends past the frozen
+    reference run (3/6/(9)/12), so fresh cases absent from the reference are expected (e.g. 1/2 months)
+    and not an error — only the fresh ∩ reference intersection is truth-checked; a mismatch *there*
+    still means the configs drifted and the merge would compare different cases.
     """
     f_overall = fresh[fresh["condition"] == "overall"].copy()
     r_overall = reference[reference["condition"] == "overall"].copy()
     f_truth = f_overall.assign(key=_case_key(f_overall)).groupby("key")["truth"].first()
     r_truth = r_overall.assign(key=_case_key(r_overall)).groupby("key")["truth"].first()
 
-    missing = sorted(set(f_truth.index) - set(r_truth.index))
-    if missing:
-        msg = f"{len(missing)} fresh case(s) have no reference match, e.g. {missing[:3]}"
-        raise ValueError(msg)
     common = f_truth.index.intersection(r_truth.index)
     bad = ~np.isclose(f_truth.loc[common].to_numpy(), r_truth.loc[common].to_numpy(), rtol=1e-6, atol=1e-9)
     if bad.any():
@@ -677,8 +684,11 @@ def merge_and_plot(mode: str, fresh: pd.DataFrame, reference_mode_dir: Path, out
     reference = _load_reference_methods(reference_mode_dir, profiles, REUSED_METHODS)
     _check_alignment(fresh, reference)
 
-    power_model = fresh[fresh["method"] == "power_model"]
-    merged = pd.concat([reference, power_model], ignore_index=True)
+    # v0 comes from the frozen reference run (slow, reference-only, absent below 3 months); power_model
+    # and the freshly-recomputed naive come from this run. Concatenating both gives the three-method
+    # comparison, with v0 simply missing at the campaign lengths the reference never covered.
+    fresh_compare = fresh[fresh["method"].isin(COMPARE_METHODS) & (fresh["method"] != "v0_binned")]
+    merged = pd.concat([reference, fresh_compare], ignore_index=True)
     merged = merged[merged["method"].isin(COMPARE_METHODS)]
 
     merged.to_csv(comparison_dir / f"merged_results_{mode}.csv", index=False)

--- a/benchmarking/baselines/study_power_model_compare_baseline.json
+++ b/benchmarking/baselines/study_power_model_compare_baseline.json
@@ -2,11 +2,13 @@
   "schema": "power_model_compare_baseline_v2",
   "modes": {
     "prepost": {
-      "recorded_utc": "2026-07-05T08:20:02Z",
-      "git_commit": "33bfc23-dirty",
+      "recorded_utc": "2026-07-08T10:59:12Z",
+      "git_commit": "f51b3c7-dirty",
       "n_replicates": 4,
       "seed": 0,
       "campaign_months": [
+        1,
+        2,
         3,
         6,
         12
@@ -21,6 +23,438 @@
         "ws_dependent_cp"
       ],
       "cells": [
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 1,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": -0.00552818,
+          "spread": 0.00982335,
+          "score": 0.01127204
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": -0.00275915,
+          "spread": 0.03354439,
+          "score": 0.03365768
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": -0.01023641,
+          "spread": 0.01488016,
+          "score": 0.0180611
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00654138,
+          "spread": 0.0103152,
+          "score": 0.01221446
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.00085318,
+          "spread": 0.01631868,
+          "score": 0.01634097
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.01094087,
+          "spread": 0.03723027,
+          "score": 0.03880458
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": 0.03324681,
+          "spread": 0.02279212,
+          "score": 0.0403092
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.35103018,
+          "spread": 0.66092342,
+          "score": 0.74835951
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.28341262,
+          "spread": 0.61907949,
+          "score": 0.68086866
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.09236661,
+          "spread": 0.03706204,
+          "score": 0.0995248
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": -0.00033841,
+          "spread": 0.01672111,
+          "score": 0.01672453
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00518031,
+          "spread": 0.01548075,
+          "score": 0.01632449
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.01021728,
+          "spread": 0.01843347,
+          "score": 0.02107571
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.02723413,
+          "spread": 0.0273549,
+          "score": 0.03860037
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.01876272,
+          "spread": 0.01391806,
+          "score": 0.02336133
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.1383166,
+          "spread": 0.1454264,
+          "score": 0.20069957
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.01523773,
+          "spread": 0.03663888,
+          "score": 0.03968118
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.00719726,
+          "spread": 0.01809048,
+          "score": 0.01946962
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.00480828,
+          "spread": 0.01527782,
+          "score": 0.01601659
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": -0.01570012,
+          "spread": 0.01338638,
+          "score": 0.02063223
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00040165,
+          "spread": 0.00525168,
+          "score": 0.00526702
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": -0.00205655,
+          "spread": 0.01544331,
+          "score": 0.01557964
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.00218608,
+          "spread": 0.00637855,
+          "score": 0.00674277
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00168191,
+          "spread": 0.00628345,
+          "score": 0.00650466
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": 0.00135914,
+          "spread": 0.00405088,
+          "score": 0.0042728
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.00118549,
+          "spread": 0.01371431,
+          "score": 0.01376545
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": 0.00173855,
+          "spread": 0.04248803,
+          "score": 0.04252358
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.07436141,
+          "spread": 0.15062306,
+          "score": 0.16797894
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.70265763,
+          "spread": 1.30322774,
+          "score": 1.48058444
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": 0.67391032,
+          "spread": 1.09902902,
+          "score": 1.28919351
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.06550277,
+          "spread": 0.11005635,
+          "score": 0.12807425
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.00287039,
+          "spread": 0.01095036,
+          "score": 0.01132032
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00362371,
+          "spread": 0.00477419,
+          "score": 0.00599368
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.00876804,
+          "spread": 0.00583406,
+          "score": 0.01053161
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00317679,
+          "spread": 0.00661549,
+          "score": 0.00733872
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00226923,
+          "spread": 0.0136659,
+          "score": 0.01385303
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.06372298,
+          "spread": 0.0992478,
+          "score": 0.11794382
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.00818451,
+          "spread": 0.01473507,
+          "score": 0.01685552
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.00605008,
+          "spread": 0.01425996,
+          "score": 0.01549032
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.00207241,
+          "spread": 0.00668681,
+          "score": 0.0070006
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": -0.00443696,
+          "spread": 0.00742062,
+          "score": 0.00864593
+        },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
@@ -244,7 +678,7 @@
           "condition_bin": "overall",
           "bias": 0.00437834,
           "spread": 0.00191899,
-          "score": 0.00478042
+          "score": 0.00478041
         },
         {
           "profile": "cp_0pct",
@@ -260,7 +694,7 @@
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00169521,
+          "bias": -0.00169522,
           "spread": 0.00749124,
           "score": 0.00768065
         },
@@ -271,7 +705,7 @@
           "condition_bin": "(0.1, 0.15]",
           "bias": 0.00362548,
           "spread": 0.00177785,
-          "score": 0.00403793
+          "score": 0.00403792
         },
         {
           "profile": "cp_0pct",
@@ -298,7 +732,7 @@
           "condition_bin": "(0.25, 0.3]",
           "bias": 0.01291283,
           "spread": 0.00684295,
-          "score": 0.01461394
+          "score": 0.01461393
         },
         {
           "profile": "cp_0pct",
@@ -324,8 +758,8 @@
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
           "bias": 0.25711471,
-          "spread": 0.06025504,
-          "score": 0.26408076
+          "spread": 0.06025505,
+          "score": 0.26408075
         },
         {
           "profile": "cp_0pct",
@@ -341,7 +775,7 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.11353768,
+          "bias": -0.11353769,
           "spread": 0.10966636,
           "score": 0.15785283
         },
@@ -360,7 +794,7 @@
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
           "bias": 0.00454826,
-          "spread": 0.0045196,
+          "spread": 0.00451961,
           "score": 0.00641198
         },
         {
@@ -388,7 +822,7 @@
           "condition_bin": "(18.0, 20.0]",
           "bias": 0.01408456,
           "spread": 0.01341591,
-          "score": 0.01945152
+          "score": 0.01945151
         },
         {
           "profile": "cp_0pct",
@@ -451,187 +885,187 @@
           "condition_bin": "(8.0, 10.0]",
           "bias": 0.00410559,
           "spread": 0.00683023,
-          "score": 0.00796919
+          "score": 0.00796918
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00114757,
-          "spread": 0.00334024,
-          "score": 0.00353187
+          "bias": 0.00114798,
+          "spread": 0.00333987,
+          "score": 0.00353165
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.138048,
+          "bias": 0.13804805,
           "spread": 0.0,
-          "score": 0.138048
+          "score": 0.13804805
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00227157,
-          "spread": 0.00328414,
-          "score": 0.0039932
+          "bias": -0.00227115,
+          "spread": 0.0032837,
+          "score": 0.0039926
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00017802,
-          "spread": 0.00240822,
-          "score": 0.00241479
+          "bias": 0.00017845,
+          "spread": 0.00240815,
+          "score": 0.00241475
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00015568,
-          "spread": 0.00405469,
-          "score": 0.00405767
+          "bias": 0.00015611,
+          "spread": 0.00405415,
+          "score": 0.00405715
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00398299,
-          "spread": 0.00469621,
-          "score": 0.00615781
+          "bias": 0.00398335,
+          "spread": 0.00469608,
+          "score": 0.00615794
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00984061,
-          "spread": 0.00660377,
-          "score": 0.01185105
+          "bias": 0.00983979,
+          "spread": 0.00660434,
+          "score": 0.01185068
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00119096,
-          "spread": 0.01223081,
-          "score": 0.01228865
+          "bias": 0.0011926,
+          "spread": 0.01223143,
+          "score": 0.01228943
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.05196744,
-          "spread": 0.04380113,
-          "score": 0.06796436
+          "bias": 0.05196386,
+          "spread": 0.04379452,
+          "score": 0.06795736
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.37437664,
-          "spread": 0.39366371,
-          "score": 0.54325775
+          "bias": 0.37437723,
+          "spread": 0.39366381,
+          "score": 0.54325823
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.8757448,
-          "spread": 0.73933271,
-          "score": 1.14609852
+          "bias": 0.87574694,
+          "spread": 0.73933485,
+          "score": 1.14610153
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.10367933,
-          "spread": 0.09153115,
-          "score": 0.13830168
+          "bias": -0.10367897,
+          "spread": 0.09153096,
+          "score": 0.13830129
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00112288,
-          "spread": 0.00277387,
-          "score": 0.00299252
+          "bias": 0.0011233,
+          "spread": 0.00277321,
+          "score": 0.00299207
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00147613,
-          "spread": 0.00257743,
-          "score": 0.0029702
+          "bias": 0.00147655,
+          "spread": 0.00257748,
+          "score": 0.00297045
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.002058,
-          "spread": 0.00211829,
-          "score": 0.0029534
+          "bias": 0.0020584,
+          "spread": 0.00211865,
+          "score": 0.00295393
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.0006109,
-          "spread": 0.00083652,
-          "score": 0.00103584
+          "bias": 0.00061132,
+          "spread": 0.00083697,
+          "score": 0.00103645
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00150718,
-          "spread": 0.00329042,
-          "score": 0.00361917
+          "bias": 0.00150759,
+          "spread": 0.0032904,
+          "score": 0.00361933
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.12407874,
-          "spread": 0.07016175,
-          "score": 0.14254194
+          "bias": -0.12408241,
+          "spread": 0.0701685,
+          "score": 0.14254846
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.0095617,
-          "spread": 0.01535523,
-          "score": 0.01808892
+          "bias": 0.00956212,
+          "spread": 0.0153549,
+          "score": 0.01808886
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.05404805,
-          "spread": 0.04191147,
-          "score": 0.06839417
+          "bias": 0.05404851,
+          "spread": 0.04191206,
+          "score": 0.0683949
         },
         {
           "profile": "cp_0pct",
@@ -647,36 +1081,468 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00143335,
-          "spread": 0.00714195,
-          "score": 0.00728436
+          "bias": 0.00143417,
+          "spread": 0.00714136,
+          "score": 0.00728395
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00093292,
-          "spread": 0.0068417,
-          "score": 0.00690501
+          "bias": 0.00093328,
+          "spread": 0.00684141,
+          "score": 0.00690477
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00086856,
-          "spread": 0.00722544,
-          "score": 0.00727746
+          "bias": 0.00086894,
+          "spread": 0.00722516,
+          "score": 0.00727723
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 1,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": -0.00501533,
+          "spread": 0.00909111,
+          "score": 0.01038276
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": -0.00415225,
+          "spread": 0.03698591,
+          "score": 0.03721826
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": -0.00848355,
+          "spread": 0.01144082,
+          "score": 0.014243
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00582569,
+          "spread": 0.0109246,
+          "score": 0.01238085
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -3.688e-05,
+          "spread": 0.01516413,
+          "score": 0.01516417
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.01054416,
+          "spread": 0.03335558,
+          "score": 0.03498248
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": 0.03063731,
+          "spread": 0.02577901,
+          "score": 0.04004001
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.30672852,
+          "spread": 0.54931144,
+          "score": 0.62914661
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.3271667,
+          "spread": 0.52502657,
+          "score": 0.6186202
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.04958925,
+          "spread": 0.09489095,
+          "score": 0.10706721
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.00205996,
+          "spread": 0.01933083,
+          "score": 0.01944027
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": -0.00192796,
+          "spread": 0.01575857,
+          "score": 0.01587606
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.0073595,
+          "spread": 0.01567233,
+          "score": 0.01731428
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.02675314,
+          "spread": 0.02311513,
+          "score": 0.03535589
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.02297654,
+          "spread": 0.01600866,
+          "score": 0.02800355
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.07833209,
+          "spread": 0.07297779,
+          "score": 0.10705921
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.01327923,
+          "spread": 0.04561313,
+          "score": 0.04750679
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.00919698,
+          "spread": 0.01732662,
+          "score": 0.01961622
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.00528581,
+          "spread": 0.01461107,
+          "score": 0.0155378
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": -0.01214389,
+          "spread": 0.01246114,
+          "score": 0.01739983
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00044264,
+          "spread": 0.00486339,
+          "score": 0.00488349
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.00415006,
+          "spread": 0.0133329,
+          "score": 0.01396385
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": -0.00174996,
+          "spread": 0.00567975,
+          "score": 0.00594323
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00095835,
+          "spread": 0.00709314,
+          "score": 0.00715759
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": 0.00473522,
+          "spread": 0.00147007,
+          "score": 0.00495817
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.00460905,
+          "spread": 0.01064962,
+          "score": 0.01160421
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": 0.00592545,
+          "spread": 0.03932208,
+          "score": 0.03976603
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.08034683,
+          "spread": 0.13583335,
+          "score": 0.15781733
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.72740659,
+          "spread": 1.19745814,
+          "score": 1.40108042
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": 1.75364893,
+          "spread": 0.16634375,
+          "score": 1.76152059
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.07990924,
+          "spread": 0.12894246,
+          "score": 0.15169589
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.00462076,
+          "spread": 0.0135352,
+          "score": 0.01430221
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": -0.00229747,
+          "spread": 0.00411668,
+          "score": 0.00471438
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.00583325,
+          "spread": 0.00303703,
+          "score": 0.0065765
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00165,
+          "spread": 0.00711384,
+          "score": 0.00730268
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00095501,
+          "spread": 0.01779914,
+          "score": 0.01782474
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.02544962,
+          "spread": 0.06187661,
+          "score": 0.06690589
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.00956815,
+          "spread": 0.0144894,
+          "score": 0.01736353
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.00589347,
+          "spread": 0.013395,
+          "score": 0.01463417
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.00198741,
+          "spread": 0.00595343,
+          "score": 0.00627639
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": -0.00206324,
+          "spread": 0.00630293,
+          "score": 0.00663203
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00134027,
-          "spread": 0.00213655,
-          "score": 0.00252214
+          "bias": 0.00134049,
+          "spread": 0.00213641,
+          "score": 0.00252213
         },
         {
           "profile": "cp_minus_10pct",
@@ -692,153 +1558,153 @@
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.01118848,
-          "spread": 0.01175001,
-          "score": 0.01622483
+          "bias": -0.01118827,
+          "spread": 0.0117501,
+          "score": 0.01622474
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -6.07e-05,
-          "spread": 0.0033935,
-          "score": 0.00339405
+          "bias": -6.048e-05,
+          "spread": 0.00339334,
+          "score": 0.00339388
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00054689,
-          "spread": 0.00248387,
-          "score": 0.00254337
+          "bias": -0.00054667,
+          "spread": 0.00248357,
+          "score": 0.00254302
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00466659,
-          "spread": 0.00955969,
-          "score": 0.01063789
+          "bias": 0.0046668,
+          "spread": 0.00955983,
+          "score": 0.01063811
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00950343,
-          "spread": 0.01641777,
-          "score": 0.01896993
+          "bias": 0.00950364,
+          "spread": 0.01641783,
+          "score": 0.0189701
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.01884857,
-          "spread": 0.0385273,
-          "score": 0.04289081
+          "bias": -0.01884836,
+          "spread": 0.03852744,
+          "score": 0.04289084
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.08841442,
-          "spread": 0.08841616,
-          "score": 0.1250381
+          "bias": 0.08841464,
+          "spread": 0.08841615,
+          "score": 0.12503825
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.25885298,
-          "spread": 0.36478578,
-          "score": 0.4472958
+          "bias": 0.25885347,
+          "spread": 0.36478645,
+          "score": 0.44729663
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.29500699,
-          "spread": 0.66079521,
-          "score": 0.72365699
+          "bias": 0.2950076,
+          "spread": 0.66079602,
+          "score": 0.72365798
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.07223784,
-          "spread": 0.18832853,
-          "score": 0.20170756
+          "bias": -0.07223758,
+          "spread": 0.1883288,
+          "score": 0.20170772
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00484427,
-          "spread": 0.00990789,
-          "score": 0.01102875
+          "bias": 0.00484448,
+          "spread": 0.00990798,
+          "score": 0.01102892
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00106259,
-          "spread": 0.00839275,
-          "score": 0.00845975
+          "bias": -0.00106236,
+          "spread": 0.00839284,
+          "score": 0.00845981
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00659428,
-          "spread": 0.01005477,
-          "score": 0.01202426
+          "bias": 0.00659451,
+          "spread": 0.01005482,
+          "score": 0.01202443
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00195204,
-          "spread": 0.00392767,
-          "score": 0.004386
+          "bias": -0.00195181,
+          "spread": 0.00392802,
+          "score": 0.00438621
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.0102423,
-          "spread": 0.01288859,
-          "score": 0.01646269
+          "bias": 0.01024253,
+          "spread": 0.01288874,
+          "score": 0.01646296
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.05059259,
-          "spread": 0.07333189,
-          "score": 0.08909083
+          "bias": -0.05059242,
+          "spread": 0.07333178,
+          "score": 0.08909064
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00010424,
-          "spread": 0.03724922,
-          "score": 0.03724936
+          "bias": 0.00010455,
+          "spread": 0.03724966,
+          "score": 0.03724981
         },
         {
           "profile": "cp_minus_10pct",
@@ -863,36 +1729,36 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00012815,
-          "spread": 0.01763245,
-          "score": 0.01763292
+          "bias": -0.00012794,
+          "spread": 0.01763233,
+          "score": 0.0176328
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00295572,
-          "spread": 0.0109533,
-          "score": 0.01134509
+          "bias": -0.00295551,
+          "spread": 0.01095313,
+          "score": 0.01134487
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00032089,
-          "spread": 0.00812739,
-          "score": 0.00813372
+          "bias": 0.0003211,
+          "spread": 0.00812731,
+          "score": 0.00813365
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00418202,
-          "spread": 0.00178584,
-          "score": 0.00454736
+          "bias": 0.00418225,
+          "spread": 0.00178571,
+          "score": 0.00454752
         },
         {
           "profile": "cp_minus_10pct",
@@ -908,63 +1774,63 @@
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00110932,
-          "spread": 0.00687604,
-          "score": 0.00696495
+          "bias": 0.00110955,
+          "spread": 0.00687601,
+          "score": 0.00696496
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00144448,
-          "spread": 0.00147965,
-          "score": 0.00206782
+          "bias": 0.00144471,
+          "spread": 0.00147979,
+          "score": 0.00206808
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00218032,
-          "spread": 0.00271426,
-          "score": 0.00348152
+          "bias": 0.00218055,
+          "spread": 0.00271445,
+          "score": 0.00348182
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.01058214,
-          "spread": 0.00544124,
-          "score": 0.01189911
+          "bias": 0.01058236,
+          "spread": 0.00544085,
+          "score": 0.01189913
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01602368,
-          "spread": 0.00532355,
-          "score": 0.01688486
+          "bias": 0.0160239,
+          "spread": 0.0053232,
+          "score": 0.01688496
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.01533586,
-          "spread": 0.01243187,
-          "score": 0.01974183
+          "bias": 0.01533608,
+          "spread": 0.01243161,
+          "score": 0.01974184
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.08294349,
-          "spread": 0.0676397,
-          "score": 0.10702688
+          "bias": 0.08294375,
+          "spread": 0.06764007,
+          "score": 0.10702731
         },
         {
           "profile": "cp_minus_10pct",
@@ -980,81 +1846,81 @@
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.07696708,
-          "spread": 0.42883409,
-          "score": 0.43568636
+          "bias": 0.07696741,
+          "spread": 0.42883376,
+          "score": 0.4356861
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.03982642,
-          "spread": 0.17303586,
-          "score": 0.17756
+          "bias": -0.03982618,
+          "spread": 0.17303589,
+          "score": 0.17755997
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00464217,
-          "spread": 0.00429241,
-          "score": 0.00632254
+          "bias": 0.0046424,
+          "spread": 0.00429271,
+          "score": 0.00632291
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00085521,
-          "spread": 0.00477439,
-          "score": 0.00485038
+          "bias": -0.00085497,
+          "spread": 0.00477452,
+          "score": 0.00485046
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00342183,
-          "spread": 0.0034355,
-          "score": 0.00484888
+          "bias": 0.00342208,
+          "spread": 0.0034353,
+          "score": 0.00484891
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.0019709,
-          "spread": 0.0003814,
-          "score": 0.00200746
+          "bias": 0.00197114,
+          "spread": 0.00038173,
+          "score": 0.00200777
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.0136171,
-          "spread": 0.01415314,
-          "score": 0.01964018
+          "bias": 0.01361734,
+          "spread": 0.01415285,
+          "score": 0.01964014
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.05547734,
-          "spread": 0.0302997,
-          "score": 0.0632124
+          "bias": -0.05547718,
+          "spread": 0.03029958,
+          "score": 0.0632122
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00100486,
-          "spread": 0.02969569,
-          "score": 0.02971269
+          "bias": -0.00100462,
+          "spread": 0.0296953,
+          "score": 0.02971229
         },
         {
           "profile": "cp_minus_10pct",
@@ -1079,207 +1945,207 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00875164,
-          "spread": 0.00747465,
-          "score": 0.0115092
+          "bias": 0.00875186,
+          "spread": 0.00747437,
+          "score": 0.01150918
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00269645,
-          "spread": 0.0050432,
-          "score": 0.0057188
+          "bias": 0.00269667,
+          "spread": 0.00504298,
+          "score": 0.00571871
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.0054049,
-          "spread": 0.00599819,
-          "score": 0.00807411
+          "bias": 0.00540512,
+          "spread": 0.00599814,
+          "score": 0.00807422
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00115183,
-          "spread": 0.00314345,
-          "score": 0.00334783
+          "bias": 0.00115206,
+          "spread": 0.00314333,
+          "score": 0.0033478
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.10729088,
+          "bias": 0.10729127,
           "spread": 0.0,
-          "score": 0.10729088
+          "score": 0.10729127
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00123358,
-          "spread": 0.00490321,
-          "score": 0.00505601
+          "bias": 0.0012342,
+          "spread": 0.00490268,
+          "score": 0.00505564
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.000559,
-          "spread": 0.00225179,
-          "score": 0.00232013
+          "bias": -0.00055893,
+          "spread": 0.00225169,
+          "score": 0.00232002
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00047804,
-          "spread": 0.00395632,
-          "score": 0.0039851
+          "bias": -0.0004779,
+          "spread": 0.00395631,
+          "score": 0.00398507
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00599877,
-          "spread": 0.00407136,
-          "score": 0.00724992
+          "bias": 0.00599941,
+          "spread": 0.00407109,
+          "score": 0.00725029
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.0124725,
-          "spread": 0.00558782,
-          "score": 0.013667
+          "bias": 0.01247322,
+          "spread": 0.00558769,
+          "score": 0.0136676
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00718757,
-          "spread": 0.01115163,
-          "score": 0.01326725
+          "bias": 0.0071893,
+          "spread": 0.01115011,
+          "score": 0.01326691
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.05504522,
-          "spread": 0.03999046,
-          "score": 0.06803832
+          "bias": 0.0550482,
+          "spread": 0.03998979,
+          "score": 0.06804034
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.34068513,
-          "spread": 0.32185705,
-          "score": 0.4686772
+          "bias": 0.34068596,
+          "spread": 0.32185731,
+          "score": 0.46867799
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.96297969,
-          "spread": 0.47458954,
-          "score": 1.07357586
+          "bias": 0.96296912,
+          "spread": 0.47457864,
+          "score": 1.07356156
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.08492257,
-          "spread": 0.08817036,
-          "score": 0.12241673
+          "bias": -0.0849399,
+          "spread": 0.08818066,
+          "score": 0.12243617
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00463037,
-          "spread": 0.00207319,
-          "score": 0.00507331
+          "bias": 0.00463089,
+          "spread": 0.00207281,
+          "score": 0.00507363
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00259881,
-          "spread": 0.00302123,
-          "score": 0.00398518
+          "bias": -0.00259919,
+          "spread": 0.00302129,
+          "score": 0.00398547
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00023985,
-          "spread": 0.00199491,
-          "score": 0.00200928
+          "bias": 0.00023996,
+          "spread": 0.00199481,
+          "score": 0.00200919
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00054074,
-          "spread": 0.00160552,
-          "score": 0.00169413
+          "bias": -0.00054252,
+          "spread": 0.00160448,
+          "score": 0.00169371
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00177452,
-          "spread": 0.00522151,
-          "score": 0.0055148
+          "bias": 0.00177519,
+          "spread": 0.00522131,
+          "score": 0.00551483
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.06924426,
-          "spread": 0.03123268,
-          "score": 0.07596215
+          "bias": -0.06924626,
+          "spread": 0.03123237,
+          "score": 0.07596384
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.01334703,
-          "spread": 0.01946872,
-          "score": 0.02360453
+          "bias": 0.0133477,
+          "spread": 0.01946837,
+          "score": 0.02360463
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.06069597,
-          "spread": 0.04405564,
-          "score": 0.07499933
+          "bias": 0.0606967,
+          "spread": 0.04405616,
+          "score": 0.07500023
         },
         {
           "profile": "cp_minus_10pct",
@@ -1295,198 +2161,630 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00142996,
-          "spread": 0.00727722,
-          "score": 0.00741639
+          "bias": 0.001431,
+          "spread": 0.00727556,
+          "score": 0.00741496
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00014163,
-          "spread": 0.00676988,
-          "score": 0.00677136
+          "bias": 0.00014236,
+          "spread": 0.00676945,
+          "score": 0.00677094
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00207635,
-          "spread": 0.00674329,
-          "score": 0.00705572
+          "bias": 0.00207671,
+          "spread": 0.00674311,
+          "score": 0.00705565
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 1,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": -0.00604154,
+          "spread": 0.01055613,
+          "score": 0.01216273
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": -0.00320362,
+          "spread": 0.02949029,
+          "score": 0.02966379
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": -0.0118884,
+          "spread": 0.01863556,
+          "score": 0.0221047
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00689891,
+          "spread": 0.00989163,
+          "score": 0.01205982
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.00218479,
+          "spread": 0.01639942,
+          "score": 0.01654431
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.00878776,
+          "spread": 0.03913736,
+          "score": 0.04011181
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": 0.02503507,
+          "spread": 0.01739417,
+          "score": 0.03048462
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.37632671,
+          "spread": 0.75648033,
+          "score": 0.84491673
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.17648466,
+          "spread": 0.78301014,
+          "score": 0.80265292
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.09445266,
+          "spread": 0.03351074,
+          "score": 0.10022113
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": -0.0022678,
+          "spread": 0.01496907,
+          "score": 0.01513988
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.0120371,
+          "spread": 0.01619967,
+          "score": 0.0201822
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.0132674,
+          "spread": 0.02329289,
+          "score": 0.0268064
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.02998644,
+          "spread": 0.0334847,
+          "score": 0.04494899
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.0153088,
+          "spread": 0.01110408,
+          "score": 0.0189119
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.22758649,
+          "spread": 0.22119702,
+          "score": 0.31737003
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.01019818,
+          "spread": 0.02949106,
+          "score": 0.03120458
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.00948193,
+          "spread": 0.02214267,
+          "score": 0.02408744
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.00508096,
+          "spread": 0.01591535,
+          "score": 0.01670672
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": -0.01896609,
+          "spread": 0.01400782,
+          "score": 0.0235782
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 2,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00036041,
+          "spread": 0.00564058,
+          "score": 0.00565209
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": -0.00755319,
+          "spread": 0.02046263,
+          "score": 0.02181215
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.00648835,
+          "spread": 0.00811816,
+          "score": 0.01039246
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.0022225,
+          "spread": 0.0054715,
+          "score": 0.00590566
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.00205313,
+          "spread": 0.0071926,
+          "score": 0.0074799
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.00819649,
+          "spread": 0.01497535,
+          "score": 0.01707172
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.01214779,
+          "spread": 0.0405083,
+          "score": 0.04229055
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.05796773,
+          "spread": 0.18054166,
+          "score": 0.18961948
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.6642457,
+          "spread": 1.43850223,
+          "score": 1.58445922
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.45411194,
+          "spread": 2.50032308,
+          "score": 2.5412267
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.10682507,
+          "spread": 0.17667972,
+          "score": 0.20646385
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.001153,
+          "spread": 0.00804941,
+          "score": 0.00813157
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00899817,
+          "spread": 0.00314201,
+          "score": 0.00953097
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.01202224,
+          "spread": 0.00693876,
+          "score": 0.01388094
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00540957,
+          "spread": 0.0087758,
+          "score": 0.01030912
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00338713,
+          "spread": 0.01303291,
+          "score": 0.01346586
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.11409722,
+          "spread": 0.12448398,
+          "score": 0.16886219
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.01072301,
+          "spread": 0.01825045,
+          "score": 0.02116747
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.01034119,
+          "spread": 0.01890435,
+          "score": 0.02154796
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.00130204,
+          "spread": 0.00512433,
+          "score": 0.00528717
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": -0.00671356,
+          "spread": 0.00844129,
+          "score": 0.01078551
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00138763,
-          "spread": 0.00241026,
-          "score": 0.00278116
+          "bias": 0.00137528,
+          "spread": 0.00241003,
+          "score": 0.00277482
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.10939043,
+          "bias": 0.10933424,
           "spread": 0.0,
-          "score": 0.10939043
+          "score": 0.10933424
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00756063,
-          "spread": 0.01306884,
-          "score": 0.01509827
+          "bias": -0.00757282,
+          "spread": 0.0130494,
+          "score": 0.01508755
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00714657,
-          "spread": 0.00463591,
-          "score": 0.00851852
+          "bias": 0.00713425,
+          "spread": 0.00462409,
+          "score": 0.00850175
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00242408,
-          "spread": 0.00187717,
-          "score": 0.00306593
+          "bias": -0.00243648,
+          "spread": 0.00189589,
+          "score": 0.00308721
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00230135,
-          "spread": 0.01154606,
-          "score": 0.01177317
+          "bias": -0.00231374,
+          "spread": 0.01156408,
+          "score": 0.01179327
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": -0.00037089,
-          "spread": 0.02423234,
-          "score": 0.02423517
+          "bias": -0.00038327,
+          "spread": 0.02424716,
+          "score": 0.02425019
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.03214808,
-          "spread": 0.04905435,
-          "score": 0.05865005
+          "bias": -0.03215972,
+          "spread": 0.04907151,
+          "score": 0.05867078
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.08605014,
-          "spread": 0.12225641,
-          "score": 0.14950336
+          "bias": 0.08603376,
+          "spread": 0.12222918,
+          "score": 0.14947167
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.26035988,
-          "spread": 0.47638924,
-          "score": 0.54289407
+          "bias": 0.26036019,
+          "spread": 0.47638966,
+          "score": 0.54289459
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.16005659,
-          "spread": 0.93873315,
-          "score": 0.95228044
+          "bias": 0.16005056,
+          "spread": 0.93873879,
+          "score": 0.95228498
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.15242804,
-          "spread": 0.19522801,
-          "score": 0.24768586
+          "bias": -0.15243897,
+          "spread": 0.19522226,
+          "score": 0.24768805
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00180737,
-          "spread": 0.00493209,
-          "score": 0.00525282
+          "bias": -0.00181988,
+          "spread": 0.00492295,
+          "score": 0.00524856
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.01008346,
-          "spread": 0.00876578,
-          "score": 0.01336095
+          "bias": 0.01007149,
+          "spread": 0.00874812,
+          "score": 0.01334033
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.01123414,
-          "spread": 0.01296106,
-          "score": 0.01715212
+          "bias": 0.0112223,
+          "spread": 0.01294531,
+          "score": 0.01713246
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00098201,
-          "spread": 0.00649239,
-          "score": 0.00656624
+          "bias": 0.00097052,
+          "spread": 0.00649685,
+          "score": 0.00656894
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.01098316,
-          "spread": 0.01750178,
-          "score": 0.02066258
+          "bias": 0.01097127,
+          "spread": 0.01748663,
+          "score": 0.02064343
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.14001326,
-          "spread": 0.15780576,
-          "score": 0.21096533
+          "bias": -0.14002318,
+          "spread": 0.15782083,
+          "score": 0.21098319
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.01080114,
-          "spread": 0.02466299,
-          "score": 0.02692448
+          "bias": -0.01080098,
+          "spread": 0.02466321,
+          "score": 0.02692462
         },
         {
           "profile": "cp_plus_10pct",
@@ -1511,27 +2809,27 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00074979,
-          "spread": 0.01834302,
-          "score": 0.01835834
+          "bias": 0.00073728,
+          "spread": 0.01835256,
+          "score": 0.01836737
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00262389,
-          "spread": 0.00956809,
-          "score": 0.00992135
+          "bias": -0.00263643,
+          "spread": 0.00957779,
+          "score": 0.00993402
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00403882,
-          "spread": 0.00787047,
-          "score": 0.00884626
+          "bias": -0.00405137,
+          "spread": 0.00787977,
+          "score": 0.00886027
         },
         {
           "profile": "cp_plus_10pct",
@@ -1754,180 +3052,180 @@
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00114411,
-          "spread": 0.00353643,
-          "score": 0.0037169
+          "bias": 0.00114401,
+          "spread": 0.00353649,
+          "score": 0.00371692
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.16074699,
+          "bias": 0.16074839,
           "spread": 0.0,
-          "score": 0.16074699
+          "score": 0.16074839
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00650249,
-          "spread": 0.00156448,
-          "score": 0.00668804
+          "bias": -0.00650195,
+          "spread": 0.00156509,
+          "score": 0.00668766
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00085351,
-          "spread": 0.00255223,
-          "score": 0.00269116
+          "bias": 0.00085335,
+          "spread": 0.00255236,
+          "score": 0.00269124
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00064925,
-          "spread": 0.00423268,
-          "score": 0.00428218
+          "bias": 0.00064905,
+          "spread": 0.00423273,
+          "score": 0.0042822
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00224599,
-          "spread": 0.00539843,
-          "score": 0.00584701
+          "bias": 0.00224606,
+          "spread": 0.00539826,
+          "score": 0.00584688
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00735454,
+          "bias": 0.00735493,
           "spread": 0.00765629,
-          "score": 0.01061641
+          "score": 0.01061667
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00282702,
-          "spread": 0.01515549,
-          "score": 0.01541691
+          "bias": -0.002826,
+          "spread": 0.01515531,
+          "score": 0.01541654
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.05148507,
-          "spread": 0.05210792,
-          "score": 0.07325263
+          "bias": 0.05148621,
+          "spread": 0.05210842,
+          "score": 0.07325379
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.41293213,
-          "spread": 0.46189054,
-          "score": 0.61956098
+          "bias": 0.41293426,
+          "spread": 0.46189177,
+          "score": 0.61956332
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.77261792,
-          "spread": 1.0642447,
-          "score": 1.31512556
+          "bias": 0.77261729,
+          "spread": 1.06424459,
+          "score": 1.31512509
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.12680542,
-          "spread": 0.11613579,
-          "score": 0.17195096
+          "bias": -0.12680534,
+          "spread": 0.11613583,
+          "score": 0.17195094
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00254882,
-          "spread": 0.00412592,
-          "score": 0.00484971
+          "bias": -0.00254872,
+          "spread": 0.00412583,
+          "score": 0.00484958
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00535681,
-          "spread": 0.00248021,
-          "score": 0.00590312
+          "bias": 0.00535686,
+          "spread": 0.0024798,
+          "score": 0.005903
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00337183,
-          "spread": 0.00250427,
-          "score": 0.00420007
+          "bias": 0.00337151,
+          "spread": 0.00250366,
+          "score": 0.00419945
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00124375,
-          "spread": 0.00101369,
-          "score": 0.00160452
+          "bias": 0.00124361,
+          "spread": 0.00101331,
+          "score": 0.00160417
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00059008,
-          "spread": 0.00177811,
-          "score": 0.00187347
+          "bias": 0.00058961,
+          "spread": 0.00177784,
+          "score": 0.00187306
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.17614422,
-          "spread": 0.11208083,
-          "score": 0.20877955
+          "bias": -0.17617382,
+          "spread": 0.11213454,
+          "score": 0.20883335
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00442618,
-          "spread": 0.01198209,
-          "score": 0.01277347
+          "bias": 0.00442626,
+          "spread": 0.01198182,
+          "score": 0.01277324
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.04817421,
-          "spread": 0.04093947,
-          "score": 0.06322021
+          "bias": 0.04817429,
+          "spread": 0.04093924,
+          "score": 0.06322012
         },
         {
           "profile": "cp_plus_10pct",
@@ -1943,198 +3241,630 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00223227,
-          "spread": 0.00772444,
-          "score": 0.00804052
+          "bias": 0.00222892,
+          "spread": 0.00772157,
+          "score": 0.00803683
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00137199,
-          "spread": 0.00702181,
-          "score": 0.00715459
+          "bias": 0.0013721,
+          "spread": 0.007022,
+          "score": 0.0071548
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00025097,
-          "spread": 0.00759217,
-          "score": 0.00759632
+          "bias": -0.00025088,
+          "spread": 0.00759232,
+          "score": 0.00759646
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": -0.00568276,
+          "spread": 0.01004317,
+          "score": 0.01153945
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": -0.00519787,
+          "spread": 0.03163461,
+          "score": 0.03205879
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": -0.01079221,
+          "spread": 0.01595232,
+          "score": 0.01926002
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00635507,
+          "spread": 0.01011095,
+          "score": 0.01194229
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.00118282,
+          "spread": 0.0160625,
+          "score": 0.016106
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.00911978,
+          "spread": 0.03651582,
+          "score": 0.03763743
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": 0.02870565,
+          "spread": 0.02024364,
+          "score": 0.03512577
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.35325568,
+          "spread": 0.69421985,
+          "score": 0.77892925
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.23206936,
+          "spread": 0.67723425,
+          "score": 0.71589274
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.06101174,
+          "spread": 0.04428518,
+          "score": 0.07538972
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.00044627,
+          "spread": 0.01672295,
+          "score": 0.0167289
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00843642,
+          "spread": 0.01677733,
+          "score": 0.01877904
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.01166653,
+          "spread": 0.02105494,
+          "score": 0.02407112
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.02870597,
+          "spread": 0.03126683,
+          "score": 0.04244582
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.01805637,
+          "spread": 0.01346377,
+          "score": 0.02252345
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.17125498,
+          "spread": 0.16392943,
+          "score": 0.23706777
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.01420242,
+          "spread": 0.03486181,
+          "score": 0.03764378
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.01042699,
+          "spread": 0.02168348,
+          "score": 0.02406025
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.00573394,
+          "spread": 0.01599775,
+          "score": 0.01699429
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": -0.01705663,
+          "spread": 0.01359256,
+          "score": 0.02181023
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 2,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00038912,
+          "spread": 0.00536846,
+          "score": 0.00538255
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": -0.00393918,
+          "spread": 0.01719586,
+          "score": 0.01764128
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.00348178,
+          "spread": 0.00650645,
+          "score": 0.00737948
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00174284,
+          "spread": 0.0062582,
+          "score": 0.00649635
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": 0.00038837,
+          "spread": 0.00447932,
+          "score": 0.00449612
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.00392734,
+          "spread": 0.01384852,
+          "score": 0.01439463
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.00679467,
+          "spread": 0.03932323,
+          "score": 0.03990594
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.06906784,
+          "spread": 0.16294035,
+          "score": 0.17697435
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.69679999,
+          "spread": 1.36682926,
+          "score": 1.5341944
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": 0.33249112,
+          "spread": 1.5088501,
+          "score": 1.54504983
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.05625402,
+          "spread": 0.14842457,
+          "score": 0.15872733
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.00263649,
+          "spread": 0.01040297,
+          "score": 0.01073186
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.0048636,
+          "spread": 0.00382702,
+          "score": 0.00618875
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.00939784,
+          "spread": 0.00579037,
+          "score": 0.01103847
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00356214,
+          "spread": 0.00716929,
+          "score": 0.00800546
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00240742,
+          "spread": 0.01366565,
+          "score": 0.01387608
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.08237378,
+          "spread": 0.10591538,
+          "score": 0.13417714
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.00874047,
+          "spread": 0.01604271,
+          "score": 0.01826922
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.00931908,
+          "spread": 0.0163303,
+          "score": 0.01880223
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.00189226,
+          "spread": 0.00453297,
+          "score": 0.00491208
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": -0.00467892,
+          "spread": 0.00791442,
+          "score": 0.00919403
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00137519,
-          "spread": 0.00231403,
-          "score": 0.00269182
+          "bias": 0.00136233,
+          "spread": 0.00231432,
+          "score": 0.00268552
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.06160172,
+          "bias": 0.06154882,
           "spread": 0.0,
-          "score": 0.06160172
+          "score": 0.06154882
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00816868,
-          "spread": 0.0121143,
-          "score": 0.01461108
+          "bias": -0.00818153,
+          "spread": 0.01209691,
+          "score": 0.01460386
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00454379,
-          "spread": 0.00396805,
-          "score": 0.00603253
+          "bias": 0.00453088,
+          "spread": 0.00395464,
+          "score": 0.00601399
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00147537,
-          "spread": 0.00148008,
-          "score": 0.00208981
+          "bias": -0.00148822,
+          "spread": 0.00148939,
+          "score": 0.00210549
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00024989,
-          "spread": 0.01060259,
-          "score": 0.01060553
+          "bias": -0.00026264,
+          "spread": 0.01062083,
+          "score": 0.01062408
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00309887,
-          "spread": 0.0207636,
-          "score": 0.02099357
+          "bias": 0.00308617,
+          "spread": 0.02077879,
+          "score": 0.02100672
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.02838872,
-          "spread": 0.04814701,
-          "score": 0.05589324
+          "bias": -0.02840053,
+          "spread": 0.04816343,
+          "score": 0.05591338
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.08242881,
-          "spread": 0.10046702,
-          "score": 0.12995434
+          "bias": 0.08241273,
+          "spread": 0.10044191,
+          "score": 0.12992473
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.26028814,
-          "spread": 0.43690788,
-          "score": 0.50856505
+          "bias": 0.26028698,
+          "spread": 0.43690631,
+          "score": 0.50856311
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.22509688,
-          "spread": 0.81065979,
-          "score": 0.84133103
+          "bias": 0.22508669,
+          "spread": 0.8106651,
+          "score": 0.84133342
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.14764521,
-          "spread": 0.18965438,
-          "score": 0.24034952
+          "bias": -0.14765746,
+          "spread": 0.18964649,
+          "score": 0.24035082
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.0007768,
-          "spread": 0.00586249,
-          "score": 0.00591373
+          "bias": 0.00076382,
+          "spread": 0.0058491,
+          "score": 0.00589877
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00690707,
-          "spread": 0.00809927,
-          "score": 0.01064452
+          "bias": 0.00689419,
+          "spread": 0.0080812,
+          "score": 0.01062241
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.01008005,
-          "spread": 0.01125107,
-          "score": 0.01510609
+          "bias": 0.01006715,
+          "spread": 0.01123366,
+          "score": 0.01508451
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00058766,
-          "spread": 0.00471047,
-          "score": 0.00474698
+          "bias": 0.00057511,
+          "spread": 0.00471795,
+          "score": 0.00475288
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.01122968,
-          "spread": 0.01617271,
-          "score": 0.01968914
+          "bias": 0.01121669,
+          "spread": 0.01615571,
+          "score": 0.01966777
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.1073357,
-          "spread": 0.13030181,
-          "score": 0.168818
+          "bias": -0.10734547,
+          "spread": 0.13031581,
+          "score": 0.16883501
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.0055892,
-          "spread": 0.02923514,
-          "score": 0.02976462
+          "bias": -0.00558984,
+          "spread": 0.02923425,
+          "score": 0.02976387
         },
         {
           "profile": "cp_plus_3pct",
@@ -2159,27 +3889,27 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -3.553e-05,
-          "spread": 0.01684411,
-          "score": 0.01684415
+          "bias": -4.831e-05,
+          "spread": 0.0168544,
+          "score": 0.01685447
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.0034051,
-          "spread": 0.00932159,
-          "score": 0.00992405
+          "bias": -0.00341791,
+          "spread": 0.00933189,
+          "score": 0.00993812
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00254079,
-          "spread": 0.00775505,
-          "score": 0.00816066
+          "bias": -0.00255363,
+          "spread": 0.00776582,
+          "score": 0.0081749
         },
         {
           "profile": "cp_plus_3pct",
@@ -2188,7 +3918,7 @@
           "condition_bin": "overall",
           "bias": 0.00443749,
           "spread": 0.00195882,
-          "score": 0.00485059
+          "score": 0.0048506
         },
         {
           "profile": "cp_plus_3pct",
@@ -2232,7 +3962,7 @@
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
           "bias": 0.00712854,
-          "spread": 0.00625593,
+          "spread": 0.00625594,
           "score": 0.00948435
         },
         {
@@ -2242,7 +3972,7 @@
           "condition_bin": "(0.25, 0.3]",
           "bias": 0.01200246,
           "spread": 0.00824462,
-          "score": 0.01456134
+          "score": 0.01456135
         },
         {
           "profile": "cp_plus_3pct",
@@ -2251,7 +3981,7 @@
           "condition_bin": "(0.3, 0.35]",
           "bias": 0.01189303,
           "spread": 0.01383608,
-          "score": 0.01824503
+          "score": 0.01824504
         },
         {
           "profile": "cp_plus_3pct",
@@ -2260,7 +3990,7 @@
           "condition_bin": "(0.35, 0.4]",
           "bias": 0.07627773,
           "spread": 0.07724374,
-          "score": 0.10855822
+          "score": 0.10855823
         },
         {
           "profile": "cp_plus_3pct",
@@ -2303,8 +4033,8 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00594514,
-          "spread": 0.00425374,
+          "bias": 0.00594515,
+          "spread": 0.00425373,
           "score": 0.0073102
         },
         {
@@ -2348,7 +4078,7 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00640041,
+          "bias": -0.0064004,
           "spread": 0.02482486,
           "score": 0.02563667
         },
@@ -2386,7 +4116,7 @@
           "condition_bin": "(6.0, 8.0]",
           "bias": 0.00341159,
           "spread": 0.00472805,
-          "score": 0.00583038
+          "score": 0.00583039
         },
         {
           "profile": "cp_plus_3pct",
@@ -2402,170 +4132,170 @@
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00114635,
-          "spread": 0.00339926,
-          "score": 0.00358735
+          "bias": 0.00114682,
+          "spread": 0.00339881,
+          "score": 0.00358708
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.1422349,
+          "bias": 0.14223447,
           "spread": 0.0,
-          "score": 0.1422349
+          "score": 0.14223447
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00372839,
-          "spread": 0.00218911,
-          "score": 0.00432355
+          "bias": -0.00372792,
+          "spread": 0.00218868,
+          "score": 0.00432293
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00029076,
-          "spread": 0.0024555,
-          "score": 0.00247265
+          "bias": 0.00029124,
+          "spread": 0.00245531,
+          "score": 0.00247253
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00035912,
-          "spread": 0.0041211,
-          "score": 0.00413671
+          "bias": 0.0003596,
+          "spread": 0.00412044,
+          "score": 0.0041361
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00350495,
-          "spread": 0.00505702,
-          "score": 0.0061529
+          "bias": 0.00350537,
+          "spread": 0.00505696,
+          "score": 0.00615309
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00912526,
-          "spread": 0.00691414,
-          "score": 0.01144883
+          "bias": 0.00912575,
+          "spread": 0.0069141,
+          "score": 0.01144919
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00075492,
-          "spread": 0.01308479,
-          "score": 0.01310655
+          "bias": 0.0007554,
+          "spread": 0.01308424,
+          "score": 0.01310603
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.05327207,
-          "spread": 0.04617997,
-          "score": 0.0705018
+          "bias": 0.05327257,
+          "spread": 0.04617958,
+          "score": 0.07050191
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.38960212,
-          "spread": 0.41924378,
-          "score": 0.57232434
+          "bias": 0.38960271,
+          "spread": 0.41924343,
+          "score": 0.57232449
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.84352372,
-          "spread": 0.83833531,
-          "score": 1.18925958
+          "bias": 0.84352647,
+          "spread": 0.8383376,
+          "score": 1.18926315
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.11597832,
-          "spread": 0.09252749,
-          "score": 0.14836545
+          "bias": -0.11597794,
+          "spread": 0.09252722,
+          "score": 0.14836499
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00014024,
-          "spread": 0.003083,
-          "score": 0.00308619
+          "bias": 0.00014072,
+          "spread": 0.00308231,
+          "score": 0.00308552
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.0025708,
-          "spread": 0.00248001,
-          "score": 0.00357204
+          "bias": 0.00257127,
+          "spread": 0.00248035,
+          "score": 0.00357262
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00234292,
-          "spread": 0.00222434,
-          "score": 0.00323062
+          "bias": 0.00234339,
+          "spread": 0.00222497,
+          "score": 0.0032314
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00070675,
-          "spread": 0.00094548,
-          "score": 0.00118044
+          "bias": 0.00070722,
+          "spread": 0.00094618,
+          "score": 0.00118128
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00119297,
-          "spread": 0.00269309,
-          "score": 0.00294549
+          "bias": 0.00119344,
+          "spread": 0.00269313,
+          "score": 0.00294572
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.13875315,
-          "spread": 0.08172503,
-          "score": 0.16103235
+          "bias": -0.13875271,
+          "spread": 0.08172529,
+          "score": 0.1610321
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00749543,
-          "spread": 0.01496999,
+          "bias": 0.0074959,
+          "spread": 0.01496975,
           "score": 0.01674163
         },
         {
@@ -2573,9 +4303,9 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.05267642,
-          "spread": 0.04122461,
-          "score": 0.06689001
+          "bias": 0.05267694,
+          "spread": 0.04122538,
+          "score": 0.0668909
         },
         {
           "profile": "cp_plus_3pct",
@@ -2591,134 +4321,566 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.0013945,
-          "spread": 0.00752013,
-          "score": 0.00764833
+          "bias": 0.00139498,
+          "spread": 0.00751943,
+          "score": 0.00764773
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00094154,
-          "spread": 0.00691517,
-          "score": 0.00697897
+          "bias": 0.00094198,
+          "spread": 0.00691472,
+          "score": 0.00697858
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00069314,
-          "spread": 0.00734955,
-          "score": 0.00738216
+          "bias": 0.00069362,
+          "spread": 0.00734911,
+          "score": 0.00738177
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": -0.00556857,
+          "spread": 0.00997365,
+          "score": 0.0114229
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": -0.00431219,
+          "spread": 0.03618159,
+          "score": 0.03643765
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": -0.01008905,
+          "spread": 0.01386021,
+          "score": 0.01714334
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.0065983,
+          "spread": 0.01135789,
+          "score": 0.01313541
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": 2.833e-05,
+          "spread": 0.01623715,
+          "score": 0.01623718
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.01124192,
+          "spread": 0.03609808,
+          "score": 0.0378081
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": 0.03052076,
+          "spread": 0.02313358,
+          "score": 0.03829725
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.35263702,
+          "spread": 0.67300591,
+          "score": 0.75979591
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.46352987,
+          "spread": 0.62241102,
+          "score": 0.77605117
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.04579072,
+          "spread": 0.03801787,
+          "score": 0.05951595
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.00114459,
+          "spread": 0.01886467,
+          "score": 0.01889936
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00222497,
+          "spread": 0.01709013,
+          "score": 0.01723436
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.00941235,
+          "spread": 0.01889785,
+          "score": 0.02111211
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.02836247,
+          "spread": 0.02807591,
+          "score": 0.03990848
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.02124022,
+          "spread": 0.01603354,
+          "score": 0.02661243
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.14176335,
+          "spread": 0.1433315,
+          "score": 0.20159555
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.01627582,
+          "spread": 0.04114204,
+          "score": 0.04424443
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.01132078,
+          "spread": 0.01779712,
+          "score": 0.0210926
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.00514457,
+          "spread": 0.01602569,
+          "score": 0.0168312
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": -0.01448099,
+          "spread": 0.01312159,
+          "score": 0.01954163
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00041763,
+          "spread": 0.005332,
+          "score": 0.00534833
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.00111924,
+          "spread": 0.01616985,
+          "score": 0.01620854
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.00068018,
+          "spread": 0.00599207,
+          "score": 0.00603055
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.0012451,
+          "spread": 0.00705219,
+          "score": 0.00716126
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": 0.00262111,
+          "spread": 0.00274651,
+          "score": 0.00379652
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.00013021,
+          "spread": 0.01344985,
+          "score": 0.01345048
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": 0.00169586,
+          "spread": 0.0421776,
+          "score": 0.04221168
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.07333253,
+          "spread": 0.14929467,
+          "score": 0.16633267
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.64862953,
+          "spread": 1.22487786,
+          "score": 1.38601805
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": 0.69164537,
+          "spread": 1.10526418,
+          "score": 1.30383366
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.11761141,
+          "spread": 0.11011602,
+          "score": 0.16111481
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.00416207,
+          "spread": 0.01277733,
+          "score": 0.01343812
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00138,
+          "spread": 0.00430215,
+          "score": 0.00451806
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.00818165,
+          "spread": 0.00528837,
+          "score": 0.00974199
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00360673,
+          "spread": 0.00799511,
+          "score": 0.00877099
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00197062,
+          "spread": 0.01697591,
+          "score": 0.0170899
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.06608531,
+          "spread": 0.10462908,
+          "score": 0.12375182
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.01106395,
+          "spread": 0.01719905,
+          "score": 0.02045039
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.00704223,
+          "spread": 0.01500173,
+          "score": 0.01657241
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.00165495,
+          "spread": 0.00647368,
+          "score": 0.00668187
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": -0.00355713,
+          "spread": 0.00754064,
+          "score": 0.00833753
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00138928,
-          "spread": 0.00231507,
-          "score": 0.00269993
+          "bias": 0.0013897,
+          "spread": 0.00231492,
+          "score": 0.00270002
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.11115727,
+          "bias": 0.11115948,
           "spread": 0.0,
-          "score": 0.11115727
+          "score": 0.11115948
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00950275,
-          "spread": 0.01325974,
-          "score": 0.01631327
+          "bias": -0.00950232,
+          "spread": 0.01326041,
+          "score": 0.01631357
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00185404,
-          "spread": 0.00357326,
-          "score": 0.00402562
+          "bias": 0.00185446,
+          "spread": 0.0035739,
+          "score": 0.00402639
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00104968,
-          "spread": 0.00193694,
-          "score": 0.00220308
+          "bias": -0.00104927,
+          "spread": 0.00193702,
+          "score": 0.00220295
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00292459,
-          "spread": 0.01028859,
-          "score": 0.01069619
+          "bias": 0.002925,
+          "spread": 0.01028772,
+          "score": 0.01069546
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00852104,
-          "spread": 0.01851184,
-          "score": 0.02037882
+          "bias": 0.00852144,
+          "spread": 0.01851106,
+          "score": 0.02037828
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.02449787,
-          "spread": 0.04097839,
-          "score": 0.04774279
+          "bias": -0.0244975,
+          "spread": 0.04097763,
+          "score": 0.04774195
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.08698324,
-          "spread": 0.10960368,
-          "score": 0.13992516
+          "bias": 0.08698378,
+          "spread": 0.1096048,
+          "score": 0.13992638
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.25458949,
-          "spread": 0.41693327,
-          "score": 0.48851731
+          "bias": 0.2545894,
+          "spread": 0.41693337,
+          "score": 0.48851734
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.22379692,
-          "spread": 0.75398323,
-          "score": 0.78649589
+          "bias": 0.22379727,
+          "spread": 0.75398291,
+          "score": 0.78649568
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.05981845,
-          "spread": 0.14810748,
+          "bias": -0.05981804,
+          "spread": 0.14810764,
           "score": 0.15973125
         },
         {
@@ -2726,63 +4888,63 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00327995,
-          "spread": 0.00847891,
-          "score": 0.0090912
+          "bias": 0.00328037,
+          "spread": 0.00847962,
+          "score": 0.00909202
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00238399,
-          "spread": 0.00792123,
-          "score": 0.0082722
+          "bias": 0.00238443,
+          "spread": 0.00792208,
+          "score": 0.00827314
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00902056,
-          "spread": 0.01046749,
-          "score": 0.01381806
+          "bias": 0.009021,
+          "spread": 0.01046836,
+          "score": 0.01381901
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00058269,
-          "spread": 0.00389613,
-          "score": 0.00393946
+          "bias": -0.00058226,
+          "spread": 0.00389548,
+          "score": 0.00393875
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.01075871,
-          "spread": 0.01422225,
-          "score": 0.01783318
+          "bias": 0.01075915,
+          "spread": 0.01422308,
+          "score": 0.01783411
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.09746254,
-          "spread": 0.10853057,
-          "score": 0.14586922
+          "bias": -0.09746225,
+          "spread": 0.10852997,
+          "score": 0.14586859
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00175035,
-          "spread": 0.03416906,
-          "score": 0.03421386
+          "bias": -0.00175046,
+          "spread": 0.03416914,
+          "score": 0.03421395
         },
         {
           "profile": "rated_plus_5pct",
@@ -2807,36 +4969,36 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00105712,
-          "spread": 0.01784892,
-          "score": 0.01788019
+          "bias": 0.00105753,
+          "spread": 0.01784843,
+          "score": 0.01787973
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00284848,
-          "spread": 0.01072025,
-          "score": 0.01109223
+          "bias": -0.00284807,
+          "spread": 0.01071968,
+          "score": 0.01109158
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00086123,
-          "spread": 0.00842701,
-          "score": 0.0084709
+          "bias": -0.00086082,
+          "spread": 0.00842639,
+          "score": 0.00847024
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00446346,
-          "spread": 0.00193895,
-          "score": 0.00486642
+          "bias": 0.00446329,
+          "spread": 0.00193841,
+          "score": 0.00486605
         },
         {
           "profile": "rated_plus_5pct",
@@ -2852,162 +5014,162 @@
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00012248,
-          "spread": 0.00719487,
-          "score": 0.00719591
+          "bias": -0.00012271,
+          "spread": 0.00719536,
+          "score": 0.00719641
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00276897,
-          "spread": 0.00158002,
-          "score": 0.00318804
+          "bias": 0.0027688,
+          "spread": 0.00157926,
+          "score": 0.00318752
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.0023371,
-          "spread": 0.00260979,
-          "score": 0.00350329
+          "bias": 0.00233695,
+          "spread": 0.00260889,
+          "score": 0.00350252
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.01004438,
-          "spread": 0.00570743,
-          "score": 0.01155267
+          "bias": 0.01004418,
+          "spread": 0.00570791,
+          "score": 0.01155274
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01500057,
-          "spread": 0.00661002,
-          "score": 0.01639236
+          "bias": 0.01500034,
+          "spread": 0.00661007,
+          "score": 0.01639217
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.01388173,
-          "spread": 0.01484037,
-          "score": 0.0203209
+          "bias": 0.01388151,
+          "spread": 0.01484025,
+          "score": 0.02032066
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.08084036,
-          "spread": 0.07564139,
-          "score": 0.11071036
+          "bias": 0.08084007,
+          "spread": 0.07564066,
+          "score": 0.11070964
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.2570325,
-          "spread": 0.04902582,
-          "score": 0.26166627
+          "bias": 0.25703257,
+          "spread": 0.04902675,
+          "score": 0.26166651
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.0325502,
-          "spread": 0.52190327,
-          "score": 0.52291733
+          "bias": 0.0325507,
+          "spread": 0.52190427,
+          "score": 0.52291837
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.08678205,
-          "spread": 0.17593908,
-          "score": 0.19617769
+          "bias": -0.08678215,
+          "spread": 0.17593955,
+          "score": 0.19617815
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00342281,
-          "spread": 0.00376111,
-          "score": 0.00508542
+          "bias": 0.00342259,
+          "spread": 0.00376094,
+          "score": 0.00508515
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00191051,
-          "spread": 0.0051771,
-          "score": 0.00551837
+          "bias": 0.00191029,
+          "spread": 0.00517734,
+          "score": 0.00551852
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00507401,
-          "spread": 0.00383998,
-          "score": 0.00636325
+          "bias": 0.00507379,
+          "spread": 0.00384042,
+          "score": 0.00636335
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.0024383,
-          "spread": 0.00154529,
-          "score": 0.00288674
+          "bias": 0.00243808,
+          "spread": 0.00154543,
+          "score": 0.00288662
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.0142071,
-          "spread": 0.01430307,
-          "score": 0.02015985
+          "bias": 0.01420687,
+          "spread": 0.01430313,
+          "score": 0.02015973
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.11496423,
-          "spread": 0.06913629,
-          "score": 0.13415141
+          "bias": -0.11496441,
+          "spread": 0.06913642,
+          "score": 0.13415163
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00377726,
-          "spread": 0.02901926,
-          "score": 0.02926406
+          "bias": -0.00377747,
+          "spread": 0.02901956,
+          "score": 0.02926438
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.19535532,
+          "bias": 0.19535657,
           "spread": 0.0,
-          "score": 0.19535532
+          "score": 0.19535657
         },
         {
           "profile": "rated_plus_5pct",
@@ -3023,117 +5185,117 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00919442,
-          "spread": 0.00782841,
-          "score": 0.01207565
+          "bias": 0.00919438,
+          "spread": 0.00782831,
+          "score": 0.01207556
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00309438,
-          "spread": 0.00527837,
-          "score": 0.00611853
+          "bias": 0.00309443,
+          "spread": 0.00527818,
+          "score": 0.00611839
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00487388,
-          "spread": 0.0068054,
-          "score": 0.00837067
+          "bias": 0.00487366,
+          "spread": 0.00680494,
+          "score": 0.00837017
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00118619,
-          "spread": 0.00340393,
-          "score": 0.00360469
+          "bias": 0.00118609,
+          "spread": 0.00340396,
+          "score": 0.00360468
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.13176651,
+          "bias": 0.13176606,
           "spread": 0.0,
-          "score": 0.13176651
+          "score": 0.13176606
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00068784,
-          "spread": 0.00440168,
-          "score": 0.0044551
+          "bias": -0.00068938,
+          "spread": 0.00439936,
+          "score": 0.00445305
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00026378,
-          "spread": 0.00253956,
-          "score": 0.00255322
+          "bias": -0.000264,
+          "spread": 0.00253938,
+          "score": 0.00255307
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00012876,
-          "spread": 0.00413159,
-          "score": 0.00413359
+          "bias": -0.00012931,
+          "spread": 0.00413092,
+          "score": 0.00413294
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00527466,
-          "spread": 0.00469744,
-          "score": 0.00706314
+          "bias": 0.0052754,
+          "spread": 0.0046988,
+          "score": 0.0070646
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01171533,
-          "spread": 0.00646168,
-          "score": 0.01337918
+          "bias": 0.01171787,
+          "spread": 0.00646594,
+          "score": 0.01338345
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00337422,
-          "spread": 0.01265661,
-          "score": 0.01309866
+          "bias": 0.00338294,
+          "spread": 0.01266773,
+          "score": 0.01311166
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.05548199,
-          "spread": 0.04650934,
-          "score": 0.07239731
+          "bias": 0.05548041,
+          "spread": 0.04650953,
+          "score": 0.07239622
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.37369025,
-          "spread": 0.38530377,
-          "score": 0.53675265
+          "bias": 0.37368849,
+          "spread": 0.38530455,
+          "score": 0.53675198
         },
         {
           "profile": "rated_plus_5pct",
@@ -3149,81 +5311,81 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.11001343,
-          "spread": 0.10215614,
-          "score": 0.15012938
+          "bias": -0.11001455,
+          "spread": 0.10215738,
+          "score": 0.15013104
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.0029983,
-          "spread": 0.00224491,
-          "score": 0.00374559
+          "bias": 0.00299655,
+          "spread": 0.00224384,
+          "score": 0.00374355
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00044052,
-          "spread": 0.00292834,
-          "score": 0.00296128
+          "bias": -0.00044182,
+          "spread": 0.00292949,
+          "score": 0.00296262
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00100362,
-          "spread": 0.00218849,
-          "score": 0.00240765
+          "bias": 0.0010021,
+          "spread": 0.00218957,
+          "score": 0.00240799
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00019423,
-          "spread": 0.00124259,
-          "score": 0.00125768
+          "bias": -0.00019575,
+          "spread": 0.00124081,
+          "score": 0.00125616
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00143008,
-          "spread": 0.0041762,
-          "score": 0.00441427
+          "bias": 0.00142855,
+          "spread": 0.00417391,
+          "score": 0.00441161
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.12428185,
-          "spread": 0.07061252,
-          "score": 0.14294092
+          "bias": -0.12426835,
+          "spread": 0.07062621,
+          "score": 0.14293595
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.01134475,
-          "spread": 0.01844583,
-          "score": 0.0216553
+          "bias": 0.01134319,
+          "spread": 0.01844431,
+          "score": 0.02165319
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.05952528,
-          "spread": 0.04383949,
-          "score": 0.07392672
+          "bias": 0.05952366,
+          "spread": 0.04383909,
+          "score": 0.07392518
         },
         {
           "profile": "rated_plus_5pct",
@@ -3239,115 +5401,547 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00170369,
-          "spread": 0.00771997,
-          "score": 0.00790572
+          "bias": 0.00170609,
+          "spread": 0.00772326,
+          "score": 0.00790945
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00068179,
-          "spread": 0.00715959,
-          "score": 0.00719198
+          "bias": 0.00068032,
+          "spread": 0.00715747,
+          "score": 0.00718973
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00162763,
-          "spread": 0.00736442,
-          "score": 0.00754214
+          "bias": 0.00163072,
+          "spread": 0.00736967,
+          "score": 0.00754793
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 1,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": -0.00579626,
+          "spread": 0.01023767,
+          "score": 0.01176463
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": -0.00981778,
+          "spread": 0.03025881,
+          "score": 0.0318117
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": -0.01621381,
+          "spread": 0.01944661,
+          "score": 0.02531913
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.0075159,
+          "spread": 0.01081032,
+          "score": 0.01316631
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": 0.0044434,
+          "spread": 0.01726123,
+          "score": 0.01782397
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.02281581,
+          "spread": 0.03738176,
+          "score": 0.04379449
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": 0.05169126,
+          "spread": 0.0208259,
+          "score": 0.05572885
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.37587072,
+          "spread": 0.67693498,
+          "score": 0.77428661
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.26329019,
+          "spread": 0.6579467,
+          "score": 0.7086717
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.09506932,
+          "spread": 0.00928017,
+          "score": 0.09552119
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": -0.00216367,
+          "spread": 0.01500843,
+          "score": 0.01516359
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00861236,
+          "spread": 0.01585736,
+          "score": 0.01804518
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.01083439,
+          "spread": 0.0201762,
+          "score": 0.02290116
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.02751414,
+          "spread": 0.02960552,
+          "score": 0.04041676
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.01868322,
+          "spread": 0.0132891,
+          "score": 0.02292734
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.16128254,
+          "spread": 0.17483213,
+          "score": 0.237862
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.01163403,
+          "spread": 0.0351423,
+          "score": 0.03701799
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.00650259,
+          "spread": 0.02000496,
+          "score": 0.02103526
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.00438901,
+          "spread": 0.01553314,
+          "score": 0.01614131
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": -0.01749595,
+          "spread": 0.01342222,
+          "score": 0.0220514
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.0004023,
+          "spread": 0.00550154,
+          "score": 0.00551623
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": -0.01272529,
+          "spread": 0.02001497,
+          "score": 0.02371776
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.00163307,
+          "spread": 0.00868255,
+          "score": 0.0088348
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00287922,
+          "spread": 0.00679336,
+          "score": 0.00737832
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": 0.00491053,
+          "spread": 0.00731052,
+          "score": 0.00880664
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.01083295,
+          "spread": 0.01215426,
+          "score": 0.01628125
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": 0.01660237,
+          "spread": 0.03932818,
+          "score": 0.04268893
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.09331262,
+          "spread": 0.16494351,
+          "score": 0.18950886
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.71499184,
+          "spread": 1.33033171,
+          "score": 1.51029659
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": 0.71793698,
+          "spread": 1.12777687,
+          "score": 1.3369047
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.09642402,
+          "spread": 0.11258164,
+          "score": 0.14823029
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.00010331,
+          "spread": 0.00953766,
+          "score": 0.00953822
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00495053,
+          "spread": 0.00372018,
+          "score": 0.00619253
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.00929292,
+          "spread": 0.00606316,
+          "score": 0.01109596
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00308879,
+          "spread": 0.00773667,
+          "score": 0.00833047
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00258513,
+          "spread": 0.01371142,
+          "score": 0.01395299
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.07921844,
+          "spread": 0.11397876,
+          "score": 0.13880461
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.00800084,
+          "spread": 0.0172468,
+          "score": 0.01901225
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.0055249,
+          "spread": 0.01615802,
+          "score": 0.01707648
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.00416083,
+          "spread": 0.00530902,
+          "score": 0.00674524
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": -0.00517292,
+          "spread": 0.00727533,
+          "score": 0.0089269
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00137962,
-          "spread": 0.00236677,
-          "score": 0.00273952
+          "bias": 0.0013791,
+          "spread": 0.00236679,
+          "score": 0.00273927
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.10372972,
+          "bias": 0.10372733,
           "spread": 0.0,
-          "score": 0.10372972
+          "score": 0.10372733
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.01310601,
-          "spread": 0.01464745,
-          "score": 0.0196549
+          "bias": -0.01310653,
+          "spread": 0.01464664,
+          "score": 0.01965465
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00287124,
-          "spread": 0.00492671,
-          "score": 0.00570232
+          "bias": 0.00287072,
+          "spread": 0.00492619,
+          "score": 0.00570161
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00268397,
-          "spread": 0.00121379,
-          "score": 0.00294567
+          "bias": -0.00268449,
+          "spread": 0.0012142,
+          "score": 0.00294631
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00414815,
-          "spread": 0.00999245,
-          "score": 0.01081925
+          "bias": 0.00414765,
+          "spread": 0.00999316,
+          "score": 0.01081972
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01658951,
-          "spread": 0.02047648,
-          "score": 0.02635333
+          "bias": 0.01658901,
+          "spread": 0.02047706,
+          "score": 0.02635347
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00882154,
-          "spread": 0.04425591,
-          "score": 0.04512655
+          "bias": -0.00882199,
+          "spread": 0.04425658,
+          "score": 0.04512729
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.10196421,
-          "spread": 0.10866385,
-          "score": 0.14901186
+          "bias": 0.10196359,
+          "spread": 0.10866284,
+          "score": 0.14901069
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.29371741,
+          "bias": 0.29371742,
           "spread": 0.46343346,
           "score": 0.54867157
         },
@@ -3356,81 +5950,81 @@
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.31237746,
-          "spread": 0.79316869,
-          "score": 0.8524648
+          "bias": 0.31237706,
+          "spread": 0.79316904,
+          "score": 0.85246499
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.1609386,
-          "spread": 0.12481819,
-          "score": 0.20366839
+          "bias": -0.16093909,
+          "spread": 0.12481761,
+          "score": 0.20366842
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00103533,
-          "spread": 0.00523487,
-          "score": 0.00533627
+          "bias": -0.00103585,
+          "spread": 0.0052343,
+          "score": 0.00533581
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00720325,
-          "spread": 0.00785582,
-          "score": 0.01065836
+          "bias": 0.00720274,
+          "spread": 0.00785505,
+          "score": 0.01065745
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00993344,
-          "spread": 0.01144156,
-          "score": 0.01515198
+          "bias": 0.00993294,
+          "spread": 0.01144084,
+          "score": 0.01515111
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00039257,
-          "spread": 0.00495326,
-          "score": 0.0049688
+          "bias": 0.00039208,
+          "spread": 0.00495355,
+          "score": 0.00496904
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.01059574,
-          "spread": 0.01575385,
-          "score": 0.01898561
+          "bias": 0.01059523,
+          "spread": 0.01575315,
+          "score": 0.01898474
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.11226496,
-          "spread": 0.13435889,
-          "score": 0.17508779
+          "bias": -0.11226535,
+          "spread": 0.13435948,
+          "score": 0.17508849
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.01135231,
+          "bias": -0.0113523,
           "spread": 0.02374957,
-          "score": 0.02632332
+          "score": 0.02632331
         },
         {
           "profile": "ti_dependent_cp",
@@ -3455,36 +6049,36 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00236125,
-          "spread": 0.01921277,
-          "score": 0.01935733
+          "bias": 0.00236073,
+          "spread": 0.01921322,
+          "score": 0.01935771
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00172219,
-          "spread": 0.0101163,
-          "score": 0.01026184
+          "bias": -0.00172271,
+          "spread": 0.01011673,
+          "score": 0.01026235
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00279129,
-          "spread": 0.00728929,
-          "score": 0.00780545
+          "bias": -0.00279181,
+          "spread": 0.00728972,
+          "score": 0.00780604
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00450188,
-          "spread": 0.00200608,
-          "score": 0.00492862
+          "bias": 0.00450183,
+          "spread": 0.00200628,
+          "score": 0.00492866
         },
         {
           "profile": "ti_dependent_cp",
@@ -3500,162 +6094,162 @@
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00718022,
-          "spread": 0.01148858,
-          "score": 0.01354781
+          "bias": -0.00717948,
+          "spread": 0.01148869,
+          "score": 0.01354751
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.0022014,
-          "spread": 0.00183995,
-          "score": 0.00286907
+          "bias": 0.00220207,
+          "spread": 0.00184063,
+          "score": 0.00287002
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00180095,
-          "spread": 0.00225621,
-          "score": 0.00288685
+          "bias": 0.00180135,
+          "spread": 0.00225736,
+          "score": 0.002888
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.01170838,
-          "spread": 0.00514264,
-          "score": 0.012788
+          "bias": 0.01170811,
+          "spread": 0.00514238,
+          "score": 0.01278764
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.02561362,
-          "spread": 0.00694697,
-          "score": 0.02653899
+          "bias": 0.0256115,
+          "spread": 0.00694892,
+          "score": 0.02653745
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.03320676,
-          "spread": 0.01392726,
-          "score": 0.03600913
+          "bias": 0.0331989,
+          "spread": 0.01393488,
+          "score": 0.03600483
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.10266283,
-          "spread": 0.08266814,
-          "score": 0.13180925
+          "bias": 0.10266375,
+          "spread": 0.08267018,
+          "score": 0.13181124
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.27641737,
-          "spread": 0.04984578,
-          "score": 0.28087571
+          "bias": 0.27641685,
+          "spread": 0.04984506,
+          "score": 0.28087507
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.03831885,
-          "spread": 0.62816404,
-          "score": 0.6293317
+          "bias": -0.03622652,
+          "spread": 0.62606985,
+          "score": 0.62711707
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.08628223,
-          "spread": 0.15658952,
-          "score": 0.17878731
+          "bias": -0.08628202,
+          "spread": 0.15658937,
+          "score": 0.17878707
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00112807,
-          "spread": 0.0029266,
-          "score": 0.00313649
+          "bias": -0.0011278,
+          "spread": 0.0029275,
+          "score": 0.00313722
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00634171,
-          "spread": 0.00373666,
-          "score": 0.00736071
+          "bias": 0.00634197,
+          "spread": 0.00373681,
+          "score": 0.007361
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00625543,
-          "spread": 0.00391653,
-          "score": 0.00738035
+          "bias": 0.00625568,
+          "spread": 0.00391655,
+          "score": 0.00738058
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00336781,
-          "spread": 0.00325974,
-          "score": 0.00468701
+          "bias": 0.00336807,
+          "spread": 0.00326025,
+          "score": 0.00468755
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.01306908,
-          "spread": 0.01294389,
-          "score": 0.01839416
+          "bias": 0.01306934,
+          "spread": 0.01294358,
+          "score": 0.01839413
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.13587017,
-          "spread": 0.09224692,
-          "score": 0.16422605
+          "bias": -0.13587595,
+          "spread": 0.09225599,
+          "score": 0.16423593
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00791375,
-          "spread": 0.0237445,
-          "score": 0.02502856
+          "bias": -0.00791352,
+          "spread": 0.02374357,
+          "score": 0.0250276
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.17856492,
+          "bias": 0.17856353,
           "spread": 0.0,
-          "score": 0.17856492
+          "score": 0.17856353
         },
         {
           "profile": "ti_dependent_cp",
@@ -3671,54 +6265,54 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.01040791,
-          "spread": 0.0079064,
-          "score": 0.01307042
+          "bias": 0.01040353,
+          "spread": 0.0079115,
+          "score": 0.01307002
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00482949,
-          "spread": 0.00442013,
-          "score": 0.00654688
+          "bias": 0.00482946,
+          "spread": 0.00441979,
+          "score": 0.00654662
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00407615,
-          "spread": 0.00703269,
-          "score": 0.00812857
+          "bias": 0.00407639,
+          "spread": 0.00703303,
+          "score": 0.00812899
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00114912,
-          "spread": 0.00346552,
-          "score": 0.00365107
+          "bias": 0.00114913,
+          "spread": 0.00346553,
+          "score": 0.00365108
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.14732603,
+          "bias": 0.14732606,
           "spread": 0.0,
-          "score": 0.14732603
+          "score": 0.14732606
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00944284,
-          "spread": 0.00209959,
-          "score": 0.00967344
+          "bias": -0.00944285,
+          "spread": 0.0020996,
+          "score": 0.00967345
         },
         {
           "profile": "ti_dependent_cp",
@@ -3726,7 +6320,7 @@
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
           "bias": -0.00170036,
-          "spread": 0.00269795,
+          "spread": 0.00269796,
           "score": 0.00318907
         },
         {
@@ -3735,35 +6329,35 @@
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
           "bias": -5.38e-05,
-          "spread": 0.00412086,
-          "score": 0.00412121
+          "spread": 0.00412084,
+          "score": 0.00412119
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00732323,
-          "spread": 0.00442582,
-          "score": 0.00855673
+          "bias": 0.00732324,
+          "spread": 0.00442597,
+          "score": 0.00855681
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.02139376,
-          "spread": 0.00639851,
-          "score": 0.02233011
+          "bias": 0.02139375,
+          "spread": 0.00639849,
+          "score": 0.0223301
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.02031811,
-          "spread": 0.01293709,
-          "score": 0.02408721
+          "bias": 0.0203181,
+          "spread": 0.01293708,
+          "score": 0.0240872
         },
         {
           "profile": "ti_dependent_cp",
@@ -3771,7 +6365,7 @@
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
           "bias": 0.07093332,
-          "spread": 0.04588397,
+          "spread": 0.04588399,
           "score": 0.08448003
         },
         {
@@ -3780,8 +6374,8 @@
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
           "bias": 0.41097163,
-          "spread": 0.41279514,
-          "score": 0.5824925
+          "spread": 0.41279517,
+          "score": 0.58249252
         },
         {
           "profile": "ti_dependent_cp",
@@ -3798,24 +6392,24 @@
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
           "bias": -0.1044863,
-          "spread": 0.08875918,
-          "score": 0.13709697
+          "spread": 0.08875919,
+          "score": 0.13709698
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00158403,
-          "spread": 0.00365838,
-          "score": 0.00398659
+          "bias": -0.00158401,
+          "spread": 0.0036584,
+          "score": 0.0039866
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00348132,
+          "bias": 0.00348131,
           "spread": 0.00224476,
           "score": 0.00414228
         },
@@ -3824,8 +6418,8 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00257357,
-          "spread": 0.00222461,
+          "bias": 0.00257356,
+          "spread": 0.00222462,
           "score": 0.00340178
         },
         {
@@ -3833,18 +6427,18 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00088592,
+          "bias": 0.00088591,
           "spread": 0.00075698,
-          "score": 0.00116528
+          "score": 0.00116527
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00080293,
-          "spread": 0.00217117,
-          "score": 0.00231488
+          "bias": 0.00080292,
+          "spread": 0.00217115,
+          "score": 0.00231486
         },
         {
           "profile": "ti_dependent_cp",
@@ -3852,7 +6446,7 @@
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
           "bias": -0.14108764,
-          "spread": 0.08825718,
+          "spread": 0.08825716,
           "score": 0.1664183
         },
         {
@@ -3860,18 +6454,18 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00574744,
-          "spread": 0.01431243,
-          "score": 0.01542332
+          "bias": 0.00574743,
+          "spread": 0.01431241,
+          "score": 0.0154233
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.04884508,
-          "spread": 0.03909368,
-          "score": 0.06256323
+          "bias": 0.04884507,
+          "spread": 0.03909367,
+          "score": 0.06256321
         },
         {
           "profile": "ti_dependent_cp",
@@ -3887,108 +6481,540 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00283658,
-          "spread": 0.00774355,
-          "score": 0.00824674
+          "bias": 0.00283657,
+          "spread": 0.00774353,
+          "score": 0.00824672
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00207953,
-          "spread": 0.00686208,
-          "score": 0.00717026
+          "bias": 0.00207947,
+          "spread": 0.00686205,
+          "score": 0.00717021
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00040686,
-          "spread": 0.00736765,
-          "score": 0.00737888
+          "bias": 0.0004069,
+          "spread": 0.0073677,
+          "score": 0.00737893
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 1,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": -0.00576143,
+          "spread": 0.01021437,
+          "score": 0.01172721
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": -0.00432517,
+          "spread": 0.0321181,
+          "score": 0.03240801
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": -0.01173348,
+          "spread": 0.01773583,
+          "score": 0.0212658
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00666119,
+          "spread": 0.00997303,
+          "score": 0.01199303
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.00077265,
+          "spread": 0.01768854,
+          "score": 0.0177054
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.00991584,
+          "spread": 0.03959464,
+          "score": 0.04081739
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": 0.02754304,
+          "spread": 0.01424948,
+          "score": 0.03101075
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.34928131,
+          "spread": 0.69640371,
+          "score": 0.77908637
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.30239236,
+          "spread": 0.65552476,
+          "score": 0.72190987
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.10362669,
+          "spread": 0.04298486,
+          "score": 0.11218819
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.00283787,
+          "spread": 0.01716401,
+          "score": 0.01739703
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00815193,
+          "spread": 0.01797129,
+          "score": 0.01973376
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.01145045,
+          "spread": 0.02112108,
+          "score": 0.02402526
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.02967438,
+          "spread": 0.03245852,
+          "score": 0.04397868
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.01931003,
+          "spread": 0.0123965,
+          "score": 0.02294669
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.22076432,
+          "spread": 0.22983606,
+          "score": 0.31868714
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.01204188,
+          "spread": 0.03568684,
+          "score": 0.03766374
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.01255752,
+          "spread": 0.02047327,
+          "score": 0.02401762
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.00736366,
+          "spread": 0.0156102,
+          "score": 0.01725983
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": -0.01755096,
+          "spread": 0.01318091,
+          "score": 0.02194932
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 2,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00039284,
+          "spread": 0.00544186,
+          "score": 0.00545602
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": -0.0069114,
+          "spread": 0.01921585,
+          "score": 0.02042098
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.00393768,
+          "spread": 0.00775031,
+          "score": 0.00869325
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00178886,
+          "spread": 0.00591941,
+          "score": 0.0061838
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": 0.00024759,
+          "spread": 0.00716249,
+          "score": 0.00716677
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.00416843,
+          "spread": 0.01643332,
+          "score": 0.01695376
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.00397426,
+          "spread": 0.04013151,
+          "score": 0.04032781
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.06585691,
+          "spread": 0.16272637,
+          "score": 0.17554772
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.66814922,
+          "spread": 1.42007272,
+          "score": 1.56940432
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.46606126,
+          "spread": 2.40631621,
+          "score": 2.45103464
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.06075126,
+          "spread": 0.15884981,
+          "score": 0.1700705
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.00500357,
+          "spread": 0.01021459,
+          "score": 0.01137425
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.0049034,
+          "spread": 0.00446422,
+          "score": 0.00663118
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.00971633,
+          "spread": 0.00633736,
+          "score": 0.0116004
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00435461,
+          "spread": 0.00636958,
+          "score": 0.00771584
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00380373,
+          "spread": 0.01268725,
+          "score": 0.01324518
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.10534837,
+          "spread": 0.13113216,
+          "score": 0.16820797
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.01125404,
+          "spread": 0.01593621,
+          "score": 0.01950939
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.01037415,
+          "spread": 0.01596324,
+          "score": 0.01903807
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 7.683e-05,
+          "spread": 0.00630461,
+          "score": 0.00630508
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": -0.00513136,
+          "spread": 0.00795298,
+          "score": 0.00946471
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00138744,
-          "spread": 0.00236675,
-          "score": 0.00274345
+          "bias": 0.00138693,
+          "spread": 0.00236677,
+          "score": 0.0027432
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.1549398,
+          "bias": 0.15493747,
           "spread": 0.0,
-          "score": 0.1549398
+          "score": 0.15493747
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00742468,
-          "spread": 0.01082196,
-          "score": 0.01312405
+          "bias": -0.00742519,
+          "spread": 0.01082126,
+          "score": 0.01312376
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00559798,
-          "spread": 0.00436483,
-          "score": 0.00709853
+          "bias": 0.00559747,
+          "spread": 0.00436438,
+          "score": 0.00709786
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.0017261,
-          "spread": 0.00135119,
-          "score": 0.00219206
+          "bias": -0.00172661,
+          "spread": 0.00135169,
+          "score": 0.00219277
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00092391,
-          "spread": 0.01077924,
-          "score": 0.01081876
+          "bias": -0.00092442,
+          "spread": 0.01077998,
+          "score": 0.01081954
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00254055,
-          "spread": 0.0230036,
-          "score": 0.02314347
+          "bias": 0.00254004,
+          "spread": 0.02300421,
+          "score": 0.02314401
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.02825304,
-          "spread": 0.0447957,
-          "score": 0.0529612
+          "bias": -0.02825352,
+          "spread": 0.04479642,
+          "score": 0.05296207
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.07923303,
-          "spread": 0.1191599,
-          "score": 0.14309771
+          "bias": 0.07923235,
+          "spread": 0.11915877,
+          "score": 0.14309639
         },
         {
           "profile": "ws_dependent_cp",
@@ -4004,81 +7030,81 @@
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.13013785,
-          "spread": 0.89845465,
-          "score": 0.90783073
+          "bias": 0.13013757,
+          "spread": 0.89845487,
+          "score": 0.9078309
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.12593502,
-          "spread": 0.23148578,
-          "score": 0.26352476
+          "bias": -0.12593548,
+          "spread": 0.23148565,
+          "score": 0.26352486
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00283276,
-          "spread": 0.0065267,
-          "score": 0.00711494
+          "bias": 0.00283226,
+          "spread": 0.00652619,
+          "score": 0.00711427
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.0071165,
-          "spread": 0.00882263,
-          "score": 0.01133505
+          "bias": 0.007116,
+          "spread": 0.00882194,
+          "score": 0.0113342
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.0110432,
-          "spread": 0.01174921,
-          "score": 0.0161244
+          "bias": 0.01104269,
+          "spread": 0.01174852,
+          "score": 0.01612355
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00131398,
-          "spread": 0.00516429,
-          "score": 0.00532883
+          "bias": 0.00131349,
+          "spread": 0.00516464,
+          "score": 0.00532905
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.01243679,
-          "spread": 0.0156261,
-          "score": 0.0199712
+          "bias": 0.01243628,
+          "spread": 0.01562541,
+          "score": 0.01997034
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.13988836,
-          "spread": 0.1544903,
-          "score": 0.20841306
+          "bias": -0.13988878,
+          "spread": 0.15449095,
+          "score": 0.20841383
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00299601,
-          "spread": 0.03156555,
-          "score": 0.03170741
+          "bias": -0.002996,
+          "spread": 0.03156554,
+          "score": 0.0317074
         },
         {
           "profile": "ws_dependent_cp",
@@ -4103,36 +7129,36 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00269462,
-          "spread": 0.01844947,
-          "score": 0.01864521
+          "bias": -0.00269515,
+          "spread": 0.01844982,
+          "score": 0.01864563
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00496993,
-          "spread": 0.01086023,
-          "score": 0.0119434
+          "bias": -0.00497044,
+          "spread": 0.01086063,
+          "score": 0.01194398
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00347798,
-          "spread": 0.00831465,
-          "score": 0.00901276
+          "bias": -0.00347849,
+          "spread": 0.00831512,
+          "score": 0.00901338
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00450881,
-          "spread": 0.0019924,
-          "score": 0.0049294
+          "bias": 0.00450929,
+          "spread": 0.00199262,
+          "score": 0.00492993
         },
         {
           "profile": "ws_dependent_cp",
@@ -4148,153 +7174,153 @@
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00317451,
-          "spread": 0.01188696,
-          "score": 0.01230355
+          "bias": -0.00317406,
+          "spread": 0.01188666,
+          "score": 0.01230315
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00484221,
-          "spread": 0.00233077,
-          "score": 0.00537396
+          "bias": 0.00484265,
+          "spread": 0.00233099,
+          "score": 0.00537445
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00252924,
-          "spread": 0.00232321,
-          "score": 0.00343429
+          "bias": 0.0025297,
+          "spread": 0.00232359,
+          "score": 0.00343489
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.0068761,
-          "spread": 0.00656909,
-          "score": 0.00950966
+          "bias": 0.00687665,
+          "spread": 0.00656888,
+          "score": 0.00950992
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01282253,
-          "spread": 0.00808343,
-          "score": 0.01515781
+          "bias": 0.01282322,
+          "spread": 0.00808337,
+          "score": 0.01515836
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.01356623,
-          "spread": 0.01469027,
-          "score": 0.01999616
+          "bias": 0.01356724,
+          "spread": 0.01469051,
+          "score": 0.01999703
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.07608965,
-          "spread": 0.07976696,
-          "score": 0.11023794
+          "bias": 0.07608815,
+          "spread": 0.07976982,
+          "score": 0.11023897
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.13879981,
-          "spread": 0.21453298,
-          "score": 0.25551866
+          "bias": 0.13880016,
+          "spread": 0.21453291,
+          "score": 0.2555188
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.05606311,
-          "spread": 0.50853144,
-          "score": 0.51161245
+          "bias": -0.05606301,
+          "spread": 0.50853131,
+          "score": 0.51161231
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.10454561,
-          "spread": 0.14297175,
-          "score": 0.17711777
+          "bias": -0.10454461,
+          "spread": 0.14297163,
+          "score": 0.17711709
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00325969,
-          "spread": 0.00275317,
-          "score": 0.00426679
+          "bias": 0.00326014,
+          "spread": 0.00275325,
+          "score": 0.00426719
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00639829,
-          "spread": 0.00481163,
-          "score": 0.00800561
+          "bias": 0.00639874,
+          "spread": 0.00481138,
+          "score": 0.00800582
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00686377,
-          "spread": 0.00402508,
-          "score": 0.00795692
+          "bias": 0.00686422,
+          "spread": 0.00402477,
+          "score": 0.00795715
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00448338,
-          "spread": 0.00285891,
-          "score": 0.00531734
+          "bias": 0.00448383,
+          "spread": 0.00285889,
+          "score": 0.00531771
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.01484839,
-          "spread": 0.01331141,
-          "score": 0.01994162
+          "bias": 0.01484884,
+          "spread": 0.01331114,
+          "score": 0.01994178
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.17801961,
-          "spread": 0.11812707,
-          "score": 0.21364687
+          "bias": -0.17801926,
+          "spread": 0.11812676,
+          "score": 0.21364641
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00406794,
-          "spread": 0.02684958,
-          "score": 0.02715599
+          "bias": -0.0040675,
+          "spread": 0.02684931,
+          "score": 0.02715566
         },
         {
           "profile": "ws_dependent_cp",
@@ -4319,134 +7345,134 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00635052,
-          "spread": 0.00866543,
-          "score": 0.01074331
+          "bias": 0.0063512,
+          "spread": 0.0086655,
+          "score": 0.01074377
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00141984,
-          "spread": 0.00506451,
-          "score": 0.00525977
+          "bias": 0.00142032,
+          "spread": 0.00506463,
+          "score": 0.00526002
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.0032373,
-          "spread": 0.00734598,
-          "score": 0.00802767
+          "bias": 0.0032378,
+          "spread": 0.00734634,
+          "score": 0.0080282
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00118508,
+          "bias": 0.00118501,
           "spread": 0.0034466,
-          "score": 0.00364464
+          "score": 0.00364462
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.16856991,
+          "bias": 0.16856937,
           "spread": 0.0,
-          "score": 0.16856991
+          "score": 0.16856937
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00328935,
-          "spread": 0.00198419,
-          "score": 0.00384146
+          "bias": -0.00329029,
+          "spread": 0.00198535,
+          "score": 0.00384287
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00022091,
-          "spread": 0.00257779,
-          "score": 0.00258724
+          "bias": 0.0002208,
+          "spread": 0.00257781,
+          "score": 0.00258725
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00036854,
-          "spread": 0.00408097,
-          "score": 0.00409757
+          "bias": 0.00036851,
+          "spread": 0.00408091,
+          "score": 0.00409751
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00368684,
-          "spread": 0.0054544,
-          "score": 0.00658356
+          "bias": 0.00368686,
+          "spread": 0.00545443,
+          "score": 0.0065836
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01032711,
-          "spread": 0.00690045,
-          "score": 0.01242036
+          "bias": 0.01032704,
+          "spread": 0.00690047,
+          "score": 0.01242032
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00289994,
-          "spread": 0.01384924,
-          "score": 0.01414959
+          "bias": 0.00289987,
+          "spread": 0.01384906,
+          "score": 0.01414941
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.05415,
-          "spread": 0.04847006,
-          "score": 0.07267441
+          "bias": 0.05414976,
+          "spread": 0.04846957,
+          "score": 0.0726739
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.40250516,
-          "spread": 0.44736843,
-          "score": 0.6017881
+          "bias": 0.40250498,
+          "spread": 0.44736801,
+          "score": 0.60178767
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.76776281,
-          "spread": 0.98995053,
-          "score": 1.25278162
+          "bias": 0.76776303,
+          "spread": 0.98995063,
+          "score": 1.25278183
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.13049529,
-          "spread": 0.10568137,
+          "bias": -0.13049535,
+          "spread": 0.10568129,
           "score": 0.16792132
         },
         {
@@ -4454,72 +7480,72 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00231897,
-          "spread": 0.00287097,
-          "score": 0.00369054
+          "bias": 0.00231891,
+          "spread": 0.00287094,
+          "score": 0.00369048
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00297186,
-          "spread": 0.00269684,
-          "score": 0.00401309
+          "bias": 0.0029718,
+          "spread": 0.00269697,
+          "score": 0.00401313
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00267491,
-          "spread": 0.00244497,
-          "score": 0.00362395
+          "bias": 0.00267485,
+          "spread": 0.0024451,
+          "score": 0.003624
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00131463,
-          "spread": 0.00098088,
-          "score": 0.00164023
+          "bias": 0.00131457,
+          "spread": 0.00098099,
+          "score": 0.00164025
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00210271,
-          "spread": 0.00291148,
-          "score": 0.00359139
+          "bias": 0.00210265,
+          "spread": 0.00291156,
+          "score": 0.00359143
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.17864555,
-          "spread": 0.11187867,
-          "score": 0.21078678
+          "bias": -0.17864509,
+          "spread": 0.111878,
+          "score": 0.21078605
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.0096974,
-          "spread": 0.01502468,
-          "score": 0.01788241
+          "bias": 0.00969734,
+          "spread": 0.0150248,
+          "score": 0.01788248
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.0558356,
-          "spread": 0.04224211,
-          "score": 0.07001436
+          "bias": 0.05583555,
+          "spread": 0.04224229,
+          "score": 0.07001442
         },
         {
           "profile": "ws_dependent_cp",
@@ -4535,39 +7561,40 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00112951,
-          "spread": 0.0080489,
-          "score": 0.00812777
+          "bias": -0.00112946,
+          "spread": 0.00804886,
+          "score": 0.00812772
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00074339,
-          "spread": 0.00740297,
-          "score": 0.0074402
+          "bias": -0.00074348,
+          "spread": 0.007403,
+          "score": 0.00744024
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00041465,
+          "bias": -0.00041474,
           "spread": 0.00773403,
           "score": 0.00774514
         }
       ]
     },
     "toggle": {
-      "recorded_utc": "2026-07-05T08:20:02Z",
-      "git_commit": "33bfc23-dirty",
+      "recorded_utc": "2026-07-08T10:59:12Z",
+      "git_commit": "f51b3c7-dirty",
       "n_replicates": 4,
       "seed": 0,
       "campaign_months": [
+        1,
+        2,
         3,
         6,
-        9,
         12
       ],
       "profiles": [
@@ -4580,6 +7607,438 @@
         "ws_dependent_cp"
       ],
       "cells": [
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 1,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": -0.00555753,
+          "spread": 0.0049139,
+          "score": 0.00741839
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": -0.00509133,
+          "spread": 0.00949189,
+          "score": 0.01077115
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": -0.00605522,
+          "spread": 0.00220942,
+          "score": 0.00644572
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00448935,
+          "spread": 0.00670135,
+          "score": 0.00806613
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.00518133,
+          "spread": 0.00719976,
+          "score": 0.00887033
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.00658246,
+          "spread": 0.00347602,
+          "score": 0.00744389
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.01029842,
+          "spread": 0.07127109,
+          "score": 0.07201129
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.14429928,
+          "spread": 0.22636582,
+          "score": 0.26844695
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.23215758,
+          "spread": 0.40645511,
+          "score": 0.46808428
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.29536802,
+          "spread": 0.38475878,
+          "score": 0.48505833
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.00661834,
+          "spread": 0.05585655,
+          "score": 0.05624728
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": -0.00663346,
+          "spread": 0.00959552,
+          "score": 0.0116652
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": -0.00073169,
+          "spread": 0.0107749,
+          "score": 0.01079971
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.00220669,
+          "spread": 0.00522144,
+          "score": 0.00566859
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": -0.00356761,
+          "spread": 0.0078895,
+          "score": 0.00865864
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00320788,
+          "spread": 0.00117319,
+          "score": 0.00341568
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.00523006,
+          "spread": 0.06325307,
+          "score": 0.06346892
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": -0.00629793,
+          "spread": 0.0,
+          "score": 0.00629793
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.00589874,
+          "spread": 0.01805582,
+          "score": 0.01899494
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.00786014,
+          "spread": 0.00724109,
+          "score": 0.01068715
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": -0.00550996,
+          "spread": 0.00431304,
+          "score": 0.00699728
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": -0.0016784,
+          "spread": 0.00298799,
+          "score": 0.00342712
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.00222455,
+          "spread": 0.01907832,
+          "score": 0.01920758
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": -0.00449782,
+          "spread": 0.00206624,
+          "score": 0.00494972
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00180734,
+          "spread": 0.00484962,
+          "score": 0.00517545
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.00311337,
+          "spread": 0.00702126,
+          "score": 0.00768057
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.00644985,
+          "spread": 0.00719724,
+          "score": 0.00966441
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.02503136,
+          "spread": 0.07486573,
+          "score": 0.07893951
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.04217336,
+          "spread": 0.22857979,
+          "score": 0.23243776
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.30079678,
+          "spread": 0.32030128,
+          "score": 0.43939915
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": 0.05140267,
+          "spread": 0.37460422,
+          "score": 0.37811447
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.0199316,
+          "spread": 0.01841845,
+          "score": 0.02713868
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": -0.0037717,
+          "spread": 0.00290538,
+          "score": 0.00476098
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": -0.00157949,
+          "spread": 0.00471946,
+          "score": 0.00497675
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": -0.0028081,
+          "spread": 0.00398713,
+          "score": 0.00487674
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": -0.00063397,
+          "spread": 0.00553577,
+          "score": 0.00557195
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00061662,
+          "spread": 0.01156135,
+          "score": 0.01157778
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": 0.00714518,
+          "spread": 0.05440152,
+          "score": 0.05486874
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": -0.00440809,
+          "spread": 0.0,
+          "score": 0.00440809
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.00580844,
+          "spread": 0.0,
+          "score": 0.00580844
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": 8.553e-05,
+          "spread": 0.01212608,
+          "score": 0.01212638
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.00088822,
+          "spread": 0.00466543,
+          "score": 0.00474923
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": -0.00024438,
+          "spread": 0.00236303,
+          "score": 0.00237563
+        },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
@@ -5014,227 +8473,11 @@
         },
         {
           "profile": "cp_0pct",
-          "campaign_months": 9,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.00076519,
-          "spread": 0.00279324,
-          "score": 0.00289615
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": 0.08700524,
-          "spread": 0.01037138,
-          "score": 0.08762121
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00104701,
-          "spread": 0.00423635,
-          "score": 0.00436381
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00145985,
-          "spread": 0.00277866,
-          "score": 0.00313881
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00084609,
-          "spread": 0.00257963,
-          "score": 0.00271484
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": -0.0017636,
-          "spread": 0.00289309,
-          "score": 0.00338825
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00492404,
-          "spread": 0.00835874,
-          "score": 0.00970128
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00555471,
-          "spread": 0.02314068,
-          "score": 0.02379802
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": 0.01107666,
-          "spread": 0.02481938,
-          "score": 0.02717892
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.01043854,
-          "spread": 0.27629086,
-          "score": 0.27648798
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": 0.26822577,
-          "spread": 0.36399723,
-          "score": 0.45214936
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.0143889,
-          "spread": 0.03240219,
-          "score": 0.03545338
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00131854,
-          "spread": 0.00287343,
-          "score": 0.00316151
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00070992,
-          "spread": 0.00221616,
-          "score": 0.00232709
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00058179,
-          "spread": 0.00212118,
-          "score": 0.00219952
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00018758,
-          "spread": 0.00204117,
-          "score": 0.00204977
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00402861,
-          "spread": 0.00900654,
-          "score": 0.00986648
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": 0.00381543,
-          "spread": 0.02381025,
-          "score": 0.02411401
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": 0.0038415,
-          "spread": 0.00711939,
-          "score": 0.00808968
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": -0.01762448,
-          "spread": 0.02640993,
-          "score": 0.0317507
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00017347,
-          "spread": 0.00424901,
-          "score": 0.00425254
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00121349,
-          "spread": 0.00316232,
-          "score": 0.00338716
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00258283,
-          "spread": 0.00488749,
-          "score": 0.00552798
-        },
-        {
-          "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00078617,
-          "spread": 0.00171221,
+          "bias": 0.00078615,
+          "spread": 0.00171222,
           "score": 0.00188407
         },
         {
@@ -5242,18 +8485,18 @@
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.07831269,
-          "spread": 0.02979286,
-          "score": 0.08378837
+          "bias": 0.07831262,
+          "spread": 0.02979285,
+          "score": 0.08378831
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00209482,
-          "spread": 0.0043012,
-          "score": 0.0047842
+          "bias": 0.00209479,
+          "spread": 0.00430119,
+          "score": 0.00478418
         },
         {
           "profile": "cp_0pct",
@@ -5261,7 +8504,7 @@
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
           "bias": 0.00099067,
-          "spread": 0.00155432,
+          "spread": 0.00155433,
           "score": 0.00184319
         },
         {
@@ -5269,70 +8512,70 @@
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00035736,
-          "spread": 0.00130429,
-          "score": 0.00135236
+          "bias": 0.00035735,
+          "spread": 0.0013043,
+          "score": 0.00135237
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00053255,
-          "spread": 0.00273946,
-          "score": 0.00279074
+          "bias": 0.00053252,
+          "spread": 0.00273944,
+          "score": 0.00279072
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00538842,
-          "spread": 0.00736278,
-          "score": 0.00912391
+          "bias": 0.00538839,
+          "spread": 0.00736277,
+          "score": 0.00912388
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00380891,
-          "spread": 0.02999745,
-          "score": 0.0302383
+          "bias": -0.00380894,
+          "spread": 0.02999743,
+          "score": 0.03023829
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.0134172,
-          "spread": 0.02004434,
-          "score": 0.02412046
+          "bias": -0.01341723,
+          "spread": 0.02004433,
+          "score": 0.02412047
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.03431052,
-          "spread": 0.23056266,
-          "score": 0.2331016
+          "bias": 0.0343105,
+          "spread": 0.23056268,
+          "score": 0.23310161
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.20263182,
-          "spread": 0.11296621,
-          "score": 0.23199358
+          "bias": -0.20263185,
+          "spread": 0.11296624,
+          "score": 0.23199361
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.00668409,
+          "bias": -0.00668412,
           "spread": 0.03875468,
           "score": 0.03932687
         },
@@ -5341,8 +8584,8 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00011123,
-          "spread": 0.00244911,
+          "bias": -0.00011126,
+          "spread": 0.0024491,
           "score": 0.00245163
         },
         {
@@ -5350,34 +8593,34 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00128149,
-          "spread": 0.00061767,
-          "score": 0.00142258
+          "bias": 0.00128147,
+          "spread": 0.00061764,
+          "score": 0.00142255
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00052731,
-          "spread": 0.00142074,
-          "score": 0.00151544
+          "bias": -0.00052734,
+          "spread": 0.00142072,
+          "score": 0.00151543
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00050808,
-          "spread": 0.00099167,
-          "score": 0.00111425
+          "bias": 0.00050805,
+          "spread": 0.00099164,
+          "score": 0.00111421
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": -0.00027697,
+          "bias": -0.000277,
           "spread": 0.00148437,
           "score": 0.00150999
         },
@@ -5386,17 +8629,17 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.0020083,
-          "spread": 0.02149184,
-          "score": 0.02158547
+          "bias": 0.00200827,
+          "spread": 0.02149181,
+          "score": 0.02158543
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.0031546,
-          "spread": 0.00438809,
+          "bias": -0.00315463,
+          "spread": 0.00438806,
           "score": 0.00540433
         },
         {
@@ -5404,27 +8647,27 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.03198219,
-          "spread": 0.02570082,
-          "score": 0.04102917
+          "bias": -0.03198222,
+          "spread": 0.02570081,
+          "score": 0.04102918
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
-          "bias": 0.02038782,
+          "bias": 0.02038776,
           "spread": 0.0,
-          "score": 0.02038782
+          "score": 0.02038776
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00141513,
-          "spread": 0.006173,
-          "score": 0.00633313
+          "bias": 0.00141521,
+          "spread": 0.00617305,
+          "score": 0.00633319
         },
         {
           "profile": "cp_0pct",
@@ -5432,17 +8675,449 @@
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
           "bias": 0.00289648,
-          "spread": 0.00315903,
-          "score": 0.00428591
+          "spread": 0.00315906,
+          "score": 0.00428594
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00052857,
-          "spread": 0.00311891,
+          "bias": 0.00052854,
+          "spread": 0.00311892,
           "score": 0.00316338
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 1,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": -0.00507537,
+          "spread": 0.00450642,
+          "score": 0.00678728
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": -0.00458179,
+          "spread": 0.01208169,
+          "score": 0.01292131
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": -0.00696713,
+          "spread": 0.00113154,
+          "score": 0.00705842
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00451897,
+          "spread": 0.0074423,
+          "score": 0.00870683
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.00209336,
+          "spread": 0.00676273,
+          "score": 0.00707931
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.00396311,
+          "spread": 0.00426413,
+          "score": 0.00582143
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.00478863,
+          "spread": 0.06613287,
+          "score": 0.06630601
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.12895112,
+          "spread": 0.21253894,
+          "score": 0.24859845
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.26504957,
+          "spread": 0.40098168,
+          "score": 0.48066369
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.04863576,
+          "spread": 0.02941132,
+          "score": 0.05683716
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.0043147,
+          "spread": 0.05464579,
+          "score": 0.05481587
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": -0.00303984,
+          "spread": 0.01045199,
+          "score": 0.01088507
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": -0.00691839,
+          "spread": 0.01125852,
+          "score": 0.01321433
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": -9.154e-05,
+          "spread": 0.00487046,
+          "score": 0.00487132
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": -0.00429368,
+          "spread": 0.00733807,
+          "score": 0.00850194
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00294149,
+          "spread": 0.00872345,
+          "score": 0.00920603
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": 0.03493627,
+          "spread": 0.06733673,
+          "score": 0.07586026
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": -0.00574933,
+          "spread": 0.0,
+          "score": 0.00574933
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.00507968,
+          "spread": 0.0174465,
+          "score": 0.01817096
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.00835538,
+          "spread": 0.00734898,
+          "score": 0.01112744
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": -0.00328646,
+          "spread": 0.00430015,
+          "score": 0.00541221
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": -0.00149097,
+          "spread": 0.00276259,
+          "score": 0.00313925
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.00376055,
+          "spread": 0.01645331,
+          "score": 0.01687759
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": -0.00572267,
+          "spread": 0.00224942,
+          "score": 0.00614889
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00143494,
+          "spread": 0.0052795,
+          "score": 0.00547103
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": 4.965e-05,
+          "spread": 0.00676449,
+          "score": 0.00676467
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.00200042,
+          "spread": 0.00639856,
+          "score": 0.00670397
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.01522701,
+          "spread": 0.0619364,
+          "score": 0.06378072
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.05657401,
+          "spread": 0.20512354,
+          "score": 0.21278225
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.08252149,
+          "spread": 0.26689303,
+          "score": 0.27935942
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.04379994,
+          "spread": 0.22422209,
+          "score": 0.22846002
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.02572446,
+          "spread": 0.0244801,
+          "score": 0.03551089
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": -0.00119478,
+          "spread": 0.004154,
+          "score": 0.00432241
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": -0.00619912,
+          "spread": 0.00523037,
+          "score": 0.00811085
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": -0.00438728,
+          "spread": 0.00436843,
+          "score": 0.00619124
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": -0.0011148,
+          "spread": 0.00550049,
+          "score": 0.00561232
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.0014959,
+          "spread": 0.01452675,
+          "score": 0.01460357
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": 0.02448306,
+          "spread": 0.0523514,
+          "score": 0.0577935
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": -0.00493396,
+          "spread": 0.0,
+          "score": 0.00493396
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.00957387,
+          "spread": 0.0,
+          "score": 0.00957387
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": 0.0003374,
+          "spread": 0.01209215,
+          "score": 0.01209685
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.00120376,
+          "spread": 0.00476461,
+          "score": 0.00491432
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00110267,
+          "spread": 0.00238917,
+          "score": 0.00263135
         },
         {
           "profile": "cp_minus_10pct",
@@ -5878,228 +9553,12 @@
         },
         {
           "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.0007924,
-          "spread": 0.00261258,
-          "score": 0.00273011
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": 0.06544886,
-          "spread": 0.00676483,
-          "score": 0.06579754
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": 0.0005364,
-          "spread": 0.00466851,
-          "score": 0.00469922
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00068757,
-          "spread": 0.00243907,
-          "score": 0.00253414
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00069111,
-          "spread": 0.00238129,
-          "score": 0.00247955
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00018659,
-          "spread": 0.00257796,
-          "score": 0.0025847
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00717613,
-          "spread": 0.00820852,
-          "score": 0.01090305
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00065595,
-          "spread": 0.01946331,
-          "score": 0.01947436
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": 0.02145622,
-          "spread": 0.02090095,
-          "score": 0.02995362
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.0491184,
-          "spread": 0.21793187,
-          "score": 0.22339856
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": -0.35598913,
-          "spread": 0.25916269,
-          "score": 0.44033347
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.00813598,
-          "spread": 0.03044753,
-          "score": 0.03151581
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00210903,
-          "spread": 0.00229882,
-          "score": 0.00311971
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00367401,
-          "spread": 0.00222467,
-          "score": 0.00429506
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00208415,
-          "spread": 0.00215068,
-          "score": 0.00299484
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00059651,
-          "spread": 0.00226658,
-          "score": 0.00234376
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.0051556,
-          "spread": 0.00999449,
-          "score": 0.01124588
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": 0.03346643,
-          "spread": 0.0389391,
-          "score": 0.05134448
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00762431,
-          "spread": 0.00933741,
-          "score": 0.01205476
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": -0.00644257,
-          "spread": 0.02636901,
-          "score": 0.02714464
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00012693,
-          "spread": 0.00403576,
-          "score": 0.00403776
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00099063,
-          "spread": 0.00275645,
-          "score": 0.00292906
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00326102,
-          "spread": 0.00449867,
-          "score": 0.00555629
-        },
-        {
-          "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00081861,
-          "spread": 0.00161825,
-          "score": 0.00181352
+          "bias": 0.00081857,
+          "spread": 0.00161829,
+          "score": 0.00181354
         },
         {
           "profile": "cp_minus_10pct",
@@ -6115,44 +9574,44 @@
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00119452,
-          "spread": 0.00479995,
-          "score": 0.00494635
+          "bias": 0.00119447,
+          "spread": 0.0048,
+          "score": 0.00494639
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 2.444e-05,
-          "spread": 0.00144278,
-          "score": 0.00144299
+          "bias": 2.439e-05,
+          "spread": 0.00144281,
+          "score": 0.00144302
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00037872,
-          "spread": 0.00123507,
-          "score": 0.00129183
+          "bias": 0.00037867,
+          "spread": 0.00123513,
+          "score": 0.00129187
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00244845,
-          "spread": 0.00249289,
-          "score": 0.0034942
+          "bias": 0.00244841,
+          "spread": 0.00249292,
+          "score": 0.00349419
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00898839,
-          "spread": 0.00744592,
+          "bias": 0.00898835,
+          "spread": 0.00744597,
           "score": 0.01167189
         },
         {
@@ -6160,98 +9619,98 @@
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00017725,
-          "spread": 0.02487833,
-          "score": 0.02487896
+          "bias": -0.0001773,
+          "spread": 0.02487834,
+          "score": 0.02487897
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.00505692,
+          "bias": -0.00505697,
           "spread": 0.02017899,
-          "score": 0.02080299
+          "score": 0.020803
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.03445755,
-          "spread": 0.20138378,
-          "score": 0.20431043
+          "bias": 0.03445751,
+          "spread": 0.20138376,
+          "score": 0.20431039
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.06860186,
+          "bias": -0.06860189,
           "spread": 0.0,
-          "score": 0.06860186
+          "score": 0.06860189
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.00178255,
-          "spread": 0.04356006,
-          "score": 0.04359652
+          "bias": -0.0017826,
+          "spread": 0.04356004,
+          "score": 0.0435965
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00312947,
-          "spread": 0.00191108,
-          "score": 0.00366686
+          "bias": 0.00312943,
+          "spread": 0.00191113,
+          "score": 0.00366684
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00276741,
-          "spread": 0.00069762,
-          "score": 0.00285399
+          "bias": -0.00276746,
+          "spread": 0.00069767,
+          "score": 0.00285405
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00198071,
-          "spread": 0.00130935,
-          "score": 0.00237437
+          "bias": -0.00198076,
+          "spread": 0.0013094,
+          "score": 0.00237444
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 2.284e-05,
-          "spread": 0.00109236,
-          "score": 0.0010926
+          "bias": 2.279e-05,
+          "spread": 0.00109242,
+          "score": 0.00109266
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00108919,
-          "spread": 0.00036964,
-          "score": 0.0011502
+          "bias": 0.00108914,
+          "spread": 0.00036957,
+          "score": 0.00115013
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.02599076,
-          "spread": 0.03790023,
+          "bias": 0.02599072,
+          "spread": 0.03790027,
           "score": 0.04595593
         },
         {
@@ -6259,18 +9718,18 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00044834,
-          "spread": 0.00358476,
-          "score": 0.00361268
+          "bias": 0.00044829,
+          "spread": 0.00358478,
+          "score": 0.0036127
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.0263721,
-          "spread": 0.02871327,
-          "score": 0.0389864
+          "bias": -0.02637215,
+          "spread": 0.02871326,
+          "score": 0.03898643
         },
         {
           "profile": "cp_minus_10pct",
@@ -6286,17 +9745,17 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00210144,
+          "bias": 0.00210139,
           "spread": 0.00513798,
-          "score": 0.00555111
+          "score": 0.0055511
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00229187,
-          "spread": 0.00321284,
+          "bias": 0.00229183,
+          "spread": 0.00321287,
           "score": 0.00394652
         },
         {
@@ -6304,9 +9763,441 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00156458,
-          "spread": 0.00304276,
-          "score": 0.00342145
+          "bias": 0.00156454,
+          "spread": 0.00304278,
+          "score": 0.00342144
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 1,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": -0.00603945,
+          "spread": 0.0053219,
+          "score": 0.00804969
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": -0.00453944,
+          "spread": 0.00686085,
+          "score": 0.00822665
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": -0.00536383,
+          "spread": 0.00421859,
+          "score": 0.00682401
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00429296,
+          "spread": 0.00598677,
+          "score": 0.00736688
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.00878083,
+          "spread": 0.00713775,
+          "score": 0.01131594
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.01040733,
+          "spread": 0.00507531,
+          "score": 0.01157891
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.0131959,
+          "spread": 0.0850221,
+          "score": 0.08604005
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.17551965,
+          "spread": 0.24308664,
+          "score": 0.29983039
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 1.26025254,
+          "spread": 1.84236851,
+          "score": 2.23216446
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -2.91593074,
+          "spread": 4.12739604,
+          "score": 5.05351859
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.01791275,
+          "spread": 0.06746081,
+          "score": 0.06979848
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": -0.00962474,
+          "spread": 0.00942968,
+          "score": 0.01347421
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00476144,
+          "spread": 0.01107514,
+          "score": 0.01205529
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.00456462,
+          "spread": 0.0059278,
+          "score": 0.00748161
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": -0.00251072,
+          "spread": 0.00685124,
+          "score": 0.0072968
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00105941,
+          "spread": 0.00389035,
+          "score": 0.00403202
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.04383688,
+          "spread": 0.08659218,
+          "score": 0.09705605
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": -0.00560666,
+          "spread": 0.0,
+          "score": 0.00560666
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.00693831,
+          "spread": 0.01801095,
+          "score": 0.01930115
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.00883292,
+          "spread": 0.00755146,
+          "score": 0.01162089
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": -0.00731603,
+          "spread": 0.00430004,
+          "score": 0.00848614
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 2,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": -0.00186561,
+          "spread": 0.00321354,
+          "score": 0.00371582
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.00197182,
+          "spread": 0.02381472,
+          "score": 0.02389621
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": -0.0028873,
+          "spread": 0.00208502,
+          "score": 0.00356143
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00187406,
+          "spread": 0.00457552,
+          "score": 0.00494444
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.00650843,
+          "spread": 0.00673874,
+          "score": 0.00936858
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.0104353,
+          "spread": 0.00889878,
+          "score": 0.01371437
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.03464331,
+          "spread": 0.08664268,
+          "score": 0.09331192
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.02918466,
+          "spread": 0.25476535,
+          "score": 0.25643153
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.33040884,
+          "spread": 0.40606742,
+          "score": 0.52350812
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": 0.04702915,
+          "spread": 0.32527225,
+          "score": 0.32865449
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.01693868,
+          "spread": 0.02559784,
+          "score": 0.03069475
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": -0.00683909,
+          "spread": 0.00292067,
+          "score": 0.00743663
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00298853,
+          "spread": 0.00494002,
+          "score": 0.00577365
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": -0.00111962,
+          "spread": 0.00397369,
+          "score": 0.00412841
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 8.32e-06,
+          "spread": 0.0058614,
+          "score": 0.00586141
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": -0.00035954,
+          "spread": 0.00791812,
+          "score": 0.00792628
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.0085638,
+          "spread": 0.05962748,
+          "score": 0.06023932
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": -0.00288071,
+          "spread": 0.0,
+          "score": 0.00288071
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.02110577,
+          "spread": 0.0,
+          "score": 0.02110577
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": 0.00079148,
+          "spread": 0.01382986,
+          "score": 0.01385249
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.00098448,
+          "spread": 0.00511739,
+          "score": 0.00521122
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": -0.00157167,
+          "spread": 0.0026789,
+          "score": 0.00310591
         },
         {
           "profile": "cp_plus_10pct",
@@ -6742,226 +10633,10 @@
         },
         {
           "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.00073792,
-          "spread": 0.00297386,
-          "score": 0.00306404
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": 0.07781408,
-          "spread": 0.00498109,
-          "score": 0.07797334
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00165879,
-          "spread": 0.00379689,
-          "score": 0.00414343
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00223498,
-          "spread": 0.00317275,
-          "score": 0.00388092
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00115803,
-          "spread": 0.00311579,
-          "score": 0.00332403
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00422323,
-          "spread": 0.00316484,
-          "score": 0.00527749
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00170351,
-          "spread": 0.00888058,
-          "score": 0.00904249
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": -0.01229099,
-          "spread": 0.02339809,
-          "score": 0.0264299
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": 0.00429751,
-          "spread": 0.02885026,
-          "score": 0.02916858
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": -0.01638358,
-          "spread": 0.33492778,
-          "score": 0.33532826
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": 0.2969365,
-          "spread": 0.4237581,
-          "score": 0.51743813
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.01303369,
-          "spread": 0.03896137,
-          "score": 0.04108364
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00469619,
-          "spread": 0.00320688,
-          "score": 0.00568668
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00483803,
-          "spread": 0.00252381,
-          "score": 0.00545675
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00047151,
-          "spread": 0.0021991,
-          "score": 0.00224908
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00013014,
-          "spread": 0.00208495,
-          "score": 0.00208901
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00242997,
-          "spread": 0.00812585,
-          "score": 0.00848141
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": -0.0277659,
-          "spread": 0.03842883,
-          "score": 0.04741013
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": 7.34e-06,
-          "spread": 0.00771328,
-          "score": 0.00771328
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": -0.02838281,
-          "spread": 0.02692825,
-          "score": 0.03912435
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00100537,
-          "spread": 0.00457801,
-          "score": 0.0046871
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00188558,
-          "spread": 0.00324053,
-          "score": 0.00374919
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00170412,
-          "spread": 0.00539967,
-          "score": 0.0056622
-        },
-        {
-          "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00075373,
+          "bias": 0.00075374,
           "spread": 0.00180637,
           "score": 0.00195732
         },
@@ -6979,16 +10654,16 @@
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00227427,
-          "spread": 0.00409982,
-          "score": 0.00468837
+          "bias": 0.00227428,
+          "spread": 0.00409983,
+          "score": 0.00468839
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.0018849,
+          "bias": 0.00188491,
           "spread": 0.00165108,
           "score": 0.00250578
         },
@@ -6997,8 +10672,8 @@
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.0003912,
-          "spread": 0.00170094,
+          "bias": 0.00039121,
+          "spread": 0.00170095,
           "score": 0.00174535
         },
         {
@@ -7006,34 +10681,34 @@
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00137031,
-          "spread": 0.00343365,
-          "score": 0.00369699
+          "bias": -0.0013703,
+          "spread": 0.00343364,
+          "score": 0.00369697
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00179674,
-          "spread": 0.00734262,
-          "score": 0.00755925
+          "bias": 0.00179675,
+          "spread": 0.00734263,
+          "score": 0.00755926
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.01015078,
-          "spread": 0.03415321,
-          "score": 0.03562977
+          "bias": -0.01015077,
+          "spread": 0.0341532,
+          "score": 0.03562975
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.02119489,
+          "bias": -0.02119488,
           "spread": 0.02326699,
           "score": 0.03147342
         },
@@ -7042,17 +10717,17 @@
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.02150366,
-          "spread": 0.26320636,
-          "score": 0.26408331
+          "bias": 0.02150368,
+          "spread": 0.26320638,
+          "score": 0.26408333
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.77346515,
-          "spread": 0.90620745,
+          "bias": 0.77346517,
+          "spread": 0.90620743,
           "score": 1.19141104
         },
         {
@@ -7060,17 +10735,17 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.01455584,
-          "spread": 0.04313903,
-          "score": 0.04552854
+          "bias": -0.01455583,
+          "spread": 0.04313902,
+          "score": 0.04552853
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00361535,
-          "spread": 0.00289619,
+          "bias": -0.00361534,
+          "spread": 0.0028962,
           "score": 0.00463235
         },
         {
@@ -7078,25 +10753,25 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00528188,
+          "bias": 0.00528189,
           "spread": 0.00088154,
-          "score": 0.00535493
+          "score": 0.00535495
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.0006447,
+          "bias": 0.00064471,
           "spread": 0.00135378,
-          "score": 0.00149945
+          "score": 0.00149946
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00088544,
+          "bias": 0.00088545,
           "spread": 0.00096523,
           "score": 0.00130984
         },
@@ -7105,7 +10780,7 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": -0.00197784,
+          "bias": -0.00197783,
           "spread": 0.00308094,
           "score": 0.00366115
         },
@@ -7114,27 +10789,27 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.0252097,
+          "bias": -0.02520969,
           "spread": 0.02164986,
-          "score": 0.03323019
+          "score": 0.03323018
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00680667,
-          "spread": 0.00617068,
-          "score": 0.00918738
+          "bias": -0.00680666,
+          "spread": 0.00617067,
+          "score": 0.00918737
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.03680593,
+          "bias": -0.03680592,
           "spread": 0.02464448,
-          "score": 0.04429477
+          "score": 0.04429476
         },
         {
           "profile": "cp_plus_10pct",
@@ -7150,17 +10825,17 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.0012508,
-          "spread": 0.00669381,
-          "score": 0.00680967
+          "bias": 0.00125081,
+          "spread": 0.00669379,
+          "score": 0.00680965
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.0033774,
-          "spread": 0.00324755,
+          "bias": 0.00337741,
+          "spread": 0.00324754,
           "score": 0.00468545
         },
         {
@@ -7168,9 +10843,441 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00061187,
+          "bias": -0.00061186,
           "spread": 0.00287815,
           "score": 0.00294247
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": -0.00570211,
+          "spread": 0.00503629,
+          "score": 0.00760777
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": -0.00388478,
+          "spread": 0.00787649,
+          "score": 0.0087824
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": -0.00581038,
+          "spread": 0.00268957,
+          "score": 0.00640268
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00448447,
+          "spread": 0.0065603,
+          "score": 0.00794657
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.00626258,
+          "spread": 0.00719599,
+          "score": 0.00953951
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.00759763,
+          "spread": 0.00412997,
+          "score": 0.00864758
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.00642761,
+          "spread": 0.08226577,
+          "score": 0.08251649
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.15985813,
+          "spread": 0.23398867,
+          "score": 0.28338193
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.26152843,
+          "spread": 0.42571451,
+          "score": 0.49962983
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -1.0684495,
+          "spread": 1.49196575,
+          "score": 1.8350875
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.01515132,
+          "spread": 0.06921116,
+          "score": 0.07085018
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": -0.00763939,
+          "spread": 0.00923419,
+          "score": 0.0119846
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00128503,
+          "spread": 0.01081719,
+          "score": 0.01089325
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.00330248,
+          "spread": 0.00577679,
+          "score": 0.00665415
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": -0.00276354,
+          "spread": 0.00727375,
+          "score": 0.00778104
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00261335,
+          "spread": 0.00085011,
+          "score": 0.00274814
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.01485464,
+          "spread": 0.06246199,
+          "score": 0.06420406
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": -0.00503732,
+          "spread": 0.0,
+          "score": 0.00503732
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.00574753,
+          "spread": 0.01901972,
+          "score": 0.01986917
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.00848166,
+          "spread": 0.00723494,
+          "score": 0.01114823
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": -0.00594363,
+          "spread": 0.00480112,
+          "score": 0.00764052
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 2,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": -0.00173431,
+          "spread": 0.00305527,
+          "score": 0.00351319
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.00295872,
+          "spread": 0.02005425,
+          "score": 0.02027133
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": -0.00404975,
+          "spread": 0.00214715,
+          "score": 0.00458375
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00186459,
+          "spread": 0.00499541,
+          "score": 0.00533206
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.00413646,
+          "spread": 0.00644246,
+          "score": 0.00765608
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.0071511,
+          "spread": 0.00716441,
+          "score": 0.0101226
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.03031155,
+          "spread": 0.07825567,
+          "score": 0.08392104
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.02914814,
+          "spread": 0.22638355,
+          "score": 0.22825233
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.31056291,
+          "spread": 0.34680314,
+          "score": 0.46553382
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": 0.10424474,
+          "spread": 0.37725177,
+          "score": 0.39138965
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.02076899,
+          "spread": 0.01918017,
+          "score": 0.02827065
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": -0.00461745,
+          "spread": 0.00293368,
+          "score": 0.00547058
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": -0.00040345,
+          "spread": 0.00484266,
+          "score": 0.00485944
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": -0.00221791,
+          "spread": 0.00430633,
+          "score": 0.00484392
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": -0.00040391,
+          "spread": 0.00592683,
+          "score": 0.00594058
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00033374,
+          "spread": 0.01056425,
+          "score": 0.01056952
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": 0.00120466,
+          "spread": 0.05429447,
+          "score": 0.05430783
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": -0.00428404,
+          "spread": 0.0,
+          "score": 0.00428404
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.00931438,
+          "spread": 0.0,
+          "score": 0.00931438
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": 0.00071993,
+          "spread": 0.01216039,
+          "score": 0.01218168
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.00109043,
+          "spread": 0.00467808,
+          "score": 0.00480348
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": -0.00058375,
+          "spread": 0.0020419,
+          "score": 0.00212371
         },
         {
           "profile": "cp_plus_3pct",
@@ -7606,228 +11713,12 @@
         },
         {
           "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.00075699,
-          "spread": 0.00284739,
-          "score": 0.00294629
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": 0.09442401,
-          "spread": 0.01683837,
-          "score": 0.09591363
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00114377,
-          "spread": 0.00417397,
-          "score": 0.00432785
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00168025,
-          "spread": 0.0029147,
-          "score": 0.00336433
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00098287,
-          "spread": 0.00273102,
-          "score": 0.00290249
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00248616,
-          "spread": 0.00285948,
-          "score": 0.00378914
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00388422,
-          "spread": 0.00813049,
-          "score": 0.00901066
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00820976,
-          "spread": 0.02254009,
-          "score": 0.02398867
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": 0.00822812,
-          "spread": 0.02520648,
-          "score": 0.02651544
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.00620087,
-          "spread": 0.29265407,
-          "score": 0.29271976
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": 0.30066216,
-          "spread": 0.40766802,
-          "score": 0.50654807
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.01189656,
-          "spread": 0.03274276,
-          "score": 0.034837
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00235126,
-          "spread": 0.00302256,
-          "score": 0.0038294
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00186325,
-          "spread": 0.00243671,
-          "score": 0.00306745
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00042449,
-          "spread": 0.00223491,
-          "score": 0.00227487
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": -5.637e-05,
-          "spread": 0.00215356,
-          "score": 0.00215429
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00361136,
-          "spread": 0.00885531,
-          "score": 0.00956339
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": -0.00810051,
-          "spread": 0.02407883,
-          "score": 0.02540489
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00280466,
-          "spread": 0.00709329,
-          "score": 0.00762764
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": -0.02079234,
-          "spread": 0.02680157,
-          "score": 0.03392117
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00018376,
-          "spread": 0.0041503,
-          "score": 0.00415437
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.0015378,
-          "spread": 0.00315782,
-          "score": 0.00351236
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00240433,
-          "spread": 0.00487367,
-          "score": 0.00543447
-        },
-        {
-          "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00077643,
-          "spread": 0.00174044,
-          "score": 0.00190578
+          "bias": 0.00077647,
+          "spread": 0.0017404,
+          "score": 0.00190575
         },
         {
           "profile": "cp_plus_3pct",
@@ -7843,17 +11734,17 @@
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00170183,
-          "spread": 0.00433604,
-          "score": 0.00465805
+          "bias": 0.00170187,
+          "spread": 0.00433597,
+          "score": 0.00465801
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00128931,
-          "spread": 0.00148056,
+          "bias": 0.00128935,
+          "spread": 0.00148052,
           "score": 0.00196325
         },
         {
@@ -7861,35 +11752,35 @@
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00035396,
-          "spread": 0.00141629,
-          "score": 0.00145985
+          "bias": 0.000354,
+          "spread": 0.00141626,
+          "score": 0.00145983
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -2.802e-05,
-          "spread": 0.00306253,
-          "score": 0.00306266
+          "bias": -2.798e-05,
+          "spread": 0.00306252,
+          "score": 0.00306264
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00431147,
-          "spread": 0.00737272,
-          "score": 0.00854083
+          "bias": 0.00431151,
+          "spread": 0.00737266,
+          "score": 0.0085408
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00585492,
-          "spread": 0.030817,
+          "bias": -0.00585488,
+          "spread": 0.03081701,
           "score": 0.03136826
         },
         {
@@ -7897,18 +11788,18 @@
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.01396428,
-          "spread": 0.01965486,
-          "score": 0.02411047
+          "bias": -0.01396424,
+          "spread": 0.01965485,
+          "score": 0.02411043
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.02625666,
-          "spread": 0.24310129,
-          "score": 0.24451513
+          "bias": 0.02625671,
+          "spread": 0.2431013,
+          "score": 0.24451514
         },
         {
           "profile": "cp_plus_3pct",
@@ -7924,81 +11815,81 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.01024876,
-          "spread": 0.04817705,
-          "score": 0.04925511
+          "bias": -0.01024872,
+          "spread": 0.04817709,
+          "score": 0.04925514
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00121734,
-          "spread": 0.00252937,
-          "score": 0.00280707
+          "bias": -0.0012173,
+          "spread": 0.00252934,
+          "score": 0.00280702
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00253061,
-          "spread": 0.00074216,
-          "score": 0.00263719
+          "bias": 0.00253065,
+          "spread": 0.00074209,
+          "score": 0.00263721
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00020421,
-          "spread": 0.0014321,
-          "score": 0.00144659
+          "bias": -0.00020417,
+          "spread": 0.00143204,
+          "score": 0.00144653
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00064157,
-          "spread": 0.00097859,
-          "score": 0.00117015
+          "bias": 0.00064161,
+          "spread": 0.00097853,
+          "score": 0.00117012
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": -0.00086849,
-          "spread": 0.00197567,
-          "score": 0.00215814
+          "bias": -0.00086845,
+          "spread": 0.00197569,
+          "score": 0.00215813
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.00410751,
-          "spread": 0.01886469,
-          "score": 0.01930668
+          "bias": -0.00410747,
+          "spread": 0.01886466,
+          "score": 0.01930664
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00402044,
-          "spread": 0.00475333,
-          "score": 0.00622559
+          "bias": -0.0040204,
+          "spread": 0.00475331,
+          "score": 0.00622556
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.0338612,
+          "bias": -0.03386116,
           "spread": 0.02604368,
-          "score": 0.04271832
+          "score": 0.04271829
         },
         {
           "profile": "cp_plus_3pct",
@@ -8014,27 +11905,459 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00135423,
-          "spread": 0.0061148,
-          "score": 0.00626296
+          "bias": 0.00135427,
+          "spread": 0.00611482,
+          "score": 0.00626299
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00322895,
-          "spread": 0.00315872,
-          "score": 0.00451704
+          "bias": 0.003229,
+          "spread": 0.0031587,
+          "score": 0.00451705
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00010538,
-          "spread": 0.00310046,
-          "score": 0.00310225
+          "bias": 0.00010542,
+          "spread": 0.00310044,
+          "score": 0.00310223
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": -0.00561522,
+          "spread": 0.00496745,
+          "score": 0.00749708
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": -0.00432504,
+          "spread": 0.01141142,
+          "score": 0.01220354
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": -0.00689908,
+          "spread": 0.00196207,
+          "score": 0.00717266
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.0047417,
+          "spread": 0.00722937,
+          "score": 0.00864566
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.00389069,
+          "spread": 0.0076059,
+          "score": 0.00854325
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.00498572,
+          "spread": 0.00263476,
+          "score": 0.00563909
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.00776772,
+          "spread": 0.0771651,
+          "score": 0.07755507
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.14396969,
+          "spread": 0.22193123,
+          "score": 0.26453873
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.26097038,
+          "spread": 0.46242392,
+          "score": 0.53098157
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.27985229,
+          "spread": 0.39453585,
+          "score": 0.48371049
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.0058981,
+          "spread": 0.06274981,
+          "score": 0.06302639
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": -0.00492633,
+          "spread": 0.01052616,
+          "score": 0.01162191
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": -0.00407622,
+          "spread": 0.01192756,
+          "score": 0.01260485
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.00116569,
+          "spread": 0.00522633,
+          "score": 0.00535476
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": -0.00438865,
+          "spread": 0.00834688,
+          "score": 0.0094303
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00303835,
+          "spread": 0.00505707,
+          "score": 0.00589962
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.00468307,
+          "spread": 0.06268184,
+          "score": 0.06285654
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": -0.00663879,
+          "spread": 0.0,
+          "score": 0.00663879
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.00507972,
+          "spread": 0.01924257,
+          "score": 0.01990176
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.00890163,
+          "spread": 0.00747427,
+          "score": 0.01162342
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": -0.00464261,
+          "spread": 0.0044183,
+          "score": 0.00640899
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": -0.00169321,
+          "spread": 0.00302697,
+          "score": 0.00346835
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.00328968,
+          "spread": 0.0163541,
+          "score": 0.01668169
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": -0.00545001,
+          "spread": 0.00262375,
+          "score": 0.00604869
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00180912,
+          "spread": 0.00547912,
+          "score": 0.00577007
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.00189893,
+          "spread": 0.00682124,
+          "score": 0.00708063
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.00472921,
+          "spread": 0.00700618,
+          "score": 0.00845293
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.02204476,
+          "spread": 0.07650097,
+          "score": 0.07961388
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.04746536,
+          "spread": 0.23891062,
+          "score": 0.24358006
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": -0.02991307,
+          "spread": 0.49378762,
+          "score": 0.49469284
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": 0.07486774,
+          "spread": 0.3448302,
+          "score": 0.35286406
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.02823505,
+          "spread": 0.02465757,
+          "score": 0.03748618
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": -0.00241671,
+          "spread": 0.00339606,
+          "score": 0.00416818
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": -0.00376338,
+          "spread": 0.00530929,
+          "score": 0.00650781
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": -0.00371849,
+          "spread": 0.00415635,
+          "score": 0.00557695
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": -0.00092845,
+          "spread": 0.00600219,
+          "score": 0.00607357
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.0008902,
+          "spread": 0.01348286,
+          "score": 0.01351222
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": 0.00823785,
+          "spread": 0.05646858,
+          "score": 0.0570663
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": -0.00546437,
+          "spread": 0.0,
+          "score": 0.00546437
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.00079073,
+          "spread": 0.0,
+          "score": 0.00079073
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.00019431,
+          "spread": 0.01248943,
+          "score": 0.01249094
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.00107104,
+          "spread": 0.00498723,
+          "score": 0.00510094
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00031731,
+          "spread": 0.00210996,
+          "score": 0.00213369
         },
         {
           "profile": "rated_plus_5pct",
@@ -8470,228 +12793,12 @@
         },
         {
           "profile": "rated_plus_5pct",
-          "campaign_months": 9,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.0007895,
-          "spread": 0.00283665,
-          "score": 0.00294447
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": 0.08417909,
-          "spread": 0.00798392,
-          "score": 0.08455686
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00086195,
-          "spread": 0.00457217,
-          "score": 0.00465271
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": 0.0011897,
-          "spread": 0.00264365,
-          "score": 0.00289901
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00094479,
-          "spread": 0.00258313,
-          "score": 0.00275049
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": -0.0011006,
-          "spread": 0.00290723,
-          "score": 0.00310859
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00531722,
-          "spread": 0.00838998,
-          "score": 0.009933
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00334889,
-          "spread": 0.02289583,
-          "score": 0.02313945
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": 0.01183945,
-          "spread": 0.02212078,
-          "score": 0.02508987
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.02457369,
-          "spread": 0.27307549,
-          "score": 0.27417894
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": 0.33991795,
-          "spread": 0.44371865,
-          "score": 0.55895479
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.01691618,
-          "spread": 0.03261349,
-          "score": 0.03673958
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00042193,
-          "spread": 0.00268214,
-          "score": 0.00271513
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": -0.001415,
-          "spread": 0.0022931,
-          "score": 0.00269454
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00135911,
-          "spread": 0.00224785,
-          "score": 0.00262678
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00022107,
-          "spread": 0.0024273,
-          "score": 0.00243735
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00463117,
-          "spread": 0.00996463,
-          "score": 0.01098824
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": 0.00539126,
-          "spread": 0.02424313,
-          "score": 0.02483536
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00571339,
-          "spread": 0.0080968,
-          "score": 0.00990964
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": -0.01363081,
-          "spread": 0.02735969,
-          "score": 0.03056716
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": -2.073e-05,
-          "spread": 0.00406952,
-          "score": 0.00406957
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00114877,
-          "spread": 0.00320451,
-          "score": 0.0034042
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00296187,
-          "spread": 0.00494231,
-          "score": 0.00576187
-        },
-        {
-          "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00082033,
-          "spread": 0.00174765,
-          "score": 0.0019306
+          "bias": 0.00082037,
+          "spread": 0.00174761,
+          "score": 0.00193058
         },
         {
           "profile": "rated_plus_5pct",
@@ -8707,35 +12814,35 @@
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00149287,
-          "spread": 0.00476778,
-          "score": 0.00499604
+          "bias": 0.00149291,
+          "spread": 0.00476772,
+          "score": 0.00499599
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00050642,
-          "spread": 0.00151976,
-          "score": 0.00160192
+          "bias": 0.00050647,
+          "spread": 0.00151973,
+          "score": 0.0016019
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00036154,
-          "spread": 0.00130918,
-          "score": 0.00135819
+          "bias": 0.00036158,
+          "spread": 0.00130913,
+          "score": 0.00135815
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.0017301,
-          "spread": 0.00281655,
+          "bias": 0.00173014,
+          "spread": 0.00281653,
           "score": 0.00330548
         },
         {
@@ -8743,36 +12850,36 @@
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00766295,
-          "spread": 0.00760188,
-          "score": 0.01079395
+          "bias": 0.00766299,
+          "spread": 0.00760181,
+          "score": 0.01079393
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00296762,
-          "spread": 0.02923635,
-          "score": 0.02938658
+          "bias": -0.00296758,
+          "spread": 0.02923636,
+          "score": 0.02938659
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.01009693,
-          "spread": 0.02083569,
-          "score": 0.02315327
+          "bias": -0.01009689,
+          "spread": 0.02083568,
+          "score": 0.02315325
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.03359286,
-          "spread": 0.23182322,
-          "score": 0.2342445
+          "bias": 0.0335929,
+          "spread": 0.23182323,
+          "score": 0.23424451
         },
         {
           "profile": "rated_plus_5pct",
@@ -8788,81 +12895,81 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.0124059,
-          "spread": 0.04069578,
-          "score": 0.04254471
+          "bias": -0.01240586,
+          "spread": 0.04069581,
+          "score": 0.04254474
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.0014453,
-          "spread": 0.00232797,
-          "score": 0.00274014
+          "bias": 0.00144534,
+          "spread": 0.00232793,
+          "score": 0.00274012
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00065299,
-          "spread": 0.0007572,
-          "score": 0.00099987
+          "bias": -0.00065295,
+          "spread": 0.00075715,
+          "score": 0.00099981
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00121353,
-          "spread": 0.00150001,
-          "score": 0.00192943
+          "bias": -0.00121349,
+          "spread": 0.00149996,
+          "score": 0.00192936
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00029592,
-          "spread": 0.00123036,
-          "score": 0.00126544
+          "bias": 0.00029597,
+          "spread": 0.0012303,
+          "score": 0.0012654
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00026915,
-          "spread": 0.00091197,
-          "score": 0.00095086
+          "bias": 0.00026919,
+          "spread": 0.00091199,
+          "score": 0.00095089
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.00365653,
-          "spread": 0.02063219,
-          "score": 0.0209537
+          "bias": 0.00365657,
+          "spread": 0.02063216,
+          "score": 0.02095368
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00174473,
-          "spread": 0.00409785,
-          "score": 0.00445382
+          "bias": -0.00174469,
+          "spread": 0.00409784,
+          "score": 0.00445379
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.03090181,
+          "bias": -0.03090177,
           "spread": 0.02876623,
-          "score": 0.04221869
+          "score": 0.04221866
         },
         {
           "profile": "rated_plus_5pct",
@@ -8878,17 +12985,17 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00171855,
-          "spread": 0.00578526,
-          "score": 0.00603512
+          "bias": 0.00171859,
+          "spread": 0.00578528,
+          "score": 0.00603514
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00295227,
-          "spread": 0.00323032,
+          "bias": 0.00295231,
+          "spread": 0.00323029,
           "score": 0.00437617
         },
         {
@@ -8896,9 +13003,441 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00098126,
-          "spread": 0.00327466,
-          "score": 0.00341852
+          "bias": 0.0009813,
+          "spread": 0.00327463,
+          "score": 0.0034185
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 1,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": -0.00581607,
+          "spread": 0.00515561,
+          "score": 0.00777219
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": -0.00986871,
+          "spread": 0.00827258,
+          "score": 0.01287738
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": -0.00860959,
+          "spread": 0.0045729,
+          "score": 0.00974867
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00544103,
+          "spread": 0.00659409,
+          "score": 0.00854909
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.00325761,
+          "spread": 0.00810843,
+          "score": 0.00873834
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.00509631,
+          "spread": 0.00678251,
+          "score": 0.00848379
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": 0.00798975,
+          "spread": 0.07354844,
+          "score": 0.07398114
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.12517141,
+          "spread": 0.21663181,
+          "score": 0.25019437
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.20967249,
+          "spread": 0.37194783,
+          "score": 0.42697511
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.25094647,
+          "spread": 0.43116882,
+          "score": 0.49887943
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.02032825,
+          "spread": 0.06137046,
+          "score": 0.0646496
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": -0.0089155,
+          "spread": 0.00928838,
+          "score": 0.01287479
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00219219,
+          "spread": 0.01095694,
+          "score": 0.01117408
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.00352367,
+          "spread": 0.00590076,
+          "score": 0.00687279
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": -0.0024294,
+          "spread": 0.00632205,
+          "score": 0.00677276
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00279857,
+          "spread": 0.00115895,
+          "score": 0.00302906
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.01568126,
+          "spread": 0.0609382,
+          "score": 0.0629235
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": -0.00536251,
+          "spread": 0.0,
+          "score": 0.00536251
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.00563899,
+          "spread": 0.01769417,
+          "score": 0.018571
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.00847239,
+          "spread": 0.00834055,
+          "score": 0.01188891
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": -0.00618396,
+          "spread": 0.00449657,
+          "score": 0.00764595
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": -0.00177698,
+          "spread": 0.00313123,
+          "score": 0.00360032
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": -0.00246512,
+          "spread": 0.02157853,
+          "score": 0.02171888
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": -0.00584925,
+          "spread": 0.00215264,
+          "score": 0.00623278
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00103075,
+          "spread": 0.00518448,
+          "score": 0.00528595
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.00110659,
+          "spread": 0.00717512,
+          "score": 0.00725995
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.00421048,
+          "spread": 0.00468238,
+          "score": 0.00629705
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.00631551,
+          "spread": 0.07866304,
+          "score": 0.07891616
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.0540423,
+          "spread": 0.23031743,
+          "score": 0.2365728
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.29524757,
+          "spread": 0.29921236,
+          "score": 0.420356
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": 0.08556152,
+          "spread": 0.39162066,
+          "score": 0.40085847
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.02147246,
+          "spread": 0.02115826,
+          "score": 0.03014529
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": -0.00599241,
+          "spread": 0.00300809,
+          "score": 0.00670504
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00089997,
+          "spread": 0.0054748,
+          "score": 0.00554828
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": -0.00189841,
+          "spread": 0.00426083,
+          "score": 0.00466462
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": -0.00044046,
+          "spread": 0.00623935,
+          "score": 0.00625488
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00047869,
+          "spread": 0.00998929,
+          "score": 0.01000075
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": 0.01065592,
+          "spread": 0.05732659,
+          "score": 0.05830855
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": -0.0034479,
+          "spread": 0.0,
+          "score": 0.0034479
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.01783496,
+          "spread": 0.0,
+          "score": 0.01783496
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": 0.0011156,
+          "spread": 0.01315533,
+          "score": 0.01320255
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.00093013,
+          "spread": 0.00473001,
+          "score": 0.00482059
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": -0.0007988,
+          "spread": 0.00262156,
+          "score": 0.00274056
         },
         {
           "profile": "ti_dependent_cp",
@@ -9334,227 +13873,11 @@
         },
         {
           "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.00075414,
-          "spread": 0.00291168,
-          "score": 0.00300776
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": 0.0839064,
-          "spread": 0.00965342,
-          "score": 0.08445989
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00136799,
-          "spread": 0.00393026,
-          "score": 0.00416153
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00018756,
-          "spread": 0.00295999,
-          "score": 0.00296593
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00043224,
-          "spread": 0.00262355,
-          "score": 0.00265892
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00099441,
-          "spread": 0.002939,
-          "score": 0.00310267
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01540289,
-          "spread": 0.00941693,
-          "score": 0.01805347
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": 0.01024272,
-          "spread": 0.02142547,
-          "score": 0.02374793
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": 0.02838716,
-          "spread": 0.02506528,
-          "score": 0.0378695
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.02876894,
-          "spread": 0.28091096,
-          "score": 0.28238028
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": 0.04726238,
-          "spread": 0.13285865,
-          "score": 0.14101473
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.01821031,
-          "spread": 0.03673256,
-          "score": 0.04099874
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00392094,
-          "spread": 0.00303917,
-          "score": 0.00496088
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00286766,
-          "spread": 0.00243131,
-          "score": 0.00375962
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00018937,
-          "spread": 0.00234147,
-          "score": 0.00234911
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00011557,
-          "spread": 0.00211562,
-          "score": 0.00211878
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00317759,
-          "spread": 0.00881885,
-          "score": 0.00937385
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": -0.00438914,
-          "spread": 0.02526758,
-          "score": 0.02564595
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00115967,
-          "spread": 0.00722656,
-          "score": 0.00731902
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": -0.02681824,
-          "spread": 0.0275371,
-          "score": 0.03843839
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00035211,
-          "spread": 0.00404276,
-          "score": 0.00405807
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00212716,
-          "spread": 0.00303636,
-          "score": 0.00370733
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00238347,
-          "spread": 0.00521159,
-          "score": 0.00573076
-        },
-        {
-          "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00076959,
-          "spread": 0.00177636,
+          "bias": 0.0007696,
+          "spread": 0.00177635,
           "score": 0.0019359
         },
         {
@@ -9571,25 +13894,25 @@
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00106296,
-          "spread": 0.00412022,
-          "score": 0.00425513
+          "bias": -0.00106295,
+          "spread": 0.00412023,
+          "score": 0.00425514
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00033942,
-          "spread": 0.00161259,
-          "score": 0.00164792
+          "bias": -0.00033941,
+          "spread": 0.00161258,
+          "score": 0.00164791
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.0002279,
+          "bias": -0.00022789,
           "spread": 0.00143497,
           "score": 0.00145295
         },
@@ -9598,8 +13921,8 @@
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00337372,
-          "spread": 0.00293756,
+          "bias": 0.00337373,
+          "spread": 0.00293755,
           "score": 0.00447339
         },
         {
@@ -9607,61 +13930,61 @@
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01510546,
-          "spread": 0.00818956,
-          "score": 0.01718266
+          "bias": 0.01510547,
+          "spread": 0.00818957,
+          "score": 0.01718267
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.01102531,
-          "spread": 0.02999368,
-          "score": 0.03195588
+          "bias": 0.01102532,
+          "spread": 0.02999366,
+          "score": 0.03195587
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.00273683,
-          "spread": 0.02022123,
-          "score": 0.0204056
+          "bias": 0.00273684,
+          "spread": 0.02022124,
+          "score": 0.02040561
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.04002302,
-          "spread": 0.23279553,
-          "score": 0.23621093
+          "bias": 0.04002303,
+          "spread": 0.23279555,
+          "score": 0.23621095
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.18983808,
-          "spread": 0.1068757,
-          "score": 0.21785526
+          "bias": -0.18983807,
+          "spread": 0.10687572,
+          "score": 0.21785525
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.00751956,
-          "spread": 0.04081701,
-          "score": 0.04150388
+          "bias": -0.00751955,
+          "spread": 0.040817,
+          "score": 0.04150387
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.0027295,
+          "bias": -0.00272949,
           "spread": 0.00261765,
           "score": 0.00378183
         },
@@ -9670,9 +13993,9 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00362435,
+          "bias": 0.00362436,
           "spread": 0.00099455,
-          "score": 0.00375833
+          "score": 0.00375834
         },
         {
           "profile": "ti_dependent_cp",
@@ -9688,8 +14011,8 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00072303,
-          "spread": 0.00105432,
+          "bias": 0.00072304,
+          "spread": 0.00105431,
           "score": 0.00127842
         },
         {
@@ -9697,7 +14020,7 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": -0.00116387,
+          "bias": -0.00116386,
           "spread": 0.00240105,
           "score": 0.00266826
         },
@@ -9706,9 +14029,9 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.00075226,
-          "spread": 0.02022216,
-          "score": 0.02023615
+          "bias": -0.00075225,
+          "spread": 0.02022215,
+          "score": 0.02023613
         },
         {
           "profile": "ti_dependent_cp",
@@ -9716,17 +14039,17 @@
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
           "bias": -0.00592225,
-          "spread": 0.00516465,
-          "score": 0.00785791
+          "spread": 0.00516464,
+          "score": 0.00785789
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.03506006,
+          "bias": -0.03506005,
           "spread": 0.02539969,
-          "score": 0.04329379
+          "score": 0.04329378
         },
         {
           "profile": "ti_dependent_cp",
@@ -9742,17 +14065,17 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00201471,
-          "spread": 0.00617601,
-          "score": 0.00649632
+          "bias": 0.00201472,
+          "spread": 0.00617599,
+          "score": 0.0064963
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00357175,
-          "spread": 0.00316836,
+          "bias": 0.00357176,
+          "spread": 0.00316835,
           "score": 0.00477451
         },
         {
@@ -9760,9 +14083,441 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -1.839e-05,
-          "spread": 0.00294385,
-          "score": 0.0029439
+          "bias": -1.838e-05,
+          "spread": 0.00294386,
+          "score": 0.00294391
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 1,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": -0.00577906,
+          "spread": 0.00511711,
+          "score": 0.00771896
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": -0.00118714,
+          "spread": 0.00710435,
+          "score": 0.00720285
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": -0.00590983,
+          "spread": 0.00320864,
+          "score": 0.00672469
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00422646,
+          "spread": 0.00646265,
+          "score": 0.00772197
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.0071668,
+          "spread": 0.00646234,
+          "score": 0.00965013
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.00913521,
+          "spread": 0.0046983,
+          "score": 0.01027259
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.01238158,
+          "spread": 0.08197994,
+          "score": 0.08290967
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": -0.17299455,
+          "spread": 0.24898535,
+          "score": 0.30318446
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 1.25900201,
+          "spread": 1.83831959,
+          "score": 2.22811691
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -2.90474691,
+          "spread": 4.13694782,
+          "score": 5.05488791
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.01853348,
+          "spread": 0.05643987,
+          "score": 0.05940496
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": -0.00492407,
+          "spread": 0.00978948,
+          "score": 0.01095812
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00056461,
+          "spread": 0.01082733,
+          "score": 0.01084204
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.00241721,
+          "spread": 0.00536584,
+          "score": 0.00588516
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": -0.00220583,
+          "spread": 0.00656028,
+          "score": 0.0069212
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00411339,
+          "spread": 0.00029507,
+          "score": 0.00412396
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.04631248,
+          "spread": 0.08395811,
+          "score": 0.09588436
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": -0.00569527,
+          "spread": 0.0,
+          "score": 0.00569527
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.00834657,
+          "spread": 0.01921057,
+          "score": 0.02094543
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.00982116,
+          "spread": 0.00789198,
+          "score": 0.01259914
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": -0.00665272,
+          "spread": 0.00435357,
+          "score": 0.00795061
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 2,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": -0.00175491,
+          "spread": 0.00309495,
+          "score": 0.00355787
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.00477368,
+          "spread": 0.02024491,
+          "score": 0.02080011
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": -0.00405047,
+          "spread": 0.00215119,
+          "score": 0.00458628
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00230141,
+          "spread": 0.00481901,
+          "score": 0.00534035
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.00526493,
+          "spread": 0.00597727,
+          "score": 0.00796538
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.00974501,
+          "spread": 0.00794117,
+          "score": 0.0125709
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.032598,
+          "spread": 0.08797266,
+          "score": 0.093818
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.01681483,
+          "spread": 0.24886116,
+          "score": 0.24942858
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.33426976,
+          "spread": 0.37768475,
+          "score": 0.50436301
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": 0.04541456,
+          "spread": 0.33516883,
+          "score": 0.33823162
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.0159064,
+          "spread": 0.0212099,
+          "score": 0.02651176
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": -0.00220925,
+          "spread": 0.00316183,
+          "score": 0.0038572
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": -0.00020891,
+          "spread": 0.00470161,
+          "score": 0.00470624
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": -0.00227127,
+          "spread": 0.00426727,
+          "score": 0.00483407
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00013498,
+          "spread": 0.00610807,
+          "score": 0.00610956
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00167934,
+          "spread": 0.0110312,
+          "score": 0.01115829
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.01019334,
+          "spread": 0.06085156,
+          "score": 0.06169941
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": -0.00386239,
+          "spread": 0.0,
+          "score": 0.00386239
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.00497069,
+          "spread": 0.0,
+          "score": 0.00497069
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.00130327,
+          "spread": 0.01407761,
+          "score": 0.01413781
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.00248072,
+          "spread": 0.00524817,
+          "score": 0.00580493
+        },
+        {
+          "profile": "ws_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": -0.00125671,
+          "spread": 0.00203552,
+          "score": 0.00239221
         },
         {
           "profile": "ws_dependent_cp",
@@ -10198,228 +14953,12 @@
         },
         {
           "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.00078046,
-          "spread": 0.00288519,
-          "score": 0.00298889
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": 0.0588008,
-          "spread": 0.00791188,
-          "score": 0.0593307
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00193178,
-          "spread": 0.00359263,
-          "score": 0.00407906
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00179515,
-          "spread": 0.00298561,
-          "score": 0.00348374
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00117417,
-          "spread": 0.00289035,
-          "score": 0.00311975
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00290568,
-          "spread": 0.0027815,
-          "score": 0.0040224
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00245353,
-          "spread": 0.00833831,
-          "score": 0.00869179
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": -0.01034311,
-          "spread": 0.02506677,
-          "score": 0.02711684
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": 0.0017693,
-          "spread": 0.03102579,
-          "score": 0.03107619
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": -0.01692588,
-          "spread": 0.31773524,
-          "score": 0.31818575
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": 0.40565569,
-          "spread": 0.52677606,
-          "score": 0.66486807
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.00995875,
-          "spread": 0.02759236,
-          "score": 0.02933453
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": 3.1e-06,
-          "spread": 0.00298088,
-          "score": 0.00298088
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00180679,
-          "spread": 0.00244631,
-          "score": 0.00304121
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00029125,
-          "spread": 0.00225848,
-          "score": 0.00227718
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.0003209,
-          "spread": 0.0023048,
-          "score": 0.00232704
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00439175,
-          "spread": 0.00912185,
-          "score": 0.01012402
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": -0.02998687,
-          "spread": 0.03895994,
-          "score": 0.0491639
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00440608,
-          "spread": 0.00716005,
-          "score": 0.00840713
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": -0.01652187,
-          "spread": 0.02698904,
-          "score": 0.0316446
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": -0.0028292,
-          "spread": 0.00510663,
-          "score": 0.00583798
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00014307,
-          "spread": 0.00349535,
-          "score": 0.00349828
-        },
-        {
-          "profile": "ws_dependent_cp",
-          "campaign_months": 9,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": 0.0017418,
-          "spread": 0.00488628,
-          "score": 0.00518745
-        },
-        {
-          "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00081161,
-          "spread": 0.00176902,
-          "score": 0.00194632
+          "bias": 0.00081165,
+          "spread": 0.00176898,
+          "score": 0.0019463
         },
         {
           "profile": "ws_dependent_cp",
@@ -10435,17 +14974,17 @@
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00224362,
-          "spread": 0.00374166,
-          "score": 0.00436278
+          "bias": 0.00224366,
+          "spread": 0.0037416,
+          "score": 0.00436275
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00139324,
-          "spread": 0.00142285,
+          "bias": 0.00139328,
+          "spread": 0.00142281,
           "score": 0.00199139
         },
         {
@@ -10453,54 +14992,54 @@
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00060646,
-          "spread": 0.00152914,
-          "score": 0.00164501
+          "bias": 0.0006065,
+          "spread": 0.00152911,
+          "score": 0.001645
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00037841,
-          "spread": 0.0031953,
-          "score": 0.00321763
+          "bias": -0.00037836,
+          "spread": 0.00319528,
+          "score": 0.00321761
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00275664,
-          "spread": 0.00690563,
-          "score": 0.00743551
+          "bias": 0.00275668,
+          "spread": 0.00690557,
+          "score": 0.00743546
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00936343,
-          "spread": 0.03322548,
-          "score": 0.03451966
+          "bias": -0.00936339,
+          "spread": 0.03322549,
+          "score": 0.03451965
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.02152047,
-          "spread": 0.0209175,
-          "score": 0.0300112
+          "bias": -0.02152043,
+          "spread": 0.02091746,
+          "score": 0.03001115
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.01730751,
-          "spread": 0.25591926,
-          "score": 0.25650383
+          "bias": 0.01730756,
+          "spread": 0.25591927,
+          "score": 0.25650384
         },
         {
           "profile": "ws_dependent_cp",
@@ -10516,81 +15055,81 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.00574894,
-          "spread": 0.04228275,
-          "score": 0.04267179
+          "bias": -0.0057489,
+          "spread": 0.04228279,
+          "score": 0.04267182
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00100645,
-          "spread": 0.00250034,
-          "score": 0.0026953
+          "bias": 0.00100649,
+          "spread": 0.0025003,
+          "score": 0.00269528
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00248546,
-          "spread": 0.00069711,
-          "score": 0.00258137
+          "bias": 0.0024855,
+          "spread": 0.00069705,
+          "score": 0.00258139
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -6.681e-05,
-          "spread": 0.00130756,
-          "score": 0.00130927
+          "bias": -6.677e-05,
+          "spread": 0.00130751,
+          "score": 0.00130921
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00097475,
-          "spread": 0.00108415,
-          "score": 0.00145791
+          "bias": 0.00097479,
+          "spread": 0.00108409,
+          "score": 0.00145789
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 9.426e-05,
-          "spread": 0.00160329,
-          "score": 0.00160606
+          "bias": 9.43e-05,
+          "spread": 0.0016033,
+          "score": 0.00160608
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.02613985,
+          "bias": -0.0261398,
           "spread": 0.02014609,
-          "score": 0.03300237
+          "score": 0.03300234
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00258973,
-          "spread": 0.0042484,
-          "score": 0.0049755
+          "bias": -0.00258969,
+          "spread": 0.00424839,
+          "score": 0.00497547
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.03121366,
+          "bias": -0.03121362,
           "spread": 0.0260096,
-          "score": 0.04062994
+          "score": 0.04062991
         },
         {
           "profile": "ws_dependent_cp",
@@ -10606,8 +15145,8 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.000943,
-          "spread": 0.00695575,
+          "bias": -0.00094296,
+          "spread": 0.00695576,
           "score": 0.00701938
         },
         {
@@ -10615,8 +15154,8 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00174189,
-          "spread": 0.00330975,
+          "bias": 0.00174193,
+          "spread": 0.00330973,
           "score": 0.00374014
         },
         {
@@ -10624,9 +15163,9 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00050767,
-          "spread": 0.00325881,
-          "score": 0.00329811
+          "bias": -0.00050763,
+          "spread": 0.00325878,
+          "score": 0.00329808
         }
       ]
     }

--- a/benchmarking/baselines/study_power_model_compare_baseline.json
+++ b/benchmarking/baselines/study_power_model_compare_baseline.json
@@ -2,8 +2,8 @@
   "schema": "power_model_compare_baseline_v2",
   "modes": {
     "prepost": {
-      "recorded_utc": "2026-07-08T10:59:12Z",
-      "git_commit": "f51b3c7-dirty",
+      "recorded_utc": "2026-07-08T13:07:31Z",
+      "git_commit": "09f3b06-dirty",
       "n_replicates": 4,
       "seed": 0,
       "campaign_months": [
@@ -28,9 +28,9 @@
           "campaign_months": 1,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00552818,
-          "spread": 0.00982335,
-          "score": 0.01127204
+          "bias": -0.00552764,
+          "spread": 0.00982332,
+          "score": 0.01127175
         },
         {
           "profile": "cp_0pct",
@@ -46,589 +46,157 @@
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00275915,
-          "spread": 0.03354439,
-          "score": 0.03365768
+          "bias": -0.01237767,
+          "spread": 0.01265919,
+          "score": 0.01770485
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.01023641,
-          "spread": 0.01488016,
-          "score": 0.0180611
+          "bias": -0.0102043,
+          "spread": 0.01482194,
+          "score": 0.01799494
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00654138,
-          "spread": 0.0103152,
-          "score": 0.01221446
+          "bias": -0.00650927,
+          "spread": 0.01022141,
+          "score": 0.01211808
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00085318,
-          "spread": 0.01631868,
-          "score": 0.01634097
+          "bias": -0.00082262,
+          "spread": 0.01615288,
+          "score": 0.01617381
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01094087,
-          "spread": 0.03723027,
-          "score": 0.03880458
+          "bias": 0.01096816,
+          "spread": 0.03705919,
+          "score": 0.03864821
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.03324681,
-          "spread": 0.02279212,
-          "score": 0.0403092
+          "bias": 0.03328244,
+          "spread": 0.02284657,
+          "score": 0.04036937
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.35103018,
-          "spread": 0.66092342,
-          "score": 0.74835951
+          "bias": 0.35107562,
+          "spread": 0.66095386,
+          "score": 0.74840771
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.28341262,
-          "spread": 0.61907949,
-          "score": 0.68086866
+          "bias": 0.03566779,
+          "spread": 0.06231811,
+          "score": 0.07180347
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
+          "bias": -0.00552764,
+          "spread": 0.00982332,
+          "score": 0.01127175
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.09236661,
-          "spread": 0.03706204,
-          "score": 0.0995248
+          "bias": 0.02297612,
+          "spread": 0.09464886,
+          "score": 0.09739768
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00033841,
-          "spread": 0.01672111,
-          "score": 0.01672453
+          "bias": 0.00019958,
+          "spread": 0.01715622,
+          "score": 0.01715738
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00518031,
-          "spread": 0.01548075,
-          "score": 0.01632449
+          "bias": 0.00572391,
+          "spread": 0.01611426,
+          "score": 0.01710066
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.01021728,
-          "spread": 0.01843347,
-          "score": 0.02107571
+          "bias": 0.00527339,
+          "spread": 0.00664729,
+          "score": 0.00848499
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.02723413,
-          "spread": 0.0273549,
-          "score": 0.03860037
+          "bias": 0.00549603,
+          "spread": 0.0095194,
+          "score": 0.01099206
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.01876272,
-          "spread": 0.01391806,
-          "score": 0.02336133
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 1,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": -0.1383166,
-          "spread": 0.1454264,
-          "score": 0.20069957
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 1,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": 0.01523773,
-          "spread": 0.03663888,
-          "score": 0.03968118
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 1,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 1,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 1,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00719726,
-          "spread": 0.01809048,
-          "score": 0.01946962
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 1,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00480828,
-          "spread": 0.01527782,
-          "score": 0.01601659
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 1,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": -0.01570012,
-          "spread": 0.01338638,
-          "score": 0.02063223
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 2,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.00040165,
-          "spread": 0.00525168,
-          "score": 0.00526702
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 2,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 2,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00205655,
-          "spread": 0.01544331,
-          "score": 0.01557964
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 2,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00218608,
-          "spread": 0.00637855,
-          "score": 0.00674277
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 2,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00168191,
-          "spread": 0.00628345,
-          "score": 0.00650466
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 2,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00135914,
-          "spread": 0.00405088,
-          "score": 0.0042728
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 2,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": -0.00118549,
-          "spread": 0.01371431,
-          "score": 0.01376545
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 2,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00173855,
-          "spread": 0.04248803,
-          "score": 0.04252358
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 2,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": 0.07436141,
-          "spread": 0.15062306,
-          "score": 0.16797894
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 2,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.70265763,
-          "spread": 1.30322774,
-          "score": 1.48058444
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 2,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": 0.67391032,
-          "spread": 1.09902902,
-          "score": 1.28919351
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.06550277,
-          "spread": 0.11005635,
-          "score": 0.12807425
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00287039,
-          "spread": 0.01095036,
-          "score": 0.01132032
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00362371,
-          "spread": 0.00477419,
-          "score": 0.00599368
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00876804,
-          "spread": 0.00583406,
-          "score": 0.01053161
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00317679,
-          "spread": 0.00661549,
-          "score": 0.00733872
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00226923,
-          "spread": 0.0136659,
-          "score": 0.01385303
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": -0.06372298,
-          "spread": 0.0992478,
-          "score": 0.11794382
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00818451,
-          "spread": 0.01473507,
-          "score": 0.01685552
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00605008,
-          "spread": 0.01425996,
-          "score": 0.01549032
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00207241,
-          "spread": 0.00668681,
-          "score": 0.0070006
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00443696,
-          "spread": 0.00742062,
-          "score": 0.00864593
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 3,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.00135806,
-          "spread": 0.00227301,
-          "score": 0.00264781
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": 0.07014485,
+          "bias": 0.0,
           "spread": 0.0,
-          "score": 0.07014485
+          "score": 0.0
         },
         {
           "profile": "cp_0pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00760448,
-          "spread": 0.01156328,
-          "score": 0.01383971
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00376899,
-          "spread": 0.00367953,
-          "score": 0.00526728
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00137496,
-          "spread": 0.00177076,
-          "score": 0.0022419
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00052424,
-          "spread": 0.01032104,
-          "score": 0.01033434
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00449611,
-          "spread": 0.01817089,
-          "score": 0.01871888
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": -0.02727116,
-          "spread": 0.04121358,
-          "score": 0.04941938
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": 0.08153458,
-          "spread": 0.10807858,
-          "score": 0.13538414
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.26597007,
-          "spread": 0.43869291,
-          "score": 0.51302198
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": 0.26813945,
-          "spread": 0.77987883,
-          "score": 0.82468767
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.09280846,
-          "spread": 0.0765284,
-          "score": 0.12029134
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00148546,
-          "spread": 0.0061467,
-          "score": 0.00632364
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.0056555,
-          "spread": 0.00728829,
-          "score": 0.00922517
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": 0.01049421,
-          "spread": 0.0105915,
-          "score": 0.01491001
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00116663,
-          "spread": 0.00452595,
-          "score": 0.00467389
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.01171744,
-          "spread": 0.01515149,
-          "score": 0.01915375
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 3,
+          "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.10054736,
-          "spread": 0.10837825,
-          "score": 0.14783645
+          "bias": -0.13787276,
+          "spread": 0.14531781,
+          "score": 0.20031516
         },
         {
           "profile": "cp_0pct",
-          "campaign_months": 3,
+          "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00457834,
-          "spread": 0.02920829,
-          "score": 0.02956494
+          "bias": 0.0,
+          "spread": 0.0,
+          "score": 0.0
         },
         {
           "profile": "cp_0pct",
-          "campaign_months": 3,
+          "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
           "bias": NaN,
@@ -637,7 +205,7 @@
         },
         {
           "profile": "cp_0pct",
-          "campaign_months": 3,
+          "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
           "bias": NaN,
@@ -646,30 +214,462 @@
         },
         {
           "profile": "cp_0pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.00667663,
+          "spread": 0.01773636,
+          "score": 0.01895141
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.00428595,
+          "spread": 0.01489817,
+          "score": 0.01550241
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": -0.01516905,
+          "spread": 0.01399724,
+          "score": 0.02064032
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00040142,
+          "spread": 0.00525189,
+          "score": 0.00526721
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.00796105,
+          "spread": 0.0,
+          "score": 0.00796105
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.00565709,
+          "spread": 0.00394075,
+          "score": 0.00689436
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.00218912,
+          "spread": 0.00632384,
+          "score": 0.00669203
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00167881,
+          "spread": 0.00624055,
+          "score": 0.00646241
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": 0.00136265,
+          "spread": 0.00408319,
+          "score": 0.00430456
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.00118281,
+          "spread": 0.01366304,
+          "score": 0.01371414
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": 0.00173881,
+          "spread": 0.04241635,
+          "score": 0.04245198
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.07436536,
+          "spread": 0.15062462,
+          "score": 0.16798209
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.52585493,
+          "spread": 1.16943946,
+          "score": 1.28222933
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.10474165,
+          "spread": 0.18502227,
+          "score": 0.21261245
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.04162282,
+          "spread": 0.10378434,
+          "score": 0.11181971
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.00291686,
+          "spread": 0.01103311,
+          "score": 0.01141217
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00366863,
+          "spread": 0.00463185,
+          "score": 0.00590871
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.00881364,
+          "spread": 0.00579696,
+          "score": 0.01054917
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00209483,
+          "spread": 0.00362836,
+          "score": 0.00418967
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.0,
+          "spread": 0.0,
+          "score": 0.0
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.06368629,
+          "spread": 0.09919371,
+          "score": 0.11787848
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.0,
+          "spread": 0.0,
+          "score": 0.0
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.0,
+          "spread": 0.0,
+          "score": 0.0
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": 0.0,
+          "spread": 0.0,
+          "score": 0.0
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.00600537,
+          "spread": 0.01422923,
+          "score": 0.0154446
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.00211916,
+          "spread": 0.00687117,
+          "score": 0.00719054
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": -0.00439079,
+          "spread": 0.007549,
+          "score": 0.00873306
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00135816,
+          "spread": 0.00227292,
+          "score": 0.00264779
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.0031976,
+          "spread": 0.00186435,
+          "score": 0.00370141
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": -0.00757629,
+          "spread": 0.01158707,
+          "score": 0.01384415
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.00379723,
+          "spread": 0.00367923,
+          "score": 0.00528731
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00134691,
+          "spread": 0.00175174,
+          "score": 0.00220969
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": 0.00055223,
+          "spread": 0.01030714,
+          "score": 0.01032192
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.00452411,
+          "spread": 0.01815746,
+          "score": 0.01871258
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.02724425,
+          "spread": 0.04120468,
+          "score": 0.04939711
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.0815674,
+          "spread": 0.10810652,
+          "score": 0.13542622
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.19983616,
+          "spread": 0.39686655,
+          "score": 0.44433945
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.02770509,
+          "spread": 0.05160903,
+          "score": 0.05857528
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.092792,
+          "spread": 0.07668247,
+          "score": 0.12037673
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.0014898,
+          "spread": 0.00616223,
+          "score": 0.00633977
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00566026,
+          "spread": 0.00735686,
+          "score": 0.00928234
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.01049923,
+          "spread": 0.01066184,
+          "score": 0.01496358
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00205935,
+          "spread": 0.00410297,
+          "score": 0.00459079
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.0,
+          "spread": 0.0,
+          "score": 0.0
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.10055363,
+          "spread": 0.10828671,
+          "score": 0.14777363
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.0,
+          "spread": 0.0,
+          "score": 0.0
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.0,
+          "spread": 0.0,
+          "score": 0.0
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": 0.0,
+          "spread": 0.0,
+          "score": 0.0
+        },
+        {
+          "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -5.767e-05,
-          "spread": 0.01488226,
-          "score": 0.01488237
+          "bias": -5.451e-05,
+          "spread": 0.01480955,
+          "score": 0.01480965
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00269237,
-          "spread": 0.01037496,
-          "score": 0.01071862
+          "bias": -0.00268907,
+          "spread": 0.01028598,
+          "score": 0.01063167
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00228259,
-          "spread": 0.00823018,
-          "score": 0.00854085
+          "bias": -0.00227865,
+          "spread": 0.00819446,
+          "score": 0.00850538
         },
         {
           "profile": "cp_0pct",
@@ -685,9 +685,9 @@
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
+          "bias": 0.00536247,
+          "spread": 0.00204004,
+          "score": 0.00573741
         },
         {
           "profile": "cp_0pct",
@@ -757,143 +757,143 @@
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.25711471,
-          "spread": 0.06025505,
-          "score": 0.26408075
+          "bias": 0.19366664,
+          "spread": 0.12165515,
+          "score": 0.22870668
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.02844991,
-          "spread": 0.56748232,
-          "score": 0.56819502
+          "bias": 0.01720545,
+          "spread": 0.40142941,
+          "score": 0.40179796
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.11353769,
-          "spread": 0.10966636,
-          "score": 0.15785283
+          "bias": -0.11331499,
+          "spread": 0.10967246,
+          "score": 0.15769698
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00158617,
-          "spread": 0.003099,
-          "score": 0.00348134
+          "bias": 0.00183943,
+          "spread": 0.00310172,
+          "score": 0.00360613
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00454826,
-          "spread": 0.00451961,
-          "score": 0.00641198
+          "bias": 0.00480268,
+          "spread": 0.004612,
+          "score": 0.00665855
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00615617,
-          "spread": 0.00379618,
-          "score": 0.00723252
+          "bias": 0.00641108,
+          "spread": 0.00392629,
+          "score": 0.00751782
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00377784,
-          "spread": 0.00224617,
-          "score": 0.00439515
+          "bias": 0.00403158,
+          "spread": 0.00221245,
+          "score": 0.00459875
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.01408456,
-          "spread": 0.01341591,
-          "score": 0.01945151
+          "bias": 0.00136961,
+          "spread": 0.00237223,
+          "score": 0.00273921
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.1137814,
-          "spread": 0.06630895,
-          "score": 0.13169314
+          "bias": -0.11354624,
+          "spread": 0.06646546,
+          "score": 0.13156901
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00380883,
-          "spread": 0.02557019,
-          "score": 0.02585231
+          "bias": 0.00036183,
+          "spread": 0.0006267,
+          "score": 0.00072366
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.18252001,
+          "bias": 0.0,
           "spread": 0.0,
-          "score": 0.18252001
+          "score": 0.0
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
+          "bias": 0.0,
+          "spread": 0.0,
+          "score": 0.0
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00943414,
-          "spread": 0.00721014,
-          "score": 0.01187389
+          "bias": 0.00969048,
+          "spread": 0.00736412,
+          "score": 0.0121711
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00290124,
-          "spread": 0.00504383,
-          "score": 0.00581871
+          "bias": 0.00315475,
+          "spread": 0.00502881,
+          "score": 0.00593645
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00410559,
-          "spread": 0.00683023,
-          "score": 0.00796918
+          "bias": 0.00435877,
+          "spread": 0.00672609,
+          "score": 0.00801493
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00114798,
-          "spread": 0.00333987,
+          "bias": 0.00114791,
+          "spread": 0.00333989,
           "score": 0.00353165
         },
         {
@@ -901,814 +901,382 @@
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.13804805,
-          "spread": 0.0,
-          "score": 0.13804805
+          "bias": 0.00114791,
+          "spread": 0.00333989,
+          "score": 0.00353165
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00227115,
+          "bias": -0.00227016,
           "spread": 0.0032837,
-          "score": 0.0039926
+          "score": 0.00399203
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00017845,
-          "spread": 0.00240815,
-          "score": 0.00241475
+          "bias": 0.00017945,
+          "spread": 0.0024082,
+          "score": 0.00241488
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00015611,
-          "spread": 0.00405415,
-          "score": 0.00405715
+          "bias": 0.00015711,
+          "spread": 0.0040542,
+          "score": 0.00405724
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00398335,
-          "spread": 0.00469608,
-          "score": 0.00615794
+          "bias": 0.00398434,
+          "spread": 0.00469482,
+          "score": 0.00615762
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00983979,
-          "spread": 0.00660434,
-          "score": 0.01185068
+          "bias": 0.00984079,
+          "spread": 0.00660396,
+          "score": 0.01185131
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.0011926,
-          "spread": 0.01223143,
-          "score": 0.01228943
+          "bias": 0.00119361,
+          "spread": 0.01223235,
+          "score": 0.01229045
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.05196386,
-          "spread": 0.04379452,
-          "score": 0.06795736
+          "bias": 0.05196499,
+          "spread": 0.04379656,
+          "score": 0.06795954
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.37437723,
-          "spread": 0.39366381,
-          "score": 0.54325823
+          "bias": 0.37437931,
+          "spread": 0.39366729,
+          "score": 0.54326218
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.87574694,
-          "spread": 0.73933485,
-          "score": 1.14610153
+          "bias": 0.43961748,
+          "spread": 0.68082491,
+          "score": 0.8104234
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.10367897,
-          "spread": 0.09153096,
-          "score": 0.13830129
+          "bias": -0.10361101,
+          "spread": 0.09147877,
+          "score": 0.1382158
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.0011233,
-          "spread": 0.00277321,
-          "score": 0.00299207
+          "bias": 0.00120616,
+          "spread": 0.00277209,
+          "score": 0.00302313
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00147655,
-          "spread": 0.00257748,
-          "score": 0.00297045
+          "bias": 0.00155942,
+          "spread": 0.00256534,
+          "score": 0.00300212
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.0020584,
-          "spread": 0.00211865,
-          "score": 0.00295393
+          "bias": 0.00214135,
+          "spread": 0.00211971,
+          "score": 0.00301307
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00061132,
-          "spread": 0.00083697,
-          "score": 0.00103645
+          "bias": 0.00069421,
+          "spread": 0.00090552,
+          "score": 0.00114101
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00150759,
-          "spread": 0.0032904,
-          "score": 0.00361933
+          "bias": 0.00159071,
+          "spread": 0.00335535,
+          "score": 0.00371332
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.12408241,
-          "spread": 0.0701685,
-          "score": 0.14254846
+          "bias": -0.12400607,
+          "spread": 0.07021904,
+          "score": 0.14250691
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00956212,
-          "spread": 0.0153549,
-          "score": 0.01808886
+          "bias": 0.00286131,
+          "spread": 0.01172776,
+          "score": 0.01207176
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.05404851,
-          "spread": 0.04191206,
-          "score": 0.0683949
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00143417,
-          "spread": 0.00714136,
-          "score": 0.00728395
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00093328,
-          "spread": 0.00684141,
-          "score": 0.00690477
-        },
-        {
-          "profile": "cp_0pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00086894,
-          "spread": 0.00722516,
-          "score": 0.00727723
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 1,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": -0.00501533,
-          "spread": 0.00909111,
-          "score": 0.01038276
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 1,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 1,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00415225,
-          "spread": 0.03698591,
-          "score": 0.03721826
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 1,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00848355,
-          "spread": 0.01144082,
-          "score": 0.014243
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 1,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00582569,
-          "spread": 0.0109246,
-          "score": 0.01238085
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 1,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": -3.688e-05,
-          "spread": 0.01516413,
-          "score": 0.01516417
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 1,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01054416,
-          "spread": 0.03335558,
-          "score": 0.03498248
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 1,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": 0.03063731,
-          "spread": 0.02577901,
-          "score": 0.04004001
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 1,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": 0.30672852,
-          "spread": 0.54931144,
-          "score": 0.62914661
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 1,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.3271667,
-          "spread": 0.52502657,
-          "score": 0.6186202
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 1,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 1,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": 0.04958925,
-          "spread": 0.09489095,
-          "score": 0.10706721
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 1,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00205996,
-          "spread": 0.01933083,
-          "score": 0.01944027
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 1,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00192796,
-          "spread": 0.01575857,
-          "score": 0.01587606
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 1,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": 0.0073595,
-          "spread": 0.01567233,
-          "score": 0.01731428
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 1,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.02675314,
-          "spread": 0.02311513,
-          "score": 0.03535589
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 1,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.02297654,
-          "spread": 0.01600866,
-          "score": 0.02800355
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 1,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": -0.07833209,
-          "spread": 0.07297779,
-          "score": 0.10705921
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 1,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": 0.01327923,
-          "spread": 0.04561313,
-          "score": 0.04750679
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 1,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 1,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 1,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00919698,
-          "spread": 0.01732662,
-          "score": 0.01961622
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 1,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00528581,
-          "spread": 0.01461107,
-          "score": 0.0155378
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 1,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": -0.01214389,
-          "spread": 0.01246114,
-          "score": 0.01739983
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 2,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.00044264,
-          "spread": 0.00486339,
-          "score": 0.00488349
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 2,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 2,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00415006,
-          "spread": 0.0133329,
-          "score": 0.01396385
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 2,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00174996,
-          "spread": 0.00567975,
-          "score": 0.00594323
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 2,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00095835,
-          "spread": 0.00709314,
-          "score": 0.00715759
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 2,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00473522,
-          "spread": 0.00147007,
-          "score": 0.00495817
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 2,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00460905,
-          "spread": 0.01064962,
-          "score": 0.01160421
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 2,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00592545,
-          "spread": 0.03932208,
-          "score": 0.03976603
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 2,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": 0.08034683,
-          "spread": 0.13583335,
-          "score": 0.15781733
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 2,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.72740659,
-          "spread": 1.19745814,
-          "score": 1.40108042
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 2,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": 1.75364893,
-          "spread": 0.16634375,
-          "score": 1.76152059
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.07990924,
-          "spread": 0.12894246,
-          "score": 0.15169589
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00462076,
-          "spread": 0.0135352,
-          "score": 0.01430221
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00229747,
-          "spread": 0.00411668,
-          "score": 0.00471438
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00583325,
-          "spread": 0.00303703,
-          "score": 0.0065765
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00165,
-          "spread": 0.00711384,
-          "score": 0.00730268
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00095501,
-          "spread": 0.01779914,
-          "score": 0.01782474
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": -0.02544962,
-          "spread": 0.06187661,
-          "score": 0.06690589
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00956815,
-          "spread": 0.0144894,
-          "score": 0.01736353
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00589347,
-          "spread": 0.013395,
-          "score": 0.01463417
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00198741,
-          "spread": 0.00595343,
-          "score": 0.00627639
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00206324,
-          "spread": 0.00630293,
-          "score": 0.00663203
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 3,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.00134049,
-          "spread": 0.00213641,
-          "score": 0.00252213
-        },
-        {
-          "profile": "cp_minus_10pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": 0.07922471,
+          "bias": 0.0,
           "spread": 0.0,
-          "score": 0.07922471
+          "score": 0.0
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": 0.0,
+          "spread": 0.0,
+          "score": 0.0
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": 0.00151711,
+          "spread": 0.00714809,
+          "score": 0.00730731
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.00101636,
+          "spread": 0.00687475,
+          "score": 0.00694948
+        },
+        {
+          "profile": "cp_0pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00095207,
+          "spread": 0.0072653,
+          "score": 0.00732742
         },
         {
           "profile": "cp_minus_10pct",
-          "campaign_months": 3,
+          "campaign_months": 1,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": -0.00501482,
+          "spread": 0.00909108,
+          "score": 0.01038249
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.01118827,
-          "spread": 0.0117501,
-          "score": 0.01622474
+          "bias": -0.01224268,
+          "spread": 0.01075626,
+          "score": 0.01629663
         },
         {
           "profile": "cp_minus_10pct",
-          "campaign_months": 3,
+          "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -6.048e-05,
-          "spread": 0.00339334,
-          "score": 0.00339388
+          "bias": -0.00848537,
+          "spread": 0.01141673,
+          "score": 0.01422474
         },
         {
           "profile": "cp_minus_10pct",
-          "campaign_months": 3,
+          "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00054667,
-          "spread": 0.00248357,
-          "score": 0.00254302
+          "bias": -0.0058273,
+          "spread": 0.01084657,
+          "score": 0.01231282
         },
         {
           "profile": "cp_minus_10pct",
-          "campaign_months": 3,
+          "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.0046668,
-          "spread": 0.00955983,
-          "score": 0.01063811
+          "bias": -3.948e-05,
+          "spread": 0.01502656,
+          "score": 0.01502661
         },
         {
           "profile": "cp_minus_10pct",
-          "campaign_months": 3,
+          "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00950364,
-          "spread": 0.01641783,
-          "score": 0.0189701
+          "bias": 0.0105389,
+          "spread": 0.03322406,
+          "score": 0.03485551
         },
         {
           "profile": "cp_minus_10pct",
-          "campaign_months": 3,
+          "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.01884836,
-          "spread": 0.03852744,
-          "score": 0.04289084
+          "bias": 0.03063751,
+          "spread": 0.02580052,
+          "score": 0.04005401
         },
         {
           "profile": "cp_minus_10pct",
-          "campaign_months": 3,
+          "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.08841464,
-          "spread": 0.08841615,
-          "score": 0.12503825
+          "bias": 0.30672274,
+          "spread": 0.54929566,
+          "score": 0.62913001
         },
         {
           "profile": "cp_minus_10pct",
-          "campaign_months": 3,
+          "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.25885347,
-          "spread": 0.36478645,
-          "score": 0.44729663
+          "bias": 0.00825423,
+          "spread": 0.11033988,
+          "score": 0.11064818
         },
         {
           "profile": "cp_minus_10pct",
-          "campaign_months": 3,
+          "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.2950076,
-          "spread": 0.66079602,
-          "score": 0.72365798
+          "bias": 0.0638973,
+          "spread": 0.09868056,
+          "score": 0.11756155
         },
         {
           "profile": "cp_minus_10pct",
-          "campaign_months": 3,
+          "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.07223758,
-          "spread": 0.1883288,
-          "score": 0.20170772
+          "bias": -0.06000267,
+          "spread": 0.13890544,
+          "score": 0.15131107
         },
         {
           "profile": "cp_minus_10pct",
-          "campaign_months": 3,
+          "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00484448,
-          "spread": 0.00990798,
-          "score": 0.01102892
+          "bias": 0.00241458,
+          "spread": 0.01965757,
+          "score": 0.01980531
         },
         {
           "profile": "cp_minus_10pct",
-          "campaign_months": 3,
+          "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00106236,
-          "spread": 0.00839284,
-          "score": 0.00845981
+          "bias": -0.0015484,
+          "spread": 0.01631979,
+          "score": 0.01639308
         },
         {
           "profile": "cp_minus_10pct",
-          "campaign_months": 3,
+          "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00659451,
-          "spread": 0.01005482,
-          "score": 0.01202443
+          "bias": 0.00557877,
+          "spread": 0.00725785,
+          "score": 0.00915418
         },
         {
           "profile": "cp_minus_10pct",
-          "campaign_months": 3,
+          "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00195181,
-          "spread": 0.00392802,
-          "score": 0.00438621
+          "bias": 0.00693428,
+          "spread": 0.01170431,
+          "score": 0.01360423
         },
         {
           "profile": "cp_minus_10pct",
-          "campaign_months": 3,
+          "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.01024253,
-          "spread": 0.01288874,
-          "score": 0.01646296
+          "bias": 0.00269719,
+          "spread": 0.00316539,
+          "score": 0.00415867
         },
         {
           "profile": "cp_minus_10pct",
-          "campaign_months": 3,
+          "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.05059242,
-          "spread": 0.07333178,
-          "score": 0.08909064
+          "bias": -0.07806877,
+          "spread": 0.07267703,
+          "score": 0.10666154
         },
         {
           "profile": "cp_minus_10pct",
-          "campaign_months": 3,
+          "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00010455,
-          "spread": 0.03724966,
-          "score": 0.03724981
+          "bias": 0.00371969,
+          "spread": 0.00265996,
+          "score": 0.00457291
         },
         {
           "profile": "cp_minus_10pct",
-          "campaign_months": 3,
+          "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
           "bias": NaN,
@@ -1717,7 +1285,7 @@
         },
         {
           "profile": "cp_minus_10pct",
-          "campaign_months": 3,
+          "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
           "bias": NaN,
@@ -1726,30 +1294,462 @@
         },
         {
           "profile": "cp_minus_10pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.00886516,
+          "spread": 0.01710289,
+          "score": 0.01926396
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.00495189,
+          "spread": 0.01439284,
+          "score": 0.01522087
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": -0.01180111,
+          "spread": 0.01298908,
+          "score": 0.01754943
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00044265,
+          "spread": 0.00486339,
+          "score": 0.0048835
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.03393016,
+          "spread": 0.0,
+          "score": 0.03393016
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.01098663,
+          "spread": 0.00650399,
+          "score": 0.01276745
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": -0.00174811,
+          "spread": 0.00565101,
+          "score": 0.00591522
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00095632,
+          "spread": 0.00705315,
+          "score": 0.00711768
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": 0.00473768,
+          "spread": 0.00153389,
+          "score": 0.0049798
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.00461084,
+          "spread": 0.0105941,
+          "score": 0.011554
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": 0.0059253,
+          "spread": 0.03926464,
+          "score": 0.0397092
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.08034964,
+          "spread": 0.13584032,
+          "score": 0.15782477
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.48189684,
+          "spread": 1.12082606,
+          "score": 1.22003099
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": 0.33128796,
+          "spread": 0.94727464,
+          "score": 1.00353423
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.08448587,
+          "spread": 0.11170671,
+          "score": 0.14005803
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.00454938,
+          "spread": 0.01364188,
+          "score": 0.01438047
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": -0.00237444,
+          "spread": 0.0039669,
+          "score": 0.00462323
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.00575524,
+          "spread": 0.00290607,
+          "score": 0.00644733
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00331092,
+          "spread": 0.00553225,
+          "score": 0.00644732
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00163464,
+          "spread": 0.00278092,
+          "score": 0.00322577
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.02552172,
+          "spread": 0.06176549,
+          "score": 0.06683064
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.00380973,
+          "spread": 0.00256992,
+          "score": 0.00459549
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.00963368,
+          "spread": 0.0,
+          "score": 0.00963368
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": 0.0,
+          "spread": 0.0,
+          "score": 0.0
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.00596279,
+          "spread": 0.01337536,
+          "score": 0.01464428
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.00191905,
+          "spread": 0.00614622,
+          "score": 0.00643885
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": -0.00213153,
+          "spread": 0.0064594,
+          "score": 0.006802
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00134073,
+          "spread": 0.00213654,
+          "score": 0.00252238
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": -0.01723172,
+          "spread": 0.04583144,
+          "score": 0.0489638
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": -0.01116482,
+          "spread": 0.01176756,
+          "score": 0.01622124
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": -3.699e-05,
+          "spread": 0.00340331,
+          "score": 0.00340351
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00052369,
+          "spread": 0.00247888,
+          "score": 0.0025336
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": 0.00468933,
+          "spread": 0.00954652,
+          "score": 0.01063607
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.00952595,
+          "spread": 0.01640502,
+          "score": 0.0189702
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.0188272,
+          "spread": 0.03851814,
+          "score": 0.0428732
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.08844033,
+          "spread": 0.08843976,
+          "score": 0.12507312
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.12638283,
+          "spread": 0.39049289,
+          "score": 0.41043552
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.08614982,
+          "spread": 0.26549983,
+          "score": 0.27912712
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.0723448,
+          "spread": 0.18836647,
+          "score": 0.20178131
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.00472542,
+          "spread": 0.00994961,
+          "score": 0.01101474
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": -0.00118748,
+          "spread": 0.00846502,
+          "score": 0.0085479
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.00646794,
+          "spread": 0.01012507,
+          "score": 0.01201463
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00065225,
+          "spread": 0.00223079,
+          "score": 0.00232419
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00223408,
+          "spread": 0.00261857,
+          "score": 0.0034421
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.05070941,
+          "spread": 0.07318243,
+          "score": 0.08903434
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": 0.01000701,
+          "spread": 0.00900665,
+          "score": 0.01346329
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": 0.00481684,
+          "spread": 0.00481684,
+          "score": 0.00681204
+        },
+        {
+          "profile": "cp_minus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": 0.0,
+          "spread": 0.0,
+          "score": 0.0
+        },
+        {
+          "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00012794,
-          "spread": 0.01763233,
-          "score": 0.0176328
+          "bias": -0.00024246,
+          "spread": 0.0175952,
+          "score": 0.01759687
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00295551,
-          "spread": 0.01095313,
-          "score": 0.01134487
+          "bias": -0.00306991,
+          "spread": 0.01087722,
+          "score": 0.01130214
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.0003211,
-          "spread": 0.00812731,
-          "score": 0.00813365
+          "bias": 0.00020693,
+          "spread": 0.00810986,
+          "score": 0.0081125
         },
         {
           "profile": "cp_minus_10pct",
@@ -1765,242 +1765,242 @@
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
+          "bias": 0.03722706,
+          "spread": 0.00461658,
+          "score": 0.03751222
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00110955,
-          "spread": 0.00687601,
-          "score": 0.00696496
+          "bias": 0.00110973,
+          "spread": 0.00687626,
+          "score": 0.00696523
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00144471,
-          "spread": 0.00147979,
-          "score": 0.00206808
+          "bias": 0.00144456,
+          "spread": 0.00147999,
+          "score": 0.00206812
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00218055,
-          "spread": 0.00271445,
-          "score": 0.00348182
+          "bias": 0.0021806,
+          "spread": 0.00271443,
+          "score": 0.00348183
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.01058236,
-          "spread": 0.00544085,
-          "score": 0.01189913
+          "bias": 0.0105824,
+          "spread": 0.00544087,
+          "score": 0.01189917
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.0160239,
-          "spread": 0.0053232,
-          "score": 0.01688496
+          "bias": 0.01602369,
+          "spread": 0.00532306,
+          "score": 0.01688471
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.01533608,
-          "spread": 0.01243161,
-          "score": 0.01974184
+          "bias": 0.01533729,
+          "spread": 0.01243233,
+          "score": 0.01974323
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.08294375,
-          "spread": 0.06764007,
-          "score": 0.10702731
+          "bias": 0.08294855,
+          "spread": 0.06763538,
+          "score": 0.10702806
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.24885428,
-          "spread": 0.03200264,
-          "score": 0.25090361
+          "bias": 0.04738599,
+          "spread": 0.35008831,
+          "score": 0.3532807
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.07696741,
-          "spread": 0.42883376,
-          "score": 0.4356861
+          "bias": -0.11330722,
+          "spread": 0.36779921,
+          "score": 0.38485684
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.03982618,
-          "spread": 0.17303589,
-          "score": 0.17755997
+          "bias": -0.03962063,
+          "spread": 0.17311704,
+          "score": 0.17759309
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.0046424,
-          "spread": 0.00429271,
-          "score": 0.00632291
+          "bias": 0.00484145,
+          "spread": 0.00423425,
+          "score": 0.00643184
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00085497,
-          "spread": 0.00477452,
-          "score": 0.00485046
+          "bias": -0.00064382,
+          "spread": 0.00480998,
+          "score": 0.00485287
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00342208,
-          "spread": 0.0034353,
-          "score": 0.00484891
+          "bias": 0.00363597,
+          "spread": 0.00357965,
+          "score": 0.00510237
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00197114,
-          "spread": 0.00038173,
-          "score": 0.00200777
+          "bias": 0.00218426,
+          "spread": 0.00026938,
+          "score": 0.0022008
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.01361734,
-          "spread": 0.01415285,
-          "score": 0.01964014
+          "bias": 0.00252881,
+          "spread": 0.0024311,
+          "score": 0.00350787
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.05547718,
-          "spread": 0.03029958,
-          "score": 0.0632122
+          "bias": -0.05530105,
+          "spread": 0.03036177,
+          "score": 0.06308758
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00100462,
-          "spread": 0.0296953,
-          "score": 0.02971229
+          "bias": 0.00597259,
+          "spread": 0.00519295,
+          "score": 0.00791446
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.19019104,
-          "spread": 0.0,
-          "score": 0.19019104
+          "bias": 0.01285704,
+          "spread": 0.00302876,
+          "score": 0.01320897
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
+          "bias": 0.0,
+          "spread": 0.0,
+          "score": 0.0
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00875186,
-          "spread": 0.00747437,
-          "score": 0.01150918
+          "bias": 0.00894666,
+          "spread": 0.00757995,
+          "score": 0.01172596
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00269667,
-          "spread": 0.00504298,
-          "score": 0.00571871
+          "bias": 0.00288945,
+          "spread": 0.00506077,
+          "score": 0.00582754
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00540512,
-          "spread": 0.00599814,
-          "score": 0.00807422
+          "bias": 0.00559829,
+          "spread": 0.00594802,
+          "score": 0.00816821
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00115206,
-          "spread": 0.00314333,
-          "score": 0.0033478
+          "bias": 0.00115185,
+          "spread": 0.00314342,
+          "score": 0.00334782
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.10729127,
-          "spread": 0.0,
-          "score": 0.10729127
+          "bias": -0.00761767,
+          "spread": 0.05319564,
+          "score": 0.05373831
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.0012342,
-          "spread": 0.00490268,
-          "score": 0.00505564
+          "bias": 0.00123415,
+          "spread": 0.00490307,
+          "score": 0.00505601
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00055893,
-          "spread": 0.00225169,
+          "bias": -0.00055843,
+          "spread": 0.00225181,
           "score": 0.00232002
         },
         {
@@ -2008,180 +2008,180 @@
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.0004779,
-          "spread": 0.00395631,
-          "score": 0.00398507
+          "bias": -0.00047751,
+          "spread": 0.00395629,
+          "score": 0.003985
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00599941,
-          "spread": 0.00407109,
-          "score": 0.00725029
+          "bias": 0.00599929,
+          "spread": 0.00407075,
+          "score": 0.00725
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01247322,
-          "spread": 0.00558769,
-          "score": 0.0136676
+          "bias": 0.01247258,
+          "spread": 0.00558814,
+          "score": 0.01366721
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.0071893,
-          "spread": 0.01115011,
-          "score": 0.01326691
+          "bias": 0.00718812,
+          "spread": 0.01115189,
+          "score": 0.01326777
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.0550482,
-          "spread": 0.03998979,
-          "score": 0.06804034
+          "bias": 0.05504582,
+          "spread": 0.0399913,
+          "score": 0.0680393
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.34068596,
-          "spread": 0.32185731,
-          "score": 0.46867799
+          "bias": 0.34068611,
+          "spread": 0.32185845,
+          "score": 0.46867887
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.96296912,
-          "spread": 0.47457864,
-          "score": 1.07356156
+          "bias": 0.08505467,
+          "spread": 0.98968656,
+          "score": 0.99333468
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.0849399,
-          "spread": 0.08818066,
-          "score": 0.12243617
+          "bias": -0.08485712,
+          "spread": 0.08811283,
+          "score": 0.12232989
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00463089,
-          "spread": 0.00207281,
-          "score": 0.00507363
+          "bias": 0.00470364,
+          "spread": 0.00202454,
+          "score": 0.00512084
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00259919,
-          "spread": 0.00302129,
-          "score": 0.00398547
+          "bias": -0.00252129,
+          "spread": 0.00299195,
+          "score": 0.00391263
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00023996,
-          "spread": 0.00199481,
-          "score": 0.00200919
+          "bias": 0.0003183,
+          "spread": 0.00201614,
+          "score": 0.00204111
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00054252,
-          "spread": 0.00160448,
-          "score": 0.00169371
+          "bias": -0.00046224,
+          "spread": 0.00168233,
+          "score": 0.00174468
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00177519,
-          "spread": 0.00522131,
-          "score": 0.00551483
+          "bias": 0.00185323,
+          "spread": 0.00529107,
+          "score": 0.00560623
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.06924626,
-          "spread": 0.03123237,
-          "score": 0.07596384
+          "bias": -0.06918067,
+          "spread": 0.03128142,
+          "score": 0.07592425
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.0133477,
-          "spread": 0.01946837,
-          "score": 0.02360463
+          "bias": 0.00637258,
+          "spread": 0.01400496,
+          "score": 0.01538664
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.0606967,
-          "spread": 0.04405616,
-          "score": 0.07500023
+          "bias": 0.00832078,
+          "spread": 0.00396427,
+          "score": 0.00921688
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
+          "bias": 0.00421786,
+          "spread": 0.00596496,
+          "score": 0.00730556
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.001431,
-          "spread": 0.00727556,
-          "score": 0.00741496
+          "bias": 0.00150032,
+          "spread": 0.00729049,
+          "score": 0.00744327
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00014236,
-          "spread": 0.00676945,
-          "score": 0.00677094
+          "bias": 0.0002125,
+          "spread": 0.00680629,
+          "score": 0.00680961
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00207671,
-          "spread": 0.00674311,
-          "score": 0.00705565
+          "bias": 0.0021475,
+          "spread": 0.00678806,
+          "score": 0.00711966
         },
         {
           "profile": "cp_plus_10pct",
@@ -2206,153 +2206,153 @@
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00320362,
-          "spread": 0.02949029,
-          "score": 0.02966379
+          "bias": -0.01315747,
+          "spread": 0.02852693,
+          "score": 0.03141504
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.0118884,
-          "spread": 0.01863556,
-          "score": 0.0221047
+          "bias": -0.01177883,
+          "spread": 0.0185783,
+          "score": 0.0219976
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00689891,
-          "spread": 0.00989163,
-          "score": 0.01205982
+          "bias": -0.00678789,
+          "spread": 0.0098621,
+          "score": 0.01197232
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00218479,
-          "spread": 0.01639942,
-          "score": 0.01654431
+          "bias": -0.0020751,
+          "spread": 0.01620303,
+          "score": 0.01633536
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00878776,
-          "spread": 0.03913736,
-          "score": 0.04011181
+          "bias": 0.00889415,
+          "spread": 0.03888923,
+          "score": 0.03989333
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.02503507,
-          "spread": 0.01739417,
-          "score": 0.03048462
+          "bias": 0.02515727,
+          "spread": 0.01759747,
+          "score": 0.03070113
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.37632671,
-          "spread": 0.75648033,
-          "score": 0.84491673
+          "bias": 0.37656574,
+          "spread": 0.75682527,
+          "score": 0.84533203
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.17648466,
-          "spread": 0.78301014,
-          "score": 0.80265292
+          "bias": 0.0539565,
+          "spread": 0.07101565,
+          "score": 0.08918815
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
+          "bias": -0.07495366,
+          "spread": 0.10976303,
+          "score": 0.13291341
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.09445266,
-          "spread": 0.03351074,
-          "score": 0.10022113
+          "bias": 0.06037622,
+          "spread": 0.08801493,
+          "score": 0.10673292
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.0022678,
-          "spread": 0.01496907,
-          "score": 0.01513988
+          "bias": -0.00154462,
+          "spread": 0.01564615,
+          "score": 0.01572221
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.0120371,
-          "spread": 0.01619967,
-          "score": 0.0201822
+          "bias": 0.01273256,
+          "spread": 0.01712177,
+          "score": 0.02133713
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.0132674,
-          "spread": 0.02329289,
-          "score": 0.0268064
+          "bias": 0.00517819,
+          "spread": 0.00701694,
+          "score": 0.00872072
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.02998644,
-          "spread": 0.0334847,
-          "score": 0.04494899
+          "bias": 0.00468173,
+          "spread": 0.00841721,
+          "score": 0.00963162
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.0153088,
-          "spread": 0.01110408,
-          "score": 0.0189119
+          "bias": -0.00269719,
+          "spread": 0.00316539,
+          "score": 0.00415867
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.22758649,
-          "spread": 0.22119702,
-          "score": 0.31737003
+          "bias": -0.2269713,
+          "spread": 0.22117219,
+          "score": 0.31691183
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.01019818,
-          "spread": 0.02949106,
-          "score": 0.03120458
+          "bias": -0.00371969,
+          "spread": 0.00265996,
+          "score": 0.00457291
         },
         {
           "profile": "cp_plus_10pct",
@@ -2377,1723 +2377,1075 @@
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00948193,
-          "spread": 0.02214267,
-          "score": 0.02408744
+          "bias": -0.00876836,
+          "spread": 0.02177186,
+          "score": 0.02347121
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00508096,
-          "spread": 0.01591535,
-          "score": 0.01670672
+          "bias": -0.0043661,
+          "spread": 0.01529442,
+          "score": 0.01590541
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.01896609,
-          "spread": 0.01400782,
-          "score": 0.0235782
+          "bias": -0.01824157,
+          "spread": 0.01474993,
+          "score": 0.0234588
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 2,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00036041,
-          "spread": 0.00564058,
-          "score": 0.00565209
+          "bias": 0.0003606,
+          "spread": 0.00564041,
+          "score": 0.00565192
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 2,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00755319,
-          "spread": 0.02046263,
-          "score": 0.02181215
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 2,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00648835,
-          "spread": 0.00811816,
-          "score": 0.01039246
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 2,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": -0.0022225,
-          "spread": 0.0054715,
-          "score": 0.00590566
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 2,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00205313,
-          "spread": 0.0071926,
-          "score": 0.0074799
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 2,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": -0.00819649,
-          "spread": 0.01497535,
-          "score": 0.01707172
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 2,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": -0.01214779,
-          "spread": 0.0405083,
-          "score": 0.04229055
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 2,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": 0.05796773,
-          "spread": 0.18054166,
-          "score": 0.18961948
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 2,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.6642457,
-          "spread": 1.43850223,
-          "score": 1.58445922
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 2,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": -0.45411194,
-          "spread": 2.50032308,
-          "score": 2.5412267
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.10682507,
-          "spread": 0.17667972,
-          "score": 0.20646385
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": 0.001153,
-          "spread": 0.00804941,
-          "score": 0.00813157
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00899817,
-          "spread": 0.00314201,
-          "score": 0.00953097
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": 0.01202224,
-          "spread": 0.00693876,
-          "score": 0.01388094
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00540957,
-          "spread": 0.0087758,
-          "score": 0.01030912
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00338713,
-          "spread": 0.01303291,
-          "score": 0.01346586
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": -0.11409722,
-          "spread": 0.12448398,
-          "score": 0.16886219
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": 0.01072301,
-          "spread": 0.01825045,
-          "score": 0.02116747
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": -0.01034119,
-          "spread": 0.01890435,
-          "score": 0.02154796
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00130204,
-          "spread": 0.00512433,
-          "score": 0.00528717
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00671356,
-          "spread": 0.00844129,
-          "score": 0.01078551
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.00137528,
-          "spread": 0.00241003,
-          "score": 0.00277482
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": 0.10933424,
+          "bias": -0.01800805,
           "spread": 0.0,
-          "score": 0.10933424
+          "score": 0.01800805
         },
         {
           "profile": "cp_plus_10pct",
-          "campaign_months": 3,
+          "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00757282,
-          "spread": 0.0130494,
-          "score": 0.01508755
+          "bias": 0.00157322,
+          "spread": 0.00590996,
+          "score": 0.00611577
         },
         {
           "profile": "cp_plus_10pct",
-          "campaign_months": 3,
+          "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00713425,
-          "spread": 0.00462409,
-          "score": 0.00850175
+          "bias": 0.00649161,
+          "spread": 0.00803883,
+          "score": 0.01033266
         },
         {
           "profile": "cp_plus_10pct",
-          "campaign_months": 3,
+          "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00243648,
-          "spread": 0.00189589,
-          "score": 0.00308721
+          "bias": -0.0022193,
+          "spread": 0.00542093,
+          "score": 0.00585762
         },
         {
           "profile": "cp_plus_10pct",
-          "campaign_months": 3,
+          "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00231374,
-          "spread": 0.01156408,
-          "score": 0.01179327
+          "bias": -0.00204945,
+          "spread": 0.00722553,
+          "score": 0.00751057
         },
         {
           "profile": "cp_plus_10pct",
-          "campaign_months": 3,
+          "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": -0.00038327,
-          "spread": 0.02424716,
-          "score": 0.02425019
+          "bias": -0.00819376,
+          "spread": 0.01493015,
+          "score": 0.01703077
         },
         {
           "profile": "cp_plus_10pct",
-          "campaign_months": 3,
+          "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.03215972,
-          "spread": 0.04907151,
-          "score": 0.05867078
+          "bias": -0.01214767,
+          "spread": 0.04042336,
+          "score": 0.04220917
         },
         {
           "profile": "cp_plus_10pct",
-          "campaign_months": 3,
+          "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.08603376,
-          "spread": 0.12222918,
-          "score": 0.14947167
+          "bias": 0.05797451,
+          "spread": 0.18055122,
+          "score": 0.18963066
         },
         {
           "profile": "cp_plus_10pct",
-          "campaign_months": 3,
+          "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.26036019,
-          "spread": 0.47638966,
-          "score": 0.54289459
+          "bias": 0.55956574,
+          "spread": 1.25891634,
+          "score": 1.37767346
         },
         {
           "profile": "cp_plus_10pct",
-          "campaign_months": 3,
+          "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.16005056,
-          "spread": 0.93873879,
-          "score": 0.95228498
+          "bias": -0.58682211,
+          "spread": 1.38770025,
+          "score": 1.50667587
         },
         {
           "profile": "cp_plus_10pct",
-          "campaign_months": 3,
+          "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.15243897,
-          "spread": 0.19522226,
-          "score": 0.24768805
+          "bias": -0.05927014,
+          "spread": 0.17362776,
+          "score": 0.18346539
         },
         {
           "profile": "cp_plus_10pct",
-          "campaign_months": 3,
+          "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00181988,
-          "spread": 0.00492295,
-          "score": 0.00524856
+          "bias": 0.00131667,
+          "spread": 0.00808126,
+          "score": 0.00818782
         },
         {
           "profile": "cp_plus_10pct",
-          "campaign_months": 3,
+          "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.01007149,
-          "spread": 0.00874812,
-          "score": 0.01334033
+          "bias": 0.00915274,
+          "spread": 0.00304398,
+          "score": 0.00964565
         },
         {
           "profile": "cp_plus_10pct",
-          "campaign_months": 3,
+          "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.0112223,
-          "spread": 0.01294531,
-          "score": 0.01713246
+          "bias": 0.0121763,
+          "spread": 0.00698466,
+          "score": 0.01403737
         },
         {
           "profile": "cp_plus_10pct",
-          "campaign_months": 3,
+          "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00097052,
-          "spread": 0.00649685,
-          "score": 0.00656894
+          "bias": 0.00227728,
+          "spread": 0.00414682,
+          "score": 0.00473097
         },
         {
           "profile": "cp_plus_10pct",
-          "campaign_months": 3,
+          "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.01097127,
-          "spread": 0.01748663,
-          "score": 0.02064343
+          "bias": -0.00163464,
+          "spread": 0.00278092,
+          "score": 0.00322577
         },
         {
           "profile": "cp_plus_10pct",
-          "campaign_months": 3,
+          "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.14002318,
-          "spread": 0.15782083,
-          "score": 0.21098319
+          "bias": -0.11394909,
+          "spread": 0.12441176,
+          "score": 0.16870886
         },
         {
           "profile": "cp_plus_10pct",
-          "campaign_months": 3,
+          "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.01080098,
-          "spread": 0.02466321,
-          "score": 0.02692462
+          "bias": -0.00380973,
+          "spread": 0.00256992,
+          "score": 0.00459549
         },
         {
           "profile": "cp_plus_10pct",
-          "campaign_months": 3,
+          "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00073728,
-          "spread": 0.01835256,
-          "score": 0.01836737
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00263643,
-          "spread": 0.00957779,
-          "score": 0.00993402
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00405137,
-          "spread": 0.00787977,
-          "score": 0.00886027
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.00457516,
-          "spread": 0.0020525,
-          "score": 0.00501446
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00227669,
-          "spread": 0.00986056,
-          "score": 0.01011998
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00581911,
-          "spread": 0.00259036,
-          "score": 0.00636961
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00241501,
-          "spread": 0.00193765,
-          "score": 0.00309625
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00558319,
-          "spread": 0.00682656,
-          "score": 0.00881896
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.0102864,
-          "spread": 0.00878572,
-          "score": 0.0135277
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": 0.01024638,
-          "spread": 0.01500011,
-          "score": 0.01816567
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": 0.07556133,
-          "spread": 0.08457501,
-          "score": 0.11341273
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.17906261,
-          "spread": 0.14815439,
-          "score": 0.23240728
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": -0.10146656,
-          "spread": 0.56396458,
-          "score": 0.57301965
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.11145663,
-          "spread": 0.15068054,
-          "score": 0.18742253
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00140209,
-          "spread": 0.00309919,
-          "score": 0.00340159
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.0092762,
-          "spread": 0.00360045,
-          "score": 0.00995043
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00792622,
-          "spread": 0.00427275,
-          "score": 0.00900452
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00427333,
-          "spread": 0.00388288,
-          "score": 0.00577391
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.01333566,
-          "spread": 0.01329998,
-          "score": 0.01883426
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": -0.17610209,
-          "spread": 0.11804766,
-          "score": 0.21200754
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00881756,
-          "spread": 0.02304719,
-          "score": 0.02467635
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": 0.1758995,
+          "bias": -0.00963368,
           "spread": 0.0,
-          "score": 0.1758995
+          "score": 0.00963368
         },
         {
           "profile": "cp_plus_10pct",
-          "campaign_months": 6,
+          "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00983778,
-          "spread": 0.00894254,
-          "score": 0.01329477
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00372966,
-          "spread": 0.00437553,
-          "score": 0.0057494
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00265908,
-          "spread": 0.00723457,
-          "score": 0.00770777
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.00114401,
-          "spread": 0.00353649,
-          "score": 0.00371692
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": 0.16074839,
+          "bias": 0.0,
           "spread": 0.0,
-          "score": 0.16074839
+          "score": 0.0
         },
         {
           "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00650195,
-          "spread": 0.00156509,
-          "score": 0.00668766
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00085335,
-          "spread": 0.00255236,
-          "score": 0.00269124
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00064905,
-          "spread": 0.00423273,
-          "score": 0.0042822
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00224606,
-          "spread": 0.00539826,
-          "score": 0.00584688
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00735493,
-          "spread": 0.00765629,
-          "score": 0.01061667
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": -0.002826,
-          "spread": 0.01515531,
-          "score": 0.01541654
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": 0.05148621,
-          "spread": 0.05210842,
-          "score": 0.07325379
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.41293426,
-          "spread": 0.46189177,
-          "score": 0.61956332
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": 0.77261729,
-          "spread": 1.06424459,
-          "score": 1.31512509
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.12680534,
-          "spread": 0.11613583,
-          "score": 0.17195094
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00254872,
-          "spread": 0.00412583,
-          "score": 0.00484958
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00535686,
-          "spread": 0.0024798,
-          "score": 0.005903
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00337151,
-          "spread": 0.00250366,
-          "score": 0.00419945
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00124361,
-          "spread": 0.00101331,
-          "score": 0.00160417
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00058961,
-          "spread": 0.00177784,
-          "score": 0.00187306
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": -0.17617382,
-          "spread": 0.11213454,
-          "score": 0.20883335
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00442626,
-          "spread": 0.01198182,
-          "score": 0.01277324
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": 0.04817429,
-          "spread": 0.04093924,
-          "score": 0.06322012
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00222892,
-          "spread": 0.00772157,
-          "score": 0.00803683
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.0013721,
-          "spread": 0.007022,
-          "score": 0.0071548
-        },
-        {
-          "profile": "cp_plus_10pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00025088,
-          "spread": 0.00759232,
-          "score": 0.00759646
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 1,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": -0.00568276,
-          "spread": 0.01004317,
-          "score": 0.01153945
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 1,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 1,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00519787,
-          "spread": 0.03163461,
-          "score": 0.03205879
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 1,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": -0.01079221,
-          "spread": 0.01595232,
-          "score": 0.01926002
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 1,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00635507,
-          "spread": 0.01011095,
-          "score": 0.01194229
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 1,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00118282,
-          "spread": 0.0160625,
-          "score": 0.016106
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 1,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00911978,
-          "spread": 0.03651582,
-          "score": 0.03763743
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 1,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": 0.02870565,
-          "spread": 0.02024364,
-          "score": 0.03512577
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 1,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": 0.35325568,
-          "spread": 0.69421985,
-          "score": 0.77892925
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 1,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.23206936,
-          "spread": 0.67723425,
-          "score": 0.71589274
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 1,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 1,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": 0.06101174,
-          "spread": 0.04428518,
-          "score": 0.07538972
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 1,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00044627,
-          "spread": 0.01672295,
-          "score": 0.0167289
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 1,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00843642,
-          "spread": 0.01677733,
-          "score": 0.01877904
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 1,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": 0.01166653,
-          "spread": 0.02105494,
-          "score": 0.02407112
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 1,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.02870597,
-          "spread": 0.03126683,
-          "score": 0.04244582
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 1,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.01805637,
-          "spread": 0.01346377,
-          "score": 0.02252345
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 1,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": -0.17125498,
-          "spread": 0.16392943,
-          "score": 0.23706777
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 1,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": 0.01420242,
-          "spread": 0.03486181,
-          "score": 0.03764378
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 1,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 1,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 1,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": -0.01042699,
-          "spread": 0.02168348,
-          "score": 0.02406025
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 1,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00573394,
-          "spread": 0.01599775,
-          "score": 0.01699429
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 1,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": -0.01705663,
-          "spread": 0.01359256,
-          "score": 0.02181023
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 2,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.00038912,
-          "spread": 0.00536846,
-          "score": 0.00538255
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 2,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 2,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00393918,
-          "spread": 0.01719586,
-          "score": 0.01764128
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 2,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00348178,
-          "spread": 0.00650645,
-          "score": 0.00737948
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 2,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00174284,
-          "spread": 0.0062582,
-          "score": 0.00649635
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 2,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00038837,
-          "spread": 0.00447932,
-          "score": 0.00449612
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 2,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": -0.00392734,
-          "spread": 0.01384852,
-          "score": 0.01439463
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 2,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00679467,
-          "spread": 0.03932323,
-          "score": 0.03990594
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 2,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": 0.06906784,
-          "spread": 0.16294035,
-          "score": 0.17697435
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 2,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.69679999,
-          "spread": 1.36682926,
-          "score": 1.5341944
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 2,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": 0.33249112,
-          "spread": 1.5088501,
-          "score": 1.54504983
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.05625402,
-          "spread": 0.14842457,
-          "score": 0.15872733
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00263649,
-          "spread": 0.01040297,
-          "score": 0.01073186
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.0048636,
-          "spread": 0.00382702,
-          "score": 0.00618875
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00939784,
-          "spread": 0.00579037,
-          "score": 0.01103847
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00356214,
-          "spread": 0.00716929,
-          "score": 0.00800546
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00240742,
-          "spread": 0.01366565,
-          "score": 0.01387608
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": -0.08237378,
-          "spread": 0.10591538,
-          "score": 0.13417714
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00874047,
-          "spread": 0.01604271,
-          "score": 0.01826922
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00931908,
-          "spread": 0.0163303,
-          "score": 0.01880223
+          "bias": -0.01017839,
+          "spread": 0.0187558,
+          "score": 0.02133962
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "cp_plus_10pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00189226,
-          "spread": 0.00453297,
-          "score": 0.00491208
+          "bias": 0.00146992,
+          "spread": 0.00527274,
+          "score": 0.0054738
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "cp_plus_10pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00467892,
-          "spread": 0.00791442,
-          "score": 0.00919403
+          "bias": -0.00654679,
+          "spread": 0.00855949,
+          "score": 0.01077615
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00136233,
-          "spread": 0.00231432,
-          "score": 0.00268552
+          "bias": 0.00137479,
+          "spread": 0.00241035,
+          "score": 0.00277486
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.06154882,
+          "bias": 0.02362693,
+          "spread": 0.04956016,
+          "score": 0.05490393
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": -0.00752838,
+          "spread": 0.01309689,
+          "score": 0.01510646
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.00717892,
+          "spread": 0.00462602,
+          "score": 0.00854031
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00239148,
+          "spread": 0.00185008,
+          "score": 0.00302357
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.00226828,
+          "spread": 0.01153174,
+          "score": 0.01175271
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": -0.00033763,
+          "spread": 0.02421819,
+          "score": 0.02422054
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.03211586,
+          "spread": 0.04904209,
+          "score": 0.05862214
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.08609015,
+          "spread": 0.12229098,
+          "score": 0.14955467
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.2637422,
+          "spread": 0.41265365,
+          "score": 0.48973767
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": 0.02555113,
+          "spread": 0.34298784,
+          "score": 0.34393825
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.15236211,
+          "spread": 0.19532295,
+          "score": 0.24772014
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": -0.00174937,
+          "spread": 0.00488448,
+          "score": 0.0051883
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.01013887,
+          "spread": 0.00882258,
+          "score": 0.01344004
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.01128934,
+          "spread": 0.01304546,
+          "score": 0.01725205
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00185811,
+          "spread": 0.00640594,
+          "score": 0.00666998
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": -0.00223408,
+          "spread": 0.00261857,
+          "score": 0.0034421
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.13996786,
+          "spread": 0.15773505,
+          "score": 0.21088231
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": -0.01000701,
+          "spread": 0.00900665,
+          "score": 0.01346329
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.00481684,
+          "spread": 0.00481684,
+          "score": 0.00681204
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": 0.0,
           "spread": 0.0,
-          "score": 0.06154882
+          "score": 0.0
         },
         {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00818153,
-          "spread": 0.01209691,
-          "score": 0.01460386
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00453088,
-          "spread": 0.00395464,
-          "score": 0.00601399
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00148822,
-          "spread": 0.00148939,
-          "score": 0.00210549
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00026264,
-          "spread": 0.01062083,
-          "score": 0.01062408
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00308617,
-          "spread": 0.02077879,
-          "score": 0.02100672
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": -0.02840053,
-          "spread": 0.04816343,
-          "score": 0.05591338
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": 0.08241273,
-          "spread": 0.10044191,
-          "score": 0.12992473
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.26028698,
-          "spread": 0.43690631,
-          "score": 0.50856311
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": 0.22508669,
-          "spread": 0.8106651,
-          "score": 0.84133342
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.14765746,
-          "spread": 0.18964649,
-          "score": 0.24035082
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00076382,
-          "spread": 0.0058491,
-          "score": 0.00589877
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00689419,
-          "spread": 0.0080812,
-          "score": 0.01062241
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": 0.01006715,
-          "spread": 0.01123366,
-          "score": 0.01508451
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00057511,
-          "spread": 0.00471795,
-          "score": 0.00475288
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.01121669,
-          "spread": 0.01615571,
-          "score": 0.01966777
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": -0.10734547,
-          "spread": 0.13031581,
-          "score": 0.16883501
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00558984,
-          "spread": 0.02923425,
-          "score": 0.02976387
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_plus_3pct",
+          "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -4.831e-05,
-          "spread": 0.0168544,
-          "score": 0.01685447
+          "bias": 0.00080708,
+          "spread": 0.01825128,
+          "score": 0.01826912
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00341791,
-          "spread": 0.00933189,
-          "score": 0.00993812
+          "bias": -0.00256626,
+          "spread": 0.00945253,
+          "score": 0.00979469
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00255363,
-          "spread": 0.00776582,
-          "score": 0.0081749
+          "bias": -0.00398075,
+          "spread": 0.00780345,
+          "score": 0.00876015
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00443749,
-          "spread": 0.00195882,
-          "score": 0.0048506
+          "bias": 0.00457547,
+          "spread": 0.00205215,
+          "score": 0.00501461
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
+          "bias": -0.02650066,
+          "spread": 0.00053702,
+          "score": 0.0265061
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00125893,
-          "spread": 0.00882351,
-          "score": 0.00891287
+          "bias": -0.00227638,
+          "spread": 0.00986092,
+          "score": 0.01012026
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.0044226,
-          "spread": 0.00182923,
-          "score": 0.00478596
+          "bias": 0.00581942,
+          "spread": 0.00258988,
+          "score": 0.0063697
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.0023729,
-          "spread": 0.00218172,
-          "score": 0.00322344
+          "bias": 0.00241532,
+          "spread": 0.00193715,
+          "score": 0.00309618
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00712854,
-          "spread": 0.00625594,
-          "score": 0.00948435
+          "bias": 0.00558352,
+          "spread": 0.00682675,
+          "score": 0.00881931
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01200246,
-          "spread": 0.00824462,
-          "score": 0.01456135
+          "bias": 0.01028672,
+          "spread": 0.00878575,
+          "score": 0.01352797
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.01189303,
-          "spread": 0.01383608,
-          "score": 0.01824504
+          "bias": 0.0102467,
+          "spread": 0.01499992,
+          "score": 0.0181657
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.07627773,
-          "spread": 0.07724374,
-          "score": 0.10855823
+          "bias": 0.07556166,
+          "spread": 0.08457475,
+          "score": 0.11341276
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.25621289,
-          "spread": 0.06263174,
-          "score": 0.26375704
+          "bias": 0.17906305,
+          "spread": 0.1481549,
+          "score": 0.23240794
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.04515741,
-          "spread": 0.53783008,
-          "score": 0.53972251
+          "bias": -0.02634082,
+          "spread": 0.50544443,
+          "score": 0.50613033
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.08566212,
-          "spread": 0.14073101,
-          "score": 0.16475198
+          "bias": -0.11121012,
+          "spread": 0.15069998,
+          "score": 0.18729168
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00070133,
-          "spread": 0.00317264,
-          "score": 0.00324924
+          "bias": -0.00110307,
+          "spread": 0.00316256,
+          "score": 0.00334941
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00594515,
-          "spread": 0.00425373,
-          "score": 0.0073102
+          "bias": 0.00956147,
+          "spread": 0.00371826,
+          "score": 0.01025901
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00674198,
-          "spread": 0.00383894,
-          "score": 0.00775834
+          "bias": 0.00820904,
+          "spread": 0.00436785,
+          "score": 0.00929873
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00367588,
-          "spread": 0.00261789,
-          "score": 0.00451281
+          "bias": 0.00455452,
+          "spread": 0.00386591,
+          "score": 0.00597402
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.01369118,
-          "spread": 0.01339336,
-          "score": 0.01915282
+          "bias": -9.778e-05,
+          "spread": 0.00342619,
+          "score": 0.00342759
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.1352824,
-          "spread": 0.08308691,
-          "score": 0.15876008
+          "bias": -0.17581003,
+          "spread": 0.1182412,
+          "score": 0.21187295
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.0064004,
-          "spread": 0.02482486,
-          "score": 0.02563667
+          "bias": -0.00513268,
+          "spread": 0.00534076,
+          "score": 0.0074073
         },
         {
-          "profile": "cp_plus_3pct",
+          "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.1791067,
+          "bias": -0.01285704,
+          "spread": 0.00302876,
+          "score": 0.01320897
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": 0.0,
           "spread": 0.0,
-          "score": 0.1791067
+          "score": 0.0
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": 0.01015016,
+          "spread": 0.0091512,
+          "score": 0.01366639
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.00403849,
+          "spread": 0.00433888,
+          "score": 0.0059275
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00296652,
+          "spread": 0.00707519,
+          "score": 0.00767193
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00114412,
+          "spread": 0.00353644,
+          "score": 0.00371691
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.00991364,
+          "spread": 0.04857429,
+          "score": 0.04957562
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": -0.00650031,
+          "spread": 0.00156636,
+          "score": 0.00668636
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.000855,
+          "spread": 0.00255201,
+          "score": 0.00269143
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00065072,
+          "spread": 0.0042328,
+          "score": 0.00428253
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": 0.00224771,
+          "spread": 0.00539659,
+          "score": 0.00584597
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.00735666,
+          "spread": 0.00765538,
+          "score": 0.01061722
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.00282425,
+          "spread": 0.01515655,
+          "score": 0.01541743
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.05148816,
+          "spread": 0.05211119,
+          "score": 0.07325713
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.41293776,
+          "spread": 0.46189709,
+          "score": 0.61956962
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": 0.78623224,
+          "spread": 0.81223859,
+          "score": 1.13043915
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.12673658,
+          "spread": 0.11609313,
+          "score": 0.17187139
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": -0.00245583,
+          "spread": 0.00414125,
+          "score": 0.00481467
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00544503,
+          "spread": 0.0024832,
+          "score": 0.00598454
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.00345875,
+          "spread": 0.00249175,
+          "score": 0.00426284
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00133069,
+          "spread": 0.00102921,
+          "score": 0.00168226
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00067691,
+          "spread": 0.0018322,
+          "score": 0.00195324
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.17608435,
+          "spread": 0.11218495,
+          "score": 0.20878496
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": -0.00183514,
+          "spread": 0.01060477,
+          "score": 0.01076238
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.00832078,
+          "spread": 0.00396427,
+          "score": 0.00921688
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": -0.00421786,
+          "spread": 0.00596496,
+          "score": 0.00730556
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": 0.00232474,
+          "spread": 0.00772591,
+          "score": 0.00806809
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.00146797,
+          "spread": 0.00705313,
+          "score": 0.00720428
+        },
+        {
+          "profile": "cp_plus_10pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": -0.00015515,
+          "spread": 0.00762341,
+          "score": 0.00762499
         },
         {
           "profile": "cp_plus_3pct",
-          "campaign_months": 6,
+          "campaign_months": 1,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": -0.00568163,
+          "spread": 0.0100431,
+          "score": 0.01153884
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": -0.01315547,
+          "spread": 0.01750782,
+          "score": 0.02189955
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": -0.0107483,
+          "spread": 0.01588643,
+          "score": 0.01918084
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00631092,
+          "spread": 0.01003108,
+          "score": 0.01185117
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.00114023,
+          "spread": 0.01589535,
+          "score": 0.01593619
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.00915887,
+          "spread": 0.03632492,
+          "score": 0.03746178
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": 0.02875476,
+          "spread": 0.02035436,
+          "score": 0.03522977
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.35333888,
+          "spread": 0.69432505,
+          "score": 0.77906075
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.04295883,
+          "spread": 0.05709694,
+          "score": 0.07145293
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.02635527,
+          "spread": 0.03761242,
+          "score": 0.04592706
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": 0.01077001,
+          "spread": 0.09407371,
+          "score": 0.0946882
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.001066,
+          "spread": 0.01726563,
+          "score": 0.0172985
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.0090542,
+          "spread": 0.01758544,
+          "score": 0.01977944
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.00501732,
+          "spread": 0.00708605,
+          "score": 0.00868249
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00546753,
+          "spread": 0.00956225,
+          "score": 0.01101501
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": -0.00080916,
+          "spread": 0.00094962,
+          "score": 0.0012476
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.17074409,
+          "spread": 0.16384509,
+          "score": 0.23664056
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": -0.00111591,
+          "spread": 0.00079799,
+          "score": 0.00137187
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
           "bias": NaN,
@@ -4102,1933 +3454,1069 @@
         },
         {
           "profile": "cp_plus_3pct",
-          "campaign_months": 6,
+          "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00868317,
-          "spread": 0.0077442,
-          "score": 0.01163486
+          "bias": -0.00982797,
+          "spread": 0.0212703,
+          "score": 0.02343106
         },
         {
           "profile": "cp_plus_3pct",
-          "campaign_months": 6,
+          "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00341159,
-          "spread": 0.00472805,
-          "score": 0.00583039
+          "bias": -0.00513185,
+          "spread": 0.01546382,
+          "score": 0.01629312
         },
         {
           "profile": "cp_plus_3pct",
-          "campaign_months": 6,
+          "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00405158,
-          "spread": 0.00692649,
-          "score": 0.00802443
+          "bias": -0.01644368,
+          "spread": 0.01425705,
+          "score": 0.02176368
         },
         {
           "profile": "cp_plus_3pct",
-          "campaign_months": 12,
+          "campaign_months": 2,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00114682,
-          "spread": 0.00339881,
-          "score": 0.00358708
+          "bias": 0.00038958,
+          "spread": 0.00536804,
+          "score": 0.00538215
         },
         {
           "profile": "cp_plus_3pct",
-          "campaign_months": 12,
+          "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.14223447,
+          "bias": 0.00017032,
           "spread": 0.0,
-          "score": 0.14223447
+          "score": 0.00017032
         },
         {
           "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00372792,
-          "spread": 0.00218868,
-          "score": 0.00432293
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00029124,
-          "spread": 0.00245531,
-          "score": 0.00247253
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": 0.0003596,
-          "spread": 0.00412044,
-          "score": 0.0041361
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00350537,
-          "spread": 0.00505696,
-          "score": 0.00615309
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00912575,
-          "spread": 0.0069141,
-          "score": 0.01144919
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": 0.0007554,
-          "spread": 0.01308424,
-          "score": 0.01310603
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": 0.05327257,
-          "spread": 0.04617958,
-          "score": 0.07050191
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.38960271,
-          "spread": 0.41924343,
-          "score": 0.57232449
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": 0.84352647,
-          "spread": 0.8383376,
-          "score": 1.18926315
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.11597794,
-          "spread": 0.09252722,
-          "score": 0.14836499
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00014072,
-          "spread": 0.00308231,
-          "score": 0.00308552
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00257127,
-          "spread": 0.00248035,
-          "score": 0.00357262
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00234339,
-          "spread": 0.00222497,
-          "score": 0.0032314
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00070722,
-          "spread": 0.00094618,
-          "score": 0.00118128
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00119344,
-          "spread": 0.00269313,
-          "score": 0.00294572
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": -0.13875271,
-          "spread": 0.08172529,
-          "score": 0.1610321
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": 0.0074959,
-          "spread": 0.01496975,
-          "score": 0.01674163
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": 0.05267694,
-          "spread": 0.04122538,
-          "score": 0.0668909
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00139498,
-          "spread": 0.00751943,
-          "score": 0.00764773
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00094198,
-          "spread": 0.00691472,
-          "score": 0.00697858
-        },
-        {
-          "profile": "cp_plus_3pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00069362,
-          "spread": 0.00734911,
-          "score": 0.00738177
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 1,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": -0.00556857,
-          "spread": 0.00997365,
-          "score": 0.0114229
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 1,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 1,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00431219,
-          "spread": 0.03618159,
-          "score": 0.03643765
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 1,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": -0.01008905,
-          "spread": 0.01386021,
-          "score": 0.01714334
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 1,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": -0.0065983,
-          "spread": 0.01135789,
-          "score": 0.01313541
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 1,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": 2.833e-05,
-          "spread": 0.01623715,
-          "score": 0.01623718
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 1,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01124192,
-          "spread": 0.03609808,
-          "score": 0.0378081
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 1,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": 0.03052076,
-          "spread": 0.02313358,
-          "score": 0.03829725
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 1,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": 0.35263702,
-          "spread": 0.67300591,
-          "score": 0.75979591
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 1,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.46352987,
-          "spread": 0.62241102,
-          "score": 0.77605117
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 1,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 1,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": 0.04579072,
-          "spread": 0.03801787,
-          "score": 0.05951595
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 1,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00114459,
-          "spread": 0.01886467,
-          "score": 0.01889936
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 1,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00222497,
-          "spread": 0.01709013,
-          "score": 0.01723436
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 1,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00941235,
-          "spread": 0.01889785,
-          "score": 0.02111211
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 1,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.02836247,
-          "spread": 0.02807591,
-          "score": 0.03990848
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 1,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.02124022,
-          "spread": 0.01603354,
-          "score": 0.02661243
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 1,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": -0.14176335,
-          "spread": 0.1433315,
-          "score": 0.20159555
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 1,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": 0.01627582,
-          "spread": 0.04114204,
-          "score": 0.04424443
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 1,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 1,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 1,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": -0.01132078,
-          "spread": 0.01779712,
-          "score": 0.0210926
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 1,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00514457,
-          "spread": 0.01602569,
-          "score": 0.0168312
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 1,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": -0.01448099,
-          "spread": 0.01312159,
-          "score": 0.01954163
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 2,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.00041763,
-          "spread": 0.005332,
-          "score": 0.00534833
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 2,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "rated_plus_5pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00111924,
-          "spread": 0.01616985,
-          "score": 0.01620854
+          "bias": 0.00448897,
+          "spread": 0.00327465,
+          "score": 0.00555645
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00068018,
-          "spread": 0.00599207,
-          "score": 0.00603055
+          "bias": 0.00348424,
+          "spread": 0.00644256,
+          "score": 0.00732438
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.0012451,
-          "spread": 0.00705219,
-          "score": 0.00716126
+          "bias": -0.0017404,
+          "spread": 0.0062089,
+          "score": 0.00644821
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00262111,
-          "spread": 0.00274651,
-          "score": 0.00379652
+          "bias": 0.00039129,
+          "spread": 0.00451747,
+          "score": 0.00453439
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00013021,
-          "spread": 0.01344985,
-          "score": 0.01345048
+          "bias": -0.00392525,
+          "spread": 0.01380187,
+          "score": 0.01434919
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00169586,
-          "spread": 0.0421776,
-          "score": 0.04221168
+          "bias": -0.00679505,
+          "spread": 0.03924455,
+          "score": 0.03982847
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.07333253,
-          "spread": 0.14929467,
-          "score": 0.16633267
+          "bias": 0.06907202,
+          "spread": 0.162945,
+          "score": 0.17698027
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.64862953,
-          "spread": 1.22487786,
-          "score": 1.38601805
+          "bias": 0.54021744,
+          "spread": 1.21438733,
+          "score": 1.32912432
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.69164537,
-          "spread": 1.10526418,
-          "score": 1.30383366
+          "bias": -0.24747673,
+          "spread": 0.54119802,
+          "score": 0.59509665
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.11761141,
-          "spread": 0.11011602,
-          "score": 0.16111481
+          "bias": -0.03215046,
+          "spread": 0.13498696,
+          "score": 0.13876286
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00416207,
-          "spread": 0.01277733,
-          "score": 0.01343812
+          "bias": 0.00270791,
+          "spread": 0.01050771,
+          "score": 0.01085103
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00138,
-          "spread": 0.00430215,
-          "score": 0.00451806
+          "bias": 0.00493222,
+          "spread": 0.00371496,
+          "score": 0.00617477
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00818165,
-          "spread": 0.00528837,
-          "score": 0.00974199
+          "bias": 0.00946682,
+          "spread": 0.0057677,
+          "score": 0.01108544
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00360673,
-          "spread": 0.00799511,
-          "score": 0.00877099
+          "bias": 0.00228919,
+          "spread": 0.00402572,
+          "score": 0.00463107
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00197062,
-          "spread": 0.01697591,
-          "score": 0.0170899
+          "bias": -0.00049039,
+          "spread": 0.00083428,
+          "score": 0.00096773
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.06608531,
-          "spread": 0.10462908,
-          "score": 0.12375182
+          "bias": -0.08231498,
+          "spread": 0.10584851,
+          "score": 0.13408827
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.01106395,
-          "spread": 0.01719905,
-          "score": 0.02045039
+          "bias": -0.00114292,
+          "spread": 0.00077098,
+          "score": 0.00137865
         },
         {
-          "profile": "rated_plus_5pct",
+          "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00704223,
-          "spread": 0.01500173,
-          "score": 0.01657241
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00165495,
-          "spread": 0.00647368,
-          "score": 0.00668187
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00355713,
-          "spread": 0.00754064,
-          "score": 0.00833753
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 3,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.0013897,
-          "spread": 0.00231492,
-          "score": 0.00270002
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": 0.11115948,
+          "bias": -0.0028901,
           "spread": 0.0,
-          "score": 0.11115948
+          "score": 0.0028901
         },
         {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00950232,
-          "spread": 0.01326041,
-          "score": 0.01631357
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00185446,
-          "spread": 0.0035739,
-          "score": 0.00402639
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00104927,
-          "spread": 0.00193702,
-          "score": 0.00220295
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": 0.002925,
-          "spread": 0.01028772,
-          "score": 0.01069546
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00852144,
-          "spread": 0.01851106,
-          "score": 0.02037828
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": -0.0244975,
-          "spread": 0.04097763,
-          "score": 0.04774195
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": 0.08698378,
-          "spread": 0.1096048,
-          "score": 0.13992638
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.2545894,
-          "spread": 0.41693337,
-          "score": 0.48851734
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 3,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": 0.22379727,
-          "spread": 0.75398291,
-          "score": 0.78649568
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.05981804,
-          "spread": 0.14810764,
-          "score": 0.15973125
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00328037,
-          "spread": 0.00847962,
-          "score": 0.00909202
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00238443,
-          "spread": 0.00792208,
-          "score": 0.00827314
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": 0.009021,
-          "spread": 0.01046836,
-          "score": 0.01381901
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00058226,
-          "spread": 0.00389548,
-          "score": 0.00393875
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.01075915,
-          "spread": 0.01422308,
-          "score": 0.01783411
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": -0.09746225,
-          "spread": 0.10852997,
-          "score": 0.14586859
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00175046,
-          "spread": 0.03416914,
-          "score": 0.03421395
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 3,
+          "profile": "cp_plus_3pct",
+          "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00105753,
-          "spread": 0.01784843,
-          "score": 0.01787973
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00284807,
-          "spread": 0.01071968,
-          "score": 0.01109158
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 3,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00086082,
-          "spread": 0.00842639,
-          "score": 0.00847024
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.00446329,
-          "spread": 0.00193841,
-          "score": 0.00486605
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00012271,
-          "spread": 0.00719536,
-          "score": 0.00719641
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": 0.0027688,
-          "spread": 0.00157926,
-          "score": 0.00318752
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00233695,
-          "spread": 0.00260889,
-          "score": 0.00350252
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": 0.01004418,
-          "spread": 0.00570791,
-          "score": 0.01155274
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01500034,
-          "spread": 0.00661007,
-          "score": 0.01639217
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": 0.01388151,
-          "spread": 0.01484025,
-          "score": 0.02032066
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": 0.08084007,
-          "spread": 0.07564066,
-          "score": 0.11070964
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.25703257,
-          "spread": 0.04902675,
-          "score": 0.26166651
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": 0.0325507,
-          "spread": 0.52190427,
-          "score": 0.52291837
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.08678215,
-          "spread": 0.17593955,
-          "score": 0.19617815
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00342259,
-          "spread": 0.00376094,
-          "score": 0.00508515
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00191029,
-          "spread": 0.00517734,
-          "score": 0.00551852
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00507379,
-          "spread": 0.00384042,
-          "score": 0.00636335
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00243808,
-          "spread": 0.00154543,
-          "score": 0.00288662
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.01420687,
-          "spread": 0.01430313,
-          "score": 0.02015973
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": -0.11496441,
-          "spread": 0.06913642,
-          "score": 0.13415163
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00377747,
-          "spread": 0.02901956,
-          "score": 0.02926438
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": 0.19535657,
+          "bias": 0.0,
           "spread": 0.0,
-          "score": 0.19535657
+          "score": 0.0
         },
         {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
+          "profile": "cp_plus_3pct",
+          "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00919438,
-          "spread": 0.00782831,
-          "score": 0.01207556
+          "bias": -0.00925067,
+          "spread": 0.01623981,
+          "score": 0.01868974
         },
         {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
+          "profile": "cp_plus_3pct",
+          "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00309443,
-          "spread": 0.00527818,
-          "score": 0.00611839
+          "bias": 0.00196349,
+          "spread": 0.00466508,
+          "score": 0.00506145
         },
         {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 6,
+          "profile": "cp_plus_3pct",
+          "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00487366,
-          "spread": 0.00680494,
-          "score": 0.00837017
+          "bias": -0.00460766,
+          "spread": 0.00805392,
+          "score": 0.00927881
         },
         {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00118609,
-          "spread": 0.00340396,
-          "score": 0.00360468
+          "bias": 0.00136341,
+          "spread": 0.00231393,
+          "score": 0.00268573
         },
         {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.13176606,
+          "bias": 0.0093264,
+          "spread": 0.0161731,
+          "score": 0.01866951
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": -0.00815,
+          "spread": 0.01212394,
+          "score": 0.01460864
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.00456248,
+          "spread": 0.00395133,
+          "score": 0.00603566
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00145666,
+          "spread": 0.00146365,
+          "score": 0.00206497
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": -0.00023099,
+          "spread": 0.01060525,
+          "score": 0.01060776
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.00311785,
+          "spread": 0.0207634,
+          "score": 0.02099619
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.02837009,
+          "spread": 0.04815151,
+          "score": 0.05588766
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.08245004,
+          "spread": 0.10047517,
+          "score": 0.12997411
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.21600857,
+          "spread": 0.38612106,
+          "score": 0.4424355
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.01707768,
+          "spread": 0.1409623,
+          "score": 0.14199302
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.14762292,
+          "spread": 0.18974688,
+          "score": 0.24040882
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.00077978,
+          "spread": 0.00585846,
+          "score": 0.00591013
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00691031,
+          "spread": 0.00815771,
+          "score": 0.01069115
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.01008349,
+          "spread": 0.0113212,
+          "score": 0.01516069
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00168652,
+          "spread": 0.00435875,
+          "score": 0.00467366
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": -0.00067022,
+          "spread": 0.00078557,
+          "score": 0.00103263
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.10734297,
+          "spread": 0.13021817,
+          "score": 0.16875806
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": -0.0030021,
+          "spread": 0.002702,
+          "score": 0.00403899
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.00144505,
+          "spread": 0.00144505,
+          "score": 0.00204361
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": 0.0,
           "spread": 0.0,
-          "score": 0.13176606
+          "score": 0.0
         },
         {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00068938,
-          "spread": 0.00439936,
-          "score": 0.00445305
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": -0.000264,
-          "spread": 0.00253938,
-          "score": 0.00255307
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00012931,
-          "spread": 0.00413092,
-          "score": 0.00413294
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": 0.0052754,
-          "spread": 0.0046988,
-          "score": 0.0070646
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01171787,
-          "spread": 0.00646594,
-          "score": 0.01338345
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00338294,
-          "spread": 0.01266773,
-          "score": 0.01311166
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": 0.05548041,
-          "spread": 0.04650953,
-          "score": 0.07239622
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.37368849,
-          "spread": 0.38530455,
-          "score": 0.53675198
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": 0.86907665,
-          "spread": 0.76205615,
-          "score": 1.15586495
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.11001455,
-          "spread": 0.10215738,
-          "score": 0.15013104
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00299655,
-          "spread": 0.00224384,
-          "score": 0.00374355
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00044182,
-          "spread": 0.00292949,
-          "score": 0.00296262
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": 0.0010021,
-          "spread": 0.00218957,
-          "score": 0.00240799
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00019575,
-          "spread": 0.00124081,
-          "score": 0.00125616
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00142855,
-          "spread": 0.00417391,
-          "score": 0.00441161
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": -0.12426835,
-          "spread": 0.07062621,
-          "score": 0.14293595
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": 0.01134319,
-          "spread": 0.01844431,
-          "score": 0.02165319
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": 0.05952366,
-          "spread": 0.04383909,
-          "score": 0.07392518
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00170609,
-          "spread": 0.00772326,
-          "score": 0.00790945
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00068032,
-          "spread": 0.00715747,
-          "score": 0.00718973
-        },
-        {
-          "profile": "rated_plus_5pct",
-          "campaign_months": 12,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00163072,
-          "spread": 0.00736967,
-          "score": 0.00754793
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 1,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": -0.00579626,
-          "spread": 0.01023767,
-          "score": 0.01176463
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 1,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 1,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00981778,
-          "spread": 0.03025881,
-          "score": 0.0318117
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 1,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": -0.01621381,
-          "spread": 0.01944661,
-          "score": 0.02531913
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 1,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": -0.0075159,
-          "spread": 0.01081032,
-          "score": 0.01316631
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 1,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": 0.0044434,
-          "spread": 0.01726123,
-          "score": 0.01782397
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 1,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.02281581,
-          "spread": 0.03738176,
-          "score": 0.04379449
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 1,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": 0.05169126,
-          "spread": 0.0208259,
-          "score": 0.05572885
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 1,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": 0.37587072,
-          "spread": 0.67693498,
-          "score": 0.77428661
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 1,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.26329019,
-          "spread": 0.6579467,
-          "score": 0.7086717
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 1,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 1,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": 0.09506932,
-          "spread": 0.00928017,
-          "score": 0.09552119
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 1,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00216367,
-          "spread": 0.01500843,
-          "score": 0.01516359
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 1,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00861236,
-          "spread": 0.01585736,
-          "score": 0.01804518
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 1,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": 0.01083439,
-          "spread": 0.0201762,
-          "score": 0.02290116
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 1,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.02751414,
-          "spread": 0.02960552,
-          "score": 0.04041676
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 1,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.01868322,
-          "spread": 0.0132891,
-          "score": 0.02292734
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 1,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": -0.16128254,
-          "spread": 0.17483213,
-          "score": 0.237862
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 1,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": 0.01163403,
-          "spread": 0.0351423,
-          "score": 0.03701799
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 1,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 1,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 1,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00650259,
-          "spread": 0.02000496,
-          "score": 0.02103526
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 1,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00438901,
-          "spread": 0.01553314,
-          "score": 0.01614131
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 1,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": -0.01749595,
-          "spread": 0.01342222,
-          "score": 0.0220514
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 2,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.0004023,
-          "spread": 0.00550154,
-          "score": 0.00551623
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 2,
-          "condition": "ti",
-          "condition_bin": "(0.0, 0.05]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 2,
-          "condition": "ti",
-          "condition_bin": "(0.05, 0.1]",
-          "bias": -0.01272529,
-          "spread": 0.02001497,
-          "score": 0.02371776
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 2,
-          "condition": "ti",
-          "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00163307,
-          "spread": 0.00868255,
-          "score": 0.0088348
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 2,
-          "condition": "ti",
-          "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00287922,
-          "spread": 0.00679336,
-          "score": 0.00737832
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 2,
-          "condition": "ti",
-          "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00491053,
-          "spread": 0.00731052,
-          "score": 0.00880664
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 2,
-          "condition": "ti",
-          "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01083295,
-          "spread": 0.01215426,
-          "score": 0.01628125
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 2,
-          "condition": "ti",
-          "condition_bin": "(0.3, 0.35]",
-          "bias": 0.01660237,
-          "spread": 0.03932818,
-          "score": 0.04268893
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 2,
-          "condition": "ti",
-          "condition_bin": "(0.35, 0.4]",
-          "bias": 0.09331262,
-          "spread": 0.16494351,
-          "score": 0.18950886
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 2,
-          "condition": "ti",
-          "condition_bin": "(0.4, 0.45]",
-          "bias": 0.71499184,
-          "spread": 1.33033171,
-          "score": 1.51029659
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 2,
-          "condition": "ti",
-          "condition_bin": "(0.45, 0.5]",
-          "bias": 0.71793698,
-          "spread": 1.12777687,
-          "score": 1.3369047
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(0.0, 2.0]",
-          "bias": -0.09642402,
-          "spread": 0.11258164,
-          "score": 0.14823029
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00010331,
-          "spread": 0.00953766,
-          "score": 0.00953822
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00495053,
-          "spread": 0.00372018,
-          "score": 0.00619253
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00929292,
-          "spread": 0.00606316,
-          "score": 0.01109596
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00308879,
-          "spread": 0.00773667,
-          "score": 0.00833047
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00258513,
-          "spread": 0.01371142,
-          "score": 0.01395299
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(2.0, 4.0]",
-          "bias": -0.07921844,
-          "spread": 0.11397876,
-          "score": 0.13880461
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00800084,
-          "spread": 0.0172468,
-          "score": 0.01901225
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(22.0, 24.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(4.0, 6.0]",
-          "bias": -0.0055249,
-          "spread": 0.01615802,
-          "score": 0.01707648
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00416083,
-          "spread": 0.00530902,
-          "score": 0.00674524
-        },
-        {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 2,
-          "condition": "ws",
-          "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00517292,
-          "spread": 0.00727533,
-          "score": 0.0089269
-        },
-        {
-          "profile": "ti_dependent_cp",
+          "profile": "cp_plus_3pct",
           "campaign_months": 3,
-          "condition": "overall",
-          "condition_bin": "overall",
-          "bias": 0.0013791,
-          "spread": 0.00236679,
-          "score": 0.00273927
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -3.394e-05,
+          "spread": 0.016776,
+          "score": 0.01677604
         },
         {
-          "profile": "ti_dependent_cp",
+          "profile": "cp_plus_3pct",
           "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.00340328,
+          "spread": 0.00922481,
+          "score": 0.00983257
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": -0.00253841,
+          "spread": 0.00771319,
+          "score": 0.00812015
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00443746,
+          "spread": 0.00195932,
+          "score": 0.00485077
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.10372733,
+          "bias": -0.00419631,
+          "spread": 0.00126739,
+          "score": 0.00438353
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": -0.00125783,
+          "spread": 0.00882422,
+          "score": 0.00891342
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.00442293,
+          "spread": 0.00182889,
+          "score": 0.00478614
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.0023726,
+          "spread": 0.00218227,
+          "score": 0.0032236
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": 0.00712826,
+          "spread": 0.0062564,
+          "score": 0.00948444
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.01200202,
+          "spread": 0.00824529,
+          "score": 0.01456136
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": 0.0118926,
+          "spread": 0.01383698,
+          "score": 0.01824544
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.07627726,
+          "spread": 0.07724377,
+          "score": 0.10855791
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.23502045,
+          "spread": 0.06549226,
+          "score": 0.24397509
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": 0.07199009,
+          "spread": 0.38200234,
+          "score": 0.38872659
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.08542429,
+          "spread": 0.14077034,
+          "score": 0.16466207
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.00096588,
+          "spread": 0.00320421,
+          "score": 0.00334662
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00620701,
+          "spread": 0.00434584,
+          "score": 0.00757715
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.0070037,
+          "spread": 0.00394883,
+          "score": 0.00804022
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00393723,
+          "spread": 0.00258257,
+          "score": 0.00470865
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00076265,
+          "spread": 0.00228925,
+          "score": 0.00241294
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.13503354,
+          "spread": 0.08325248,
+          "score": 0.1586349
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": -0.00163125,
+          "spread": 0.00157234,
+          "score": 0.00226566
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.00385711,
+          "spread": 0.00090863,
+          "score": 0.00396269
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": 0.0,
           "spread": 0.0,
-          "score": 0.10372733
+          "score": 0.0
         },
         {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": 0.00895324,
+          "spread": 0.00791612,
+          "score": 0.01195096
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.00367902,
+          "spread": 0.00472195,
+          "score": 0.00598598
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00431854,
+          "spread": 0.00680793,
+          "score": 0.00806212
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00114635,
+          "spread": 0.00339926,
+          "score": 0.00358735
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.0037772,
+          "spread": 0.01315697,
+          "score": 0.01368843
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.01310653,
-          "spread": 0.01464664,
-          "score": 0.01965465
+          "bias": -0.00372718,
+          "spread": 0.00218923,
+          "score": 0.00432257
         },
         {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00287072,
-          "spread": 0.00492619,
-          "score": 0.00570161
+          "bias": 0.00029198,
+          "spread": 0.00245536,
+          "score": 0.00247266
         },
         {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00268449,
-          "spread": 0.0012142,
-          "score": 0.00294631
+          "bias": 0.00036033,
+          "spread": 0.00412119,
+          "score": 0.00413692
         },
         {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00414765,
-          "spread": 0.00999316,
-          "score": 0.01081972
+          "bias": 0.00350616,
+          "spread": 0.00505564,
+          "score": 0.00615245
         },
         {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01658901,
-          "spread": 0.02047706,
-          "score": 0.02635347
+          "bias": 0.00912605,
+          "spread": 0.00691414,
+          "score": 0.01144946
         },
         {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00882199,
-          "spread": 0.04425658,
-          "score": 0.04512729
+          "bias": 0.00075617,
+          "spread": 0.01308583,
+          "score": 0.01310766
         },
         {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.10196359,
-          "spread": 0.10866284,
-          "score": 0.14901069
+          "bias": 0.05327346,
+          "spread": 0.04618211,
+          "score": 0.07050425
         },
         {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.29371742,
-          "spread": 0.46343346,
-          "score": 0.54867157
+          "bias": 0.38960461,
+          "spread": 0.41924769,
+          "score": 0.57232891
         },
         {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.31237706,
-          "spread": 0.79316904,
-          "score": 0.85246499
+          "bias": 0.54295983,
+          "spread": 0.67069861,
+          "score": 0.86292641
         },
         {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.16093909,
-          "spread": 0.12481761,
-          "score": 0.20366842
+          "bias": -0.11591051,
+          "spread": 0.09247767,
+          "score": 0.14828137
         },
         {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00103585,
-          "spread": 0.0052343,
-          "score": 0.00533581
+          "bias": 0.00022562,
+          "spread": 0.00308694,
+          "score": 0.00309517
         },
         {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00720274,
-          "spread": 0.00785505,
-          "score": 0.01065745
+          "bias": 0.00265481,
+          "spread": 0.00247048,
+          "score": 0.00362648
         },
         {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00993294,
-          "spread": 0.01144084,
-          "score": 0.01515111
+          "bias": 0.00242673,
+          "spread": 0.00222316,
+          "score": 0.00329111
         },
         {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00039208,
-          "spread": 0.00495355,
-          "score": 0.00496904
+          "bias": 0.00079047,
+          "spread": 0.0009978,
+          "score": 0.00127297
         },
         {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.01059523,
-          "spread": 0.01575315,
-          "score": 0.01898474
+          "bias": 0.00127691,
+          "spread": 0.0027559,
+          "score": 0.00303734
         },
         {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.11226535,
-          "spread": 0.13435948,
-          "score": 0.17508849
+          "bias": -0.13867452,
+          "spread": 0.08177455,
+          "score": 0.16098975
         },
         {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.0113523,
-          "spread": 0.02374957,
-          "score": 0.02632331
+          "bias": 0.00105014,
+          "spread": 0.01205876,
+          "score": 0.0121044
         },
         {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.00249623,
+          "spread": 0.00118928,
+          "score": 0.00276506
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": -0.00126536,
+          "spread": 0.00178949,
+          "score": 0.00219167
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": 0.00148064,
+          "spread": 0.00752839,
+          "score": 0.00767261
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.00102792,
+          "spread": 0.00694896,
+          "score": 0.00702457
+        },
+        {
+          "profile": "cp_plus_3pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00077954,
+          "spread": 0.00738644,
+          "score": 0.00742746
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": -0.00556888,
+          "spread": 0.0099739,
+          "score": 0.01142327
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": -0.01289789,
+          "spread": 0.00846594,
+          "score": 0.01542815
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": -0.01007844,
+          "spread": 0.01380967,
+          "score": 0.01709626
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00658765,
+          "spread": 0.01126084,
+          "score": 0.01304621
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": 3.775e-05,
+          "spread": 0.01608132,
+          "score": 0.01608136
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.01124825,
+          "spread": 0.03594243,
+          "score": 0.03766141
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": 0.03053361,
+          "spread": 0.02316792,
+          "score": 0.03832824
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.35264613,
+          "spread": 0.67299757,
+          "score": 0.75979275
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.04643265,
+          "spread": 0.05692117,
+          "score": 0.07345754
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": 0.00819991,
+          "spread": 0.01277066,
+          "score": 0.01517657
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.00324452,
+          "spread": 0.08175568,
+          "score": 0.08182003
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.00359966,
+          "spread": 0.01886135,
+          "score": 0.01920177
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00475625,
+          "spread": 0.01705226,
+          "score": 0.01770315
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": -0.01855692,
+          "spread": 0.03119639,
+          "score": 0.0362984
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": -0.030373,
+          "spread": 0.03325879,
+          "score": 0.04504072
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": -0.04836857,
+          "spread": 0.00159402,
+          "score": 0.04839482
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.13957078,
+          "spread": 0.14427113,
+          "score": 0.20073406
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": -0.04807698,
+          "spread": 0.00139316,
+          "score": 0.04809716
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
           "bias": NaN,
@@ -6036,8 +4524,8 @@
           "score": NaN
         },
         {
-          "profile": "ti_dependent_cp",
-          "campaign_months": 3,
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
           "bias": NaN,
@@ -6045,44 +4533,908 @@
           "score": NaN
         },
         {
-          "profile": "ti_dependent_cp",
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.00894436,
+          "spread": 0.01689006,
+          "score": 0.01911218
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.00275039,
+          "spread": 0.01520935,
+          "score": 0.01545603
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": -0.01209561,
+          "spread": 0.01311884,
+          "score": 0.01784399
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00041786,
+          "spread": 0.00533179,
+          "score": 0.00534813
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.02149576,
+          "spread": 0.0,
+          "score": 0.02149576
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": 0.00909011,
+          "spread": 0.00654999,
+          "score": 0.01120413
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.00068268,
+          "spread": 0.00594326,
+          "score": 0.00598234
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00124245,
+          "spread": 0.0070082,
+          "score": 0.00711748
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": 0.00262419,
+          "spread": 0.00278699,
+          "score": 0.00382802
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.00013252,
+          "spread": 0.0133952,
+          "score": 0.01339586
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": 0.00169578,
+          "spread": 0.04210453,
+          "score": 0.04213867
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.07333648,
+          "spread": 0.14929805,
+          "score": 0.16633744
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.4882196,
+          "spread": 1.096562,
+          "score": 1.20033603
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.09095479,
+          "spread": 0.18638214,
+          "score": 0.20739112
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.08155984,
+          "spread": 0.11260811,
+          "score": 0.1390417
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.00583718,
+          "spread": 0.01211701,
+          "score": 0.0134497
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00310665,
+          "spread": 0.00425346,
+          "score": 0.00526718
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.0099272,
+          "spread": 0.00548776,
+          "score": 0.01134305
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": -0.03388324,
+          "spread": 0.02705885,
+          "score": 0.04336191
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": -0.04878756,
+          "spread": 0.00132291,
+          "score": 0.04880549
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.0644845,
+          "spread": 0.10534034,
+          "score": 0.12351048
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": -0.04792307,
+          "spread": 0.00123925,
+          "score": 0.04793909
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.04487183,
+          "spread": 0.0,
+          "score": 0.04487183
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": -0.04956386,
+          "spread": 0.0,
+          "score": 0.04956386
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.0054092,
+          "spread": 0.01467961,
+          "score": 0.0156445
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.00330579,
+          "spread": 0.00623283,
+          "score": 0.00705523
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": -0.00191414,
+          "spread": 0.00735389,
+          "score": 0.00759893
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00138896,
+          "spread": 0.00231509,
+          "score": 0.00269979
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.01821258,
+          "spread": 0.00307466,
+          "score": 0.01847029
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": -0.00947169,
+          "spread": 0.0132848,
+          "score": 0.0163156
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.00188512,
+          "spread": 0.0035837,
+          "score": 0.00404927
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00101903,
+          "spread": 0.00192669,
+          "score": 0.00217958
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": 0.00295491,
+          "spread": 0.01026796,
+          "score": 0.01068468
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.00855126,
+          "spread": 0.01849163,
+          "score": 0.02037313
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.02446899,
+          "spread": 0.04096321,
+          "score": 0.04771495
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.08701918,
+          "spread": 0.10963875,
+          "score": 0.13997498
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.19481839,
+          "spread": 0.37567217,
+          "score": 0.42318292
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.01631716,
+          "spread": 0.05972684,
+          "score": 0.06191563
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.0586742,
+          "spread": 0.14834797,
+          "score": 0.15952987
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.0045,
+          "spread": 0.00868889,
+          "score": 0.00978503
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00363762,
+          "spread": 0.00794015,
+          "score": 0.00873374
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.01028658,
+          "spread": 0.01045967,
+          "score": 0.01467032
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": -0.02325363,
+          "spread": 0.02635452,
+          "score": 0.03514672
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": -0.04853016,
+          "spread": 0.001238,
+          "score": 0.04854595
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.09634471,
+          "spread": 0.10897946,
+          "score": 0.14546074
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": -0.04492176,
+          "spread": 0.00440256,
+          "score": 0.04513698
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.04720487,
+          "spread": 0.00233305,
+          "score": 0.04726249
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": -0.04956386,
+          "spread": 0.0,
+          "score": 0.04956386
+        },
+        {
+          "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00236073,
-          "spread": 0.01921322,
-          "score": 0.01935771
+          "bias": 0.00225066,
+          "spread": 0.01763,
+          "score": 0.01777308
         },
         {
-          "profile": "ti_dependent_cp",
+          "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00172271,
-          "spread": 0.01011673,
-          "score": 0.01026235
+          "bias": -0.00165677,
+          "spread": 0.01060994,
+          "score": 0.01073851
         },
         {
-          "profile": "ti_dependent_cp",
+          "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00279181,
-          "spread": 0.00728972,
-          "score": 0.00780604
+          "bias": 0.00033264,
+          "spread": 0.00820544,
+          "score": 0.00821218
         },
         {
-          "profile": "ti_dependent_cp",
+          "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00450183,
-          "spread": 0.00200628,
-          "score": 0.00492866
+          "bias": 0.00446299,
+          "spread": 0.00193873,
+          "score": 0.0048659
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.02053612,
+          "spread": 0.00230878,
+          "score": 0.02066549
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": -0.00012301,
+          "spread": 0.00719517,
+          "score": 0.00719622
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.00276849,
+          "spread": 0.0015796,
+          "score": 0.00318742
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00233664,
+          "spread": 0.00260934,
+          "score": 0.00350265
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": 0.01004388,
+          "spread": 0.0057077,
+          "score": 0.01155237
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.01500004,
+          "spread": 0.00661009,
+          "score": 0.0163919
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": 0.01388121,
+          "spread": 0.01484041,
+          "score": 0.02032057
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.08083976,
+          "spread": 0.07564091,
+          "score": 0.1107096
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.19739002,
+          "spread": 0.11168786,
+          "score": 0.22679726
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": 0.02699408,
+          "spread": 0.36908456,
+          "score": 0.37007039
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.0861745,
+          "spread": 0.17585216,
+          "score": 0.19583163
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.00414319,
+          "spread": 0.0037962,
+          "score": 0.00561936
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00265164,
+          "spread": 0.00528384,
+          "score": 0.00591186
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.0058205,
+          "spread": 0.00412395,
+          "score": 0.00713339
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.0031815,
+          "spread": 0.00127448,
+          "score": 0.00342728
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": -0.03526707,
+          "spread": 0.02341804,
+          "score": 0.04233404
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.11430998,
+          "spread": 0.06954034,
+          "score": 0.13380071
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": -0.03435447,
+          "spread": 0.02180616,
+          "score": 0.04069076
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.04333881,
+          "spread": 0.00157149,
+          "score": 0.04336729
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": -0.02478194,
+          "spread": 0.02478192,
+          "score": 0.03504694
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": 0.00991178,
+          "spread": 0.00829485,
+          "score": 0.0129247
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.00380414,
+          "spread": 0.00533879,
+          "score": 0.00655547
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00558413,
+          "spread": 0.00674545,
+          "score": 0.00875692
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00118574,
+          "spread": 0.00340433,
+          "score": 0.00360492
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": 0.02119027,
+          "spread": 0.002646,
+          "score": 0.02135483
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": -0.00068742,
+          "spread": 0.00440209,
+          "score": 0.00445544
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": -0.00026337,
+          "spread": 0.00253967,
+          "score": 0.00255329
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00012835,
+          "spread": 0.00413221,
+          "score": 0.0041342
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": 0.00527507,
+          "spread": 0.00469658,
+          "score": 0.00706288
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.01171574,
+          "spread": 0.00646127,
+          "score": 0.01337933
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": 0.00337463,
+          "spread": 0.01265757,
+          "score": 0.0130997
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.05548249,
+          "spread": 0.04651099,
+          "score": 0.07239875
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.3736913,
+          "spread": 0.38530635,
+          "score": 0.53675522
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": 0.44629413,
+          "spread": 0.68491463,
+          "score": 0.81748792
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.10984504,
+          "spread": 0.1020589,
+          "score": 0.14993983
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.00320692,
+          "spread": 0.00226221,
+          "score": 0.00392454
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": -0.00022652,
+          "spread": 0.00284568,
+          "score": 0.00285468
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.00121891,
+          "spread": 0.00215006,
+          "score": 0.00247154
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 2.109e-05,
+          "spread": 0.00139165,
+          "score": 0.00139181
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00164596,
+          "spread": 0.004337,
+          "score": 0.00463883
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.12409537,
+          "spread": 0.07071082,
+          "score": 0.14282745
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": -0.00793813,
+          "spread": 0.02582734,
+          "score": 0.02701972
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.04572629,
+          "spread": 0.00201169,
+          "score": 0.04577052
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": -0.0312851,
+          "spread": 0.02228091,
+          "score": 0.03840829
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": 0.00190974,
+          "spread": 0.00780579,
+          "score": 0.00803601
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.00088789,
+          "spread": 0.00728803,
+          "score": 0.00734191
+        },
+        {
+          "profile": "rated_plus_5pct",
+          "campaign_months": 12,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": 0.00183409,
+          "spread": 0.00750336,
+          "score": 0.00772427
         },
         {
           "profile": "ti_dependent_cp",
-          "campaign_months": 6,
+          "campaign_months": 1,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": -0.00579568,
+          "spread": 0.01023763,
+          "score": 0.01176432
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
           "bias": NaN,
@@ -6091,169 +5443,169 @@
         },
         {
           "profile": "ti_dependent_cp",
-          "campaign_months": 6,
+          "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00717948,
-          "spread": 0.01148869,
-          "score": 0.01354751
+          "bias": -0.0305893,
+          "spread": 0.03399556,
+          "score": 0.04573186
         },
         {
           "profile": "ti_dependent_cp",
-          "campaign_months": 6,
+          "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00220207,
-          "spread": 0.00184063,
-          "score": 0.00287002
+          "bias": -0.01612096,
+          "spread": 0.01934357,
+          "score": 0.02518053
         },
         {
           "profile": "ti_dependent_cp",
-          "campaign_months": 6,
+          "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00180135,
-          "spread": 0.00225736,
-          "score": 0.002888
+          "bias": -0.00742374,
+          "spread": 0.01066915,
+          "score": 0.0129978
         },
         {
           "profile": "ti_dependent_cp",
-          "campaign_months": 6,
+          "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.01170811,
-          "spread": 0.00514238,
-          "score": 0.01278764
+          "bias": 0.00453326,
+          "spread": 0.01704392,
+          "score": 0.01763649
         },
         {
           "profile": "ti_dependent_cp",
-          "campaign_months": 6,
+          "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.0256115,
-          "spread": 0.00694892,
-          "score": 0.02653745
+          "bias": 0.0229007,
+          "spread": 0.03714277,
+          "score": 0.04363516
         },
         {
           "profile": "ti_dependent_cp",
-          "campaign_months": 6,
+          "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.0331989,
-          "spread": 0.01393488,
-          "score": 0.03600483
+          "bias": 0.0517879,
+          "spread": 0.02091167,
+          "score": 0.05585055
         },
         {
           "profile": "ti_dependent_cp",
-          "campaign_months": 6,
+          "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.10266375,
-          "spread": 0.08267018,
-          "score": 0.13181124
+          "bias": 0.37598916,
+          "spread": 0.67698561,
+          "score": 0.77438838
         },
         {
           "profile": "ti_dependent_cp",
-          "campaign_months": 6,
+          "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.27641685,
-          "spread": 0.04984506,
-          "score": 0.28087507
+          "bias": 0.07444869,
+          "spread": 0.05232376,
+          "score": 0.09099661
         },
         {
           "profile": "ti_dependent_cp",
-          "campaign_months": 6,
+          "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.03622652,
-          "spread": 0.62606985,
-          "score": 0.62711707
+          "bias": 0.03796194,
+          "spread": 0.0125278,
+          "score": 0.03997568
         },
         {
           "profile": "ti_dependent_cp",
-          "campaign_months": 6,
+          "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.08628202,
-          "spread": 0.15658937,
-          "score": 0.17878707
+          "bias": 0.041219,
+          "spread": 0.08163636,
+          "score": 0.09145218
         },
         {
           "profile": "ti_dependent_cp",
-          "campaign_months": 6,
+          "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.0011278,
-          "spread": 0.0029275,
-          "score": 0.00313722
+          "bias": -0.00156928,
+          "spread": 0.01553968,
+          "score": 0.01561872
         },
         {
           "profile": "ti_dependent_cp",
-          "campaign_months": 6,
+          "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00634197,
-          "spread": 0.00373681,
-          "score": 0.007361
+          "bias": 0.00919727,
+          "spread": 0.01664891,
+          "score": 0.01902041
         },
         {
           "profile": "ti_dependent_cp",
-          "campaign_months": 6,
+          "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00625568,
-          "spread": 0.00391655,
-          "score": 0.00738058
+          "bias": 0.00512078,
+          "spread": 0.0072704,
+          "score": 0.00889276
         },
         {
           "profile": "ti_dependent_cp",
-          "campaign_months": 6,
+          "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00336807,
-          "spread": 0.00326025,
-          "score": 0.00468755
+          "bias": 0.00529656,
+          "spread": 0.00932285,
+          "score": 0.01072236
         },
         {
           "profile": "ti_dependent_cp",
-          "campaign_months": 6,
+          "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.01306934,
-          "spread": 0.01294358,
-          "score": 0.01839413
+          "bias": -0.00101017,
+          "spread": 0.00110969,
+          "score": 0.00150062
         },
         {
           "profile": "ti_dependent_cp",
-          "campaign_months": 6,
+          "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.13587595,
-          "spread": 0.09225599,
-          "score": 0.16423593
+          "bias": -0.16078739,
+          "spread": 0.17472698,
+          "score": 0.23744916
         },
         {
           "profile": "ti_dependent_cp",
-          "campaign_months": 6,
+          "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00791352,
-          "spread": 0.02374357,
-          "score": 0.0250276
+          "bias": -0.00146186,
+          "spread": 0.00076184,
+          "score": 0.00164846
         },
         {
           "profile": "ti_dependent_cp",
-          "campaign_months": 6,
+          "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.17856353,
-          "spread": 0.0,
-          "score": 0.17856353
+          "bias": NaN,
+          "spread": NaN,
+          "score": NaN
         },
         {
           "profile": "ti_dependent_cp",
-          "campaign_months": 6,
+          "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
           "bias": NaN,
@@ -6262,30 +5614,678 @@
         },
         {
           "profile": "ti_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.00591674,
+          "spread": 0.01958846,
+          "score": 0.02046254
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.00380158,
+          "spread": 0.0150533,
+          "score": 0.01552591
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 1,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": -0.01690147,
+          "spread": 0.01418452,
+          "score": 0.02206491
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00040254,
+          "spread": 0.00550132,
+          "score": 0.00551603
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": -0.04119399,
+          "spread": 0.0,
+          "score": 0.04119399
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": -0.00934051,
+          "spread": 0.01446033,
+          "score": 0.01721471
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.00165253,
+          "spread": 0.00862205,
+          "score": 0.00877898
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00285987,
+          "spread": 0.00676258,
+          "score": 0.00734243
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": 0.00493026,
+          "spread": 0.00735033,
+          "score": 0.00885069
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.01085199,
+          "spread": 0.01214242,
+          "score": 0.01628509
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": 0.01661925,
+          "spread": 0.0392764,
+          "score": 0.0426478
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.09333203,
+          "spread": 0.16493701,
+          "score": 0.18951276
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.54684342,
+          "spread": 1.18834487,
+          "score": 1.30812892
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": -0.06746429,
+          "spread": 0.1978012,
+          "score": 0.20898982
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.06020858,
+          "spread": 0.11586327,
+          "score": 0.13057324
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": 0.00016569,
+          "spread": 0.00965182,
+          "score": 0.00965325
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00500951,
+          "spread": 0.00369348,
+          "score": 0.0062239
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.00935194,
+          "spread": 0.00609582,
+          "score": 0.01116323
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00197811,
+          "spread": 0.00354809,
+          "score": 0.00406224
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": -0.00059618,
+          "spread": 0.00100752,
+          "score": 0.00117069
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.07916917,
+          "spread": 0.11389531,
+          "score": 0.13870796
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": -0.00154293,
+          "spread": 0.00068076,
+          "score": 0.00168644
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.0076749,
+          "spread": 0.0,
+          "score": 0.0076749
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": 0.0,
+          "spread": 0.0,
+          "score": 0.0
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": -0.00546366,
+          "spread": 0.01608929,
+          "score": 0.01699167
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": 0.00422401,
+          "spread": 0.00547637,
+          "score": 0.00691613
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 2,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": -0.00511055,
+          "spread": 0.00740402,
+          "score": 0.00899652
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00137974,
+          "spread": 0.00236671,
+          "score": 0.00273952
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": -0.00160525,
+          "spread": 0.04695774,
+          "score": 0.04698517
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": -0.01307559,
+          "spread": 0.01467539,
+          "score": 0.01965549
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.00290152,
+          "spread": 0.00492107,
+          "score": 0.00571277
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": -0.00265385,
+          "spread": 0.00119345,
+          "score": 0.00290986
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": 0.0041781,
+          "spread": 0.00998021,
+          "score": 0.01081948
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.0166191,
+          "spread": 0.02046464,
+          "score": 0.02636278
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": -0.00879348,
+          "spread": 0.04424513,
+          "score": 0.0451105
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.10199877,
+          "spread": 0.10869598,
+          "score": 0.14905893
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.23303424,
+          "spread": 0.41493286,
+          "score": 0.47589309
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": 0.00890264,
+          "spread": 0.0626253,
+          "score": 0.06325492
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.16094759,
+          "spread": 0.12472715,
+          "score": 0.20361972
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": -0.00102914,
+          "spread": 0.0052149,
+          "score": 0.00531548
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00720969,
+          "spread": 0.00794211,
+          "score": 0.01072645
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.00993999,
+          "spread": 0.01153979,
+          "score": 0.01523057
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00186184,
+          "spread": 0.00432796,
+          "score": 0.00471144
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": -0.00100438,
+          "spread": 0.0010145,
+          "score": 0.00142759
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.11227088,
+          "spread": 0.1342482,
+          "score": 0.17500666
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": -0.00656546,
+          "spread": 0.00712254,
+          "score": 0.00968689
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.00383745,
+          "spread": 0.00383745,
+          "score": 0.00542697
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": 0.0,
+          "spread": 0.0,
+          "score": 0.0
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(4.0, 6.0]",
+          "bias": 0.00236653,
+          "spread": 0.01913387,
+          "score": 0.01927966
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(6.0, 8.0]",
+          "bias": -0.00171734,
+          "spread": 0.01000018,
+          "score": 0.01014657
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 3,
+          "condition": "ws",
+          "condition_bin": "(8.0, 10.0]",
+          "bias": -0.00278571,
+          "spread": 0.00726765,
+          "score": 0.00778325
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "overall",
+          "condition_bin": "overall",
+          "bias": 0.00450206,
+          "spread": 0.00200664,
+          "score": 0.00492902
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.0, 0.05]",
+          "bias": -0.05174671,
+          "spread": 0.00393016,
+          "score": 0.05189574
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.05, 0.1]",
+          "bias": -0.00717826,
+          "spread": 0.01148773,
+          "score": 0.01354604
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.1, 0.15]",
+          "bias": 0.00220182,
+          "spread": 0.00184079,
+          "score": 0.00286993
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.15, 0.2]",
+          "bias": 0.00180108,
+          "spread": 0.00225713,
+          "score": 0.00288765
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.2, 0.25]",
+          "bias": 0.01170843,
+          "spread": 0.00514224,
+          "score": 0.01278788
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.25, 0.3]",
+          "bias": 0.02561283,
+          "spread": 0.00694758,
+          "score": 0.02653839
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.3, 0.35]",
+          "bias": 0.03320671,
+          "spread": 0.01392755,
+          "score": 0.03600919
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.35, 0.4]",
+          "bias": 0.10266824,
+          "spread": 0.08266351,
+          "score": 0.13181056
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.4, 0.45]",
+          "bias": 0.22021299,
+          "spread": 0.10643567,
+          "score": 0.244586
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ti",
+          "condition_bin": "(0.45, 0.5]",
+          "bias": 0.0044087,
+          "spread": 0.44623051,
+          "score": 0.44625229
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(0.0, 2.0]",
+          "bias": -0.08600661,
+          "spread": 0.15661971,
+          "score": 0.17868092
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(10.0, 12.0]",
+          "bias": -0.00085488,
+          "spread": 0.00293253,
+          "score": 0.0030546
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(12.0, 14.0]",
+          "bias": 0.00660691,
+          "spread": 0.00384629,
+          "score": 0.00764494
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(14.0, 16.0]",
+          "bias": 0.00651918,
+          "spread": 0.00402588,
+          "score": 0.00766208
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(16.0, 18.0]",
+          "bias": 0.00363031,
+          "spread": 0.00322644,
+          "score": 0.00485686
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(18.0, 20.0]",
+          "bias": 0.00076378,
+          "spread": 0.00253982,
+          "score": 0.00265218
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(2.0, 4.0]",
+          "bias": -0.13561918,
+          "spread": 0.09240991,
+          "score": 0.16411019
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(20.0, 22.0]",
+          "bias": -0.00346702,
+          "spread": 0.00316474,
+          "score": 0.00469423
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(22.0, 24.0]",
+          "bias": -0.01083697,
+          "spread": 0.0024781,
+          "score": 0.0111167
+        },
+        {
+          "profile": "ti_dependent_cp",
+          "campaign_months": 6,
+          "condition": "ws",
+          "condition_bin": "(24.0, 26.0]",
+          "bias": 0.0,
+          "spread": 0.0,
+          "score": 0.0
+        },
+        {
+          "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.01040353,
-          "spread": 0.0079115,
-          "score": 0.01307002
+          "bias": 0.01068245,
+          "spread": 0.00808683,
+          "score": 0.01339819
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00482946,
-          "spread": 0.00441979,
-          "score": 0.00654662
+          "bias": 0.00510606,
+          "spread": 0.00442408,
+          "score": 0.00675606
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00407639,
-          "spread": 0.00703303,
-          "score": 0.00812899
+          "bias": 0.00435363,
+          "spread": 0.00688645,
+          "score": 0.00814722
         },
         {
           "profile": "ti_dependent_cp",
@@ -6301,216 +6301,216 @@
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.14732606,
-          "spread": 0.0,
-          "score": 0.14732606
+          "bias": -0.01246608,
+          "spread": 0.04776898,
+          "score": 0.0493688
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00944285,
-          "spread": 0.0020996,
-          "score": 0.00967345
+          "bias": -0.00944123,
+          "spread": 0.00210166,
+          "score": 0.00967232
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00170036,
-          "spread": 0.00269796,
-          "score": 0.00318907
+          "bias": -0.00169875,
+          "spread": 0.00269823,
+          "score": 0.00318845
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -5.38e-05,
-          "spread": 0.00412084,
-          "score": 0.00412119
+          "bias": -5.218e-05,
+          "spread": 0.00412116,
+          "score": 0.00412149
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00732324,
-          "spread": 0.00442597,
-          "score": 0.00855681
+          "bias": 0.00732484,
+          "spread": 0.00442396,
+          "score": 0.00855715
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.02139375,
-          "spread": 0.00639849,
-          "score": 0.0223301
+          "bias": 0.02139537,
+          "spread": 0.0063981,
+          "score": 0.02233154
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.0203181,
-          "spread": 0.01293708,
-          "score": 0.0240872
+          "bias": 0.02031971,
+          "spread": 0.01293879,
+          "score": 0.02408948
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.07093332,
-          "spread": 0.04588399,
-          "score": 0.08448003
+          "bias": 0.0709351,
+          "spread": 0.04588684,
+          "score": 0.08448308
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.41097163,
-          "spread": 0.41279517,
-          "score": 0.58249252
+          "bias": 0.41097484,
+          "spread": 0.41280025,
+          "score": 0.58249839
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.90293703,
-          "spread": 0.77197378,
-          "score": 1.18795572
+          "bias": 0.4725847,
+          "spread": 0.69511153,
+          "score": 0.84054526
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.1044863,
-          "spread": 0.08875919,
-          "score": 0.13709698
+          "bias": -0.1044143,
+          "spread": 0.08870986,
+          "score": 0.13701017
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00158401,
-          "spread": 0.0036584,
-          "score": 0.0039866
+          "bias": -0.0014935,
+          "spread": 0.00367088,
+          "score": 0.00396306
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00348131,
-          "spread": 0.00224476,
-          "score": 0.00414228
+          "bias": 0.0035689,
+          "spread": 0.00224659,
+          "score": 0.00421713
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00257356,
-          "spread": 0.00222462,
-          "score": 0.00340178
+          "bias": 0.00266061,
+          "spread": 0.00221509,
+          "score": 0.003462
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00088591,
-          "spread": 0.00075698,
-          "score": 0.00116527
+          "bias": 0.00097284,
+          "spread": 0.00079809,
+          "score": 0.00125832
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00080292,
-          "spread": 0.00217115,
-          "score": 0.00231486
+          "bias": 0.00089008,
+          "spread": 0.00222988,
+          "score": 0.00240096
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.14108764,
-          "spread": 0.08825716,
-          "score": 0.1664183
+          "bias": -0.14100351,
+          "spread": 0.08830591,
+          "score": 0.16637284
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00574743,
-          "spread": 0.01431241,
-          "score": 0.0154233
+          "bias": -0.00087729,
+          "spread": 0.0118906,
+          "score": 0.01192292
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.04884507,
-          "spread": 0.03909367,
-          "score": 0.06256321
+          "bias": -0.00677894,
+          "spread": 0.00314573,
+          "score": 0.00747326
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
+          "bias": -0.00310114,
+          "spread": 0.00438568,
+          "score": 0.00537133
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00283657,
-          "spread": 0.00774353,
-          "score": 0.00824672
+          "bias": 0.00292882,
+          "spread": 0.00774207,
+          "score": 0.00827753
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00207947,
-          "spread": 0.00686205,
-          "score": 0.00717021
+          "bias": 0.00217204,
+          "spread": 0.00689809,
+          "score": 0.00723197
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.0004069,
-          "spread": 0.0073677,
-          "score": 0.00737893
+          "bias": 0.00049926,
+          "spread": 0.00740506,
+          "score": 0.00742187
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00576143,
-          "spread": 0.01021437,
-          "score": 0.01172721
+          "bias": -0.00576117,
+          "spread": 0.01021458,
+          "score": 0.01172727
         },
         {
           "profile": "ws_dependent_cp",
@@ -6526,153 +6526,153 @@
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00432517,
-          "spread": 0.0321181,
-          "score": 0.03240801
+          "bias": -0.01757764,
+          "spread": 0.02059181,
+          "score": 0.0270739
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.01173348,
-          "spread": 0.01773583,
-          "score": 0.0212658
+          "bias": -0.011678,
+          "spread": 0.01767152,
+          "score": 0.02118156
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00666119,
-          "spread": 0.00997303,
-          "score": 0.01199303
+          "bias": -0.00660563,
+          "spread": 0.00985821,
+          "score": 0.0118667
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00077265,
-          "spread": 0.01768854,
-          "score": 0.0177054
+          "bias": -0.00071799,
+          "spread": 0.01751422,
+          "score": 0.01752893
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00991584,
-          "spread": 0.03959464,
-          "score": 0.04081739
+          "bias": 0.00996829,
+          "spread": 0.03941595,
+          "score": 0.04065691
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.02754304,
-          "spread": 0.01424948,
-          "score": 0.03101075
+          "bias": 0.02760476,
+          "spread": 0.01433547,
+          "score": 0.03110512
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.34928131,
-          "spread": 0.69640371,
-          "score": 0.77908637
+          "bias": 0.34935334,
+          "spread": 0.69642743,
+          "score": 0.77913986
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.30239236,
-          "spread": 0.65552476,
-          "score": 0.72190987
+          "bias": 0.03639874,
+          "spread": 0.06867144,
+          "score": 0.07772152
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
+          "bias": -0.09604807,
+          "spread": 0.10745482,
+          "score": 0.14412415
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.10362669,
-          "spread": 0.04298486,
-          "score": 0.11218819
+          "bias": 0.07520685,
+          "spread": 0.08206966,
+          "score": 0.11131711
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00283787,
-          "spread": 0.01716401,
-          "score": 0.01739703
+          "bias": 0.00344459,
+          "spread": 0.01771928,
+          "score": 0.01805098
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00815193,
-          "spread": 0.01797129,
-          "score": 0.01973376
+          "bias": 0.00875915,
+          "spread": 0.01878457,
+          "score": 0.02072638
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.01145045,
-          "spread": 0.02112108,
-          "score": 0.02402526
+          "bias": 0.00540114,
+          "spread": 0.00660409,
+          "score": 0.00853149
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.02967438,
-          "spread": 0.03245852,
-          "score": 0.04397868
+          "bias": 0.00554853,
+          "spread": 0.00961034,
+          "score": 0.01109707
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.01931003,
-          "spread": 0.0123965,
-          "score": 0.02294669
+          "bias": 0.0,
+          "spread": 0.0,
+          "score": 0.0
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.22076432,
-          "spread": 0.22983606,
-          "score": 0.31868714
+          "bias": -0.220221,
+          "spread": 0.22977746,
+          "score": 0.31826871
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.01204188,
-          "spread": 0.03568684,
-          "score": 0.03766374
+          "bias": 0.0,
+          "spread": 0.0,
+          "score": 0.0
         },
         {
           "profile": "ws_dependent_cp",
@@ -6697,34 +6697,34 @@
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.01255752,
-          "spread": 0.02047327,
-          "score": 0.02401762
+          "bias": -0.01192855,
+          "spread": 0.02009793,
+          "score": 0.02337129
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00736366,
-          "spread": 0.0156102,
-          "score": 0.01725983
+          "bias": -0.00674657,
+          "spread": 0.01514127,
+          "score": 0.01657632
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.01755096,
-          "spread": 0.01318091,
-          "score": 0.02194932
+          "bias": -0.01693939,
+          "spread": 0.01386759,
+          "score": 0.02189185
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00039284,
+          "bias": 0.00039283,
           "spread": 0.00544186,
           "score": 0.00545602
         },
@@ -6733,646 +6733,646 @@
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
+          "bias": 0.0207169,
+          "spread": 0.0,
+          "score": 0.0207169
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.0069114,
-          "spread": 0.01921585,
-          "score": 0.02042098
+          "bias": -0.00182977,
+          "spread": 0.01089273,
+          "score": 0.01104534
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00393768,
-          "spread": 0.00775031,
-          "score": 0.00869325
+          "bias": 0.00395413,
+          "spread": 0.00768367,
+          "score": 0.00864141
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00178886,
-          "spread": 0.00591941,
-          "score": 0.0061838
+          "bias": -0.00177237,
+          "spread": 0.00587289,
+          "score": 0.0061345
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00024759,
-          "spread": 0.00716249,
-          "score": 0.00716677
+          "bias": 0.00026472,
+          "spread": 0.00720617,
+          "score": 0.00721103
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": -0.00416843,
-          "spread": 0.01643332,
-          "score": 0.01695376
+          "bias": -0.00415187,
+          "spread": 0.01641956,
+          "score": 0.01693635
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00397426,
-          "spread": 0.04013151,
-          "score": 0.04032781
+          "bias": -0.00395999,
+          "spread": 0.04006272,
+          "score": 0.04025795
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.06585691,
-          "spread": 0.16272637,
-          "score": 0.17554772
+          "bias": 0.0658755,
+          "spread": 0.16271972,
+          "score": 0.17554854
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.66814922,
-          "spread": 1.42007272,
-          "score": 1.56940432
+          "bias": 0.55275017,
+          "spread": 1.24596182,
+          "score": 1.36306772
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.46606126,
-          "spread": 2.40631621,
-          "score": 2.45103464
+          "bias": -0.58629904,
+          "spread": 1.33781165,
+          "score": 1.46064594
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.06075126,
-          "spread": 0.15884981,
-          "score": 0.1700705
+          "bias": -0.0136498,
+          "spread": 0.15981595,
+          "score": 0.16039781
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00500357,
-          "spread": 0.01021459,
-          "score": 0.01137425
+          "bias": 0.00513592,
+          "spread": 0.01023765,
+          "score": 0.0114537
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.0049034,
-          "spread": 0.00446422,
-          "score": 0.00663118
+          "bias": 0.005033,
+          "spread": 0.00427677,
+          "score": 0.00660469
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00971633,
-          "spread": 0.00633736,
-          "score": 0.0116004
+          "bias": 0.00984687,
+          "spread": 0.00625955,
+          "score": 0.01166803
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00435461,
-          "spread": 0.00636958,
-          "score": 0.00771584
+          "bias": 0.00193712,
+          "spread": 0.00335519,
+          "score": 0.00387424
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00380373,
-          "spread": 0.01268725,
-          "score": 0.01324518
+          "bias": 0.0,
+          "spread": 0.0,
+          "score": 0.0
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.10534837,
-          "spread": 0.13113216,
-          "score": 0.16820797
+          "bias": -0.10521498,
+          "spread": 0.13112854,
+          "score": 0.16812164
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.01125404,
-          "spread": 0.01593621,
-          "score": 0.01950939
+          "bias": 0.0,
+          "spread": 0.0,
+          "score": 0.0
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
+          "bias": 0.0,
+          "spread": 0.0,
+          "score": 0.0
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
+          "bias": 0.0,
+          "spread": 0.0,
+          "score": 0.0
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.01037415,
-          "spread": 0.01596324,
-          "score": 0.01903807
+          "bias": -0.01023407,
+          "spread": 0.01592088,
+          "score": 0.01892645
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 7.683e-05,
-          "spread": 0.00630461,
-          "score": 0.00630508
+          "bias": 0.00021675,
+          "spread": 0.00649624,
+          "score": 0.00649985
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00513136,
-          "spread": 0.00795298,
-          "score": 0.00946471
+          "bias": -0.00499582,
+          "spread": 0.00807243,
+          "score": 0.00949328
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00138693,
-          "spread": 0.00236677,
-          "score": 0.0027432
+          "bias": 0.00138709,
+          "spread": 0.00236699,
+          "score": 0.00274348
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.15493747,
-          "spread": 0.0,
-          "score": 0.15493747
+          "bias": 0.02605638,
+          "spread": 0.01345874,
+          "score": 0.02932699
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00742519,
-          "spread": 0.01082126,
-          "score": 0.01312376
+          "bias": -0.00738239,
+          "spread": 0.01086444,
+          "score": 0.01313529
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00559747,
-          "spread": 0.00436438,
-          "score": 0.00709786
+          "bias": 0.00564015,
+          "spread": 0.00436533,
+          "score": 0.00713214
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00172661,
-          "spread": 0.00135169,
-          "score": 0.00219277
+          "bias": -0.00168392,
+          "spread": 0.00131156,
+          "score": 0.00213443
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00092442,
-          "spread": 0.01077998,
-          "score": 0.01081954
+          "bias": -0.00088145,
+          "spread": 0.01075023,
+          "score": 0.01078631
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00254004,
-          "spread": 0.02300421,
-          "score": 0.02314401
+          "bias": 0.00258348,
+          "spread": 0.02297799,
+          "score": 0.02312277
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.02825352,
-          "spread": 0.04479642,
-          "score": 0.05296207
+          "bias": -0.02821146,
+          "spread": 0.04476783,
+          "score": 0.05291545
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.07923235,
-          "spread": 0.11915877,
-          "score": 0.14309639
+          "bias": 0.07928645,
+          "spread": 0.11921801,
+          "score": 0.14317568
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.2592838,
-          "spread": 0.46714828,
-          "score": 0.53428045
+          "bias": 0.25281926,
+          "spread": 0.40476432,
+          "score": 0.47723342
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.13013757,
-          "spread": 0.89845487,
-          "score": 0.9078309
+          "bias": 0.00829701,
+          "spread": 0.32546137,
+          "score": 0.32556711
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.12593548,
-          "spread": 0.23148565,
-          "score": 0.26352486
+          "bias": -0.12588086,
+          "spread": 0.2315992,
+          "score": 0.26359852
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00283226,
-          "spread": 0.00652619,
-          "score": 0.00711427
+          "bias": 0.00286508,
+          "spread": 0.00654821,
+          "score": 0.00714757
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.007116,
-          "spread": 0.00882194,
-          "score": 0.0113342
+          "bias": 0.00714898,
+          "spread": 0.00889916,
+          "score": 0.01141504
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.01104269,
-          "spread": 0.01174852,
-          "score": 0.01612355
+          "bias": 0.0110761,
+          "spread": 0.01183247,
+          "score": 0.01620763
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00131349,
-          "spread": 0.00516464,
-          "score": 0.00532905
+          "bias": 0.00223968,
+          "spread": 0.00485853,
+          "score": 0.00534991
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.01243628,
-          "spread": 0.01562541,
-          "score": 0.01997034
+          "bias": 0.0,
+          "spread": 0.0,
+          "score": 0.0
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.13988878,
-          "spread": 0.15449095,
-          "score": 0.20841383
+          "bias": -0.13986662,
+          "spread": 0.1544022,
+          "score": 0.20833317
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.002996,
-          "spread": 0.03156554,
-          "score": 0.0317074
+          "bias": 0.0,
+          "spread": 0.0,
+          "score": 0.0
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
+          "bias": 0.0,
+          "spread": 0.0,
+          "score": 0.0
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
+          "bias": 0.0,
+          "spread": 0.0,
+          "score": 0.0
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00269515,
-          "spread": 0.01844982,
-          "score": 0.01864563
+          "bias": -0.00266165,
+          "spread": 0.01835771,
+          "score": 0.01854966
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00497044,
-          "spread": 0.01086063,
-          "score": 0.01194398
+          "bias": -0.00493749,
+          "spread": 0.01074569,
+          "score": 0.01182577
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00347849,
-          "spread": 0.00831512,
-          "score": 0.00901338
+          "bias": -0.00344563,
+          "spread": 0.00826027,
+          "score": 0.00895011
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00450929,
-          "spread": 0.00199262,
-          "score": 0.00492993
+          "bias": 0.00450881,
+          "spread": 0.0019924,
+          "score": 0.0049294
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
+          "bias": -0.0179209,
+          "spread": 0.02133788,
+          "score": 0.0278651
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00317406,
-          "spread": 0.01188666,
-          "score": 0.01230315
+          "bias": -0.00317454,
+          "spread": 0.01188696,
+          "score": 0.01230356
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00484265,
-          "spread": 0.00233099,
-          "score": 0.00537445
+          "bias": 0.00484217,
+          "spread": 0.00233075,
+          "score": 0.00537392
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.0025297,
-          "spread": 0.00232359,
-          "score": 0.00343489
+          "bias": 0.00252922,
+          "spread": 0.0023232,
+          "score": 0.00343427
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00687665,
-          "spread": 0.00656888,
-          "score": 0.00950992
+          "bias": 0.00687617,
+          "spread": 0.00656909,
+          "score": 0.00950971
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01282322,
-          "spread": 0.00808337,
-          "score": 0.01515836
+          "bias": 0.01282272,
+          "spread": 0.0080833,
+          "score": 0.0151579
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.01356724,
-          "spread": 0.01469051,
-          "score": 0.01999703
+          "bias": 0.01356674,
+          "spread": 0.01469049,
+          "score": 0.01999667
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.07608815,
-          "spread": 0.07976982,
-          "score": 0.11023897
+          "bias": 0.07608757,
+          "spread": 0.07976925,
+          "score": 0.11023816
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.13880016,
-          "spread": 0.21453291,
-          "score": 0.2555188
+          "bias": 0.13879978,
+          "spread": 0.21453297,
+          "score": 0.25551864
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.05606301,
-          "spread": 0.50853131,
-          "score": 0.51161231
+          "bias": -0.00152207,
+          "spread": 0.45041908,
+          "score": 0.45042166
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.10454461,
-          "spread": 0.14297163,
-          "score": 0.17711709
+          "bias": -0.10430663,
+          "spread": 0.14298267,
+          "score": 0.17698564
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00326014,
-          "spread": 0.00275325,
-          "score": 0.00426719
+          "bias": 0.00353271,
+          "spread": 0.00276589,
+          "score": 0.00448667
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00639874,
-          "spread": 0.00481138,
-          "score": 0.00800582
+          "bias": 0.00666932,
+          "spread": 0.00490026,
+          "score": 0.00827601
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00686422,
-          "spread": 0.00402477,
-          "score": 0.00795715
+          "bias": 0.00713499,
+          "spread": 0.00414649,
+          "score": 0.00825236
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00448383,
-          "spread": 0.00285889,
-          "score": 0.00531771
+          "bias": 0.00475334,
+          "spread": 0.00281176,
+          "score": 0.0055227
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.01484884,
-          "spread": 0.01331114,
-          "score": 0.01994178
+          "bias": 0.00154389,
+          "spread": 0.00267409,
+          "score": 0.00308778
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.17801926,
-          "spread": 0.11812676,
-          "score": 0.21364641
+          "bias": -0.17773994,
+          "spread": 0.11831149,
+          "score": 0.21351603
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.0040675,
-          "spread": 0.02684931,
-          "score": 0.02715566
+          "bias": 0.00067931,
+          "spread": 0.0011766,
+          "score": 0.00135862
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.18405273,
+          "bias": 0.0,
           "spread": 0.0,
-          "score": 0.18405273
+          "score": 0.0
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
+          "bias": 0.0,
+          "spread": 0.0,
+          "score": 0.0
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.0063512,
-          "spread": 0.0086655,
-          "score": 0.01074377
+          "bias": 0.00664822,
+          "spread": 0.00884916,
+          "score": 0.01106826
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00142032,
-          "spread": 0.00506463,
-          "score": 0.00526002
+          "bias": 0.001708,
+          "spread": 0.00507256,
+          "score": 0.0053524
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.0032378,
-          "spread": 0.00734634,
-          "score": 0.0080282
+          "bias": 0.00351774,
+          "spread": 0.00723001,
+          "score": 0.00804037
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00118501,
+          "bias": 0.001185,
           "spread": 0.0034466,
           "score": 0.00364462
         },
@@ -7381,213 +7381,213 @@
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.16856937,
-          "spread": 0.0,
-          "score": 0.16856937
+          "bias": 0.00039802,
+          "spread": 0.02991569,
+          "score": 0.02991834
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00329029,
-          "spread": 0.00198535,
-          "score": 0.00384287
+          "bias": -0.00328812,
+          "spread": 0.0019835,
+          "score": 0.00384005
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.0002208,
-          "spread": 0.00257781,
-          "score": 0.00258725
+          "bias": 0.00022213,
+          "spread": 0.00257766,
+          "score": 0.00258721
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00036851,
-          "spread": 0.00408091,
-          "score": 0.00409751
+          "bias": 0.00036981,
+          "spread": 0.00408111,
+          "score": 0.00409784
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00368686,
-          "spread": 0.00545443,
-          "score": 0.0065836
+          "bias": 0.00368817,
+          "spread": 0.00545285,
+          "score": 0.00658302
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01032704,
-          "spread": 0.00690047,
-          "score": 0.01242032
+          "bias": 0.01032838,
+          "spread": 0.00689988,
+          "score": 0.0124211
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00289987,
-          "spread": 0.01384906,
-          "score": 0.01414941
+          "bias": 0.00290124,
+          "spread": 0.01385051,
+          "score": 0.0141511
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.05414976,
-          "spread": 0.04846957,
-          "score": 0.0726739
+          "bias": 0.0541513,
+          "spread": 0.04847203,
+          "score": 0.07267669
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.40250498,
-          "spread": 0.44736801,
-          "score": 0.60178767
+          "bias": 0.40250784,
+          "spread": 0.44737262,
+          "score": 0.60179301
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.76776303,
-          "spread": 0.98995063,
-          "score": 1.25278183
+          "bias": 0.71361694,
+          "spread": 0.74393195,
+          "score": 1.0308656
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.13049535,
-          "spread": 0.10568129,
-          "score": 0.16792132
+          "bias": -0.13042886,
+          "spread": 0.10563538,
+          "score": 0.16784076
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00231891,
-          "spread": 0.00287094,
-          "score": 0.00369048
+          "bias": 0.00240437,
+          "spread": 0.00287827,
+          "score": 0.00375039
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.0029718,
-          "spread": 0.00269697,
-          "score": 0.00401313
+          "bias": 0.00305625,
+          "spread": 0.00268369,
+          "score": 0.00406729
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00267485,
-          "spread": 0.0024451,
-          "score": 0.003624
+          "bias": 0.00275929,
+          "spread": 0.00243764,
+          "score": 0.00368181
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00131457,
-          "spread": 0.00098099,
-          "score": 0.00164025
+          "bias": 0.00139895,
+          "spread": 0.00102308,
+          "score": 0.00173314
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00210265,
-          "spread": 0.00291156,
-          "score": 0.00359143
+          "bias": 0.00218725,
+          "spread": 0.00297554,
+          "score": 0.00369295
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.17864509,
-          "spread": 0.111878,
-          "score": 0.21078605
+          "bias": -0.17855832,
+          "spread": 0.11193077,
+          "score": 0.21074053
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00969734,
-          "spread": 0.0150248,
-          "score": 0.01788248
+          "bias": 0.00332773,
+          "spread": 0.01202088,
+          "score": 0.01247298
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.05583555,
-          "spread": 0.04224229,
-          "score": 0.07001442
+          "bias": 0.0,
+          "spread": 0.0,
+          "score": 0.0
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
+          "bias": 0.0,
+          "spread": 0.0,
+          "score": 0.0
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00112946,
-          "spread": 0.00804886,
-          "score": 0.00812772
+          "bias": -0.00103729,
+          "spread": 0.00805827,
+          "score": 0.00812475
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00074348,
-          "spread": 0.007403,
-          "score": 0.00744024
+          "bias": -0.00065312,
+          "spread": 0.00743765,
+          "score": 0.00746627
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00041474,
-          "spread": 0.00773403,
-          "score": 0.00774514
+          "bias": -0.00032666,
+          "spread": 0.00777162,
+          "score": 0.00777848
         }
       ]
     },
     "toggle": {
-      "recorded_utc": "2026-07-08T10:59:12Z",
-      "git_commit": "f51b3c7-dirty",
+      "recorded_utc": "2026-07-08T13:07:31Z",
+      "git_commit": "09f3b06-dirty",
       "n_replicates": 4,
       "seed": 0,
       "campaign_months": [
@@ -7612,9 +7612,9 @@
           "campaign_months": 1,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00555753,
-          "spread": 0.0049139,
-          "score": 0.00741839
+          "bias": -0.00555726,
+          "spread": 0.00491433,
+          "score": 0.00741848
         },
         {
           "profile": "cp_0pct",
@@ -7630,153 +7630,153 @@
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00509133,
-          "spread": 0.00949189,
-          "score": 0.01077115
+          "bias": -0.00854218,
+          "spread": 0.00258257,
+          "score": 0.00892404
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00605522,
-          "spread": 0.00220942,
-          "score": 0.00644572
+          "bias": -0.00608136,
+          "spread": 0.00224869,
+          "score": 0.0064838
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00448935,
-          "spread": 0.00670135,
-          "score": 0.00806613
+          "bias": -0.00451501,
+          "spread": 0.00679228,
+          "score": 0.008156
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00518133,
-          "spread": 0.00719976,
-          "score": 0.00887033
+          "bias": -0.00520719,
+          "spread": 0.00725422,
+          "score": 0.00892964
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": -0.00658246,
-          "spread": 0.00347602,
-          "score": 0.00744389
+          "bias": -0.00660855,
+          "spread": 0.00351323,
+          "score": 0.00748437
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.01029842,
-          "spread": 0.07127109,
-          "score": 0.07201129
+          "bias": -0.03207282,
+          "spread": 0.0489486,
+          "score": 0.05852035
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.14429928,
-          "spread": 0.22636582,
-          "score": 0.26844695
+          "bias": -0.00555726,
+          "spread": 0.00491433,
+          "score": 0.00741848
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.23215758,
-          "spread": 0.40645511,
-          "score": 0.46808428
+          "bias": -0.00555726,
+          "spread": 0.00491433,
+          "score": 0.00741848
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.29536802,
-          "spread": 0.38475878,
-          "score": 0.48505833
+          "bias": -0.00555726,
+          "spread": 0.00491433,
+          "score": 0.00741848
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.00661834,
-          "spread": 0.05585655,
-          "score": 0.05624728
+          "bias": -0.00665186,
+          "spread": 0.05601843,
+          "score": 0.05641198
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00663346,
-          "spread": 0.00959552,
-          "score": 0.0116652
+          "bias": -0.00667319,
+          "spread": 0.00975321,
+          "score": 0.01181764
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00073169,
-          "spread": 0.0107749,
-          "score": 0.01079971
+          "bias": 0.00099963,
+          "spread": 0.01053117,
+          "score": 0.01057851
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00220669,
-          "spread": 0.00522144,
-          "score": 0.00566859
+          "bias": -0.00167349,
+          "spread": 0.00289857,
+          "score": 0.00334698
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00356761,
-          "spread": 0.0078895,
-          "score": 0.00865864
+          "bias": 0.0,
+          "spread": 0.0,
+          "score": 0.0
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00320788,
-          "spread": 0.00117319,
-          "score": 0.00341568
+          "bias": 0.0,
+          "spread": 0.0,
+          "score": 0.0
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.00523006,
-          "spread": 0.06325307,
-          "score": 0.06346892
+          "bias": -0.00525868,
+          "spread": 0.06341937,
+          "score": 0.06363702
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00629793,
+          "bias": 0.0,
           "spread": 0.0,
-          "score": 0.00629793
+          "score": 0.0
         },
         {
           "profile": "cp_0pct",
@@ -7801,36 +7801,36 @@
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00589874,
-          "spread": 0.01805582,
-          "score": 0.01899494
+          "bias": -0.00593797,
+          "spread": 0.01816215,
+          "score": 0.01910819
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00786014,
-          "spread": 0.00724109,
-          "score": 0.01068715
+          "bias": -0.00789732,
+          "spread": 0.00776733,
+          "score": 0.01107696
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00550996,
-          "spread": 0.00431304,
-          "score": 0.00699728
+          "bias": -0.00555236,
+          "spread": 0.00404525,
+          "score": 0.0068697
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 2,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.0016784,
-          "spread": 0.00298799,
-          "score": 0.00342712
+          "bias": -0.00167815,
+          "spread": 0.00298766,
+          "score": 0.00342671
         },
         {
           "profile": "cp_0pct",
@@ -7846,162 +7846,162 @@
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00222455,
-          "spread": 0.01907832,
-          "score": 0.01920758
+          "bias": -0.00037392,
+          "spread": 0.00180566,
+          "score": 0.00184397
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00449782,
-          "spread": 0.00206624,
-          "score": 0.00494972
+          "bias": -0.00448994,
+          "spread": 0.00211709,
+          "score": 0.00496403
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00180734,
-          "spread": 0.00484962,
-          "score": 0.00517545
+          "bias": 0.00181531,
+          "spread": 0.0048812,
+          "score": 0.00520782
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00311337,
-          "spread": 0.00702126,
-          "score": 0.00768057
+          "bias": -0.00310547,
+          "spread": 0.00703932,
+          "score": 0.00769389
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": -0.00644985,
-          "spread": 0.00719724,
-          "score": 0.00966441
+          "bias": -0.00644217,
+          "spread": 0.00718768,
+          "score": 0.00965216
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.02503136,
-          "spread": 0.07486573,
-          "score": 0.07893951
+          "bias": -0.02502376,
+          "spread": 0.07486508,
+          "score": 0.07893649
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.04217336,
-          "spread": 0.22857979,
-          "score": 0.23243776
+          "bias": 0.09505343,
+          "spread": 0.18227348,
+          "score": 0.20556939
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.30079678,
-          "spread": 0.32030128,
-          "score": 0.43939915
+          "bias": -0.00631329,
+          "spread": 0.00811635,
+          "score": 0.01028264
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.05140267,
-          "spread": 0.37460422,
-          "score": 0.37811447
+          "bias": -0.00167815,
+          "spread": 0.00298766,
+          "score": 0.00342671
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.0199316,
-          "spread": 0.01841845,
-          "score": 0.02713868
+          "bias": 0.01990818,
+          "spread": 0.01843146,
+          "score": 0.02713032
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.0037717,
-          "spread": 0.00290538,
-          "score": 0.00476098
+          "bias": -0.00379461,
+          "spread": 0.0029617,
+          "score": 0.0048136
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00157949,
-          "spread": 0.00471946,
-          "score": 0.00497675
+          "bias": -0.00160216,
+          "spread": 0.0048158,
+          "score": 0.00507532
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.0028081,
-          "spread": 0.00398713,
-          "score": 0.00487674
+          "bias": -0.0028309,
+          "spread": 0.00406114,
+          "score": 0.00495044
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00063397,
-          "spread": 0.00553577,
-          "score": 0.00557195
+          "bias": 0.0,
+          "spread": 0.0,
+          "score": 0.0
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00061662,
-          "spread": 0.01156135,
-          "score": 0.01157778
+          "bias": 0.0,
+          "spread": 0.0,
+          "score": 0.0
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.00714518,
-          "spread": 0.05440152,
-          "score": 0.05486874
+          "bias": 0.00712918,
+          "spread": 0.05453523,
+          "score": 0.05499924
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00440809,
+          "bias": 0.0,
           "spread": 0.0,
-          "score": 0.00440809
+          "score": 0.0
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.00580844,
+          "bias": 0.0,
           "spread": 0.0,
-          "score": 0.00580844
+          "score": 0.0
         },
         {
           "profile": "cp_0pct",
@@ -8017,27 +8017,27 @@
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 8.553e-05,
-          "spread": 0.01212608,
-          "score": 0.01212638
+          "bias": 6.3e-05,
+          "spread": 0.01217825,
+          "score": 0.01217841
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00088822,
-          "spread": 0.00466543,
-          "score": 0.00474923
+          "bias": -0.00091075,
+          "spread": 0.00479557,
+          "score": 0.00488129
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00024438,
-          "spread": 0.00236303,
-          "score": 0.00237563
+          "bias": -0.00026725,
+          "spread": 0.00247988,
+          "score": 0.00249423
         },
         {
           "profile": "cp_0pct",
@@ -8062,162 +8062,162 @@
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00626549,
-          "spread": 0.01507388,
-          "score": 0.01632416
+          "bias": 0.00073143,
+          "spread": 0.01045936,
+          "score": 0.01048491
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00104529,
-          "spread": 0.00259834,
-          "score": 0.00280072
+          "bias": -0.00100744,
+          "spread": 0.00264446,
+          "score": 0.00282986
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00294701,
-          "spread": 0.00300944,
-          "score": 0.00421208
+          "bias": 0.00298486,
+          "spread": 0.00299647,
+          "score": 0.00422944
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00060275,
-          "spread": 0.00539895,
-          "score": 0.00543249
+          "bias": 0.00064048,
+          "spread": 0.00538697,
+          "score": 0.00542491
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00176562,
-          "spread": 0.00642177,
-          "score": 0.00666008
+          "bias": 0.00180376,
+          "spread": 0.00646884,
+          "score": 0.00671561
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00880981,
-          "spread": 0.03347998,
-          "score": 0.03461967
+          "bias": -0.00877237,
+          "spread": 0.03348075,
+          "score": 0.03461091
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.00525816,
-          "spread": 0.03355232,
-          "score": 0.03396184
+          "bias": 0.00529553,
+          "spread": 0.03353415,
+          "score": 0.03394969
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": -0.00309804,
-          "spread": 0.39262184,
-          "score": 0.39263407
+          "bias": -0.1548114,
+          "spread": 0.27164374,
+          "score": 0.31266099
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.13970076,
-          "spread": 0.0,
-          "score": 0.13970076
+          "bias": 0.00109247,
+          "spread": 0.00203933,
+          "score": 0.00231352
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.00112799,
-          "spread": 0.0237243,
-          "score": 0.0237511
+          "bias": 0.00125386,
+          "spread": 0.02350618,
+          "score": 0.0235396
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00144293,
-          "spread": 0.00107359,
-          "score": 0.00179851
+          "bias": -0.00131209,
+          "spread": 0.00106754,
+          "score": 0.00169152
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00042966,
-          "spread": 0.00308348,
-          "score": 0.00311327
+          "bias": 0.00056096,
+          "spread": 0.00315139,
+          "score": 0.00320092
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -6.872e-05,
-          "spread": 0.00418204,
-          "score": 0.00418261
+          "bias": 6.197e-05,
+          "spread": 0.00410225,
+          "score": 0.00410272
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 7.713e-05,
-          "spread": 0.00226979,
-          "score": 0.0022711
+          "bias": -0.00062363,
+          "spread": 0.00108017,
+          "score": 0.00124727
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00626161,
-          "spread": 0.01984828,
-          "score": 0.02081254
+          "bias": 0.0,
+          "spread": 0.0,
+          "score": 0.0
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.00827962,
-          "spread": 0.03606995,
-          "score": 0.03700802
+          "bias": 0.00841854,
+          "spread": 0.0362672,
+          "score": 0.03723146
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.04152811,
-          "spread": 0.04543682,
-          "score": 0.06155557
+          "bias": 0.0,
+          "spread": 0.0,
+          "score": 0.0
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.00589594,
-          "spread": 0.0016241,
-          "score": 0.00611554
+          "bias": 0.0,
+          "spread": 0.0,
+          "score": 0.0
         },
         {
           "profile": "cp_0pct",
@@ -8233,27 +8233,27 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00017567,
-          "spread": 0.01294009,
-          "score": 0.01294128
+          "bias": -4.478e-05,
+          "spread": 0.01293028,
+          "score": 0.01293036
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00475042,
-          "spread": 0.00503898,
-          "score": 0.00692516
+          "bias": 0.00488225,
+          "spread": 0.00507183,
+          "score": 0.00703987
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00063143,
-          "spread": 0.00378763,
-          "score": 0.00383991
+          "bias": 0.00076327,
+          "spread": 0.0039741,
+          "score": 0.00404673
         },
         {
           "profile": "cp_0pct",
@@ -8269,423 +8269,423 @@
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.09991353,
-          "spread": 0.00139605,
-          "score": 0.09992328
+          "bias": 0.00235001,
+          "spread": 0.00181394,
+          "score": 0.00296866
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00038136,
-          "spread": 0.01140599,
-          "score": 0.01141236
+          "bias": 0.00039128,
+          "spread": 0.01141579,
+          "score": 0.0114225
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00034296,
-          "spread": 0.00167901,
-          "score": 0.00171367
+          "bias": 0.00035277,
+          "spread": 0.00168249,
+          "score": 0.00171907
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00298447,
-          "spread": 0.00132447,
-          "score": 0.00326516
+          "bias": 0.00299429,
+          "spread": 0.00131465,
+          "score": 0.00327018
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00058405,
-          "spread": 0.00223748,
-          "score": 0.00231246
+          "bias": -0.00057428,
+          "spread": 0.00222472,
+          "score": 0.00229765
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00140003,
-          "spread": 0.01025746,
-          "score": 0.01035256
+          "bias": 0.00140993,
+          "spread": 0.01026565,
+          "score": 0.01036202
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.0034845,
-          "spread": 0.02066779,
-          "score": 0.02095947
+          "bias": 0.00349407,
+          "spread": 0.02065543,
+          "score": 0.02094887
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.03619672,
-          "spread": 0.03056769,
-          "score": 0.04737707
+          "bias": -0.0361877,
+          "spread": 0.03055484,
+          "score": 0.04736188
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.07191635,
-          "spread": 0.19698838,
-          "score": 0.20970547
+          "bias": 0.05408209,
+          "spread": 0.17338282,
+          "score": 0.18162179
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.41875035,
-          "spread": 0.42432365,
-          "score": 0.59615637
+          "bias": 0.00153161,
+          "spread": 0.00154332,
+          "score": 0.00217432
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.00345974,
-          "spread": 0.01474473,
-          "score": 0.01514519
+          "bias": 0.00345852,
+          "spread": 0.01462605,
+          "score": 0.0150294
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00115735,
-          "spread": 0.00132352,
-          "score": 0.00175817
+          "bias": 0.00115779,
+          "spread": 0.00128684,
+          "score": 0.00173102
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00064108,
-          "spread": 0.00226347,
-          "score": 0.00235251
+          "bias": 0.00064171,
+          "spread": 0.00232911,
+          "score": 0.0024159
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00024849,
-          "spread": 0.00273065,
-          "score": 0.00274194
+          "bias": 0.00024906,
+          "spread": 0.00276377,
+          "score": 0.00277497
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00056721,
-          "spread": 0.00222648,
-          "score": 0.00229759
+          "bias": 0.00056791,
+          "spread": 0.00231979,
+          "score": 0.0023883
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00229598,
-          "spread": 0.01193218,
-          "score": 0.01215107
+          "bias": 9.614e-05,
+          "spread": 0.00016652,
+          "score": 0.00019228
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.00831764,
-          "spread": 0.02783203,
-          "score": 0.02904832
+          "bias": -0.00831306,
+          "spread": 0.02798172,
+          "score": 0.02919047
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00380259,
-          "spread": 0.0088869,
-          "score": 0.00966627
+          "bias": 0.0,
+          "spread": 0.0,
+          "score": 0.0
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.01266316,
-          "spread": 0.01494434,
-          "score": 0.01958798
+          "bias": 0.0,
+          "spread": 0.0,
+          "score": 0.0
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
+          "bias": 0.0,
+          "spread": 0.0,
+          "score": 0.0
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.0029708,
-          "spread": 0.00534069,
-          "score": 0.00611136
+          "bias": 0.00297115,
+          "spread": 0.0053148,
+          "score": 0.00608892
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00043602,
-          "spread": 0.00294669,
-          "score": 0.00297877
+          "bias": 0.00043659,
+          "spread": 0.00297499,
+          "score": 0.00300686
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00274591,
-          "spread": 0.00504028,
-          "score": 0.00573973
+          "bias": 0.00274702,
+          "spread": 0.00516232,
+          "score": 0.00584771
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00078615,
-          "spread": 0.00171222,
-          "score": 0.00188407
+          "bias": 0.0007862,
+          "spread": 0.00171218,
+          "score": 0.00188405
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.07831262,
-          "spread": 0.02979285,
-          "score": 0.08378831
+          "bias": 0.00136543,
+          "spread": 0.00160209,
+          "score": 0.00210501
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00209479,
-          "spread": 0.00430119,
-          "score": 0.00478418
+          "bias": 0.00209517,
+          "spread": 0.00430115,
+          "score": 0.00478431
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00099067,
-          "spread": 0.00155433,
-          "score": 0.00184319
+          "bias": 0.00099102,
+          "spread": 0.00155434,
+          "score": 0.00184339
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00035735,
-          "spread": 0.0013043,
-          "score": 0.00135237
+          "bias": 0.00035771,
+          "spread": 0.00130418,
+          "score": 0.00135234
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00053252,
-          "spread": 0.00273944,
-          "score": 0.00279072
+          "bias": 0.0005329,
+          "spread": 0.00273945,
+          "score": 0.0027908
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00538839,
-          "spread": 0.00736277,
-          "score": 0.00912388
+          "bias": 0.00538877,
+          "spread": 0.00736276,
+          "score": 0.00912409
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00380894,
-          "spread": 0.02999743,
-          "score": 0.03023829
+          "bias": -0.00380856,
+          "spread": 0.02999761,
+          "score": 0.03023841
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.01341723,
-          "spread": 0.02004433,
-          "score": 0.02412047
+          "bias": -0.01341685,
+          "spread": 0.02004463,
+          "score": 0.02412051
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.0343105,
-          "spread": 0.23056268,
-          "score": 0.23310161
+          "bias": 0.03431081,
+          "spread": 0.23056244,
+          "score": 0.23310142
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.20263185,
-          "spread": 0.11296624,
-          "score": 0.23199361
+          "bias": -0.10064593,
+          "spread": 0.12955433,
+          "score": 0.16405465
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.00668412,
-          "spread": 0.03875468,
-          "score": 0.03932687
+          "bias": -0.0067243,
+          "spread": 0.03876545,
+          "score": 0.03934433
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00011126,
-          "spread": 0.0024491,
-          "score": 0.00245163
+          "bias": -0.00015222,
+          "spread": 0.00244182,
+          "score": 0.00244656
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00128147,
-          "spread": 0.00061764,
-          "score": 0.00142255
+          "bias": 0.00124048,
+          "spread": 0.00063618,
+          "score": 0.0013941
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00052734,
-          "spread": 0.00142072,
-          "score": 0.00151543
+          "bias": -0.00056824,
+          "spread": 0.00143652,
+          "score": 0.00154483
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00050805,
-          "spread": 0.00099164,
-          "score": 0.00111421
+          "bias": 0.0004671,
+          "spread": 0.00101511,
+          "score": 0.00111742
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": -0.000277,
-          "spread": 0.00148437,
-          "score": 0.00150999
+          "bias": -0.00031793,
+          "spread": 0.00148923,
+          "score": 0.00152279
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.00200827,
-          "spread": 0.02149181,
-          "score": 0.02158543
+          "bias": 0.00196803,
+          "spread": 0.02152768,
+          "score": 0.02161745
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00315463,
-          "spread": 0.00438806,
-          "score": 0.00540433
+          "bias": -0.00085396,
+          "spread": 0.00228378,
+          "score": 0.00243821
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.03198222,
-          "spread": 0.02570081,
-          "score": 0.04102918
+          "bias": 0.0,
+          "spread": 0.0,
+          "score": 0.0
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
-          "bias": 0.02038776,
+          "bias": 0.0,
           "spread": 0.0,
-          "score": 0.02038776
+          "score": 0.0
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00141521,
-          "spread": 0.00617305,
-          "score": 0.00633319
+          "bias": 0.00137435,
+          "spread": 0.00621371,
+          "score": 0.00636388
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00289648,
-          "spread": 0.00315906,
-          "score": 0.00428594
+          "bias": 0.00285544,
+          "spread": 0.00317819,
+          "score": 0.00427252
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00052854,
-          "spread": 0.00311892,
-          "score": 0.00316338
+          "bias": 0.00048749,
+          "spread": 0.00308945,
+          "score": 0.00312768
         },
         {
           "profile": "cp_minus_10pct",
@@ -8710,153 +8710,153 @@
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00458179,
-          "spread": 0.01208169,
-          "score": 0.01292131
+          "bias": -0.00499391,
+          "spread": 0.01375917,
+          "score": 0.01463741
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00696713,
-          "spread": 0.00113154,
-          "score": 0.00705842
+          "bias": -0.00721926,
+          "spread": 0.0011793,
+          "score": 0.00731495
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00451897,
-          "spread": 0.0074423,
-          "score": 0.00870683
+          "bias": -0.00476991,
+          "spread": 0.00761916,
+          "score": 0.00898909
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00209336,
-          "spread": 0.00676273,
-          "score": 0.00707931
+          "bias": -0.00234172,
+          "spread": 0.00690072,
+          "score": 0.00728722
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": -0.00396311,
-          "spread": 0.00426413,
-          "score": 0.00582143
+          "bias": -0.00421,
+          "spread": 0.00414075,
+          "score": 0.00590507
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00478863,
-          "spread": 0.06613287,
-          "score": 0.06630601
+          "bias": 0.00398258,
+          "spread": 0.06245687,
+          "score": 0.06258372
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.12895112,
-          "spread": 0.21253894,
-          "score": 0.24859845
+          "bias": -0.04086111,
+          "spread": 0.18498537,
+          "score": 0.18944449
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.26504957,
-          "spread": 0.40098168,
-          "score": 0.48066369
+          "bias": -1.32397735,
+          "spread": 2.22321078,
+          "score": 2.58758231
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.04863576,
-          "spread": 0.02941132,
-          "score": 0.05683716
+          "bias": 1.99522174,
+          "spread": 3.58522966,
+          "score": 4.10302102
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.0043147,
-          "spread": 0.05464579,
-          "score": 0.05481587
+          "bias": -0.00563065,
+          "spread": 0.054523,
+          "score": 0.05481297
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00303984,
-          "spread": 0.01045199,
-          "score": 0.01088507
+          "bias": -0.00424526,
+          "spread": 0.00992942,
+          "score": 0.01079887
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00691839,
-          "spread": 0.01125852,
-          "score": 0.01321433
+          "bias": 0.00191455,
+          "spread": 0.01296664,
+          "score": 0.01310722
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -9.154e-05,
-          "spread": 0.00487046,
-          "score": 0.00487132
+          "bias": -0.00107473,
+          "spread": 0.00348257,
+          "score": 0.00364463
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00429368,
-          "spread": 0.00733807,
-          "score": 0.00850194
+          "bias": 0.00048533,
+          "spread": 0.00062741,
+          "score": 0.00079321
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00294149,
-          "spread": 0.00872345,
-          "score": 0.00920603
+          "bias": 0.00246201,
+          "spread": 0.00348181,
+          "score": 0.00426432
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.03493627,
-          "spread": 0.06733673,
-          "score": 0.07586026
+          "bias": 0.03390598,
+          "spread": 0.06876383,
+          "score": 0.07666863
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00574933,
-          "spread": 0.0,
-          "score": 0.00574933
+          "bias": 0.00085042,
+          "spread": 0.00026532,
+          "score": 0.00089085
         },
         {
           "profile": "cp_minus_10pct",
@@ -8881,27 +8881,27 @@
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00507968,
-          "spread": 0.0174465,
-          "score": 0.01817096
+          "bias": -0.00622885,
+          "spread": 0.01874137,
+          "score": 0.01974937
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00835538,
-          "spread": 0.00734898,
-          "score": 0.01112744
+          "bias": -0.00950934,
+          "spread": 0.00925142,
+          "score": 0.01326711
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00328646,
-          "spread": 0.00430015,
-          "score": 0.00541221
+          "bias": -0.00446816,
+          "spread": 0.00368922,
+          "score": 0.00579438
         },
         {
           "profile": "cp_minus_10pct",
@@ -8926,162 +8926,162 @@
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00376055,
-          "spread": 0.01645331,
-          "score": 0.01687759
+          "bias": 0.00917701,
+          "spread": 0.01062145,
+          "score": 0.01403683
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00572267,
-          "spread": 0.00224942,
-          "score": 0.00614889
+          "bias": -0.00577329,
+          "spread": 0.00227033,
+          "score": 0.00620365
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00143494,
-          "spread": 0.0052795,
-          "score": 0.00547103
+          "bias": 0.00138499,
+          "spread": 0.00534011,
+          "score": 0.00551679
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 4.965e-05,
-          "spread": 0.00676449,
-          "score": 0.00676467
+          "bias": 9.1e-07,
+          "spread": 0.00680675,
+          "score": 0.00680675
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": -0.00200042,
-          "spread": 0.00639856,
-          "score": 0.00670397
+          "bias": -0.00204889,
+          "spread": 0.00641047,
+          "score": 0.00672994
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.01522701,
-          "spread": 0.0619364,
-          "score": 0.06378072
+          "bias": -0.01527326,
+          "spread": 0.06194481,
+          "score": 0.06379994
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.05657401,
-          "spread": 0.20512354,
-          "score": 0.21278225
+          "bias": 0.12072078,
+          "spread": 0.16356336,
+          "score": 0.20328916
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.08252149,
-          "spread": 0.26689303,
-          "score": 0.27935942
+          "bias": -0.1714385,
+          "spread": 0.20733368,
+          "score": 0.26903236
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.04379994,
-          "spread": 0.22422209,
-          "score": 0.22846002
+          "bias": -0.27550006,
+          "spread": 0.38871942,
+          "score": 0.47644839
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.02572446,
-          "spread": 0.0244801,
-          "score": 0.03551089
+          "bias": 0.0255841,
+          "spread": 0.02440216,
+          "score": 0.03535551
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00119478,
-          "spread": 0.004154,
-          "score": 0.00432241
+          "bias": -0.00132058,
+          "spread": 0.00422899,
+          "score": 0.00443039
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00619912,
-          "spread": 0.00523037,
-          "score": 0.00811085
+          "bias": -0.0063318,
+          "spread": 0.00531823,
+          "score": 0.00826893
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00438728,
-          "spread": 0.00436843,
-          "score": 0.00619124
+          "bias": -0.00452121,
+          "spread": 0.00446615,
+          "score": 0.00635514
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.0011148,
-          "spread": 0.00550049,
-          "score": 0.00561232
+          "bias": 0.00046326,
+          "spread": 0.00058458,
+          "score": 0.00074588
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.0014959,
-          "spread": 0.01452675,
-          "score": 0.01460357
+          "bias": 0.00156458,
+          "spread": 0.00270993,
+          "score": 0.00312916
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.02448306,
-          "spread": 0.0523514,
-          "score": 0.0577935
+          "bias": 0.02436518,
+          "spread": 0.05242084,
+          "score": 0.05780663
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00493396,
-          "spread": 0.0,
-          "score": 0.00493396
+          "bias": 0.00033875,
+          "spread": 0.00024636,
+          "score": 0.00041886
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.00957387,
+          "bias": 0.01510048,
           "spread": 0.0,
-          "score": 0.00957387
+          "score": 0.01510048
         },
         {
           "profile": "cp_minus_10pct",
@@ -9097,27 +9097,27 @@
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.0003374,
-          "spread": 0.01209215,
-          "score": 0.01209685
+          "bias": 0.00021562,
+          "spread": 0.01207646,
+          "score": 0.01207838
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00120376,
-          "spread": 0.00476461,
-          "score": 0.00491432
+          "bias": -0.00132489,
+          "spread": 0.00481218,
+          "score": 0.00499123
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00110267,
-          "spread": 0.00238917,
-          "score": 0.00263135
+          "bias": 0.00098091,
+          "spread": 0.00241275,
+          "score": 0.00260453
         },
         {
           "profile": "cp_minus_10pct",
@@ -9142,162 +9142,162 @@
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00620213,
-          "spread": 0.01575515,
-          "score": 0.01693196
+          "bias": -0.00146605,
+          "spread": 0.00925575,
+          "score": 0.00937114
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00239855,
-          "spread": 0.00221343,
-          "score": 0.00326379
+          "bias": -0.00235733,
+          "spread": 0.00228774,
+          "score": 0.00328493
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00276354,
-          "spread": 0.00336455,
-          "score": 0.004354
+          "bias": 0.00280399,
+          "spread": 0.00335633,
+          "score": 0.00437348
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00324433,
-          "spread": 0.0046821,
-          "score": 0.00569629
+          "bias": 0.00328413,
+          "spread": 0.00467682,
+          "score": 0.00571473
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00478809,
-          "spread": 0.00590133,
-          "score": 0.00759944
+          "bias": 0.00482793,
+          "spread": 0.00597507,
+          "score": 0.00768182
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00588776,
-          "spread": 0.03296949,
-          "score": 0.03349109
+          "bias": -0.00584852,
+          "spread": 0.03298585,
+          "score": 0.03350032
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.016652,
-          "spread": 0.04071155,
-          "score": 0.04398544
+          "bias": 0.01668992,
+          "spread": 0.0406862,
+          "score": 0.04397636
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.25345534,
-          "spread": 0.23035636,
-          "score": 0.34249623
+          "bias": 0.15920985,
+          "spread": 0.27612565,
+          "score": 0.3187368
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.13575446,
-          "spread": 0.0,
-          "score": 0.13575446
+          "bias": -0.33860231,
+          "spread": 0.49449524,
+          "score": 0.59931383
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.01368057,
-          "spread": 0.01980035,
-          "score": 0.02406682
+          "bias": 0.01373438,
+          "spread": 0.01967239,
+          "score": 0.02399242
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00164609,
-          "spread": 0.00197628,
-          "score": 0.00257202
+          "bias": 0.00169823,
+          "spread": 0.00192317,
+          "score": 0.00256565
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00433223,
-          "spread": 0.00276973,
-          "score": 0.00514195
+          "bias": -0.00427691,
+          "spread": 0.00285569,
+          "score": 0.00514266
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00140239,
-          "spread": 0.00352411,
-          "score": 0.00379289
+          "bias": -0.00134713,
+          "spread": 0.00346691,
+          "score": 0.00371944
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00047104,
-          "spread": 0.00187939,
-          "score": 0.00193752
+          "bias": -0.00042544,
+          "spread": 0.0017426,
+          "score": 0.00179378
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00649219,
-          "spread": 0.02308871,
-          "score": 0.0239841
+          "bias": 0.00210724,
+          "spread": 0.00255566,
+          "score": 0.00331238
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.02682856,
-          "spread": 0.04304938,
-          "score": 0.05072495
+          "bias": 0.02688248,
+          "spread": 0.04312597,
+          "score": 0.05081847
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.05012588,
-          "spread": 0.05446733,
-          "score": 0.07402225
+          "bias": 0.00775178,
+          "spread": 0.01048521,
+          "score": 0.01303954
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.00050255,
-          "spread": 0.00992141,
-          "score": 0.00993413
+          "bias": 0.00755024,
+          "spread": 0.00755024,
+          "score": 0.01067766
         },
         {
           "profile": "cp_minus_10pct",
@@ -9313,27 +9313,27 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00027304,
-          "spread": 0.0120311,
-          "score": 0.01203419
+          "bias": 0.000323,
+          "spread": 0.01202633,
+          "score": 0.01203066
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00392286,
-          "spread": 0.00447588,
-          "score": 0.00595167
+          "bias": 0.00397318,
+          "spread": 0.00449348,
+          "score": 0.00599812
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00160461,
-          "spread": 0.0039046,
-          "score": 0.00422145
+          "bias": 0.00165524,
+          "spread": 0.00401505,
+          "score": 0.00434286
         },
         {
           "profile": "cp_minus_10pct",
@@ -9349,423 +9349,423 @@
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.10402685,
-          "spread": 0.00349178,
-          "score": 0.10408543
+          "bias": 0.04035882,
+          "spread": 0.01000038,
+          "score": 0.04157935
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00160443,
-          "spread": 0.01149208,
-          "score": 0.01160354
+          "bias": 0.00161126,
+          "spread": 0.01150017,
+          "score": 0.01161249
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00062045,
-          "spread": 0.00158835,
-          "score": 0.00170523
+          "bias": -0.0006136,
+          "spread": 0.00159073,
+          "score": 0.00170497
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00284365,
-          "spread": 0.00108833,
-          "score": 0.0030448
+          "bias": 0.00285043,
+          "spread": 0.00107992,
+          "score": 0.00304814
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00135869,
-          "spread": 0.00196758,
-          "score": 0.00239111
+          "bias": 0.00136524,
+          "spread": 0.00195698,
+          "score": 0.00238614
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00508013,
-          "spread": 0.00893081,
-          "score": 0.01027459
+          "bias": 0.00508674,
+          "spread": 0.00893921,
+          "score": 0.01028515
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00651446,
-          "spread": 0.01854484,
-          "score": 0.01965577
+          "bias": 0.0065207,
+          "spread": 0.01853386,
+          "score": 0.01964748
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.01802192,
-          "spread": 0.03407175,
-          "score": 0.03854444
+          "bias": -0.01801613,
+          "spread": 0.03406112,
+          "score": 0.03853233
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.14234619,
-          "spread": 0.07866562,
-          "score": 0.16263676
+          "bias": -0.01772958,
+          "spread": 0.28552573,
+          "score": 0.28607566
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.38981747,
-          "spread": 0.39092983,
-          "score": 0.55207227
+          "bias": -0.09360749,
+          "spread": 0.11471668,
+          "score": 0.14806174
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.00753842,
-          "spread": 0.01493608,
-          "score": 0.01673064
+          "bias": 0.00751962,
+          "spread": 0.01479795,
+          "score": 0.01659891
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00401644,
-          "spread": 0.00205854,
-          "score": 0.00451324
+          "bias": 0.00400088,
+          "spread": 0.00199015,
+          "score": 0.00446852
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00375532,
-          "spread": 0.00194932,
-          "score": 0.00423111
+          "bias": -0.00377145,
+          "spread": 0.002052,
+          "score": 0.00429355
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00132167,
-          "spread": 0.00251583,
-          "score": 0.00284186
+          "bias": -0.00133816,
+          "spread": 0.00257645,
+          "score": 0.00290323
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00010743,
-          "spread": 0.00213501,
-          "score": 0.00213771
+          "bias": 9.1e-05,
+          "spread": 0.00228297,
+          "score": 0.00228478
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00290285,
-          "spread": 0.01387595,
-          "score": 0.01417634
+          "bias": 0.00169442,
+          "spread": 0.00204958,
+          "score": 0.0026593
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.02941021,
-          "spread": 0.04717522,
-          "score": 0.05559192
+          "bias": 0.02940018,
+          "spread": 0.04724771,
+          "score": 0.05564815
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00055395,
-          "spread": 0.01338655,
-          "score": 0.01339801
+          "bias": 0.00593647,
+          "spread": 0.00607219,
+          "score": 0.00849195
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.02572829,
-          "spread": 0.01530423,
-          "score": 0.02993601
+          "bias": 0.01509847,
+          "spread": 2.01e-06,
+          "score": 0.01509847
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
+          "bias": 0.0,
+          "spread": 0.0,
+          "score": 0.0
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00302009,
-          "spread": 0.00479272,
-          "score": 0.0056649
+          "bias": 0.00300491,
+          "spread": 0.00477069,
+          "score": 0.00563817
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 6.183e-05,
-          "spread": 0.00277583,
-          "score": 0.00277652
+          "bias": 4.687e-05,
+          "spread": 0.00279457,
+          "score": 0.00279496
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00352785,
-          "spread": 0.00487659,
-          "score": 0.00601888
+          "bias": 0.00351336,
+          "spread": 0.00498562,
+          "score": 0.00609919
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00081857,
-          "spread": 0.00161829,
-          "score": 0.00181354
+          "bias": 0.00081861,
+          "spread": 0.00161825,
+          "score": 0.00181352
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.0715607,
-          "spread": 0.00746359,
-          "score": 0.07194887
+          "bias": 0.01375606,
+          "spread": 0.05117808,
+          "score": 0.05299457
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00119447,
-          "spread": 0.0048,
-          "score": 0.00494639
+          "bias": 0.00119462,
+          "spread": 0.00479995,
+          "score": 0.00494638
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 2.439e-05,
-          "spread": 0.00144281,
-          "score": 0.00144302
+          "bias": 2.454e-05,
+          "spread": 0.00144275,
+          "score": 0.00144296
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00037867,
-          "spread": 0.00123513,
-          "score": 0.00129187
+          "bias": 0.00037881,
+          "spread": 0.00123509,
+          "score": 0.00129188
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00244841,
-          "spread": 0.00249292,
-          "score": 0.00349419
+          "bias": 0.00244855,
+          "spread": 0.0024929,
+          "score": 0.00349427
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00898835,
-          "spread": 0.00744597,
-          "score": 0.01167189
+          "bias": 0.00898849,
+          "spread": 0.00744594,
+          "score": 0.01167197
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.0001773,
-          "spread": 0.02487834,
-          "score": 0.02487897
+          "bias": -0.00017716,
+          "spread": 0.02487837,
+          "score": 0.02487901
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.00505697,
-          "spread": 0.02017899,
-          "score": 0.020803
+          "bias": -0.00505683,
+          "spread": 0.02017909,
+          "score": 0.02080306
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.03445751,
-          "spread": 0.20138376,
-          "score": 0.20431039
+          "bias": 0.03445762,
+          "spread": 0.2013837,
+          "score": 0.20431036
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.06860189,
-          "spread": 0.0,
-          "score": 0.06860189
+          "bias": -0.58643104,
+          "spread": 0.54929485,
+          "score": 0.80350867
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.0017826,
-          "spread": 0.04356004,
-          "score": 0.0435965
+          "bias": -0.001833,
+          "spread": 0.04356545,
+          "score": 0.04360399
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00312943,
-          "spread": 0.00191113,
-          "score": 0.00366684
+          "bias": 0.00308202,
+          "spread": 0.00189955,
+          "score": 0.00362038
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00276746,
-          "spread": 0.00069767,
-          "score": 0.00285405
+          "bias": -0.00281769,
+          "spread": 0.00071337,
+          "score": 0.00290659
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00198076,
-          "spread": 0.0013094,
-          "score": 0.00237444
+          "bias": -0.00203143,
+          "spread": 0.0013246,
+          "score": 0.00242514
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 2.279e-05,
-          "spread": 0.00109242,
-          "score": 0.00109266
+          "bias": -2.801e-05,
+          "spread": 0.00110866,
+          "score": 0.00110902
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00108914,
-          "spread": 0.00036957,
-          "score": 0.00115013
+          "bias": 0.00103838,
+          "spread": 0.00036696,
+          "score": 0.00110132
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.02599072,
-          "spread": 0.03790027,
-          "score": 0.04595593
+          "bias": 0.02594694,
+          "spread": 0.03792878,
+          "score": 0.04595472
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00044829,
-          "spread": 0.00358478,
-          "score": 0.0036127
+          "bias": 0.00374583,
+          "spread": 0.00383116,
+          "score": 0.00535808
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.02637215,
-          "spread": 0.02871326,
-          "score": 0.03898643
+          "bias": 0.00868406,
+          "spread": 0.0071939,
+          "score": 0.01127675
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
-          "bias": 0.02126093,
-          "spread": 0.0,
-          "score": 0.02126093
+          "bias": 0.00284956,
+          "spread": 0.00402989,
+          "score": 0.00493558
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00210139,
-          "spread": 0.00513798,
-          "score": 0.0055511
+          "bias": 0.00205575,
+          "spread": 0.00517599,
+          "score": 0.00556929
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00229183,
-          "spread": 0.00321287,
-          "score": 0.00394652
+          "bias": 0.00224602,
+          "spread": 0.00322905,
+          "score": 0.00393337
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00156454,
-          "spread": 0.00304278,
-          "score": 0.00342144
+          "bias": 0.00151856,
+          "spread": 0.00300965,
+          "score": 0.00337106
         },
         {
           "profile": "cp_plus_10pct",
@@ -9790,153 +9790,153 @@
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00453944,
-          "spread": 0.00686085,
-          "score": 0.00822665
+          "bias": -0.01050764,
+          "spread": 0.01487169,
+          "score": 0.01820928
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00536383,
-          "spread": 0.00421859,
-          "score": 0.00682401
+          "bias": -0.00520793,
+          "spread": 0.00416893,
+          "score": 0.00667102
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00429296,
-          "spread": 0.00598677,
-          "score": 0.00736688
+          "bias": -0.00413503,
+          "spread": 0.0060418,
+          "score": 0.00732132
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00878083,
-          "spread": 0.00713775,
-          "score": 0.01131594
+          "bias": -0.00862137,
+          "spread": 0.00714664,
+          "score": 0.01119833
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": -0.01040733,
-          "spread": 0.00507531,
-          "score": 0.01157891
+          "bias": -0.01024604,
+          "spread": 0.00518371,
+          "score": 0.01148269
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.0131959,
-          "spread": 0.0850221,
-          "score": 0.08604005
+          "bias": -0.0688304,
+          "spread": 0.03847626,
+          "score": 0.07885459
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.17551965,
-          "spread": 0.24308664,
-          "score": 0.29983039
+          "bias": 0.02974629,
+          "spread": 0.1943186,
+          "score": 0.1965822
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 1.26025254,
-          "spread": 1.84236851,
-          "score": 2.23216446
+          "bias": 1.31286254,
+          "spread": 2.21952573,
+          "score": 2.57874049
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -2.91593074,
-          "spread": 4.12739604,
-          "score": 5.05351859
+          "bias": -2.00633656,
+          "spread": 3.58484177,
+          "score": 4.10809894
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.01791275,
-          "spread": 0.06746081,
-          "score": 0.06979848
+          "bias": -0.01676706,
+          "spread": 0.06779056,
+          "score": 0.06983334
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00962474,
-          "spread": 0.00942968,
-          "score": 0.01347421
+          "bias": -0.00838933,
+          "spread": 0.00998036,
+          "score": 0.01303796
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00476144,
-          "spread": 0.01107514,
-          "score": 0.01205529
+          "bias": -0.00027134,
+          "spread": 0.01510156,
+          "score": 0.01510399
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00456462,
-          "spread": 0.0059278,
-          "score": 0.00748161
+          "bias": -0.00199422,
+          "spread": 0.00184921,
+          "score": 0.00271966
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00251072,
-          "spread": 0.00685124,
-          "score": 0.0072968
+          "bias": -0.00048533,
+          "spread": 0.00062741,
+          "score": 0.00079321
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00105941,
-          "spread": 0.00389035,
-          "score": 0.00403202
+          "bias": -0.00246201,
+          "spread": 0.00348181,
+          "score": 0.00426432
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.04383688,
-          "spread": 0.08659218,
-          "score": 0.09705605
+          "bias": -0.04257952,
+          "spread": 0.08565782,
+          "score": 0.09565708
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00560666,
-          "spread": 0.0,
-          "score": 0.00560666
+          "bias": -0.00085042,
+          "spread": 0.00026532,
+          "score": 0.00089085
         },
         {
           "profile": "cp_plus_10pct",
@@ -9961,36 +9961,36 @@
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00693831,
-          "spread": 0.01801095,
-          "score": 0.01930115
+          "bias": -0.00570293,
+          "spread": 0.01690292,
+          "score": 0.01783906
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00883292,
-          "spread": 0.00755146,
-          "score": 0.01162089
+          "bias": -0.00758806,
+          "spread": 0.00657672,
+          "score": 0.01004151
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00731603,
-          "spread": 0.00430004,
-          "score": 0.00848614
+          "bias": -0.00606272,
+          "spread": 0.00447217,
+          "score": 0.00753372
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 2,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00186561,
-          "spread": 0.00321354,
-          "score": 0.00371582
+          "bias": -0.00186534,
+          "spread": 0.00321318,
+          "score": 0.00371538
         },
         {
           "profile": "cp_plus_10pct",
@@ -10006,162 +10006,162 @@
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00197182,
-          "spread": 0.02381472,
-          "score": 0.02389621
+          "bias": -0.00881201,
+          "spread": 0.01421908,
+          "score": 0.01672823
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.0028873,
-          "spread": 0.00208502,
-          "score": 0.00356143
+          "bias": -0.00283621,
+          "spread": 0.00215035,
+          "score": 0.00355923
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00187406,
-          "spread": 0.00457552,
-          "score": 0.00494444
+          "bias": 0.0019264,
+          "spread": 0.00459726,
+          "score": 0.00498456
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00650843,
-          "spread": 0.00673874,
-          "score": 0.00936858
+          "bias": -0.00645576,
+          "spread": 0.00675631,
+          "score": 0.00934476
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": -0.0104353,
-          "spread": 0.00889878,
-          "score": 0.01371437
+          "bias": -0.01038237,
+          "spread": 0.00889251,
+          "score": 0.01367005
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.03464331,
-          "spread": 0.08664268,
-          "score": 0.09331192
+          "bias": -0.03459064,
+          "spread": 0.08664887,
+          "score": 0.09329812
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.02918466,
-          "spread": 0.25476535,
-          "score": 0.25643153
+          "bias": 0.07135446,
+          "spread": 0.2107669,
+          "score": 0.22251774
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.33040884,
-          "spread": 0.40606742,
-          "score": 0.52350812
+          "bias": 0.15812331,
+          "spread": 0.21668884,
+          "score": 0.26824808
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.04702915,
-          "spread": 0.32527225,
-          "score": 0.32865449
+          "bias": 0.27214375,
+          "spread": 0.38833403,
+          "score": 0.4741999
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.01693868,
-          "spread": 0.02559784,
-          "score": 0.03069475
+          "bias": 0.01703663,
+          "spread": 0.02573858,
+          "score": 0.03086619
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00683909,
-          "spread": 0.00292067,
-          "score": 0.00743663
+          "bias": -0.00674016,
+          "spread": 0.00302733,
+          "score": 0.00738881
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00298853,
-          "spread": 0.00494002,
-          "score": 0.00577365
+          "bias": 0.00308275,
+          "spread": 0.00499547,
+          "score": 0.0058701
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00111962,
-          "spread": 0.00397369,
-          "score": 0.00412841
+          "bias": -0.00102656,
+          "spread": 0.00399939,
+          "score": 0.00412904
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 8.32e-06,
-          "spread": 0.0058614,
-          "score": 0.00586141
+          "bias": -0.00046326,
+          "spread": 0.00058458,
+          "score": 0.00074588
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": -0.00035954,
-          "spread": 0.00791812,
-          "score": 0.00792628
+          "bias": -0.00156458,
+          "spread": 0.00270993,
+          "score": 0.00312916
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.0085638,
-          "spread": 0.05962748,
-          "score": 0.06023932
+          "bias": -0.00844312,
+          "spread": 0.05986743,
+          "score": 0.06045986
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00288071,
-          "spread": 0.0,
-          "score": 0.00288071
+          "bias": -0.00033875,
+          "spread": 0.00024636,
+          "score": 0.00041886
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.02110577,
+          "bias": -0.01510048,
           "spread": 0.0,
-          "score": 0.02110577
+          "score": 0.01510048
         },
         {
           "profile": "cp_plus_10pct",
@@ -10177,27 +10177,27 @@
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00079148,
-          "spread": 0.01382986,
-          "score": 0.01385249
+          "bias": 0.00089566,
+          "spread": 0.01397102,
+          "score": 0.0139997
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00098448,
-          "spread": 0.00511739,
-          "score": 0.00521122
+          "bias": -0.00088125,
+          "spread": 0.00532605,
+          "score": 0.00539846
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00157167,
-          "spread": 0.0026789,
-          "score": 0.00310591
+          "bias": -0.00146924,
+          "spread": 0.00281002,
+          "score": 0.00317095
         },
         {
           "profile": "cp_plus_10pct",
@@ -10222,162 +10222,162 @@
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00462201,
-          "spread": 0.01253401,
-          "score": 0.01335906
+          "bias": 0.00315561,
+          "spread": 0.01162236,
+          "score": 0.01204314
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00012874,
-          "spread": 0.00312991,
-          "score": 0.00313256
+          "bias": 0.00015412,
+          "spread": 0.00314956,
+          "score": 0.00315332
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00303212,
-          "spread": 0.00295513,
-          "score": 0.00423398
+          "bias": 0.00305776,
+          "spread": 0.00292532,
+          "score": 0.00423171
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00144294,
-          "spread": 0.00580964,
-          "score": 0.00598614
+          "bias": -0.00141693,
+          "spread": 0.00577928,
+          "score": 0.00595045
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": -0.00045564,
-          "spread": 0.00629911,
-          "score": 0.00631557
+          "bias": -0.00042926,
+          "spread": 0.00629118,
+          "score": 0.00630581
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.01047368,
-          "spread": 0.0343042,
-          "score": 0.03586748
+          "bias": -0.01044832,
+          "spread": 0.03427753,
+          "score": 0.03583457
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.00609102,
-          "spread": 0.03484146,
-          "score": 0.03536987
+          "bias": -0.00606458,
+          "spread": 0.03482255,
+          "score": 0.0353467
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": -0.29478963,
-          "spread": 1.0255897,
-          "score": 1.06711534
+          "bias": -0.51037459,
+          "spread": 0.87892263,
+          "score": 1.01635979
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.11607878,
-          "spread": 0.22894819,
-          "score": 0.25669351
+          "bias": 0.1304416,
+          "spread": 0.14661915,
+          "score": 0.19624522
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.00411284,
-          "spread": 0.03158383,
-          "score": 0.03185049
+          "bias": -0.00390732,
+          "spread": 0.03131147,
+          "score": 0.03155432
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00437843,
-          "spread": 0.00129452,
-          "score": 0.00456578
+          "bias": -0.00414992,
+          "spread": 0.00131735,
+          "score": 0.00435399
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00497048,
-          "spread": 0.00361374,
-          "score": 0.00614531
+          "bias": 0.00518843,
+          "spread": 0.00362114,
+          "score": 0.00632712
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00159759,
-          "spread": 0.00405169,
-          "score": 0.00435528
+          "bias": 0.00181303,
+          "spread": 0.0039217,
+          "score": 0.00432051
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00070121,
-          "spread": 0.0024377,
-          "score": 0.00253655
+          "bias": -0.00083817,
+          "spread": 0.00072758,
+          "score": 0.00110991
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00602112,
-          "spread": 0.01652665,
-          "score": 0.01758932
+          "bias": -0.00210724,
+          "spread": 0.00255566,
+          "score": 0.00331238
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.00949748,
-          "spread": 0.03935106,
-          "score": 0.04048096
+          "bias": -0.00924612,
+          "spread": 0.03965478,
+          "score": 0.04071845
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.03448373,
-          "spread": 0.03735182,
-          "score": 0.05083588
+          "bias": -0.00775178,
+          "spread": 0.01048521,
+          "score": 0.01303954
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.00287912,
-          "spread": 0.01657175,
-          "score": 0.01682
+          "bias": -0.00755024,
+          "spread": 0.00755024,
+          "score": 0.01067766
         },
         {
           "profile": "cp_plus_10pct",
@@ -10393,27 +10393,27 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00054626,
-          "spread": 0.01342159,
-          "score": 0.0134327
+          "bias": -0.00030927,
+          "spread": 0.01342848,
+          "score": 0.01343204
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00587609,
-          "spread": 0.00553481,
-          "score": 0.00807233
+          "bias": 0.00611462,
+          "spread": 0.00558366,
+          "score": 0.00828045
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00115645,
-          "spread": 0.00391798,
-          "score": 0.00408509
+          "bias": -0.00091886,
+          "spread": 0.00419345,
+          "score": 0.00429294
         },
         {
           "profile": "cp_plus_10pct",
@@ -10429,423 +10429,423 @@
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.11097184,
-          "spread": 0.00127506,
-          "score": 0.11097916
+          "bias": -0.0356588,
+          "spread": 0.0063725,
+          "score": 0.03622373
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00088451,
-          "spread": 0.01087806,
-          "score": 0.01091396
+          "bias": -0.00086998,
+          "spread": 0.01089088,
+          "score": 0.01092557
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.001521,
-          "spread": 0.00187424,
-          "score": 0.00241375
+          "bias": 0.00153526,
+          "spread": 0.00187957,
+          "score": 0.0024269
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00290232,
-          "spread": 0.0020719,
-          "score": 0.00356598
+          "bias": 0.00291676,
+          "spread": 0.00206024,
+          "score": 0.003571
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00231884,
-          "spread": 0.00264673,
-          "score": 0.00351884
+          "bias": -0.00230415,
+          "spread": 0.00263115,
+          "score": 0.00349744
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": -0.00065631,
-          "spread": 0.00947881,
-          "score": 0.00950151
+          "bias": -0.00064135,
+          "spread": 0.00948792,
+          "score": 0.00950957
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00030573,
-          "spread": 0.02369738,
-          "score": 0.02369936
+          "bias": -0.00029102,
+          "spread": 0.02368483,
+          "score": 0.02368661
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.05297534,
-          "spread": 0.02901196,
-          "score": 0.06039934
+          "bias": -0.05296129,
+          "spread": 0.02899539,
+          "score": 0.06037906
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": -0.0116932,
-          "spread": 0.31498272,
-          "score": 0.31519969
+          "bias": 0.11600997,
+          "spread": 0.35117785,
+          "score": 0.36984347
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.50170699,
-          "spread": 0.5587453,
-          "score": 0.75093689
+          "bias": 0.09667072,
+          "spread": 0.11446583,
+          "score": 0.14982541
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.00243786,
-          "spread": 0.01783365,
-          "score": 0.0179995
+          "bias": -0.00241904,
+          "spread": 0.01769988,
+          "score": 0.01786442
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00210045,
-          "spread": 0.00115683,
-          "score": 0.00239795
+          "bias": -0.00207792,
+          "spread": 0.00118363,
+          "score": 0.00239139
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00522835,
-          "spread": 0.00244538,
-          "score": 0.00577197
+          "bias": 0.00524984,
+          "spread": 0.00248665,
+          "score": 0.00580898
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00165234,
-          "spread": 0.00294366,
-          "score": 0.00337571
+          "bias": 0.00167362,
+          "spread": 0.00295136,
+          "score": 0.00339286
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.0009369,
-          "spread": 0.00238967,
-          "score": 0.00256677
+          "bias": 0.0009583,
+          "spread": 0.00242978,
+          "score": 0.00261193
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00187852,
-          "spread": 0.00998692,
-          "score": 0.01016205
+          "bias": -0.00158098,
+          "spread": 0.00206184,
+          "score": 0.0025982
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.04105406,
-          "spread": 0.04603644,
-          "score": 0.06168298
+          "bias": -0.04102636,
+          "spread": 0.04615402,
+          "score": 0.06175238
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00806007,
-          "spread": 0.00789964,
-          "score": 0.01128579
+          "bias": -0.00593647,
+          "spread": 0.00607219,
+          "score": 0.00849195
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.00177022,
-          "spread": 0.01464623,
-          "score": 0.01475283
+          "bias": -0.01509847,
+          "spread": 2.01e-06,
+          "score": 0.01509847
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
+          "bias": 0.0,
+          "spread": 0.0,
+          "score": 0.0
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00243025,
-          "spread": 0.00595023,
-          "score": 0.00642739
+          "bias": 0.00245345,
+          "spread": 0.00591631,
+          "score": 0.00640485
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00104472,
-          "spread": 0.00287479,
-          "score": 0.00305873
+          "bias": 0.00106813,
+          "spread": 0.002901,
+          "score": 0.00309139
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00172737,
-          "spread": 0.00538048,
-          "score": 0.00565096
+          "bias": 0.00175141,
+          "spread": 0.00552304,
+          "score": 0.00579408
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00075374,
-          "spread": 0.00180637,
-          "score": 0.00195732
+          "bias": 0.00075376,
+          "spread": 0.00180629,
+          "score": 0.00195726
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.09048642,
-          "spread": 0.03705711,
-          "score": 0.09778048
+          "bias": -0.01102522,
+          "spread": 0.04940131,
+          "score": 0.05061664
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00227428,
-          "spread": 0.00409983,
-          "score": 0.00468839
+          "bias": 0.00227483,
+          "spread": 0.00409979,
+          "score": 0.00468862
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00188491,
-          "spread": 0.00165108,
-          "score": 0.00250578
+          "bias": 0.00188545,
+          "spread": 0.00165134,
+          "score": 0.00250637
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00039121,
-          "spread": 0.00170095,
-          "score": 0.00174535
+          "bias": 0.00039176,
+          "spread": 0.00170059,
+          "score": 0.00174513
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.0013703,
-          "spread": 0.00343364,
-          "score": 0.00369697
+          "bias": -0.00136973,
+          "spread": 0.00343363,
+          "score": 0.00369676
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00179675,
-          "spread": 0.00734263,
-          "score": 0.00755926
+          "bias": 0.00179732,
+          "spread": 0.0073426,
+          "score": 0.00755937
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.01015077,
-          "spread": 0.0341532,
-          "score": 0.03562975
+          "bias": -0.01015019,
+          "spread": 0.03415352,
+          "score": 0.03562989
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.02119488,
-          "spread": 0.02326699,
-          "score": 0.03147342
+          "bias": -0.0211943,
+          "spread": 0.02326746,
+          "score": 0.03147338
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.02150368,
-          "spread": 0.26320638,
-          "score": 0.26408333
+          "bias": 0.02150415,
+          "spread": 0.26320595,
+          "score": 0.26408294
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.77346517,
-          "spread": 0.90620743,
-          "score": 1.19141104
+          "bias": 0.58000457,
+          "spread": 0.67009365,
+          "score": 0.88624534
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.01455583,
-          "spread": 0.04313902,
-          "score": 0.04552853
+          "bias": -0.01458565,
+          "spread": 0.04314657,
+          "score": 0.04554522
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00361534,
-          "spread": 0.0028962,
-          "score": 0.00463235
+          "bias": -0.00364804,
+          "spread": 0.00288959,
+          "score": 0.00465381
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00528189,
-          "spread": 0.00088154,
-          "score": 0.00535495
+          "bias": 0.00525082,
+          "spread": 0.00089039,
+          "score": 0.00532578
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00064471,
-          "spread": 0.00135378,
-          "score": 0.00149946
+          "bias": 0.00061404,
+          "spread": 0.00136949,
+          "score": 0.00150085
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00088545,
-          "spread": 0.00096523,
-          "score": 0.00130984
+          "bias": 0.00085478,
+          "spread": 0.00098524,
+          "score": 0.00130436
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": -0.00197783,
-          "spread": 0.00308094,
-          "score": 0.00366115
+          "bias": -0.00200849,
+          "spread": 0.0030809,
+          "score": 0.00367776
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.02520969,
-          "spread": 0.02164986,
-          "score": 0.03323018
+          "bias": -0.02524338,
+          "spread": 0.02165946,
+          "score": 0.033262
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00680666,
-          "spread": 0.00617067,
-          "score": 0.00918737
+          "bias": -0.00536946,
+          "spread": 0.00423133,
+          "score": 0.00683632
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.03680592,
-          "spread": 0.02464448,
-          "score": 0.04429476
+          "bias": -0.00868406,
+          "spread": 0.0071939,
+          "score": 0.01127675
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
-          "bias": 0.0190549,
-          "spread": 0.0,
-          "score": 0.0190549
+          "bias": -0.00284956,
+          "spread": 0.00402989,
+          "score": 0.00493558
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00125081,
-          "spread": 0.00669379,
-          "score": 0.00680965
+          "bias": 0.00121731,
+          "spread": 0.00673497,
+          "score": 0.0068441
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00337741,
-          "spread": 0.00324754,
-          "score": 0.00468545
+          "bias": 0.00334366,
+          "spread": 0.00326858,
+          "score": 0.00467586
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00061186,
-          "spread": 0.00287815,
-          "score": 0.00294247
+          "bias": -0.00064558,
+          "spread": 0.0028609,
+          "score": 0.00293284
         },
         {
           "profile": "cp_plus_3pct",
@@ -10870,153 +10870,153 @@
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00388478,
-          "spread": 0.00787649,
-          "score": 0.0087824
+          "bias": -0.00853385,
+          "spread": 0.00522728,
+          "score": 0.01000755
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00581038,
-          "spread": 0.00268957,
-          "score": 0.00640268
+          "bias": -0.00577662,
+          "spread": 0.00269471,
+          "score": 0.00637423
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00448447,
-          "spread": 0.0065603,
-          "score": 0.00794657
+          "bias": -0.00444985,
+          "spread": 0.00664623,
+          "score": 0.00799834
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00626258,
-          "spread": 0.00719599,
-          "score": 0.00953951
+          "bias": -0.00622801,
+          "spread": 0.00724356,
+          "score": 0.00955287
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": -0.00759763,
-          "spread": 0.00412997,
-          "score": 0.00864758
+          "bias": -0.0075629,
+          "spread": 0.00422495,
+          "score": 0.00866301
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00642761,
-          "spread": 0.08226577,
-          "score": 0.08251649
+          "bias": -0.04347856,
+          "spread": 0.0462047,
+          "score": 0.06344494
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.15985813,
-          "spread": 0.23398867,
-          "score": 0.28338193
+          "bias": 0.00503362,
+          "spread": 0.06157958,
+          "score": 0.06178497
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.26152843,
-          "spread": 0.42571451,
-          "score": 0.49962983
+          "bias": 0.38996849,
+          "spread": 0.66458221,
+          "score": 0.77054846
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -1.0684495,
-          "spread": 1.49196575,
-          "score": 1.8350875
+          "bias": -0.60579124,
+          "spread": 1.07532692,
+          "score": 1.23422486
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.01515132,
-          "spread": 0.06921116,
-          "score": 0.07085018
+          "bias": -0.014784,
+          "spread": 0.06941923,
+          "score": 0.07097603
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00763939,
-          "spread": 0.00923419,
-          "score": 0.0119846
+          "bias": -0.00726967,
+          "spread": 0.00956051,
+          "score": 0.01201047
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00128503,
-          "spread": 0.01081719,
-          "score": 0.01089325
+          "bias": 0.00085593,
+          "spread": 0.01142044,
+          "score": 0.01145247
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00330248,
-          "spread": 0.00577679,
-          "score": 0.00665415
+          "bias": -0.00183006,
+          "spread": 0.00268577,
+          "score": 0.00325
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00276354,
-          "spread": 0.00727375,
-          "score": 0.00778104
+          "bias": -0.0001456,
+          "spread": 0.00018822,
+          "score": 0.00023796
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00261335,
-          "spread": 0.00085011,
-          "score": 0.00274814
+          "bias": -0.0007386,
+          "spread": 0.00104454,
+          "score": 0.0012793
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.01485464,
-          "spread": 0.06246199,
-          "score": 0.06420406
+          "bias": -0.014486,
+          "spread": 0.06219812,
+          "score": 0.06386275
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00503732,
-          "spread": 0.0,
-          "score": 0.00503732
+          "bias": -0.00025513,
+          "spread": 7.959e-05,
+          "score": 0.00026725
         },
         {
           "profile": "cp_plus_3pct",
@@ -11041,27 +11041,27 @@
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00574753,
-          "spread": 0.01901972,
-          "score": 0.01986917
+          "bias": -0.00538367,
+          "spread": 0.01872168,
+          "score": 0.01948038
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00848166,
-          "spread": 0.00723494,
-          "score": 0.01114823
+          "bias": -0.00811276,
+          "spread": 0.00730391,
+          "score": 0.01091623
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00594363,
-          "spread": 0.00480112,
-          "score": 0.00764052
+          "bias": -0.00557507,
+          "spread": 0.00463935,
+          "score": 0.00725292
         },
         {
           "profile": "cp_plus_3pct",
@@ -11086,162 +11086,162 @@
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00295872,
-          "spread": 0.02005425,
-          "score": 0.02027133
+          "bias": -0.00319283,
+          "spread": 0.00503106,
+          "score": 0.00595867
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00404975,
-          "spread": 0.00214715,
-          "score": 0.00458375
+          "bias": -0.00402428,
+          "spread": 0.00219911,
+          "score": 0.00458595
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00186459,
-          "spread": 0.00499541,
-          "score": 0.00533206
+          "bias": 0.00189036,
+          "spread": 0.00501339,
+          "score": 0.00535794
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00413646,
-          "spread": 0.00644246,
-          "score": 0.00765608
+          "bias": -0.0041108,
+          "spread": 0.00644857,
+          "score": 0.0076474
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": -0.0071511,
-          "spread": 0.00716441,
-          "score": 0.0101226
+          "bias": -0.00712542,
+          "spread": 0.00716812,
+          "score": 0.0101071
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.03031155,
-          "spread": 0.07825567,
-          "score": 0.08392104
+          "bias": -0.03028645,
+          "spread": 0.07825554,
+          "score": 0.08391185
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.02914814,
-          "spread": 0.22638355,
-          "score": 0.22825233
+          "bias": 0.07904704,
+          "spread": 0.17959607,
+          "score": 0.19622228
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.31056291,
-          "spread": 0.34680314,
-          "score": 0.46553382
+          "bias": 0.04304639,
+          "spread": 0.06832226,
+          "score": 0.08075223
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.10424474,
-          "spread": 0.37725177,
-          "score": 0.39138965
+          "bias": 0.08046842,
+          "spread": 0.11640007,
+          "score": 0.14150669
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.02076899,
-          "spread": 0.01918017,
-          "score": 0.02827065
+          "bias": 0.02078212,
+          "spread": 0.01925928,
+          "score": 0.02833401
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00461745,
-          "spread": 0.00293368,
-          "score": 0.00547058
+          "bias": -0.00460553,
+          "spread": 0.0030068,
+          "score": 0.00550016
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00040345,
-          "spread": 0.00484266,
-          "score": 0.00485944
+          "bias": -0.00039148,
+          "spread": 0.00494304,
+          "score": 0.00495852
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00221791,
-          "spread": 0.00430633,
-          "score": 0.00484392
+          "bias": -0.00220616,
+          "spread": 0.00437909,
+          "score": 0.00490343
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00040391,
-          "spread": 0.00592683,
-          "score": 0.00594058
+          "bias": -0.00013898,
+          "spread": 0.00017537,
+          "score": 0.00022376
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00033374,
-          "spread": 0.01056425,
-          "score": 0.01056952
+          "bias": -0.00046937,
+          "spread": 0.00081298,
+          "score": 0.00093875
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.00120466,
-          "spread": 0.05429447,
-          "score": 0.05430783
+          "bias": 0.00122657,
+          "spread": 0.05446568,
+          "score": 0.05447948
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00428404,
-          "spread": 0.0,
-          "score": 0.00428404
+          "bias": -0.00010162,
+          "spread": 7.391e-05,
+          "score": 0.00012566
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.00931438,
+          "bias": -0.00453015,
           "spread": 0.0,
-          "score": 0.00931438
+          "score": 0.00453015
         },
         {
           "profile": "cp_plus_3pct",
@@ -11257,27 +11257,27 @@
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00071993,
-          "spread": 0.01216039,
-          "score": 0.01218168
+          "bias": 0.00073275,
+          "spread": 0.01224441,
+          "score": 0.01226632
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00109043,
-          "spread": 0.00467808,
-          "score": 0.00480348
+          "bias": -0.00107788,
+          "spread": 0.00484117,
+          "score": 0.00495972
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00058375,
-          "spread": 0.0020419,
-          "score": 0.00212371
+          "bias": -0.00057168,
+          "spread": 0.00217459,
+          "score": 0.00224848
         },
         {
           "profile": "cp_plus_3pct",
@@ -11302,162 +11302,162 @@
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00557187,
-          "spread": 0.01421215,
-          "score": 0.01526535
+          "bias": 0.00106644,
+          "spread": 0.01040561,
+          "score": 0.01046012
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00068776,
-          "spread": 0.00269132,
-          "score": 0.00277781
+          "bias": -0.00065281,
+          "spread": 0.00273101,
+          "score": 0.00280795
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00297799,
-          "spread": 0.00301756,
-          "score": 0.00423959
+          "bias": 0.00301307,
+          "spread": 0.0029964,
+          "score": 0.00424936
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 9.083e-05,
-          "spread": 0.00513351,
-          "score": 0.00513431
+          "bias": 0.00012597,
+          "spread": 0.00511524,
+          "score": 0.00511679
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00037013,
-          "spread": 0.00621353,
-          "score": 0.00622454
+          "bias": 0.00040568,
+          "spread": 0.00624477,
+          "score": 0.00625794
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00842065,
-          "spread": 0.03296512,
-          "score": 0.03402362
+          "bias": -0.00838578,
+          "spread": 0.03295904,
+          "score": 0.03400911
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.0022208,
-          "spread": 0.04079836,
-          "score": 0.04085876
+          "bias": 0.00225583,
+          "spread": 0.04078184,
+          "score": 0.04084418
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": -0.06242089,
-          "spread": 0.59753952,
-          "score": 0.60079102
+          "bias": -0.25641146,
+          "spread": 0.4518962,
+          "score": 0.51957388
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.10045121,
-          "spread": 0.0,
-          "score": 0.10045121
+          "bias": 0.10300091,
+          "spread": 0.14834932,
+          "score": 0.18060096
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.00089303,
-          "spread": 0.02485,
-          "score": 0.02486604
+          "bias": 0.00104875,
+          "spread": 0.02461906,
+          "score": 0.02464139
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00248037,
-          "spread": 0.00097879,
-          "score": 0.0026665
+          "bias": -0.00231611,
+          "spread": 0.00099292,
+          "score": 0.00251997
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00168399,
-          "spread": 0.00339745,
-          "score": 0.0037919
+          "bias": 0.00184623,
+          "spread": 0.00344283,
+          "score": 0.00390662
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00039572,
-          "spread": 0.00422927,
-          "score": 0.00424774
+          "bias": 0.00055692,
+          "spread": 0.00413339,
+          "score": 0.00417074
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00053356,
-          "spread": 0.00262165,
-          "score": 0.00267539
+          "bias": -0.00064048,
+          "spread": 0.00084411,
+          "score": 0.00105959
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00631935,
-          "spread": 0.01879188,
-          "score": 0.01982597
+          "bias": -0.00063217,
+          "spread": 0.0007667,
+          "score": 0.00099371
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.00479341,
-          "spread": 0.03663691,
-          "score": 0.03694915
+          "bias": 0.00496958,
+          "spread": 0.03686192,
+          "score": 0.0371954
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.03699225,
-          "spread": 0.040132,
-          "score": 0.05458025
+          "bias": -0.00232553,
+          "spread": 0.00314556,
+          "score": 0.00391186
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.00374382,
-          "spread": 0.00492627,
-          "score": 0.00618743
+          "bias": -0.00226507,
+          "spread": 0.00226507,
+          "score": 0.0032033
         },
         {
           "profile": "cp_plus_3pct",
@@ -11473,27 +11473,27 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 2.502e-05,
-          "spread": 0.01306915,
-          "score": 0.01306917
+          "bias": 0.00019147,
+          "spread": 0.01307715,
+          "score": 0.01307856
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00518104,
-          "spread": 0.00519413,
-          "score": 0.00733636
+          "bias": 0.00534842,
+          "spread": 0.00523344,
+          "score": 0.00748295
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00020629,
-          "spread": 0.00411198,
-          "score": 0.00411715
+          "bias": 0.00037341,
+          "spread": 0.00430131,
+          "score": 0.00431749
         },
         {
           "profile": "cp_plus_3pct",
@@ -11509,207 +11509,207 @@
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.10042786,
-          "spread": 0.00634688,
-          "score": 0.10062822
+          "bias": -0.00905263,
+          "spread": 0.00064199,
+          "score": 0.00907537
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 2.651e-05,
-          "spread": 0.01056869,
-          "score": 0.01056872
+          "bias": 3.808e-05,
+          "spread": 0.01057964,
+          "score": 0.01057971
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00067371,
-          "spread": 0.00172481,
-          "score": 0.00185171
+          "bias": 0.00068513,
+          "spread": 0.0017286,
+          "score": 0.00185942
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00289377,
-          "spread": 0.00153442,
-          "score": 0.00327542
+          "bias": 0.00290525,
+          "spread": 0.00152411,
+          "score": 0.00328076
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00082413,
-          "spread": 0.00231124,
-          "score": 0.00245377
+          "bias": -0.00081263,
+          "spread": 0.00229753,
+          "score": 0.002437
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00090026,
-          "spread": 0.00979039,
-          "score": 0.0098317
+          "bias": 0.00091192,
+          "spread": 0.00979873,
+          "score": 0.00984107
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00232253,
-          "spread": 0.02191979,
-          "score": 0.02204249
+          "bias": 0.00233391,
+          "spread": 0.02190811,
+          "score": 0.02203208
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.04303445,
-          "spread": 0.0298016,
-          "score": 0.05234595
+          "bias": -0.04302372,
+          "spread": 0.02978741,
+          "score": 0.05232906
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.04621937,
-          "spread": 0.22929515,
-          "score": 0.23390703
+          "bias": 0.0721999,
+          "spread": 0.20361228,
+          "score": 0.21603422
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.44579868,
-          "spread": 0.48121388,
-          "score": 0.65597505
+          "bias": 0.03007334,
+          "spread": 0.03428337,
+          "score": 0.04560433
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.00390251,
-          "spread": 0.01560467,
-          "score": 0.01608525
+          "bias": -0.00389619,
+          "spread": 0.01546617,
+          "score": 0.01594938
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00021901,
-          "spread": 0.0011489,
-          "score": 0.00116959
+          "bias": 0.00022757,
+          "spread": 0.00110158,
+          "score": 0.00112484
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00221343,
-          "spread": 0.00218762,
-          "score": 0.00311206
+          "bias": 0.00222205,
+          "spread": 0.00224794,
+          "score": 0.00316081
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00062805,
-          "spread": 0.00272739,
-          "score": 0.00279877
+          "bias": 0.00063661,
+          "spread": 0.00275202,
+          "score": 0.0028247
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00073204,
-          "spread": 0.00232095,
-          "score": 0.00243366
+          "bias": 0.00074072,
+          "spread": 0.00239267,
+          "score": 0.0025047
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00239106,
-          "spread": 0.01140899,
-          "score": 0.01165686
+          "bias": -0.00040458,
+          "spread": 0.00064311,
+          "score": 0.00075979
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.01895379,
-          "spread": 0.03239429,
-          "score": 0.0375318
+          "bias": -0.01894063,
+          "spread": 0.03254489,
+          "score": 0.03765525
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00499793,
-          "spread": 0.00787411,
-          "score": 0.00932636
+          "bias": -0.00178094,
+          "spread": 0.00182166,
+          "score": 0.00254758
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.00792418,
-          "spread": 0.01463036,
-          "score": 0.01663851
+          "bias": -0.00452954,
+          "spread": 6e-07,
+          "score": 0.00452954
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
+          "bias": 0.0,
+          "spread": 0.0,
+          "score": 0.0
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.0024462,
-          "spread": 0.00547274,
-          "score": 0.00599456
+          "bias": 0.00245485,
+          "spread": 0.00545276,
+          "score": 0.00597987
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00074927,
-          "spread": 0.00272289,
-          "score": 0.0028241
+          "bias": 0.00075806,
+          "spread": 0.00273887,
+          "score": 0.00284184
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00236633,
-          "spread": 0.0054216,
-          "score": 0.00591551
+          "bias": 0.00237576,
+          "spread": 0.00554981,
+          "score": 0.00603694
         },
         {
           "profile": "cp_plus_3pct",
@@ -11725,216 +11725,216 @@
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.08161088,
-          "spread": 0.02014117,
-          "score": 0.08405951
+          "bias": -0.00235176,
+          "spread": 0.01425535,
+          "score": 0.01444804
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00170187,
-          "spread": 0.00433597,
-          "score": 0.00465801
+          "bias": 0.00170224,
+          "spread": 0.00433603,
+          "score": 0.0046582
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00128935,
-          "spread": 0.00148052,
-          "score": 0.00196325
+          "bias": 0.00128971,
+          "spread": 0.00148068,
+          "score": 0.00196361
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.000354,
-          "spread": 0.00141626,
-          "score": 0.00145983
+          "bias": 0.00035437,
+          "spread": 0.00141615,
+          "score": 0.00145981
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -2.798e-05,
-          "spread": 0.00306252,
-          "score": 0.00306264
+          "bias": -2.761e-05,
+          "spread": 0.00306257,
+          "score": 0.0030627
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00431151,
-          "spread": 0.00737266,
-          "score": 0.0085408
+          "bias": 0.00431188,
+          "spread": 0.00737273,
+          "score": 0.00854105
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00585488,
-          "spread": 0.03081701,
-          "score": 0.03136826
+          "bias": -0.0058545,
+          "spread": 0.03081722,
+          "score": 0.03136839
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.01396424,
-          "spread": 0.01965485,
-          "score": 0.02411043
+          "bias": -0.01396387,
+          "spread": 0.01965514,
+          "score": 0.02411046
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.02625671,
-          "spread": 0.2431013,
-          "score": 0.24451514
+          "bias": 0.026257,
+          "spread": 0.243101,
+          "score": 0.24451488
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.10096379,
-          "spread": 0.21095981,
-          "score": 0.23387546
+          "bias": 0.10893246,
+          "spread": 0.14961516,
+          "score": 0.18507019
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.01024872,
-          "spread": 0.04817709,
-          "score": 0.04925514
+          "bias": -0.01028444,
+          "spread": 0.04818128,
+          "score": 0.04926668
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.0012173,
-          "spread": 0.00252934,
-          "score": 0.00280702
+          "bias": -0.0012544,
+          "spread": 0.00252328,
+          "score": 0.00281789
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00253065,
-          "spread": 0.00074209,
-          "score": 0.00263721
+          "bias": 0.00249411,
+          "spread": 0.00075281,
+          "score": 0.00260524
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00020417,
-          "spread": 0.00143204,
-          "score": 0.00144653
+          "bias": -0.00024052,
+          "spread": 0.00144458,
+          "score": 0.00146446
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00064161,
-          "spread": 0.00097853,
-          "score": 0.00117012
+          "bias": 0.00060524,
+          "spread": 0.00099793,
+          "score": 0.00116712
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": -0.00086845,
-          "spread": 0.00197569,
-          "score": 0.00215813
+          "bias": -0.0009048,
+          "spread": 0.0019767,
+          "score": 0.00217394
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.00410747,
-          "spread": 0.01886466,
-          "score": 0.01930664
+          "bias": -0.00414451,
+          "spread": 0.01889925,
+          "score": 0.01934834
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.0040204,
-          "spread": 0.00475331,
-          "score": 0.00622556
+          "bias": -0.00221619,
+          "spread": 0.00247844,
+          "score": 0.00332478
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.03386116,
-          "spread": 0.02604368,
-          "score": 0.04271829
+          "bias": -0.00260522,
+          "spread": 0.00215817,
+          "score": 0.00338303
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
-          "bias": 0.02200699,
-          "spread": 0.0,
-          "score": 0.02200699
+          "bias": -0.00085487,
+          "spread": 0.00120897,
+          "score": 0.00148067
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00135427,
-          "spread": 0.00611482,
-          "score": 0.00626299
+          "bias": 0.00131701,
+          "spread": 0.00615466,
+          "score": 0.00629399
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.003229,
-          "spread": 0.0031587,
-          "score": 0.00451705
+          "bias": 0.00319149,
+          "spread": 0.00318034,
+          "score": 0.00450557
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00010542,
-          "spread": 0.00310044,
-          "score": 0.00310223
+          "bias": 6.79e-05,
+          "spread": 0.00307645,
+          "score": 0.0030772
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 1,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00561522,
-          "spread": 0.00496745,
-          "score": 0.00749708
+          "bias": -0.00561549,
+          "spread": 0.00496701,
+          "score": 0.007497
         },
         {
           "profile": "rated_plus_5pct",
@@ -11950,153 +11950,153 @@
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00432504,
-          "spread": 0.01141142,
-          "score": 0.01220354
+          "bias": -0.00673717,
+          "spread": 0.00663401,
+          "score": 0.00945514
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00689908,
-          "spread": 0.00196207,
-          "score": 0.00717266
+          "bias": -0.00699078,
+          "spread": 0.00204094,
+          "score": 0.00728261
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.0047417,
-          "spread": 0.00722937,
-          "score": 0.00864566
+          "bias": -0.00483314,
+          "spread": 0.00733603,
+          "score": 0.00878502
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00389069,
-          "spread": 0.0076059,
-          "score": 0.00854325
+          "bias": -0.00398177,
+          "spread": 0.00769281,
+          "score": 0.00866221
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": -0.00498572,
-          "spread": 0.00263476,
-          "score": 0.00563909
+          "bias": -0.00507686,
+          "spread": 0.00266905,
+          "score": 0.0057357
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00776772,
-          "spread": 0.0771651,
-          "score": 0.07755507
+          "bias": -0.02098164,
+          "spread": 0.05659131,
+          "score": 0.06035566
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.14396969,
-          "spread": 0.22193123,
-          "score": 0.26453873
+          "bias": 0.00814056,
+          "spread": 0.00779428,
+          "score": 0.01127029
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.26097038,
-          "spread": 0.46242392,
-          "score": 0.53098157
+          "bias": 0.00814027,
+          "spread": 0.00778183,
+          "score": 0.01126148
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.27985229,
-          "spread": 0.39453585,
-          "score": 0.48371049
+          "bias": 0.00814057,
+          "spread": 0.00780229,
+          "score": 0.01127584
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.0058981,
-          "spread": 0.06274981,
-          "score": 0.06302639
+          "bias": -0.00085809,
+          "spread": 0.06352774,
+          "score": 0.06353353
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00492633,
-          "spread": 0.01052616,
-          "score": 0.01162191
+          "bias": 0.00015835,
+          "spread": 0.01123872,
+          "score": 0.01123984
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00407622,
-          "spread": 0.01192756,
-          "score": 0.01260485
+          "bias": -0.00751143,
+          "spread": 0.02252137,
+          "score": 0.02374097
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00116569,
-          "spread": 0.00522633,
-          "score": 0.00535476
+          "bias": -0.03754144,
+          "spread": 0.02044011,
+          "score": 0.04274527
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00438865,
-          "spread": 0.00834688,
-          "score": 0.0094303
+          "bias": -0.04937198,
+          "spread": 0.00035907,
+          "score": 0.04937329
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00303835,
-          "spread": 0.00505707,
-          "score": 0.00589962
+          "bias": -0.04834897,
+          "spread": 0.00170345,
+          "score": 0.04837897
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.00468307,
-          "spread": 0.06268184,
-          "score": 0.06285654
+          "bias": 0.00029071,
+          "spread": 0.06235168,
+          "score": 0.06235236
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00663879,
-          "spread": 0.0,
-          "score": 0.00663879
+          "bias": -0.04945674,
+          "spread": 1.461e-05,
+          "score": 0.04945674
         },
         {
           "profile": "rated_plus_5pct",
@@ -12121,36 +12121,36 @@
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00507972,
-          "spread": 0.01924257,
-          "score": 0.01990176
+          "bias": -8.023e-05,
+          "spread": 0.01861284,
+          "score": 0.01861301
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00890163,
-          "spread": 0.00747427,
-          "score": 0.01162342
+          "bias": -0.00391149,
+          "spread": 0.0069744,
+          "score": 0.00799638
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00464261,
-          "spread": 0.0044183,
-          "score": 0.00640899
+          "bias": 0.0003763,
+          "spread": 0.00485884,
+          "score": 0.00487339
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 2,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00169321,
-          "spread": 0.00302697,
-          "score": 0.00346835
+          "bias": -0.00169296,
+          "spread": 0.00302663,
+          "score": 0.00346794
         },
         {
           "profile": "rated_plus_5pct",
@@ -12166,162 +12166,162 @@
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00328968,
-          "spread": 0.0163541,
-          "score": 0.01668169
+          "bias": 0.00479628,
+          "spread": 0.00454419,
+          "score": 0.00660711
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00545001,
-          "spread": 0.00262375,
-          "score": 0.00604869
+          "bias": -0.00542221,
+          "spread": 0.00261283,
+          "score": 0.00601891
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00180912,
-          "spread": 0.00547912,
-          "score": 0.00577007
+          "bias": 0.00183732,
+          "spread": 0.00558396,
+          "score": 0.00587847
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00189893,
-          "spread": 0.00682124,
-          "score": 0.00708063
+          "bias": -0.00187089,
+          "spread": 0.0069045,
+          "score": 0.00715349
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": -0.00472921,
-          "spread": 0.00700618,
-          "score": 0.00845293
+          "bias": -0.00470224,
+          "spread": 0.00694953,
+          "score": 0.00839089
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.02204476,
-          "spread": 0.07650097,
-          "score": 0.07961388
+          "bias": -0.02201602,
+          "spread": 0.07652441,
+          "score": 0.07962845
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.04746536,
-          "spread": 0.23891062,
-          "score": 0.24358006
+          "bias": 0.10440512,
+          "spread": 0.19036735,
+          "score": 0.21711784
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": -0.02991307,
-          "spread": 0.49378762,
-          "score": 0.49469284
+          "bias": 0.00554183,
+          "spread": 0.01227853,
+          "score": 0.01347124
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.07486774,
-          "spread": 0.3448302,
-          "score": 0.35286406
+          "bias": 0.01355158,
+          "spread": 0.00447692,
+          "score": 0.01427194
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.02823505,
-          "spread": 0.02465757,
-          "score": 0.03748618
+          "bias": 0.03049141,
+          "spread": 0.02583212,
+          "score": 0.03996279
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00241671,
-          "spread": 0.00339606,
-          "score": 0.00416818
+          "bias": -0.0002187,
+          "spread": 0.00286783,
+          "score": 0.00287616
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00376338,
-          "spread": 0.00530929,
-          "score": 0.00650781
+          "bias": -0.00150456,
+          "spread": 0.00522543,
+          "score": 0.00543772
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00371849,
-          "spread": 0.00415635,
-          "score": 0.00557695
+          "bias": -0.00145335,
+          "spread": 0.00379004,
+          "score": 0.00405914
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00092845,
-          "spread": 0.00600219,
-          "score": 0.00607357
+          "bias": -0.04931545,
+          "spread": 0.00031108,
+          "score": 0.04931643
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.0008902,
-          "spread": 0.01348286,
-          "score": 0.01351222
+          "bias": -0.04880387,
+          "spread": 0.00129025,
+          "score": 0.04882092
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.00823785,
-          "spread": 0.05646858,
-          "score": 0.0570663
+          "bias": 0.0104415,
+          "spread": 0.05688689,
+          "score": 0.05783722
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00546437,
-          "spread": 0.0,
-          "score": 0.00546437
+          "bias": -0.04956249,
+          "spread": 9.114e-05,
+          "score": 0.04956257
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.00079073,
+          "bias": -0.0421986,
           "spread": 0.0,
-          "score": 0.00079073
+          "score": 0.0421986
         },
         {
           "profile": "rated_plus_5pct",
@@ -12337,27 +12337,27 @@
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00019431,
-          "spread": 0.01248943,
-          "score": 0.01249094
+          "bias": 0.00198584,
+          "spread": 0.01350972,
+          "score": 0.01365489
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00107104,
-          "spread": 0.00498723,
-          "score": 0.00510094
+          "bias": 0.0010968,
+          "spread": 0.00547688,
+          "score": 0.00558562
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00031731,
-          "spread": 0.00210996,
-          "score": 0.00213369
+          "bias": 0.00248595,
+          "spread": 0.00177993,
+          "score": 0.00305746
         },
         {
           "profile": "rated_plus_5pct",
@@ -12382,162 +12382,162 @@
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00602296,
-          "spread": 0.01672004,
-          "score": 0.01777177
+          "bias": -0.00076508,
+          "spread": 0.0111403,
+          "score": 0.01116654
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00170529,
-          "spread": 0.0024218,
-          "score": 0.00296195
+          "bias": -0.00166058,
+          "spread": 0.00248235,
+          "score": 0.00298657
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00291755,
-          "spread": 0.00323512,
-          "score": 0.00435639
+          "bias": 0.0029619,
+          "spread": 0.00322118,
+          "score": 0.00437594
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00201465,
-          "spread": 0.00537907,
-          "score": 0.00574397
+          "bias": 0.00205856,
+          "spread": 0.0053676,
+          "score": 0.00574881
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00443378,
-          "spread": 0.00687267,
-          "score": 0.00817875
+          "bias": 0.00447798,
+          "spread": 0.00692627,
+          "score": 0.00824776
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00587004,
-          "spread": 0.03583265,
-          "score": 0.03631028
+          "bias": -0.00582665,
+          "spread": 0.03583524,
+          "score": 0.03630585
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.00932902,
-          "spread": 0.03445855,
-          "score": 0.03569905
+          "bias": 0.00937227,
+          "spread": 0.03443791,
+          "score": 0.03569046
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": -0.0008645,
-          "spread": 0.3914892,
-          "score": 0.39149016
+          "bias": -0.14537272,
+          "spread": 0.27736183,
+          "score": 0.31314982
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.10943494,
-          "spread": 0.0,
-          "score": 0.10943494
+          "bias": 0.0171565,
+          "spread": 0.00131362,
+          "score": 0.01720671
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.00542124,
-          "spread": 0.02231917,
-          "score": 0.02296813
+          "bias": 0.00730949,
+          "spread": 0.02197462,
+          "score": 0.02315843
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -9.68e-05,
-          "spread": 0.00150447,
-          "score": 0.00150758
+          "bias": 0.00182017,
+          "spread": 0.00120412,
+          "score": 0.00218241
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00172808,
-          "spread": 0.00315398,
-          "score": 0.00359636
+          "bias": 0.00024138,
+          "spread": 0.00294515,
+          "score": 0.00295503
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00088345,
-          "spread": 0.00417624,
-          "score": 0.00426866
+          "bias": 0.00109231,
+          "spread": 0.00363812,
+          "score": 0.00379856
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.0002073,
-          "spread": 0.00226362,
-          "score": 0.00227309
+          "bias": -0.03747212,
+          "spread": 0.02044059,
+          "score": 0.04268463
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.0067822,
-          "spread": 0.02181575,
-          "score": 0.02284569
+          "bias": -0.04858036,
+          "spread": 0.00120721,
+          "score": 0.04859536
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.01185268,
-          "spread": 0.03776123,
-          "score": 0.03957773
+          "bias": 0.01377771,
+          "spread": 0.0382645,
+          "score": 0.04066937
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.04924854,
-          "spread": 0.05425639,
-          "score": 0.07327466
+          "bias": -0.04602255,
+          "spread": 0.0050346,
+          "score": 0.04629711
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.00133359,
-          "spread": 0.0034737,
-          "score": 0.00372089
+          "bias": -0.04586812,
+          "spread": 0.00366953,
+          "score": 0.04601467
         },
         {
           "profile": "rated_plus_5pct",
@@ -12553,27 +12553,27 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00031381,
-          "spread": 0.01348472,
-          "score": 0.01348837
+          "bias": 0.00157774,
+          "spread": 0.01391952,
+          "score": 0.01400865
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.0047784,
-          "spread": 0.00503187,
-          "score": 0.00693922
+          "bias": 0.0066774,
+          "spread": 0.00571219,
+          "score": 0.00878731
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.0010901,
-          "spread": 0.00413611,
-          "score": 0.00427735
+          "bias": 0.0029807,
+          "spread": 0.00446965,
+          "score": 0.00537237
         },
         {
           "profile": "rated_plus_5pct",
@@ -12589,432 +12589,432 @@
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.10164792,
-          "spread": 0.00250186,
-          "score": 0.1016787
+          "bias": 0.0175834,
+          "spread": 0.00201412,
+          "score": 0.01769838
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00137207,
-          "spread": 0.01171213,
-          "score": 0.01179222
+          "bias": 0.00138184,
+          "spread": 0.01172119,
+          "score": 0.01180236
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -3.595e-05,
-          "spread": 0.0015597,
-          "score": 0.00156011
+          "bias": -2.622e-05,
+          "spread": 0.00156253,
+          "score": 0.00156275
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00305746,
-          "spread": 0.00121236,
-          "score": 0.00328906
+          "bias": 0.00306714,
+          "spread": 0.00120196,
+          "score": 0.00329425
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00018015,
-          "spread": 0.00231083,
-          "score": 0.00231784
+          "bias": 0.00018967,
+          "spread": 0.00229941,
+          "score": 0.00230721
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00336328,
-          "spread": 0.0104468,
-          "score": 0.01097484
+          "bias": 0.0033729,
+          "spread": 0.01045491,
+          "score": 0.01098551
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00289919,
-          "spread": 0.01934283,
-          "score": 0.01955889
+          "bias": 0.00290846,
+          "spread": 0.01933122,
+          "score": 0.01954879
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.03602702,
-          "spread": 0.03012932,
-          "score": 0.04696512
+          "bias": -0.03601828,
+          "spread": 0.03011744,
+          "score": 0.04695079
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.0765849,
-          "spread": 0.19281135,
-          "score": 0.20746437
+          "bias": 0.0613419,
+          "spread": 0.1690647,
+          "score": 0.17984911
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.41325608,
-          "spread": 0.42579017,
-          "score": 0.59336149
+          "bias": 0.01852055,
+          "spread": 0.0031945,
+          "score": 0.01879403
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.00452616,
-          "spread": 0.01564593,
-          "score": 0.01628746
+          "bias": 0.00512072,
+          "spread": 0.01570464,
+          "score": 0.0165184
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00260782,
-          "spread": 0.00170352,
-          "score": 0.00311492
+          "bias": 0.00320913,
+          "spread": 0.00161684,
+          "score": 0.00359343
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00148795,
-          "spread": 0.0020974,
-          "score": 0.00257159
+          "bias": -0.00087112,
+          "spread": 0.001907,
+          "score": 0.00209654
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00039887,
-          "spread": 0.0027636,
-          "score": 0.00279224
+          "bias": 0.00022056,
+          "spread": 0.00252601,
+          "score": 0.00253562
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00050141,
-          "spread": 0.00237393,
-          "score": 0.00242631
+          "bias": 0.00112159,
+          "spread": 0.00221687,
+          "score": 0.00248444
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00245173,
-          "spread": 0.01344041,
-          "score": 0.01366219
+          "bias": -0.03608785,
+          "spread": 0.02195866,
+          "score": 0.04224353
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.00485938,
-          "spread": 0.02672749,
-          "score": 0.02716565
+          "bias": -0.00426888,
+          "spread": 0.02683228,
+          "score": 0.02716974
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00227943,
-          "spread": 0.01143223,
-          "score": 0.01165725
+          "bias": -0.04679427,
+          "spread": 0.00299786,
+          "score": 0.0468902
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.01966403,
-          "spread": 0.01522153,
-          "score": 0.02486702
+          "bias": -0.04224692,
+          "spread": 4.832e-05,
+          "score": 0.04224695
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
+          "bias": -2e-08,
+          "spread": 0.0,
+          "score": 2e-08
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00296481,
-          "spread": 0.00516055,
-          "score": 0.00595159
+          "bias": 0.00355718,
+          "spread": 0.00506221,
+          "score": 0.00618704
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00037223,
-          "spread": 0.00293996,
-          "score": 0.00296343
+          "bias": 0.00096428,
+          "spread": 0.00316888,
+          "score": 0.00331234
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00324014,
-          "spread": 0.00514212,
-          "score": 0.00607782
+          "bias": 0.00383457,
+          "spread": 0.00537181,
+          "score": 0.00660002
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00082037,
-          "spread": 0.00174761,
-          "score": 0.00193058
+          "bias": 0.00082033,
+          "spread": 0.00174765,
+          "score": 0.0019306
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.08170354,
-          "spread": 0.0186518,
-          "score": 0.08380548
+          "bias": 0.02165923,
+          "spread": 0.00050763,
+          "score": 0.02166518
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00149291,
-          "spread": 0.00476772,
-          "score": 0.00499599
+          "bias": 0.00149312,
+          "spread": 0.00476782,
+          "score": 0.00499615
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00050647,
-          "spread": 0.00151973,
-          "score": 0.0016019
+          "bias": 0.00050667,
+          "spread": 0.00151979,
+          "score": 0.00160202
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00036158,
-          "spread": 0.00130913,
-          "score": 0.00135815
+          "bias": 0.00036178,
+          "spread": 0.00130919,
+          "score": 0.00135826
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00173014,
-          "spread": 0.00281653,
-          "score": 0.00330548
+          "bias": 0.00173033,
+          "spread": 0.0028166,
+          "score": 0.00330564
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00766299,
-          "spread": 0.00760181,
-          "score": 0.01079393
+          "bias": 0.00766319,
+          "spread": 0.00760194,
+          "score": 0.01079416
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00296758,
-          "spread": 0.02923636,
-          "score": 0.02938659
+          "bias": -0.00296738,
+          "spread": 0.02923648,
+          "score": 0.02938669
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.01009689,
-          "spread": 0.02083568,
-          "score": 0.02315325
+          "bias": -0.01009669,
+          "spread": 0.02083591,
+          "score": 0.02315337
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.0335929,
-          "spread": 0.23182323,
-          "score": 0.23424451
+          "bias": 0.03359304,
+          "spread": 0.23182303,
+          "score": 0.23424434
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.17312048,
-          "spread": 0.07524223,
-          "score": 0.18876465
+          "bias": -0.07630034,
+          "spread": 0.11048249,
+          "score": 0.13426884
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.01240586,
-          "spread": 0.04069581,
-          "score": 0.04254474
+          "bias": -0.01223974,
+          "spread": 0.04069808,
+          "score": 0.04249877
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00144534,
-          "spread": 0.00232793,
-          "score": 0.00274012
+          "bias": 0.00161652,
+          "spread": 0.00243459,
+          "score": 0.00292239
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00065295,
-          "spread": 0.00075715,
-          "score": 0.00099981
+          "bias": -0.00047705,
+          "spread": 0.00082502,
+          "score": 0.00095301
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00121349,
-          "spread": 0.00149996,
-          "score": 0.00192936
+          "bias": -0.00103696,
+          "spread": 0.00153428,
+          "score": 0.00185184
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00029597,
-          "spread": 0.0012303,
-          "score": 0.0012654
+          "bias": 0.00047279,
+          "spread": 0.00129472,
+          "score": 0.00137835
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00026919,
-          "spread": 0.00091199,
-          "score": 0.00095089
+          "bias": 0.00044566,
+          "spread": 0.00082174,
+          "score": 0.00093481
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.00365657,
-          "spread": 0.02063216,
-          "score": 0.02095368
+          "bias": 0.00382566,
+          "spread": 0.02064012,
+          "score": 0.02099167
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00174469,
-          "spread": 0.00409784,
-          "score": 0.00445379
+          "bias": -0.02351643,
+          "spread": 0.02259581,
+          "score": 0.03261277
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.03090177,
-          "spread": 0.02876623,
-          "score": 0.04221866
+          "bias": -0.04559027,
+          "spread": 0.00362919,
+          "score": 0.0457345
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
-          "bias": 0.0226202,
-          "spread": 0.0,
-          "score": 0.0226202
+          "bias": -0.0152419,
+          "spread": 0.02155527,
+          "score": 0.02639972
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00171859,
-          "spread": 0.00578528,
-          "score": 0.00603514
+          "bias": 0.00188696,
+          "spread": 0.0057346,
+          "score": 0.00603708
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00295231,
-          "spread": 0.00323029,
-          "score": 0.00437617
+          "bias": 0.00312134,
+          "spread": 0.00327989,
+          "score": 0.00452775
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.0009813,
-          "spread": 0.00327463,
-          "score": 0.0034185
+          "bias": 0.00115023,
+          "spread": 0.00337879,
+          "score": 0.00356921
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 1,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00581607,
-          "spread": 0.00515561,
-          "score": 0.00777219
+          "bias": -0.00581636,
+          "spread": 0.00515516,
+          "score": 0.00777211
         },
         {
           "profile": "ti_dependent_cp",
@@ -13030,153 +13030,153 @@
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00986871,
-          "spread": 0.00827258,
-          "score": 0.01287738
+          "bias": -0.02742901,
+          "spread": 0.02306132,
+          "score": 0.03583539
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00860959,
-          "spread": 0.0045729,
-          "score": 0.00974867
+          "bias": -0.0086316,
+          "spread": 0.0045907,
+          "score": 0.00977646
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00544103,
-          "spread": 0.00659409,
-          "score": 0.00854909
+          "bias": -0.00546251,
+          "spread": 0.00664793,
+          "score": 0.0086043
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00325761,
-          "spread": 0.00810843,
-          "score": 0.00873834
+          "bias": -0.00327895,
+          "spread": 0.00813782,
+          "score": 0.00877358
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00509631,
-          "spread": 0.00678251,
-          "score": 0.00848379
+          "bias": 0.00507508,
+          "spread": 0.0067922,
+          "score": 0.00847882
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00798975,
-          "spread": 0.07354844,
-          "score": 0.07398114
+          "bias": 0.00431771,
+          "spread": 0.05852366,
+          "score": 0.05868271
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.12517141,
-          "spread": 0.21663181,
-          "score": 0.25019437
+          "bias": 0.03808611,
+          "spread": 0.00906957,
+          "score": 0.0391511
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.20967249,
-          "spread": 0.37194783,
-          "score": 0.42697511
+          "bias": 0.03808611,
+          "spread": 0.00906957,
+          "score": 0.0391511
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.25094647,
-          "spread": 0.43116882,
-          "score": 0.49887943
+          "bias": 0.03808611,
+          "spread": 0.00906957,
+          "score": 0.0391511
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.02032825,
-          "spread": 0.06137046,
-          "score": 0.0646496
+          "bias": -0.01965577,
+          "spread": 0.06163829,
+          "score": 0.06469643
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.0089155,
-          "spread": 0.00928838,
-          "score": 0.01287479
+          "bias": -0.008212,
+          "spread": 0.00974432,
+          "score": 0.01274319
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00219219,
-          "spread": 0.01095694,
-          "score": 0.01117408
+          "bias": -8.05e-05,
+          "spread": 0.0129627,
+          "score": 0.01296295
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00352367,
-          "spread": 0.00590076,
-          "score": 0.00687279
+          "bias": -0.00203369,
+          "spread": 0.00247751,
+          "score": 0.0032053
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.0024294,
-          "spread": 0.00632205,
-          "score": 0.00677276
+          "bias": -0.00020347,
+          "spread": 0.00025669,
+          "score": 0.00032755
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00279857,
-          "spread": 0.00115895,
-          "score": 0.00302906
+          "bias": -0.00087854,
+          "spread": 0.00124244,
+          "score": 0.00152167
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.01568126,
-          "spread": 0.0609382,
-          "score": 0.0629235
+          "bias": -0.01499305,
+          "spread": 0.06032155,
+          "score": 0.06215691
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00536251,
-          "spread": 0.0,
-          "score": 0.00536251
+          "bias": -0.00062043,
+          "spread": 0.00018256,
+          "score": 0.00064674
         },
         {
           "profile": "ti_dependent_cp",
@@ -13201,27 +13201,27 @@
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00563899,
-          "spread": 0.01769417,
-          "score": 0.018571
+          "bias": -0.00493962,
+          "spread": 0.01706626,
+          "score": 0.01776674
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00847239,
-          "spread": 0.00834055,
-          "score": 0.01188891
+          "bias": -0.0077666,
+          "spread": 0.00798188,
+          "score": 0.01113689
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00618396,
-          "spread": 0.00449657,
-          "score": 0.00764595
+          "bias": -0.00547664,
+          "spread": 0.00448003,
+          "score": 0.00707561
         },
         {
           "profile": "ti_dependent_cp",
@@ -13246,162 +13246,162 @@
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00246512,
-          "spread": 0.02157853,
-          "score": 0.02171888
+          "bias": -0.02486969,
+          "spread": 0.02536616,
+          "score": 0.03552385
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00584925,
-          "spread": 0.00215264,
-          "score": 0.00623278
+          "bias": -0.00575804,
+          "spread": 0.00222531,
+          "score": 0.00617309
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00103075,
-          "spread": 0.00518448,
-          "score": 0.00528595
+          "bias": 0.00112286,
+          "spread": 0.0051868,
+          "score": 0.00530695
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00110659,
-          "spread": 0.00717512,
-          "score": 0.00725995
+          "bias": -0.00101532,
+          "spread": 0.00717875,
+          "score": 0.00725019
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00421048,
-          "spread": 0.00468238,
-          "score": 0.00629705
+          "bias": 0.0043009,
+          "spread": 0.00476265,
+          "score": 0.00641721
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00631551,
-          "spread": 0.07866304,
-          "score": 0.07891616
+          "bias": -0.00622365,
+          "spread": 0.07871528,
+          "score": 0.07896093
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.0540423,
-          "spread": 0.23031743,
-          "score": 0.2365728
+          "bias": 0.11952667,
+          "spread": 0.17308874,
+          "score": 0.21034813
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.29524757,
-          "spread": 0.29921236,
-          "score": 0.420356
+          "bias": 0.0310431,
+          "spread": 0.02110872,
+          "score": 0.03754001
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.08556152,
-          "spread": 0.39162066,
-          "score": 0.40085847
+          "bias": 0.04088511,
+          "spread": 0.00715243,
+          "score": 0.04150601
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.02147246,
-          "spread": 0.02115826,
-          "score": 0.03014529
+          "bias": 0.02151148,
+          "spread": 0.02121685,
+          "score": 0.03021422
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00599241,
-          "spread": 0.00300809,
-          "score": 0.00670504
+          "bias": -0.00595322,
+          "spread": 0.00309914,
+          "score": 0.0067116
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00089997,
-          "spread": 0.0054748,
-          "score": 0.00554828
+          "bias": 0.00093787,
+          "spread": 0.00557124,
+          "score": 0.00564962
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00189841,
-          "spread": 0.00426083,
-          "score": 0.00466462
+          "bias": -0.00186108,
+          "spread": 0.00432889,
+          "score": 0.004712
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00044046,
-          "spread": 0.00623935,
-          "score": 0.00625488
+          "bias": -0.0002114,
+          "spread": 0.00022852,
+          "score": 0.00031131
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00047869,
-          "spread": 0.00998929,
-          "score": 0.01000075
+          "bias": -0.0005705,
+          "spread": 0.00098813,
+          "score": 0.00114099
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.01065592,
-          "spread": 0.05732659,
-          "score": 0.05830855
+          "bias": 0.0107068,
+          "spread": 0.05751592,
+          "score": 0.05850399
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.0034479,
-          "spread": 0.0,
-          "score": 0.0034479
+          "bias": -0.00025218,
+          "spread": 0.00018569,
+          "score": 0.00031317
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.01783496,
+          "bias": -0.01203016,
           "spread": 0.0,
-          "score": 0.01783496
+          "score": 0.01203016
         },
         {
           "profile": "ti_dependent_cp",
@@ -13417,27 +13417,27 @@
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.0011156,
-          "spread": 0.01315533,
-          "score": 0.01320255
+          "bias": 0.00115613,
+          "spread": 0.01324401,
+          "score": 0.01329438
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00093013,
-          "spread": 0.00473001,
-          "score": 0.00482059
+          "bias": -0.00088988,
+          "spread": 0.004908,
+          "score": 0.00498802
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.0007988,
-          "spread": 0.00262156,
-          "score": 0.00274056
+          "bias": -0.00075869,
+          "spread": 0.00274513,
+          "score": 0.00284805
         },
         {
           "profile": "ti_dependent_cp",
@@ -13462,162 +13462,162 @@
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.0017654,
-          "spread": 0.0125938,
-          "score": 0.01271694
+          "bias": -0.00579401,
+          "spread": 0.01375559,
+          "score": 0.01492605
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00258819,
-          "spread": 0.00280386,
-          "score": 0.0038158
+          "bias": -0.00253478,
+          "spread": 0.00286559,
+          "score": 0.0038258
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00234516,
-          "spread": 0.00320471,
-          "score": 0.00397114
+          "bias": 0.00239864,
+          "spread": 0.00319087,
+          "score": 0.00399189
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00357849,
-          "spread": 0.00594441,
-          "score": 0.00693841
+          "bias": 0.00363155,
+          "spread": 0.0059236,
+          "score": 0.00694818
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01262039,
-          "spread": 0.00559863,
-          "score": 0.01380648
+          "bias": 0.01267331,
+          "spread": 0.00564746,
+          "score": 0.01387467
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00751404,
-          "spread": 0.02957532,
-          "score": 0.03051492
+          "bias": 0.0075656,
+          "spread": 0.02957395,
+          "score": 0.03052633
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.02409448,
-          "spread": 0.04142929,
-          "score": 0.0479263
+          "bias": 0.02414625,
+          "spread": 0.04141152,
+          "score": 0.047937
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.05998405,
-          "spread": 0.4351595,
-          "score": 0.43927426
+          "bias": -0.12753408,
+          "spread": 0.28316924,
+          "score": 0.31056362
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.12075539,
-          "spread": 0.0,
-          "score": 0.12075539
+          "bias": 0.04314064,
+          "spread": 0.00572961,
+          "score": 0.04351946
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.00017354,
-          "spread": 0.02341826,
-          "score": 0.0234189
+          "bias": 0.00035981,
+          "spread": 0.02319203,
+          "score": 0.02319482
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00382132,
-          "spread": 0.00122748,
-          "score": 0.00401363
+          "bias": -0.00362242,
+          "spread": 0.00122484,
+          "score": 0.00382389
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00325766,
-          "spread": 0.00362044,
-          "score": 0.00487031
+          "bias": 0.00345094,
+          "spread": 0.00365081,
+          "score": 0.00502368
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00096689,
-          "spread": 0.00421472,
-          "score": 0.0043242
+          "bias": 0.00115835,
+          "spread": 0.00409175,
+          "score": 0.00425256
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00075554,
-          "spread": 0.00262637,
-          "score": 0.00273288
+          "bias": -0.00063443,
+          "spread": 0.00071071,
+          "score": 0.00095268
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00694813,
-          "spread": 0.01836788,
-          "score": 0.01963812
+          "bias": -0.00091043,
+          "spread": 0.00096716,
+          "score": 0.00132826
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.00824648,
-          "spread": 0.03675142,
-          "score": 0.03766526
+          "bias": 0.00845515,
+          "spread": 0.03697759,
+          "score": 0.03793194
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.03630374,
-          "spread": 0.03827476,
-          "score": 0.05275338
+          "bias": -0.00608012,
+          "spread": 0.0082431,
+          "score": 0.01024288
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.00487821,
-          "spread": 0.01001534,
-          "score": 0.01114019
+          "bias": -0.00601508,
+          "spread": 0.00601508,
+          "score": 0.00850661
         },
         {
           "profile": "ti_dependent_cp",
@@ -13633,27 +13633,27 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00073842,
-          "spread": 0.0128231,
-          "score": 0.01284434
+          "bias": 0.00094072,
+          "spread": 0.0128405,
+          "score": 0.01287491
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00535876,
-          "spread": 0.00526726,
-          "score": 0.00751401
+          "bias": 0.00556334,
+          "spread": 0.00532112,
+          "score": 0.00769838
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00029182,
-          "spread": 0.00399343,
-          "score": 0.00400408
+          "bias": -8.78e-05,
+          "spread": 0.0042106,
+          "score": 0.00421151
         },
         {
           "profile": "ti_dependent_cp",
@@ -13669,207 +13669,207 @@
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.09220031,
-          "spread": 0.00996345,
-          "score": 0.09273709
+          "bias": -0.06080087,
+          "spread": 0.00954969,
+          "score": 0.06154626
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00409293,
-          "spread": 0.01161022,
-          "score": 0.01231054
+          "bias": -0.00408036,
+          "spread": 0.01162063,
+          "score": 0.01231619
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00129664,
-          "spread": 0.00201232,
-          "score": 0.00239389
+          "bias": -0.00128435,
+          "spread": 0.00201779,
+          "score": 0.00239187
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00234622,
-          "spread": 0.001423,
-          "score": 0.00274402
+          "bias": 0.0023585,
+          "spread": 0.00141243,
+          "score": 0.00274909
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00280707,
-          "spread": 0.00235841,
-          "score": 0.0036663
+          "bias": 0.0028193,
+          "spread": 0.00234789,
+          "score": 0.00366893
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01283981,
-          "spread": 0.00835734,
-          "score": 0.01532011
+          "bias": 0.01285202,
+          "spread": 0.00836467,
+          "score": 0.01533435
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.020458,
-          "spread": 0.02209266,
-          "score": 0.03011006
+          "bias": 0.02046988,
+          "spread": 0.02208509,
+          "score": 0.03011257
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.01754336,
-          "spread": 0.02736331,
-          "score": 0.03250415
+          "bias": -0.01753212,
+          "spread": 0.02735064,
+          "score": 0.03248742
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.08227427,
-          "spread": 0.19390897,
-          "score": 0.21064126
+          "bias": 0.07390378,
+          "spread": 0.16856457,
+          "score": 0.18405375
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.42231354,
-          "spread": 0.51657264,
-          "score": 0.66723011
+          "bias": 0.04291997,
+          "spread": 0.00478849,
+          "score": 0.04318626
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.00127243,
-          "spread": 0.01874918,
-          "score": 0.01879231
+          "bias": -0.00126594,
+          "spread": 0.01863747,
+          "score": 0.01868042
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00134209,
-          "spread": 0.000964,
-          "score": 0.00165242
+          "bias": -0.00133329,
+          "spread": 0.00091385,
+          "score": 0.00161641
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00326517,
-          "spread": 0.00247265,
-          "score": 0.00409577
+          "bias": 0.00327386,
+          "spread": 0.002535,
+          "score": 0.00414058
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00100459,
-          "spread": 0.00275846,
-          "score": 0.0029357
+          "bias": 0.00101319,
+          "spread": 0.00277772,
+          "score": 0.00295673
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00075246,
-          "spread": 0.00223272,
-          "score": 0.0023561
+          "bias": 0.00076117,
+          "spread": 0.00229052,
+          "score": 0.00241369
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.0020364,
-          "spread": 0.01159298,
-          "score": 0.01177047
+          "bias": -0.0006193,
+          "spread": 0.0007541,
+          "score": 0.00097581
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.01228161,
-          "spread": 0.03174856,
-          "score": 0.03404129
+          "bias": -0.01226876,
+          "spread": 0.03189475,
+          "score": 0.03417305
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00753871,
-          "spread": 0.00835462,
-          "score": 0.01125309
+          "bias": -0.00437423,
+          "spread": 0.00437593,
+          "score": 0.0061873
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.00092385,
-          "spread": 0.01457297,
-          "score": 0.01460223
+          "bias": -0.01242973,
+          "spread": 0.00039957,
+          "score": 0.01243615
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
+          "bias": 0.0,
+          "spread": 0.0,
+          "score": 0.0
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00319532,
-          "spread": 0.00547021,
-          "score": 0.00633508
+          "bias": 0.00320425,
+          "spread": 0.00543306,
+          "score": 0.00630756
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00095895,
-          "spread": 0.00291294,
-          "score": 0.00306672
+          "bias": 0.00096819,
+          "spread": 0.00294431,
+          "score": 0.00309941
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00242888,
-          "spread": 0.00534672,
-          "score": 0.00587256
+          "bias": 0.00243873,
+          "spread": 0.00548611,
+          "score": 0.00600373
         },
         {
           "profile": "ti_dependent_cp",
@@ -13885,207 +13885,207 @@
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.07146664,
-          "spread": 0.01432502,
-          "score": 0.07288818
+          "bias": -0.03269808,
+          "spread": 0.04941493,
+          "score": 0.05925368
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00106295,
-          "spread": 0.00412023,
-          "score": 0.00425514
+          "bias": -0.00106241,
+          "spread": 0.00412038,
+          "score": 0.00425515
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00033941,
-          "spread": 0.00161258,
-          "score": 0.00164791
+          "bias": -0.00033888,
+          "spread": 0.00161301,
+          "score": 0.00164822
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00022789,
-          "spread": 0.00143497,
-          "score": 0.00145295
+          "bias": -0.00022736,
+          "spread": 0.00143491,
+          "score": 0.00145281
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00337373,
-          "spread": 0.00293755,
-          "score": 0.00447339
+          "bias": 0.00337426,
+          "spread": 0.0029378,
+          "score": 0.00447396
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01510547,
-          "spread": 0.00818957,
-          "score": 0.01718267
+          "bias": 0.01510599,
+          "spread": 0.00818971,
+          "score": 0.0171832
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.01102532,
-          "spread": 0.02999366,
-          "score": 0.03195587
+          "bias": 0.01102584,
+          "spread": 0.02999397,
+          "score": 0.03195633
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.00273684,
-          "spread": 0.02022124,
-          "score": 0.02040561
+          "bias": 0.00273735,
+          "spread": 0.02022156,
+          "score": 0.02040599
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.04002303,
-          "spread": 0.23279555,
-          "score": 0.23621095
+          "bias": 0.04002344,
+          "spread": 0.23279517,
+          "score": 0.23621064
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.18983807,
-          "spread": 0.10687572,
-          "score": 0.21785525
+          "bias": -0.07547839,
+          "spread": 0.13709352,
+          "score": 0.15649799
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.00751955,
-          "spread": 0.040817,
-          "score": 0.04150387
+          "bias": -0.00754971,
+          "spread": 0.04082219,
+          "score": 0.04151445
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00272949,
-          "spread": 0.00261765,
-          "score": 0.00378183
+          "bias": -0.00276143,
+          "spread": 0.00260984,
+          "score": 0.00379958
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00362436,
-          "spread": 0.00099455,
-          "score": 0.00375834
+          "bias": 0.00359343,
+          "spread": 0.00100574,
+          "score": 0.00373152
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 7.458e-05,
-          "spread": 0.00149271,
-          "score": 0.00149458
+          "bias": 4.392e-05,
+          "spread": 0.00151049,
+          "score": 0.00151113
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00072304,
-          "spread": 0.00105431,
-          "score": 0.00127842
+          "bias": 0.00069236,
+          "spread": 0.00107306,
+          "score": 0.00127703
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": -0.00116386,
-          "spread": 0.00240105,
-          "score": 0.00266826
+          "bias": -0.00119453,
+          "spread": 0.00240677,
+          "score": 0.0026869
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.00075225,
-          "spread": 0.02022215,
-          "score": 0.02023613
+          "bias": -0.00078411,
+          "spread": 0.02024698,
+          "score": 0.02026216
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00592225,
-          "spread": 0.00516464,
-          "score": 0.00785789
+          "bias": -0.0043106,
+          "spread": 0.00340769,
+          "score": 0.00549487
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.03506005,
-          "spread": 0.02539969,
-          "score": 0.04329378
+          "bias": -0.00704505,
+          "spread": 0.00572633,
+          "score": 0.00907874
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
-          "bias": 0.01961863,
-          "spread": 0.0,
-          "score": 0.01961863
+          "bias": -0.00234884,
+          "spread": 0.00332176,
+          "score": 0.00406831
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00201472,
-          "spread": 0.00617599,
-          "score": 0.0064963
+          "bias": 0.00198235,
+          "spread": 0.00620726,
+          "score": 0.00651612
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00357176,
-          "spread": 0.00316835,
-          "score": 0.00477451
+          "bias": 0.00353915,
+          "spread": 0.0031831,
+          "score": 0.00476001
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -1.838e-05,
-          "spread": 0.00294386,
-          "score": 0.00294391
+          "bias": -5.098e-05,
+          "spread": 0.00292221,
+          "score": 0.00292265
         },
         {
           "profile": "ws_dependent_cp",
@@ -14110,153 +14110,153 @@
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00118714,
-          "spread": 0.00710435,
-          "score": 0.00720285
+          "bias": -0.01174297,
+          "spread": 0.00976875,
+          "score": 0.01527501
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00590983,
-          "spread": 0.00320864,
-          "score": 0.00672469
+          "bias": -0.00571369,
+          "spread": 0.00317985,
+          "score": 0.00653894
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00422646,
-          "spread": 0.00646265,
-          "score": 0.00772197
+          "bias": -0.00402897,
+          "spread": 0.00649183,
+          "score": 0.00764045
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.0071668,
-          "spread": 0.00646234,
-          "score": 0.00965013
+          "bias": -0.00696767,
+          "spread": 0.00645774,
+          "score": 0.00950005
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": -0.00913521,
-          "spread": 0.0046983,
-          "score": 0.01027259
+          "bias": -0.00893404,
+          "spread": 0.00477166,
+          "score": 0.01012847
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.01238158,
-          "spread": 0.08197994,
-          "score": 0.08290967
+          "bias": -0.07157369,
+          "spread": 0.03363677,
+          "score": 0.07908366
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.17299455,
-          "spread": 0.24898535,
-          "score": 0.30318446
+          "bias": 0.01188424,
+          "spread": 0.18075445,
+          "score": 0.18114471
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 1.25900201,
-          "spread": 1.83831959,
-          "score": 2.22811691
+          "bias": 1.28732249,
+          "spread": 2.21173535,
+          "score": 2.55909602
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -2.90474691,
-          "spread": 4.13694782,
-          "score": 5.05488791
+          "bias": -2.03072304,
+          "spread": 3.58793004,
+          "score": 4.12275127
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.01853348,
-          "spread": 0.05643987,
-          "score": 0.05940496
+          "bias": -0.01841801,
+          "spread": 0.05652544,
+          "score": 0.05945039
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00492407,
-          "spread": 0.00978948,
-          "score": 0.01095812
+          "bias": -0.00480753,
+          "spread": 0.00996684,
+          "score": 0.01106573
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00056461,
-          "spread": 0.01082733,
-          "score": 0.01084204
+          "bias": 0.00174327,
+          "spread": 0.0108223,
+          "score": 0.01096181
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00241721,
-          "spread": 0.00536584,
-          "score": 0.00588516
+          "bias": -0.00165075,
+          "spread": 0.00285919,
+          "score": 0.0033015
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00220583,
-          "spread": 0.00656028,
-          "score": 0.0069212
+          "bias": 0.0,
+          "spread": 0.0,
+          "score": 0.0
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00411339,
-          "spread": 0.00029507,
-          "score": 0.00412396
+          "bias": 0.0,
+          "spread": 0.0,
+          "score": 0.0
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.04631248,
-          "spread": 0.08395811,
-          "score": 0.09588436
+          "bias": -0.04615541,
+          "spread": 0.08384239,
+          "score": 0.0957072
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00569527,
+          "bias": 0.0,
           "spread": 0.0,
-          "score": 0.00569527
+          "score": 0.0
         },
         {
           "profile": "ws_dependent_cp",
@@ -14281,27 +14281,27 @@
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00834657,
-          "spread": 0.01921057,
-          "score": 0.02094543
+          "bias": -0.00822283,
+          "spread": 0.01920844,
+          "score": 0.02089448
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00982116,
-          "spread": 0.00789198,
-          "score": 0.01259914
+          "bias": -0.00969731,
+          "spread": 0.00831789,
+          "score": 0.01277596
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00665272,
-          "spread": 0.00435357,
-          "score": 0.00795061
+          "bias": -0.00653559,
+          "spread": 0.00415433,
+          "score": 0.00774418
         },
         {
           "profile": "ws_dependent_cp",
@@ -14326,162 +14326,162 @@
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00477368,
-          "spread": 0.02024491,
-          "score": 0.02080011
+          "bias": -0.00814327,
+          "spread": 0.01464793,
+          "score": 0.01675932
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00405047,
-          "spread": 0.00215119,
-          "score": 0.00458628
+          "bias": -0.0039941,
+          "spread": 0.0022259,
+          "score": 0.00457247
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00230141,
-          "spread": 0.00481901,
-          "score": 0.00534035
+          "bias": 0.00235856,
+          "spread": 0.004833,
+          "score": 0.00537779
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00526493,
-          "spread": 0.00597727,
-          "score": 0.00796538
+          "bias": -0.00520759,
+          "spread": 0.005991,
+          "score": 0.00793796
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": -0.00974501,
-          "spread": 0.00794117,
-          "score": 0.0125709
+          "bias": -0.00968718,
+          "spread": 0.00794984,
+          "score": 0.01253162
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.032598,
-          "spread": 0.08797266,
-          "score": 0.093818
+          "bias": -0.03253975,
+          "spread": 0.08798125,
+          "score": 0.09380584
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.01681483,
-          "spread": 0.24886116,
-          "score": 0.24942858
+          "bias": 0.05468174,
+          "spread": 0.20892042,
+          "score": 0.21595795
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.33426976,
-          "spread": 0.37768475,
-          "score": 0.50436301
+          "bias": 0.13860007,
+          "spread": 0.20194126,
+          "score": 0.24492907
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.04541456,
-          "spread": 0.33516883,
-          "score": 0.33823162
+          "bias": 0.2417389,
+          "spread": 0.36441397,
+          "score": 0.43730451
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.0159064,
-          "spread": 0.0212099,
-          "score": 0.02651176
+          "bias": 0.01594594,
+          "spread": 0.02127409,
+          "score": 0.02658684
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00220925,
-          "spread": 0.00316183,
-          "score": 0.0038572
+          "bias": -0.00217099,
+          "spread": 0.00321512,
+          "score": 0.00387945
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00020891,
-          "spread": 0.00470161,
-          "score": 0.00470624
+          "bias": -0.00017076,
+          "spread": 0.00480293,
+          "score": 0.00480596
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00227127,
-          "spread": 0.00426727,
-          "score": 0.00483407
+          "bias": -0.00223335,
+          "spread": 0.00434244,
+          "score": 0.0048831
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00013498,
-          "spread": 0.00610807,
-          "score": 0.00610956
+          "bias": 0.0,
+          "spread": 0.0,
+          "score": 0.0
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00167934,
-          "spread": 0.0110312,
-          "score": 0.01115829
+          "bias": 0.0,
+          "spread": 0.0,
+          "score": 0.0
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.01019334,
-          "spread": 0.06085156,
-          "score": 0.06169941
+          "bias": -0.01013735,
+          "spread": 0.06103319,
+          "score": 0.06186935
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00386239,
+          "bias": 0.0,
           "spread": 0.0,
-          "score": 0.00386239
+          "score": 0.0
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.00497069,
+          "bias": 0.0,
           "spread": 0.0,
-          "score": 0.00497069
+          "score": 0.0
         },
         {
           "profile": "ws_dependent_cp",
@@ -14497,27 +14497,27 @@
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00130327,
-          "spread": 0.01407761,
-          "score": 0.01413781
+          "bias": -0.00126089,
+          "spread": 0.01416916,
+          "score": 0.01422515
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00248072,
-          "spread": 0.00524817,
-          "score": 0.00580493
+          "bias": -0.00243968,
+          "spread": 0.00540776,
+          "score": 0.00593262
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00125671,
-          "spread": 0.00203552,
-          "score": 0.00239221
+          "bias": -0.00121723,
+          "spread": 0.0021567,
+          "score": 0.00247649
         },
         {
           "profile": "ws_dependent_cp",
@@ -14542,162 +14542,162 @@
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00619823,
-          "spread": 0.01295294,
-          "score": 0.01435956
+          "bias": 0.00153855,
+          "spread": 0.0108509,
+          "score": 0.01095944
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00043501,
-          "spread": 0.00272055,
-          "score": 0.00275511
+          "bias": -0.00039634,
+          "spread": 0.00276257,
+          "score": 0.00279086
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00328832,
-          "spread": 0.00306644,
-          "score": 0.00449623
+          "bias": 0.00332722,
+          "spread": 0.00304477,
+          "score": 0.0045101
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00111624,
-          "spread": 0.00508757,
-          "score": 0.00520859
+          "bias": -0.00107709,
+          "spread": 0.0050679,
+          "score": 0.00518109
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": -0.00016317,
-          "spread": 0.00631757,
-          "score": 0.00631967
+          "bias": -0.00012332,
+          "spread": 0.0063422,
+          "score": 0.0063434
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.01312923,
-          "spread": 0.0355466,
-          "score": 0.03789377
+          "bias": -0.01308967,
+          "spread": 0.03553554,
+          "score": 0.0378697
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.01979892,
-          "spread": 0.03888474,
-          "score": 0.04363508
+          "bias": -0.01975826,
+          "spread": 0.03887462,
+          "score": 0.04360762
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": -0.30548084,
-          "spread": 1.02446175,
-          "score": 1.06903715
+          "bias": -0.51525338,
+          "spread": 0.87938982,
+          "score": 1.01922152
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.09850146,
-          "spread": 0.20865727,
-          "score": 0.2307388
+          "bias": 0.10818731,
+          "spread": 0.12876622,
+          "score": 0.16818214
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.00184029,
-          "spread": 0.03173601,
-          "score": 0.03178932
+          "bias": 0.00201656,
+          "spread": 0.03149731,
+          "score": 0.0315618
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -2.209e-05,
-          "spread": 0.00110935,
-          "score": 0.00110957
+          "bias": 0.0001639,
+          "spread": 0.00106951,
+          "score": 0.001082
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00169587,
-          "spread": 0.00339526,
-          "score": 0.00379523
+          "bias": 0.00188018,
+          "spread": 0.00343407,
+          "score": 0.00391509
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00055405,
-          "spread": 0.00434683,
-          "score": 0.004382
+          "bias": 0.00073754,
+          "spread": 0.00423589,
+          "score": 0.00429962
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00106609,
-          "spread": 0.00243525,
-          "score": 0.00265838
+          "bias": -0.00040548,
+          "spread": 0.00070232,
+          "score": 0.00081096
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00683389,
-          "spread": 0.01965939,
-          "score": 0.02081331
+          "bias": 0.0,
+          "spread": 0.0,
+          "score": 0.0
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.00889162,
-          "spread": 0.03987032,
-          "score": 0.04084976
+          "bias": -0.00867661,
+          "spread": 0.04013474,
+          "score": 0.04106192
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.04269812,
-          "spread": 0.04573599,
-          "score": 0.06256924
+          "bias": 0.0,
+          "spread": 0.0,
+          "score": 0.0
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.00108458,
-          "spread": 0.00296588,
-          "score": 0.00315797
+          "bias": 0.0,
+          "spread": 0.0,
+          "score": 0.0
         },
         {
           "profile": "ws_dependent_cp",
@@ -14713,27 +14713,27 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00217476,
-          "spread": 0.01432198,
-          "score": 0.01448616
+          "bias": -0.00197373,
+          "spread": 0.01434168,
+          "score": 0.01447686
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00417069,
-          "spread": 0.00589848,
-          "score": 0.00722404
+          "bias": 0.00436844,
+          "spread": 0.00594697,
+          "score": 0.00737901
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00083339,
-          "spread": 0.00400587,
-          "score": 0.00409164
+          "bias": -0.00064094,
+          "spread": 0.00422538,
+          "score": 0.00427371
         },
         {
           "profile": "ws_dependent_cp",
@@ -14749,423 +14749,423 @@
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.08244228,
-          "spread": 0.00987504,
-          "score": 0.08303159
+          "bias": -0.06328166,
+          "spread": 0.01265777,
+          "score": 0.06453517
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00045843,
-          "spread": 0.0109291,
-          "score": 0.01093871
+          "bias": 0.00047125,
+          "spread": 0.01094098,
+          "score": 0.01095112
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00093071,
-          "spread": 0.00170265,
-          "score": 0.00194042
+          "bias": 0.00094329,
+          "spread": 0.001707,
+          "score": 0.0019503
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00318412,
-          "spread": 0.00159781,
-          "score": 0.00356253
+          "bias": 0.00319677,
+          "spread": 0.00158767,
+          "score": 0.00356931
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00174366,
-          "spread": 0.00266288,
-          "score": 0.00318297
+          "bias": -0.00173092,
+          "spread": 0.00264969,
+          "score": 0.00316496
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": -0.00081146,
-          "spread": 0.00979919,
-          "score": 0.00983273
+          "bias": -0.00079849,
+          "spread": 0.0098074,
+          "score": 0.00983985
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00025058,
-          "spread": 0.02722257,
-          "score": 0.02722373
+          "bias": -0.00023778,
+          "spread": 0.02721129,
+          "score": 0.02721233
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.06190185,
-          "spread": 0.03094796,
-          "score": 0.06920704
+          "bias": -0.06188952,
+          "spread": 0.03093521,
+          "score": 0.06919032
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": -0.00102284,
-          "spread": 0.31231902,
-          "score": 0.31232069
+          "bias": 0.09462763,
+          "spread": 0.31717433,
+          "score": 0.33098934
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.46708843,
-          "spread": 0.50607784,
-          "score": 0.68868453
+          "bias": 0.07667768,
+          "spread": 0.09103134,
+          "score": 0.11902173
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.00033106,
-          "spread": 0.01675099,
-          "score": 0.01675426
+          "bias": 0.00034261,
+          "spread": 0.01660054,
+          "score": 0.01660408
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00262884,
-          "spread": 0.0013521,
-          "score": 0.00295618
+          "bias": 0.00264299,
+          "spread": 0.00128796,
+          "score": 0.00294011
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00216875,
-          "spread": 0.00210913,
-          "score": 0.00302522
+          "bias": 0.00218292,
+          "spread": 0.00216147,
+          "score": 0.00307199
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00072798,
-          "spread": 0.00261586,
-          "score": 0.00271527
+          "bias": 0.00074208,
+          "spread": 0.00263765,
+          "score": 0.00274005
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00119491,
-          "spread": 0.00238836,
-          "score": 0.00267059
+          "bias": 0.00120913,
+          "spread": 0.00246258,
+          "score": 0.00274341
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00299498,
-          "spread": 0.0119596,
-          "score": 0.0123289
+          "bias": 0.00024169,
+          "spread": 0.00041862,
+          "score": 0.00048338
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.04419039,
-          "spread": 0.0500032,
-          "score": 0.06673163
+          "bias": -0.04417091,
+          "spread": 0.05011062,
+          "score": 0.06679928
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00311832,
-          "spread": 0.00812964,
-          "score": 0.00870718
+          "bias": 0.0,
+          "spread": 0.0,
+          "score": 0.0
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": 0.01418975,
-          "spread": 0.01528826,
-          "score": 0.02085857
+          "bias": 0.0,
+          "spread": 0.0,
+          "score": 0.0
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
-          "bias": NaN,
-          "spread": NaN,
-          "score": NaN
+          "bias": 0.0,
+          "spread": 0.0,
+          "score": 0.0
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00051355,
-          "spread": 0.00573834,
-          "score": 0.00576127
+          "bias": 0.00052873,
+          "spread": 0.00570452,
+          "score": 0.00572898
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00070437,
-          "spread": 0.0031724,
-          "score": 0.00324965
+          "bias": -0.00068926,
+          "spread": 0.00320598,
+          "score": 0.00327924
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00169731,
-          "spread": 0.00546905,
-          "score": 0.00572637
+          "bias": 0.00171268,
+          "spread": 0.0056037,
+          "score": 0.00585958
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00081165,
-          "spread": 0.00176898,
-          "score": 0.0019463
+          "bias": 0.00081161,
+          "spread": 0.00176902,
+          "score": 0.00194632
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.06692428,
-          "spread": 0.02069775,
-          "score": 0.07005181
+          "bias": -0.0374423,
+          "spread": 0.04703681,
+          "score": 0.06011978
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00224366,
-          "spread": 0.0037416,
-          "score": 0.00436275
+          "bias": 0.00224415,
+          "spread": 0.00374172,
+          "score": 0.0043631
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00139328,
-          "spread": 0.00142281,
-          "score": 0.00199139
+          "bias": 0.00139376,
+          "spread": 0.00142309,
+          "score": 0.00199192
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.0006065,
-          "spread": 0.00152911,
-          "score": 0.001645
+          "bias": 0.00060698,
+          "spread": 0.00152907,
+          "score": 0.00164514
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00037836,
-          "spread": 0.00319528,
-          "score": 0.00321761
+          "bias": -0.00037788,
+          "spread": 0.00319549,
+          "score": 0.00321776
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00275668,
-          "spread": 0.00690557,
-          "score": 0.00743546
+          "bias": 0.00275718,
+          "spread": 0.00690574,
+          "score": 0.00743581
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00936339,
-          "spread": 0.03322549,
-          "score": 0.03451965
+          "bias": -0.00936288,
+          "spread": 0.03322585,
+          "score": 0.03451986
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.02152043,
-          "spread": 0.02091746,
-          "score": 0.03001115
+          "bias": -0.02151993,
+          "spread": 0.02091784,
+          "score": 0.03001106
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.01730756,
-          "spread": 0.25591927,
-          "score": 0.25650384
+          "bias": 0.01730795,
+          "spread": 0.25591884,
+          "score": 0.25650345
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.67475697,
-          "spread": 0.78100991,
-          "score": 1.03212085
+          "bias": 0.5043107,
+          "spread": 0.57955308,
+          "score": 0.76825195
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.0057489,
-          "spread": 0.04228279,
-          "score": 0.04267182
+          "bias": -0.00578604,
+          "spread": 0.04229151,
+          "score": 0.04268548
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00100649,
-          "spread": 0.0025003,
-          "score": 0.00269528
+          "bias": 0.00096816,
+          "spread": 0.00248853,
+          "score": 0.00267023
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.0024855,
-          "spread": 0.00069705,
-          "score": 0.00258139
+          "bias": 0.00244761,
+          "spread": 0.00071362,
+          "score": 0.00254952
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -6.677e-05,
-          "spread": 0.00130751,
-          "score": 0.00130921
+          "bias": -0.00010456,
+          "spread": 0.00132061,
+          "score": 0.00132474
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00097479,
-          "spread": 0.00108409,
-          "score": 0.00145789
+          "bias": 0.00093696,
+          "spread": 0.00109996,
+          "score": 0.00144492
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 9.43e-05,
-          "spread": 0.0016033,
-          "score": 0.00160608
+          "bias": 5.649e-05,
+          "spread": 0.0016046,
+          "score": 0.0016056
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.0261398,
-          "spread": 0.02014609,
-          "score": 0.03300234
+          "bias": -0.02618156,
+          "spread": 0.02015505,
+          "score": 0.03304089
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00258969,
-          "spread": 0.00424839,
-          "score": 0.00497547
+          "bias": -0.00061484,
+          "spread": 0.00190444,
+          "score": 0.00200123
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(22.0, 24.0]",
-          "bias": -0.03121362,
-          "spread": 0.0260096,
-          "score": 0.04062991
+          "bias": 0.0,
+          "spread": 0.0,
+          "score": 0.0
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(24.0, 26.0]",
-          "bias": 0.02100715,
+          "bias": 0.0,
           "spread": 0.0,
-          "score": 0.02100715
+          "score": 0.0
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00094296,
-          "spread": 0.00695576,
-          "score": 0.00701938
+          "bias": -0.00098403,
+          "spread": 0.0069983,
+          "score": 0.00706714
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00174193,
-          "spread": 0.00330973,
-          "score": 0.00374014
+          "bias": 0.00170148,
+          "spread": 0.00333035,
+          "score": 0.00373982
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00050763,
-          "spread": 0.00325878,
-          "score": 0.00329808
+          "bias": -0.00054711,
+          "spread": 0.00323314,
+          "score": 0.0032791
         }
       ]
     }

--- a/docs/v1/findings.md
+++ b/docs/v1/findings.md
@@ -7,6 +7,98 @@ from, not just conclusions.
 
 ---
 
+## F17 — conditional decomposition hardened (count floor + physics imputation + corrected re-level); out-of-the-box method promoted onto the class and scored 1–12 months; the frozen reference is stale (Issue 14)
+
+*2026-07-08 — Issue 14, both efforts. New module
+`benchmarking/baselines/power_model/conditional.py` (`impute_uncovered_bins`, `relevel_conditional`).
+New `PowerModelMethod` internals: the per-reporting-bin count floor `_MIN_BIN_MATCHED_COUNT = 50`,
+imputation + corrected re-level wired into `_conditional_by_bin`, and a `covered` flag on the per-run
+`conditional/` CSV. Class defaults promoted (see below). `study_power_model_compare.py` now scores
+1/2/3/6/12 months in both modes with `naive_ratio` recomputed fresh; benchmark JSON regenerated on the
+new grid under the new conditional default. A/B'd on the covered profiles (`cp_0pct`,
+`ti_dependent_cp`, `ws_dependent_cp`) against the pure-B benchmark; full 7-profile regen for the ship.*
+
+### Effort B — the benchmarked config is now the out-of-the-box config, scored 1–12 months
+- **Defaults promoted onto the class** so a bare `PowerModelMethod` *is* the benchmarked method:
+  `min_child_samples=50` (F14, merged under user `model_params` on the LightGBM path), 
+  `availability_feature=False` (F13), and `era5_exclude=CURATED_ERA5_EXCLUDE` (F13) with the **untouched
+  default** applied drop-if-present (a non-Open-Meteo frame is not broken; an explicitly-set exclude
+  keeps the strict typo guard). `reference_stat_cols` stays driver-level — it names a source-specific
+  SCADA tag (`wtc_ActPower_min`), i.e. schema description, not tuning.
+- **Grid extended to 1/2/3/6/12 months both modes**; `naive_ratio` recomputed fresh (cheap, no wind_up
+  pipeline) so the merge no longer depends on the reference run's naive; v0 stays reference-only and is
+  simply absent below 3 months; the alignment guard now checks truth on the fresh∩reference
+  intersection only.
+- **Out-of-the-box power_model, overall P50, mean over 7 profiles [pp]** (regenerated benchmark). The
+  short-campaign regime (F16) is now visible in the committed benchmark:
+  | months | prepost bias / spread / score | toggle bias / spread / score |
+  | --- | --- | --- |
+  | 1 | −0.56 / 1.00 / 1.15 | −0.57 / 0.50 / 0.76 |
+  | 2 | +0.04 / 0.53 / 0.54 | −0.17 / 0.30 / 0.35 |
+  | 3 | +0.14 / 0.23 / 0.27 | +0.11 / 0.21 / 0.23 |
+  | 6 | +0.44 / 0.20 / 0.49 | +0.15 / 0.16 / 0.22 |
+  | 12 | +0.12 / 0.34 / 0.36 | +0.08 / 0.17 / 0.19 |
+
+### Effort A — the conditional decomposition, hardened
+- **Every per-bin number is now a trustworthy measured value or a flagged, physics-informed
+  imputation.** A bin is `covered` only if its two-direction shape is finite **and** both directions
+  have `≥ _MIN_BIN_MATCHED_COUNT` matched rows; otherwise it is imputed (ws: bfill from the nearest
+  covered bin above, then 0 uplift above the last covered bin — 0-at-rated; ti: the overall uplift) and
+  flagged `covered=False`. Never a bare NaN, so `summarize_errors` (which drops non-finite errors)
+  cannot be gamed by abstention, and the imputation prior is itself benchmarked.
+- **Corrected re-level (the pure-bug fix).** `relevel_conditional` pins imputed bins at their imputed
+  uplift and solves one λ over the **measured** bins only
+  (`λ = S_m / (Σactual/one_plus_overall − C_i)`), so measured + imputed together energy-aggregate to the
+  headline **exactly** even when coverage is imperfect (the old re-level solved λ over covered bins only
+  and silently absorbed the uncovered bins' MWh). Guards: no measured bins or a non-positive denominator
+  → overall uplift in every bin.
+- **Result (A/B vs the pure-B benchmark, 309/321 conditional cells over all lengths + covered
+  profiles):** overall P50 **bit-identical** (Δbias/Δspread/Δscore = 0.000 pp — the headline is the
+  single full-window fit, untouched by construction); conditional mean **Δscore −3.7 pp prepost / −2.6 pp
+  toggle** (Δbias −2.0/−1.4, Δspread −2.7/−2.0). The before/after view (longest campaign, covered
+  profiles) reads **12 better / 57 ~ / 0 worse** prepost and **15 better / 54 ~ / 0 worse** toggle — the
+  F7/F9 sparse-extreme "worse" bins are gone.
+- **Floor value chosen on evidence, not the one bad bin** (`floor_threshold_evidence.py`, 14.6k bins
+  from the A/B run): the raw two-direction shape `|u_b|` p90 by per-side matched count is 13 pp (<10,
+  mostly degenerate → imputed anyway), **60 pp (10–25), 55 pp (25–50)**, 52 pp (50–100), then falls to
+  25 pp (100–200), 13 pp (200–500), 10 pp (500+). The combine is untrustworthy below ~50 (a floor of 25
+  would leave the wild 25–50 bucket unfloored); 50 is the smallest value that catches it, and raising
+  higher would impute away ~940 moderately-populated 50–100 bins for no done-when gain. Kish ESS was not
+  needed (no balance reweighting shipped — see below), so the floor compares raw per-side counts.
+
+### Decisions
+- **Coverage stays method-internal (user decision, trims the issue's "coverage in the leaderboard"
+  bullet).** The `covered` flag lives only on the per-run `conditional/` CSV and drives the re-level;
+  the harness seam (`MethodOutput.p50_by_condition`) is unchanged `[condition, condition_bin,
+  p50_uplift]`. Rationale: once imputation makes every bin finite, `summarize_errors` drops nothing, so
+  the F16 "deltas dominated by a few exploding cells" problem — the reason a coverage view was wanted —
+  is dissolved by the imputation itself. The method reports its single best per-bin estimate; the
+  leaderboard scores that.
+- **Per-bin balance (post-stratify each reporting bin to the intersection of the two directions'
+  ERA5-cell supports) — DEFERRED, not shipped.** The floor + imputation + corrected re-level already
+  clear every Issue-14 done-when with margin (0 worse bins, conditional score materially better, overall
+  unchanged), so per the adopt-only-if-it-helps protocol the extra within-bin reweighting is not built —
+  it would thread ERA5 cell codes and a custom per-bin reduction into the core conditional path for a
+  residual imbalance the floor already tames (YAGNI). Tracked as a follow-up; the design is a pure
+  intersect-cell-support mask over the matched fwd/rev rows within each reporting bin, with the floor
+  switching to Kish ESS `(Σw)²/Σw²` if it is ever adopted.
+
+### The frozen reference dir is stale (flagged for regeneration)
+- The naive-consistency check (`naive_consistency_check.py`, requested to run once before trusting the
+  reference) **failed**, but in the *good* direction: current-code `naive_ratio` on the `cp_0pct`
+  placebo has a **much tighter prepost spread** than the frozen 30-June reference (3-mo score 1.91 vs
+  7.19, spread 1.57 vs 7.15; 6/12-mo better too), toggle essentially identical. Every input to naive —
+  `naive_ratio.py`, `filtering.py`, the study config, the turbine set, the data span, and (via the
+  passing alignment guard) the ground truth — is byte-identical between the reference era and HEAD, and
+  the reference predates power_model (methods `[naive, oracle, rlearner, v0]`, ~26–30 June), so the
+  30-June run was produced by a **local/uncommitted state** git can't reproduce. The committed benchmark
+  is power_model-only and alignment-guarded, so this does not affect it; naive is now recomputed fresh
+  (the correct, current-code bar). **The frozen v0 in that reference is from the same stale state** and
+  should be regenerated (run `study_overnight_prepost` / `study_overnight_toggle`, both `include_v0=True`,
+  on current committed code) before v0 comparison numbers are trusted.
+
+---
+
 ## F16 — a finite time-decay half-life (548 d) is the default, applied to the headline fit only; the double-ratio toggle estimator validated as opt-in; the 1–2-month regime flips the training-window verdict (Issue 13 extension)
 
 *2026-07-04/05 — three user-directed follow-ups to F15, A/B'd against the post-F15 benchmark.

--- a/docs/v1/issues.md
+++ b/docs/v1/issues.md
@@ -558,6 +558,14 @@ config behaves identically to the benchmarked configuration; `study_power_model_
 scores 1/2/3/6/12-month campaigns in both modes with naive computed fresh where the reference
 lacks it; the benchmark JSON is regenerated on the new grid.
 
+*Shipped 2026-07-08 (findings F17): count floor (`_MIN_BIN_MATCHED_COUNT=50`) + physics imputation +
+corrected pinned-imputed re-level — overall P50 bit-identical, conditional score −3.7 pp prepost /
+−2.6 pp toggle, sparse-extreme "worse" bins eliminated (0 worse). Coverage kept method-internal (per-run
+CSV), not surfaced to the leaderboard (user decision). Per-bin balance **deferred** — floor cleared the
+done-when, so adopt-only-if-it-helps left it unbuilt (follow-up). Defaults promoted to the class; grid
+1–12 months both modes with fresh naive; benchmark regenerated. Note: the frozen 30-June reference dir is
+stale (its v0 needs regenerating on current code — see F17).*
+
 ---
 
 ## Issue 15 — The headline estimator configures itself: regime-adaptive training window and estimator (WS2)

--- a/tests/benchmarking/baselines/test_power_model_conditional.py
+++ b/tests/benchmarking/baselines/test_power_model_conditional.py
@@ -34,6 +34,10 @@ class TestImputeUncoveredBins:
         out = impute_uncovered_bins(one_plus_u, condition="ws", measured=measured, one_plus_overall=1.03)
         assert out.tolist() == pytest.approx([1.20, 1.05, 1.10])
 
+    def test_unknown_condition_raises(self) -> None:
+        with pytest.raises(ValueError, match="unknown condition"):
+            impute_uncovered_bins(np.array([1.1]), condition="wd", measured=np.array([True]), one_plus_overall=1.0)
+
     def test_measured_bin_with_nan_shape_is_not_trusted(self) -> None:
         # a bin flagged measured but carrying a NaN shape (shouldn't happen, but be defensive) is filled
         one_plus_u = np.array([1.05, np.nan, 1.02])

--- a/tests/benchmarking/baselines/test_power_model_conditional.py
+++ b/tests/benchmarking/baselines/test_power_model_conditional.py
@@ -5,11 +5,7 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from benchmarking.baselines.power_model.conditional import (
-    impute_uncovered_bins,
-    intersect_cell_support,
-    relevel_conditional,
-)
+from benchmarking.baselines.power_model.conditional import impute_uncovered_bins, relevel_conditional
 
 
 class TestImputeUncoveredBins:
@@ -44,26 +40,6 @@ class TestImputeUncoveredBins:
         measured = np.array([True, True, True])
         out = impute_uncovered_bins(one_plus_u, condition="ti", measured=measured, one_plus_overall=1.04)
         assert out.tolist() == pytest.approx([1.05, 1.04, 1.02])
-
-
-class TestIntersectCellSupport:
-    def test_restricts_both_sides_to_common_cells(self) -> None:
-        # fwd rows sit in cells {0, 1}; rev rows only in cell {0} -> intersection {0}
-        fwd = np.array([0, 0, 1, 1])
-        rev = np.array([0, 0, 0])
-        fwd_mask, rev_mask = intersect_cell_support(fwd, rev)
-        assert fwd_mask.tolist() == [True, True, False, False]
-        assert rev_mask.tolist() == [True, True, True]
-
-    def test_all_false_when_supports_disjoint(self) -> None:
-        fwd_mask, rev_mask = intersect_cell_support(np.array([0, 1]), np.array([2, 3]))
-        assert not fwd_mask.any()
-        assert not rev_mask.any()
-
-    def test_identity_when_supports_equal(self) -> None:
-        fwd_mask, rev_mask = intersect_cell_support(np.array([5, 6, 7]), np.array([7, 5, 6]))
-        assert fwd_mask.all()
-        assert rev_mask.all()
 
 
 def _agg(sum_actual: np.ndarray, one_plus_u: np.ndarray) -> float:

--- a/tests/benchmarking/baselines/test_power_model_conditional.py
+++ b/tests/benchmarking/baselines/test_power_model_conditional.py
@@ -1,0 +1,105 @@
+"""Unit tests for the pure conditional-decomposition helpers (imputation + energy-identity re-level)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from benchmarking.baselines.power_model.conditional import (
+    impute_uncovered_bins,
+    intersect_cell_support,
+    relevel_conditional,
+)
+
+
+class TestImputeUncoveredBins:
+    def test_ws_bfills_low_holes_from_the_nearest_covered_bin_above(self) -> None:
+        one_plus_u = np.array([np.nan, np.nan, 1.08, 1.06, np.nan])
+        measured = np.array([False, False, True, True, False])
+        out = impute_uncovered_bins(one_plus_u, condition="ws", measured=measured, one_plus_overall=1.03)
+        # low holes take the nearest covered bin above; trailing hole -> 1.0 (0 uplift at rated)
+        assert out.tolist() == pytest.approx([1.08, 1.08, 1.08, 1.06, 1.0])
+
+    def test_ws_all_uncovered_top_fills_to_zero_uplift(self) -> None:
+        one_plus_u = np.array([np.nan, np.nan])
+        measured = np.array([False, False])
+        out = impute_uncovered_bins(one_plus_u, condition="ws", measured=measured, one_plus_overall=1.03)
+        assert out.tolist() == pytest.approx([1.0, 1.0])
+
+    def test_ti_fills_uncovered_at_overall(self) -> None:
+        one_plus_u = np.array([1.07, np.nan, np.nan])
+        measured = np.array([True, False, False])
+        out = impute_uncovered_bins(one_plus_u, condition="ti", measured=measured, one_plus_overall=1.03)
+        assert out.tolist() == pytest.approx([1.07, 1.03, 1.03])
+
+    def test_measured_bins_pass_through_even_if_shape_is_finite_elsewhere(self) -> None:
+        one_plus_u = np.array([1.20, 1.05, 1.10])
+        measured = np.array([True, True, True])
+        out = impute_uncovered_bins(one_plus_u, condition="ws", measured=measured, one_plus_overall=1.03)
+        assert out.tolist() == pytest.approx([1.20, 1.05, 1.10])
+
+    def test_measured_bin_with_nan_shape_is_not_trusted(self) -> None:
+        # a bin flagged measured but carrying a NaN shape (shouldn't happen, but be defensive) is filled
+        one_plus_u = np.array([1.05, np.nan, 1.02])
+        measured = np.array([True, True, True])
+        out = impute_uncovered_bins(one_plus_u, condition="ti", measured=measured, one_plus_overall=1.04)
+        assert out.tolist() == pytest.approx([1.05, 1.04, 1.02])
+
+
+class TestIntersectCellSupport:
+    def test_restricts_both_sides_to_common_cells(self) -> None:
+        # fwd rows sit in cells {0, 1}; rev rows only in cell {0} -> intersection {0}
+        fwd = np.array([0, 0, 1, 1])
+        rev = np.array([0, 0, 0])
+        fwd_mask, rev_mask = intersect_cell_support(fwd, rev)
+        assert fwd_mask.tolist() == [True, True, False, False]
+        assert rev_mask.tolist() == [True, True, True]
+
+    def test_all_false_when_supports_disjoint(self) -> None:
+        fwd_mask, rev_mask = intersect_cell_support(np.array([0, 1]), np.array([2, 3]))
+        assert not fwd_mask.any()
+        assert not rev_mask.any()
+
+    def test_identity_when_supports_equal(self) -> None:
+        fwd_mask, rev_mask = intersect_cell_support(np.array([5, 6, 7]), np.array([7, 5, 6]))
+        assert fwd_mask.all()
+        assert rev_mask.all()
+
+
+def _agg(sum_actual: np.ndarray, one_plus_u: np.ndarray) -> float:
+    """Energy-weighted aggregation of a per-bin (1+u): ratio-of-sums Σactual / Σ(actual/(1+u))."""
+    a = np.asarray(sum_actual, float)
+    u = np.asarray(one_plus_u, float)
+    return float(a.sum() / (a / u).sum())
+
+
+class TestRelevelConditionalPinned:
+    def test_measured_and_pinned_imputed_aggregate_to_overall(self) -> None:
+        sum_actual = np.array([1000.0, 2000.0, 500.0])
+        one_plus_u = np.array([1.10, 0.95, 1.02])  # last is an imputed pin
+        measured = np.array([True, True, False])
+        final = relevel_conditional(sum_actual, one_plus_u, measured=measured, one_plus_overall=1.05)
+        assert final[2] == pytest.approx(1.02)  # imputed bin unchanged (pinned)
+        assert _agg(sum_actual, final) == pytest.approx(1.05)  # whole thing aggregates to overall
+
+    def test_all_measured_reduces_to_a_single_scale(self) -> None:
+        sum_actual = np.array([1000.0, 1000.0])
+        one_plus_u = np.array([1.1, 1.1])
+        measured = np.array([True, True])
+        final = relevel_conditional(sum_actual, one_plus_u, measured=measured, one_plus_overall=1.1)
+        assert final == pytest.approx(one_plus_u)
+
+    def test_no_measured_bins_falls_back_to_overall_everywhere(self) -> None:
+        sum_actual = np.array([1000.0, 500.0])
+        one_plus_u = np.array([1.5, 0.7])  # imputed pins only
+        measured = np.array([False, False])
+        final = relevel_conditional(sum_actual, one_plus_u, measured=measured, one_plus_overall=1.04)
+        assert final.tolist() == pytest.approx([1.04, 1.04])
+
+    def test_nonpositive_denominator_falls_back_to_overall(self) -> None:
+        # imputed counterfactual energy already exceeds the headline total -> cannot solve λ>0
+        sum_actual = np.array([1000.0, 1000.0])
+        one_plus_u = np.array([1.10, 0.20])  # bin 1 imputed with a huge implied cf
+        measured = np.array([True, False])
+        final = relevel_conditional(sum_actual, one_plus_u, measured=measured, one_plus_overall=1.5)
+        assert final.tolist() == pytest.approx([1.5, 1.5])

--- a/tests/benchmarking/baselines/test_power_model_method.py
+++ b/tests/benchmarking/baselines/test_power_model_method.py
@@ -14,7 +14,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from benchmarking.baselines.power_model import PowerModelMethod
+from benchmarking.baselines.power_model import CURATED_ERA5_EXCLUDE, PowerModelMethod
 from benchmarking.baselines.rlearner.nuisance import make_outcome_model
 
 if TYPE_CHECKING:
@@ -23,7 +23,6 @@ from benchmarking.baselines.power_model.method import (
     _clip_predictions,
     _combine_uplift,
     _implied_shrinkage,
-    _relevel_conditional,
 )
 from benchmarking.harness.method import MethodInput
 from benchmarking.synthetic import ToggleSchedule
@@ -416,6 +415,59 @@ class TestConditionalUplift:
         bc = out.p50_by_condition
         assert list(bc.columns) == ["condition", "condition_bin", "p50_uplift"]
         assert set(bc["condition"]) == {"ws", "ti"}
+        # Issue 14: imputation fills every uncovered bin, so the reported per-bin estimate is never NaN
+        # (a bare NaN would let abstention game the conditional score, which drops non-finite errors).
+        assert bc["p50_uplift"].notna().all()
+
+    def test_conditional_csv_carries_covered_flag(self, tmp_path: Path) -> None:
+        n = 4000
+        idx = pd.date_range("2019-01-01", periods=n, freq="10min", tz="UTC")
+        changeover = idx[n // 2]
+        treated = np.asarray(idx >= changeover)
+        scada = _toy_scada(n, uplift=0.05, treated=treated)
+        method = PowerModelMethod(
+            active_power_col=_POWER,
+            availability_col=_AVAIL,
+            baseline_rated_power_kw=2300.0,
+            wind_speed_col=_WS,
+            wind_speed_sd_col=_WS_SD,
+            era5_hourly_df=_toy_era5(idx),
+            model_params=_FAST_PARAMS,
+            out_dir=tmp_path,
+        )
+        mi = MethodInput(scada_df=scada, test_wtg="T1", upgrade_timing=pd.Timestamp(changeover), turbine_col=_TURBINE)
+        method.estimate(mi)
+        files = sorted(tmp_path.rglob("*_conditional_by_bin_*.csv"))
+        assert files, "no conditional_by_bin CSV written"
+        per_bin = pd.read_csv(files[0])
+        assert "covered" in per_bin.columns
+        assert per_bin["covered"].dtype == bool
+        assert per_bin["covered"].any()  # well-populated toy data has at least some measured bins
+        assert per_bin["p50_uplift"].notna().all()  # measured-or-imputed, never bare NaN
+
+    def test_count_floor_marks_sparse_bins_uncovered(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # force every bin below an impossibly-high floor (string target avoids a function-level import)
+        monkeypatch.setattr("benchmarking.baselines.power_model.method._MIN_BIN_MATCHED_COUNT", 10**9)
+        n = 4000
+        idx = pd.date_range("2019-01-01", periods=n, freq="10min", tz="UTC")
+        changeover = idx[n // 2]
+        treated = np.asarray(idx >= changeover)
+        scada = _toy_scada(n, uplift=0.05, treated=treated)
+        method = PowerModelMethod(
+            active_power_col=_POWER,
+            availability_col=_AVAIL,
+            baseline_rated_power_kw=2300.0,
+            wind_speed_col=_WS,
+            wind_speed_sd_col=_WS_SD,
+            era5_hourly_df=_toy_era5(idx),
+            model_params=_FAST_PARAMS,
+            out_dir=tmp_path,
+        )
+        mi = MethodInput(scada_df=scada, test_wtg="T1", upgrade_timing=pd.Timestamp(changeover), turbine_col=_TURBINE)
+        method.estimate(mi)
+        per_bin = pd.read_csv(sorted(tmp_path.rglob("*_conditional_by_bin_*.csv"))[0])
+        assert (~per_bin["covered"]).all()  # nothing clears an impossibly-high floor
+        assert per_bin["p50_uplift"].notna().all()  # all imputed, still never NaN
 
     def test_ws_only_when_no_sd_column_configured(self) -> None:
         n = 4000
@@ -635,31 +687,32 @@ class TestFeatureConfig:
             method.estimate(self._prepost_mi(n=300))
 
 
-class TestRelevelConditional:
-    def test_releveled_bins_aggregate_to_overall(self) -> None:
-        # a per-bin corrected *shape* is rescaled by one factor so its energy-weighted aggregation
-        # (ratio-of-sums Σactual / Σ(actual/(1+u_b))) equals a target overall ratio.
-        sum_actual = np.array([1000.0, 2000.0, 500.0])
-        one_plus_u = np.array([1.10, 0.95, 1.30])
-        final = _relevel_conditional(sum_actual, one_plus_u, one_plus_overall=1.05)
-        agg = sum_actual.sum() / (sum_actual / final).sum()
-        assert agg == pytest.approx(1.05)
+class TestPromotedDefaults:
+    def test_effective_lgbm_params_include_tuned_min_child_samples(self) -> None:
+        m = PowerModelMethod(active_power_col="p", availability_col="a", baseline_rated_power_kw=2300.0)
+        assert m._make_model().get_params()["min_child_samples"] == 50  # noqa: SLF001
 
-    def test_identity_when_already_aggregated(self) -> None:
-        # bins that already aggregate to the overall need no re-level (λ = 1)
-        sum_actual = np.array([1000.0, 1000.0])
-        one_plus_u = np.array([1.1, 1.1])  # aggregates to 1.1
-        final = _relevel_conditional(sum_actual, one_plus_u, one_plus_overall=1.1)
-        assert final == pytest.approx(one_plus_u)
+    def test_explicit_model_params_override_the_tuned_default(self) -> None:
+        m = PowerModelMethod(
+            active_power_col="p",
+            availability_col="a",
+            baseline_rated_power_kw=2300.0,
+            model_params={"min_child_samples": 123},
+        )
+        assert m._make_model().get_params()["min_child_samples"] == 123  # noqa: SLF001
 
-    def test_nan_bin_excluded_but_others_still_aggregate(self) -> None:
-        sum_actual = np.array([1000.0, 0.0, 500.0])
-        one_plus_u = np.array([1.1, np.nan, 0.9])
-        final = _relevel_conditional(sum_actual, one_plus_u, one_plus_overall=1.05)
-        assert np.isnan(final[1])
-        finite = np.isfinite(final)
-        agg = sum_actual[finite].sum() / (sum_actual[finite] / final[finite]).sum()
-        assert agg == pytest.approx(1.05)
+    def test_availability_feature_defaults_off(self) -> None:
+        m = PowerModelMethod(active_power_col="p", availability_col="a", baseline_rated_power_kw=2300.0)
+        assert m.availability_feature is False
+
+    def test_era5_exclude_defaults_to_curated_set(self) -> None:
+        m = PowerModelMethod(active_power_col="p", availability_col="a", baseline_rated_power_kw=2300.0)
+        assert m.era5_exclude == CURATED_ERA5_EXCLUDE
+
+
+# The re-level is now the pinned-imputed ``relevel_conditional`` in power_model.conditional; its unit
+# coverage lives in test_power_model_conditional.py (TestRelevelConditionalPinned). Kept here only:
+# the direction-combine helpers, still in method.py.
 
 
 class TestCombineDirections:

--- a/tests/benchmarking/baselines/test_power_model_method.py
+++ b/tests/benchmarking/baselines/test_power_model_method.py
@@ -441,8 +441,9 @@ class TestConditionalUplift:
         assert files, "no conditional_by_bin CSV written"
         per_bin = pd.read_csv(files[0])
         assert "covered" in per_bin.columns
-        assert per_bin["covered"].dtype == bool
-        assert per_bin["covered"].any()  # well-populated toy data has at least some measured bins
+        # don't assert the CSV round-trip dtype (read_csv bool inference is version-dependent); the
+        # column's meaning is what matters — at least some bins measured in well-populated toy data.
+        assert per_bin["covered"].any()
         assert per_bin["p50_uplift"].notna().all()  # measured-or-imputed, never bare NaN
 
     def test_count_floor_marks_sparse_bins_uncovered(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/benchmarking/baselines/test_study_power_model_compare.py
+++ b/tests/benchmarking/baselines/test_study_power_model_compare.py
@@ -11,9 +11,13 @@ import pytest
 if TYPE_CHECKING:
     from pathlib import Path
 
+from benchmarking.baselines.power_model import CURATED_ERA5_EXCLUDE, TUNED_MODEL_PARAMS
 from benchmarking.baselines.study_power_model_compare import (
     _BASELINE_SCHEMA,
     _MATERIAL_PP,
+    PREPOST_CAMPAIGN_MONTHS,
+    TOGGLE_CAMPAIGN_MONTHS,
+    _check_alignment,
     _conditional_plot_subset,
     _load_baseline_cells,
     _make_power_model,
@@ -35,6 +39,52 @@ def test_make_power_model_defaults_to_conditional_on(tmp_path: Path) -> None:
     # the compare sweep runs power_model at its default: conditional uplift on, matching on the F6 set
     assert method.conditional_uplift is True
     assert method.matching_vars == ("wind_speed_100m", "wind_gusts_10m", "wind_direction_100m")
+
+
+def test_thinned_driver_matches_promoted_defaults(tmp_path: Path) -> None:
+    # the driver now passes only data-schema config; the F13/F14 behaviour lives on the class, so the
+    # constructed method must still carry the benchmarked defaults (Issue 14 promotion).
+    era5 = pd.DataFrame({"wind_speed_100m": [1.0]})
+    method = _make_power_model(tmp_path, era5_hourly_df=era5)
+    assert method.availability_feature is False
+    assert method.era5_exclude == CURATED_ERA5_EXCLUDE
+    assert method._make_model().get_params()["min_child_samples"] == TUNED_MODEL_PARAMS["min_child_samples"]  # noqa: SLF001
+    assert method.reference_stat_cols == ("wtc_ActPower_min",)  # schema description stays driver-level
+
+
+def _overall_rows(truth: float, *, months: list[int], method: str = "power_model") -> pd.DataFrame:
+    """Minimal tidy overall-condition rows for the alignment guard (one case per campaign length)."""
+    return pd.DataFrame(
+        {
+            "method": method,
+            "profile": "cp_0pct",
+            "test_wtg": "T1",
+            "campaign_months": months,
+            "treatment_start": "2020-01-01 00:00:00+00:00",
+            "condition": "overall",
+            "truth": truth,
+        }
+    )
+
+
+def test_campaign_grids_are_the_extended_range() -> None:
+    assert PREPOST_CAMPAIGN_MONTHS == [1, 2, 3, 6, 12]
+    assert TOGGLE_CAMPAIGN_MONTHS == [1, 2, 3, 6, 12]
+
+
+def test_alignment_ignores_fresh_cases_absent_from_reference() -> None:
+    # fresh spans 1-12 months; the frozen reference only has 3/6/12 — the extra short campaigns must
+    # not trip the guard, which now checks truth only on the intersection.
+    fresh = _overall_rows(0.05, months=[1, 2, 3, 6, 12])
+    reference = _overall_rows(0.05, months=[3, 6, 12], method="v0_binned")
+    _check_alignment(fresh, reference)  # must not raise
+
+
+def test_alignment_still_fails_on_truth_mismatch_in_intersection() -> None:
+    fresh = _overall_rows(0.05, months=[1, 2, 3, 6, 12])
+    reference = _overall_rows(0.09, months=[3, 6, 12], method="v0_binned")  # same keys, different truth
+    with pytest.raises(ValueError, match="disagree on ground truth"):
+        _check_alignment(fresh, reference)
 
 
 def test_power_model_leaderboard_includes_overall_and_conditional_cells() -> None:


### PR DESCRIPTION
Improved the conditional uplift distribution calculation (impute missing bins, require minimum matched count, add covered flag to csv). Promoted benchmarked defaults to the power_model class and re-ran benchmark results including 1 and 2 months.
Findings recorded in `findings.md` F17.