### PR TITLE
v1 issue 15

### DIFF
--- a/benchmarking/baselines/inspect_short_campaigns.py
+++ b/benchmarking/baselines/inspect_short_campaigns.py
@@ -63,8 +63,8 @@ _DEFAULT_OUTPUT_DIR = Path.home() / "temp" / "wind-up-benchmarking" / "short_cam
 # the decay weights.
 VARIANTS: dict[str, tuple[tuple[str, ...], dict[str, Any]]] = {
     "default": (("prepost", "toggle"), {}),
-    "hl90": (("prepost", "toggle"), {"time_decay_half_life_days": 90}),
-    "hl365": (("prepost", "toggle"), {"time_decay_half_life_days": 365}),
+    "hl90": (("prepost", "toggle"), {"adaptive_time_decay": False, "time_decay_half_life_days": 90}),
+    "hl365": (("prepost", "toggle"), {"adaptive_time_decay": False, "time_decay_half_life_days": 365}),
     "mcs200": (("toggle",), {"model_params": {"min_child_samples": 200}}),
     "tco_true": (("toggle",), {"toggle_campaign_only": True}),
     "double_ratio": (("toggle",), {"toggle_estimator": "double_ratio"}),

--- a/benchmarking/baselines/power_model/method.py
+++ b/benchmarking/baselines/power_model/method.py
@@ -78,6 +78,12 @@ _MIN_HOLDOUT_ROWS = 20  # below this, report the in-sample fit (no point splitti
 _N_FOLDS = 5
 _N_BLOCKS = 25
 _MIN_EARLY_STOPPING_ROWS = 200  # below this a valid split is too small for early stopping to mean anything
+# Adaptive time-decay half-life = this multiple of the campaign's own duration (Issue 15 / F20): a
+# scale-free "trust pre-campaign data within ~k campaign-durations" rule that gives a short half-life
+# for a short campaign (drift protection) and a long one for a long campaign (use the plentiful recent
+# data), reproducing F16's regime map with one mechanism-anchored constant. k=2 -> 1mo~60d, 12mo~730d.
+_TIME_DECAY_CAMPAIGN_MULTIPLE = 2.0
+_MIN_TIME_DECAY_DURATION_DAYS = 1.0  # floor the campaign duration so the half-life can't degenerate to 0
 _EARLY_STOPPING_CEILING = 3000  # capacity ceiling when early stopping picks the tree count
 
 # The removal-ablation verdict (findings F13): raw Open-Meteo columns the curated feature set does
@@ -268,16 +274,21 @@ class PowerModelMethod:
         ``era5_hourly_df``; mutually exclusive with ``calibrate_slope`` and, like it, with
         ``early_stopping`` / ``n_seed_ensemble > 1`` (the out-of-fold basis must match the final
         model configuration).
-    :param time_decay_half_life_days: training rows are sample-weighted by their proximity in
-        time to the campaign data: ``0.5 ** (days_outside_campaign / half_life)``. Rows inside
-        the campaign interval (for toggle, the interleaved on and off rows) weigh 1; rows outside
-        decay with their distance to it — so distant history informs the fit without dominating
-        it (Issue 13's recency weighting; the alternative to the rejected F11 drift *feature*).
-        Default **548 days (1.5 years)**: finite by design so an arbitrarily long SCADA history
-        cannot dominate the campaign era (year-old data still weighs ~63%, decade-old ~1%); on
-        the 2.5-year benchmark dataset it is neutral-to-slightly-better at every campaign length
-        (findings F16). Shorter half-lives (~90 days) measurably help 1-3-month campaigns at a
-        small long-prepost bias cost; ``None`` disables the weighting.
+    :param adaptive_time_decay: when ``True`` (**default**, the Issue 15 self-configuring behaviour)
+        the headline fit's time-decay half-life is set automatically to
+        ``_TIME_DECAY_CAMPAIGN_MULTIPLE * campaign_duration_days`` — a short half-life for a short
+        campaign (down-weight the stale pre-campaign era that dominates a sliver campaign) and a long
+        one for a long campaign (use the plentiful recent data). This subsumes the fixed default:
+        the best half-life is regime-dependent (F16 — short helps 1-3-month campaigns in both modes,
+        long is safe at 12 months), and a campaign-proportional half-life gets both ends right with no
+        manual tuning. When ``True``, ``time_decay_half_life_days`` must be left ``None``.
+    :param time_decay_half_life_days: **expert override** (used only when ``adaptive_time_decay=False``):
+        a *fixed* half-life for the campaign-proximity training weights
+        ``0.5 ** (days_outside_campaign / half_life)``. Rows inside the campaign interval (for toggle,
+        the interleaved on and off rows) weigh 1; rows outside decay with their distance to it — so
+        distant history informs the fit without dominating it (Issue 13's recency weighting; the
+        alternative to the rejected F11 drift *feature*). ``None`` disables the weighting entirely.
+        The default self-configuring behaviour is ``adaptive_time_decay=True`` (this left ``None``).
     :param toggle_estimator: how a **toggle** headline is estimated (ignored for prepost).
         ``"counterfactual"`` (default): ``Σactual/Σprediction - 1`` — needs the model to be
         absolutely calibrated. ``"double_ratio"``: the naive-adoption hybrid — the model only
@@ -289,6 +300,15 @@ class PowerModelMethod:
         ``counterfactual = fold_ensemble_prediction * rho_off`` so every downstream sum and the
         conditional re-level stay self-consistent. Cannot be combined with the calibrations
         (it *is* one) or ``early_stopping`` / ``n_seed_ensemble > 1``.
+    :param rho_off_scope: **temporary Issue 15 A/B knob** for ``toggle_estimator="double_ratio"``
+        (ignored otherwise): which off rows the calibration ratio ``rho_off = Σy_off/Σpred_off`` is
+        measured over. ``"campaign"`` (default) uses the campaign-window off rows only, ``"all"``
+        the reproduces the pre-Issue-15 behaviour of measuring over every off row. The ON window
+        lives entirely in the campaign, so with all-data training (``toggle_campaign_only=False``)
+        an ``"all"`` ratio straddles the stale pre-campaign era and subtracts the wrong era's
+        miscalibration at short campaigns (F16); ``"campaign"`` keeps numerator and denominator in
+        the same era. With ``toggle_campaign_only=True`` every off row is already in-campaign, so
+        the two scopes coincide. To be removed once the era-local default is confirmed.
     """
 
     active_power_col: str
@@ -321,8 +341,10 @@ class PowerModelMethod:
     early_stopping: bool = False
     calibrate_slope: bool = False
     calibrate_residuals: bool = False
-    time_decay_half_life_days: float | None = 548.0
+    adaptive_time_decay: bool = True
+    time_decay_half_life_days: float | None = None
     toggle_estimator: str = "counterfactual"
+    rho_off_scope: str = "campaign"  # temporary Issue 15 A/B knob; see :attr:`toggle_estimator`
     # Not configuration: latches the missing-sample_weight warning so it fires once per instance.
     _warned_no_sample_weight: bool = field(default=False, init=False, repr=False, compare=False)
 
@@ -382,6 +404,7 @@ class PowerModelMethod:
             upgraded_sel=upgraded_sel,
             weights=weights,
             double_ratio=double_ratio,
+            campaign_mask=self._campaign_mask(index, upgrade_timing=mi.upgrade_timing),
         )
         sum_actual = float(fit["y_upgraded"].sum())
         sum_counter = float(fit["pred_upgraded"].sum())
@@ -771,6 +794,18 @@ class PowerModelMethod:
             frames.append(solar_altitude_azimuth(index, latitude=self.latitude, longitude=self.longitude))
         return pd.concat(frames, axis=1)
 
+    def _effective_half_life(self, *, campaign_start: pd.Timestamp, campaign_end: pd.Timestamp) -> float | None:
+        """Return the time-decay half-life (days) for this campaign, or ``None`` when decay is off.
+
+        ``adaptive_time_decay`` (the default) sets it to ``_TIME_DECAY_CAMPAIGN_MULTIPLE`` times the
+        campaign's own duration (Issue 15 / F20); otherwise the fixed ``time_decay_half_life_days``
+        expert override is used verbatim.
+        """
+        if not self.adaptive_time_decay:
+            return self.time_decay_half_life_days
+        duration_days = max((campaign_end - campaign_start).total_seconds() / 86400.0, _MIN_TIME_DECAY_DURATION_DAYS)
+        return _TIME_DECAY_CAMPAIGN_MULTIPLE * duration_days
+
     def _time_decay_weights(
         self, index: pd.DatetimeIndex, *, campaign_start: pd.Timestamp, campaign_end: pd.Timestamp
     ) -> np.ndarray | None:
@@ -781,13 +816,15 @@ class PowerModelMethod:
         the interleaved on **and** off rows) weighs exactly 1, and rows outside decay with their
         distance to it — so distant history still informs the fit without dominating it. With
         today's flows only pre-campaign rows exist outside the interval, but the definition is
-        two-sided on purpose.
+        two-sided on purpose. The half-life is the ``adaptive_time_decay`` campaign-proportional
+        value by default (:meth:`_effective_half_life`).
         """
-        if self.time_decay_half_life_days is None:
+        half_life = self._effective_half_life(campaign_start=campaign_start, campaign_end=campaign_end)
+        if half_life is None:
             return None
         seconds_outside = np.maximum((campaign_start - index).total_seconds(), (index - campaign_end).total_seconds())
         days_outside = np.maximum(seconds_outside / 86400.0, 0.0)
-        return np.asarray(0.5 ** (days_outside / self.time_decay_half_life_days), dtype=float)
+        return np.asarray(0.5 ** (days_outside / half_life), dtype=float)
 
     def _select_rows(
         self, scada: pd.DataFrame, *, mi: MethodInput, index: pd.DatetimeIndex, y: pd.Series, timebase: pd.Timedelta
@@ -811,6 +848,7 @@ class PowerModelMethod:
         upgraded_sel: np.ndarray,
         weights: np.ndarray | None = None,
         double_ratio: bool = False,
+        campaign_mask: np.ndarray | None = None,
     ) -> dict[str, Any]:
         """Fit on baseline, predict the upgraded counterfactual; also a held-out baseline fit metric.
 
@@ -834,8 +872,15 @@ class PowerModelMethod:
                     f"out-of-fold basis, got {len(y_base)}."
                 )
                 raise ValueError(msg)
+            campaign_off = campaign_mask[baseline_sel] if campaign_mask is not None else None
             return self._fit_predict_double_ratio(
-                x_base, y_base=y_base, x_up=x_up, y_up=y_up, baseline_sel=baseline_sel, w_base=w_base
+                x_base,
+                y_base=y_base,
+                x_up=x_up,
+                y_up=y_up,
+                baseline_sel=baseline_sel,
+                w_base=w_base,
+                campaign_off=campaign_off,
             )
 
         y_valid, pred_valid, valid_local = self._holdout_fit(x_base, y_base, w_base=w_base)
@@ -871,6 +916,7 @@ class PowerModelMethod:
         y_up: np.ndarray,
         baseline_sel: np.ndarray,
         w_base: np.ndarray | None,
+        campaign_off: np.ndarray | None = None,
     ) -> dict[str, Any]:
         """Estimate via the toggle ratio-of-ratios: a model-normalised naive comparison (Issue 13 hybrid).
 
@@ -885,6 +931,10 @@ class PowerModelMethod:
         (The scaled counterfactual may exceed the clip ceiling by the ~0-3 % calibration factor;
         that is deliberate — re-clipping after scaling would break the identity.) The full
         out-of-fold off-row predictions double as the held-out fit-quality diagnostic.
+
+        ``rho_off`` is measured over the ``rho_off_scope`` off rows (``campaign_off`` marks the
+        campaign-window subset among the fitted-on off rows): Issue 15's era-local default keeps it
+        in the ON window's era, while the models still train on every off row (see :attr:`rho_off_scope`).
         """
         n = len(y_base)
         folds = time_block_folds(n, n_folds=_N_FOLDS, n_blocks=_N_BLOCKS)
@@ -903,16 +953,19 @@ class PowerModelMethod:
             preds_on.append(np.asarray(model.predict(x_up), dtype=float))
             models.append(model)
         pred_off = _clip_predictions(oof, y_train=y_base, rated_power_kw=self.baseline_rated_power_kw)
-        rho_off = _ratio(y_base, pred_off) + 1.0
+        rho_scope = self._rho_off_mask(campaign_off, n_off=n)
+        rho_off = _ratio(y_base[rho_scope], pred_off[rho_scope]) + 1.0
         pred_up = (
             _clip_predictions(np.mean(preds_on, axis=0), y_train=y_base, rated_power_kw=self.baseline_rated_power_kw)
             * rho_off
         )
         logger.info(
-            "%s double-ratio toggle estimator: rho_off=%.5f over %d off rows (%d folds)",
+            "%s double-ratio toggle estimator: rho_off=%.5f over %d of %d off rows (scope=%s, %d folds)",
             self.name,
             rho_off,
+            int(rho_scope.sum()),
             n,
+            self.rho_off_scope,
             _N_FOLDS,
         )
         return {
@@ -924,6 +977,24 @@ class PowerModelMethod:
             "baseline_valid_pos": np.flatnonzero(baseline_sel),
             "calibration": IDENTITY_CALIBRATION,
         }
+
+    def _rho_off_mask(self, campaign_off: np.ndarray | None, *, n_off: int) -> np.ndarray:
+        """Which off rows the double-ratio ``rho_off`` is measured over (Issue 15 ``rho_off_scope``).
+
+        ``"all"`` → every off row; ``"campaign"`` → the campaign-window off rows only. Falls back to
+        all rows (with a warning) if the campaign subset is unavailable or empty, so ``rho_off`` is
+        never taken over zero rows.
+        """
+        if self.rho_off_scope == "all" or campaign_off is None:
+            return np.ones(n_off, dtype=bool)
+        if not campaign_off.any():
+            logger.warning(
+                "%s double-ratio: no campaign-window off rows for rho_off_scope='campaign'; "
+                "falling back to all off rows.",
+                self.name,
+            )
+            return np.ones(n_off, dtype=bool)
+        return campaign_off
 
     def _validate_model_config(self) -> None:
         """Fail loudly on model-fundamentals config combinations that would silently misbehave."""
@@ -958,8 +1029,22 @@ class PowerModelMethod:
         if self.time_decay_half_life_days is not None and self.time_decay_half_life_days <= 0:
             msg = f"time_decay_half_life_days must be positive, got {self.time_decay_half_life_days}"
             raise ValueError(msg)
+        if self.adaptive_time_decay and self.time_decay_half_life_days is not None:
+            msg = (
+                "adaptive_time_decay sets the half-life from the campaign duration; a fixed "
+                "time_decay_half_life_days is only used with adaptive_time_decay=False. Set "
+                "adaptive_time_decay=False to use the fixed override, or leave time_decay_half_life_days=None."
+            )
+            raise ValueError(msg)
+        self._validate_toggle_config()
+
+    def _validate_toggle_config(self) -> None:
+        """Fail loudly on toggle-estimator config that would silently misbehave."""
         if self.toggle_estimator not in ("counterfactual", "double_ratio"):
             msg = f"unknown toggle_estimator {self.toggle_estimator!r}; expected 'counterfactual' or 'double_ratio'"
+            raise ValueError(msg)
+        if self.rho_off_scope not in ("campaign", "all"):
+            msg = f"unknown rho_off_scope {self.rho_off_scope!r}; expected 'campaign' or 'all'"
             raise ValueError(msg)
         if self.toggle_estimator == "double_ratio" and (
             self.calibrate_slope or self.calibrate_residuals or self.early_stopping or self.n_seed_ensemble > 1
@@ -987,7 +1072,7 @@ class PowerModelMethod:
                 self._warned_no_sample_weight = True
                 logger.warning(
                     "%s: outcome model %s does not accept sample_weight; time-decay weights are ignored "
-                    "for its fits (set time_decay_half_life_days=None to silence this).",
+                    "for its fits (set adaptive_time_decay=False and time_decay_half_life_days=None to silence).",
                     self.name,
                     type(model).__name__,
                 )
@@ -1299,6 +1384,8 @@ class PowerModelMethod:
             "early_stopping": self.early_stopping,
             "calibrate_slope": self.calibrate_slope,
             "calibrate_residuals": self.calibrate_residuals,
+            "adaptive_time_decay": self.adaptive_time_decay,
             "time_decay_half_life_days": self.time_decay_half_life_days,
             "toggle_estimator": self.toggle_estimator,
+            "rho_off_scope": self.rho_off_scope,
         }

--- a/benchmarking/baselines/power_model/method.py
+++ b/benchmarking/baselines/power_model/method.py
@@ -303,7 +303,7 @@ class PowerModelMethod:
     :param rho_off_scope: **temporary Issue 15 A/B knob** for ``toggle_estimator="double_ratio"``
         (ignored otherwise): which off rows the calibration ratio ``rho_off = Σy_off/Σpred_off`` is
         measured over. ``"campaign"`` (default) uses the campaign-window off rows only, ``"all"``
-        the reproduces the pre-Issue-15 behaviour of measuring over every off row. The ON window
+        this reproduces the pre-Issue-15 behaviour of measuring over every off row. The ON window
         lives entirely in the campaign, so with all-data training (``toggle_campaign_only=False``)
         an ``"all"`` ratio straddles the stale pre-campaign era and subtracts the wrong era's
         miscalibration at short campaigns (F16); ``"campaign"`` keeps numerator and denominator in

--- a/benchmarking/baselines/study_power_model_compare_baseline.json
+++ b/benchmarking/baselines/study_power_model_compare_baseline.json
@@ -2,8 +2,8 @@
   "schema": "power_model_compare_baseline_v2",
   "modes": {
     "prepost": {
-      "recorded_utc": "2026-07-08T13:07:31Z",
-      "git_commit": "09f3b06-dirty",
+      "recorded_utc": "2026-07-10T11:14:14Z",
+      "git_commit": "ac9f2c7-dirty",
       "n_replicates": 4,
       "seed": 0,
       "campaign_months": [
@@ -28,9 +28,9 @@
           "campaign_months": 1,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00552764,
-          "spread": 0.00982332,
-          "score": 0.01127175
+          "bias": -0.00427156,
+          "spread": 0.01114357,
+          "score": 0.01193421
         },
         {
           "profile": "cp_0pct",
@@ -46,126 +46,126 @@
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.01237767,
-          "spread": 0.01265919,
-          "score": 0.01770485
+          "bias": -0.01115676,
+          "spread": 0.01167136,
+          "score": 0.01614602
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.0102043,
-          "spread": 0.01482194,
-          "score": 0.01799494
+          "bias": -0.00898334,
+          "spread": 0.01382097,
+          "score": 0.01648392
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00650927,
-          "spread": 0.01022141,
-          "score": 0.01211808
+          "bias": -0.00527994,
+          "spread": 0.00899484,
+          "score": 0.01043
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00082262,
-          "spread": 0.01615288,
-          "score": 0.01617381
+          "bias": 0.00050815,
+          "spread": 0.02069748,
+          "score": 0.02070372
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01096816,
-          "spread": 0.03705919,
-          "score": 0.03864821
+          "bias": 0.01240869,
+          "spread": 0.04168514,
+          "score": 0.04349283
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.03328244,
-          "spread": 0.02284657,
-          "score": 0.04036937
+          "bias": 0.03446818,
+          "spread": 0.01738502,
+          "score": 0.03860433
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.35107562,
-          "spread": 0.66095386,
-          "score": 0.74840771
+          "bias": 0.34957643,
+          "spread": 0.65137589,
+          "score": 0.73925248
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.03566779,
-          "spread": 0.06231811,
-          "score": 0.07180347
+          "bias": 0.03689501,
+          "spread": 0.06119778,
+          "score": 0.07145915
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.00552764,
-          "spread": 0.00982332,
-          "score": 0.01127175
+          "bias": -0.00427156,
+          "spread": 0.01114357,
+          "score": 0.01193421
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.02297612,
-          "spread": 0.09464886,
-          "score": 0.09739768
+          "bias": 0.02316829,
+          "spread": 0.09330566,
+          "score": 0.09613904
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00019958,
-          "spread": 0.01715622,
-          "score": 0.01715738
+          "bias": 0.00154545,
+          "spread": 0.01818854,
+          "score": 0.01825408
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00572391,
-          "spread": 0.01611426,
-          "score": 0.01710066
+          "bias": 0.00710267,
+          "spread": 0.01863823,
+          "score": 0.01994572
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00527339,
-          "spread": 0.00664729,
-          "score": 0.00848499
+          "bias": 0.00464549,
+          "spread": 0.00964782,
+          "score": 0.01070799
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00549603,
-          "spread": 0.0095194,
-          "score": 0.01099206
+          "bias": 0.00674783,
+          "spread": 0.01168758,
+          "score": 0.01349566
         },
         {
           "profile": "cp_0pct",
@@ -181,9 +181,9 @@
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.13787276,
-          "spread": 0.14531781,
-          "score": 0.20031516
+          "bias": -0.13629404,
+          "spread": 0.14721011,
+          "score": 0.20061626
         },
         {
           "profile": "cp_0pct",
@@ -217,171 +217,171 @@
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00667663,
-          "spread": 0.01773636,
-          "score": 0.01895141
+          "bias": -0.00543197,
+          "spread": 0.01280537,
+          "score": 0.01390984
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00428595,
-          "spread": 0.01489817,
-          "score": 0.01550241
+          "bias": -0.00298969,
+          "spread": 0.01310923,
+          "score": 0.01344582
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.01516905,
-          "spread": 0.01399724,
-          "score": 0.02064032
+          "bias": -0.01380184,
+          "spread": 0.01769964,
+          "score": 0.02244478
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 2,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00040142,
-          "spread": 0.00525189,
-          "score": 0.00526721
+          "bias": -7.315e-05,
+          "spread": 0.0019407,
+          "score": 0.00194208
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.00796105,
+          "bias": 0.00227809,
           "spread": 0.0,
-          "score": 0.00796105
+          "score": 0.00227809
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00565709,
-          "spread": 0.00394075,
-          "score": 0.00689436
+          "bias": 0.00519496,
+          "spread": 0.00464732,
+          "score": 0.00697031
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00218912,
-          "spread": 0.00632384,
-          "score": 0.00669203
+          "bias": 0.00170902,
+          "spread": 0.00259978,
+          "score": 0.00311121
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00167881,
-          "spread": 0.00624055,
-          "score": 0.00646241
+          "bias": -0.00215632,
+          "spread": 0.00271323,
+          "score": 0.00346574
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00136265,
-          "spread": 0.00408319,
-          "score": 0.00430456
+          "bias": 0.00091155,
+          "spread": 0.00639658,
+          "score": 0.0064612
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": -0.00118281,
-          "spread": 0.01366304,
-          "score": 0.01371414
+          "bias": -0.00163335,
+          "spread": 0.01443178,
+          "score": 0.01452391
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00173881,
-          "spread": 0.04241635,
-          "score": 0.04245198
+          "bias": 0.00113116,
+          "spread": 0.03889175,
+          "score": 0.03890819
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.07436536,
-          "spread": 0.15062462,
-          "score": 0.16798209
+          "bias": 0.0734547,
+          "spread": 0.14705051,
+          "score": 0.16437593
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.52585493,
-          "spread": 1.16943946,
-          "score": 1.28222933
+          "bias": 0.52182559,
+          "spread": 1.16038722,
+          "score": 1.27232089
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.10474165,
-          "spread": 0.18502227,
-          "score": 0.21261245
+          "bias": -0.10536964,
+          "spread": 0.18412492,
+          "score": 0.21214322
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.04162282,
-          "spread": 0.10378434,
-          "score": 0.11181971
+          "bias": -0.04174168,
+          "spread": 0.10226973,
+          "score": 0.11046024
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00291686,
-          "spread": 0.01103311,
-          "score": 0.01141217
+          "bias": 0.00245693,
+          "spread": 0.00957671,
+          "score": 0.00988686
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00366863,
-          "spread": 0.00463185,
-          "score": 0.00590871
+          "bias": 0.0032232,
+          "spread": 0.00464144,
+          "score": 0.00565084
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00881364,
-          "spread": 0.00579696,
-          "score": 0.01054917
+          "bias": 0.00838602,
+          "spread": 0.00863136,
+          "score": 0.01203435
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00209483,
-          "spread": 0.00362836,
-          "score": 0.00418967
+          "bias": 0.00156169,
+          "spread": 0.00270493,
+          "score": 0.00312338
         },
         {
           "profile": "cp_0pct",
@@ -397,9 +397,9 @@
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.06368629,
-          "spread": 0.09919371,
-          "score": 0.11787848
+          "bias": -0.06402925,
+          "spread": 0.0997352,
+          "score": 0.11851943
         },
         {
           "profile": "cp_0pct",
@@ -433,171 +433,171 @@
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00600537,
-          "spread": 0.01422923,
-          "score": 0.0154446
+          "bias": -0.00648565,
+          "spread": 0.01111623,
+          "score": 0.0128699
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00211916,
-          "spread": 0.00687117,
-          "score": 0.00719054
+          "bias": 0.00166307,
+          "spread": 0.00496166,
+          "score": 0.00523296
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00439079,
-          "spread": 0.007549,
-          "score": 0.00873306
+          "bias": -0.00484791,
+          "spread": 0.00517465,
+          "score": 0.00709079
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00135816,
-          "spread": 0.00227292,
-          "score": 0.00264779
+          "bias": 0.0020602,
+          "spread": 0.00188177,
+          "score": 0.00279025
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.0031976,
-          "spread": 0.00186435,
-          "score": 0.00370141
+          "bias": 0.00385033,
+          "spread": 0.00063609,
+          "score": 0.00390252
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00757629,
-          "spread": 0.01158707,
-          "score": 0.01384415
+          "bias": -0.00686936,
+          "spread": 0.01246252,
+          "score": 0.01423034
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00379723,
-          "spread": 0.00367923,
-          "score": 0.00528731
+          "bias": 0.00450261,
+          "spread": 0.00389331,
+          "score": 0.00595243
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00134691,
-          "spread": 0.00175174,
-          "score": 0.00220969
+          "bias": -0.00064666,
+          "spread": 0.00126734,
+          "score": 0.00142278
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00055223,
-          "spread": 0.01030714,
-          "score": 0.01032192
+          "bias": 0.00124703,
+          "spread": 0.00957772,
+          "score": 0.00965856
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00452411,
-          "spread": 0.01815746,
-          "score": 0.01871258
+          "bias": 0.00521519,
+          "spread": 0.01738851,
+          "score": 0.01815375
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.02724425,
-          "spread": 0.04120468,
-          "score": 0.04939711
+          "bias": -0.02658971,
+          "spread": 0.04058404,
+          "score": 0.04851883
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.0815674,
-          "spread": 0.10810652,
-          "score": 0.13542622
+          "bias": 0.08241864,
+          "spread": 0.10913283,
+          "score": 0.1367582
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.19983616,
-          "spread": 0.39686655,
-          "score": 0.44433945
+          "bias": 0.20079174,
+          "spread": 0.39746756,
+          "score": 0.44530639
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.02770509,
-          "spread": 0.05160903,
-          "score": 0.05857528
+          "bias": -0.02701854,
+          "spread": 0.05171558,
+          "score": 0.05834812
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.092792,
-          "spread": 0.07668247,
-          "score": 0.12037673
+          "bias": -0.09208892,
+          "spread": 0.07732793,
+          "score": 0.12024964
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.0014898,
-          "spread": 0.00616223,
-          "score": 0.00633977
+          "bias": 0.0022153,
+          "spread": 0.0070258,
+          "score": 0.00736678
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00566026,
-          "spread": 0.00735686,
-          "score": 0.00928234
+          "bias": 0.00639001,
+          "spread": 0.00825535,
+          "score": 0.0104395
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.01049923,
-          "spread": 0.01066184,
-          "score": 0.01496358
+          "bias": 0.01123541,
+          "spread": 0.01156745,
+          "score": 0.01612576
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00205935,
-          "spread": 0.00410297,
-          "score": 0.00459079
+          "bias": 0.00216293,
+          "spread": 0.0046405,
+          "score": 0.00511981
         },
         {
           "profile": "cp_0pct",
@@ -613,9 +613,9 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.10055363,
-          "spread": 0.10828671,
-          "score": 0.14777363
+          "bias": -0.09997799,
+          "spread": 0.10776326,
+          "score": 0.14699836
         },
         {
           "profile": "cp_0pct",
@@ -649,198 +649,198 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -5.451e-05,
-          "spread": 0.01480955,
-          "score": 0.01480965
+          "bias": 0.00065378,
+          "spread": 0.01397078,
+          "score": 0.01398607
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00268907,
-          "spread": 0.01028598,
-          "score": 0.01063167
+          "bias": -0.00198012,
+          "spread": 0.00946997,
+          "score": 0.00967477
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00227865,
-          "spread": 0.00819446,
-          "score": 0.00850538
+          "bias": -0.00156768,
+          "spread": 0.0074083,
+          "score": 0.00757235
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00437834,
-          "spread": 0.00191899,
-          "score": 0.00478041
+          "bias": 0.00411251,
+          "spread": 0.00186499,
+          "score": 0.00451563
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.00536247,
-          "spread": 0.00204004,
-          "score": 0.00573741
+          "bias": 0.0045877,
+          "spread": 0.00216092,
+          "score": 0.00507115
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00169522,
-          "spread": 0.00749124,
-          "score": 0.00768065
+          "bias": -0.00195736,
+          "spread": 0.0077471,
+          "score": 0.00799054
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00362548,
-          "spread": 0.00177785,
-          "score": 0.00403792
+          "bias": 0.00335956,
+          "spread": 0.00154181,
+          "score": 0.00369646
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00236303,
-          "spread": 0.00218283,
-          "score": 0.00321693
+          "bias": 0.00209719,
+          "spread": 0.00186581,
+          "score": 0.00280704
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00833612,
-          "spread": 0.00583444,
-          "score": 0.01017505
+          "bias": 0.00807123,
+          "spread": 0.0061478,
+          "score": 0.01014595
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01291283,
-          "spread": 0.00684295,
-          "score": 0.01461393
+          "bias": 0.01264514,
+          "spread": 0.00688214,
+          "score": 0.01439665
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.01259167,
-          "spread": 0.01241933,
-          "score": 0.01768587
+          "bias": 0.01232488,
+          "spread": 0.01250207,
+          "score": 0.01755575
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.08169339,
-          "spread": 0.07834736,
-          "score": 0.11319063
+          "bias": 0.08136714,
+          "spread": 0.07776332,
+          "score": 0.11255108
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.19366664,
-          "spread": 0.12165515,
-          "score": 0.22870668
+          "bias": 0.19339641,
+          "spread": 0.12203666,
+          "score": 0.22868125
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.01720545,
-          "spread": 0.40142941,
-          "score": 0.40179796
+          "bias": 0.01706269,
+          "spread": 0.40158028,
+          "score": 0.40194261
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.11331499,
-          "spread": 0.10967246,
-          "score": 0.15769698
+          "bias": -0.11354121,
+          "spread": 0.10967922,
+          "score": 0.1578643
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00183943,
-          "spread": 0.00310172,
-          "score": 0.00360613
+          "bias": 0.00157401,
+          "spread": 0.00322722,
+          "score": 0.00359061
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00480268,
-          "spread": 0.004612,
-          "score": 0.00665855
+          "bias": 0.0045378,
+          "spread": 0.00497307,
+          "score": 0.00673224
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00641108,
-          "spread": 0.00392629,
-          "score": 0.00751782
+          "bias": 0.00614587,
+          "spread": 0.00436966,
+          "score": 0.00754093
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00403158,
-          "spread": 0.00221245,
-          "score": 0.00459875
+          "bias": 0.00376543,
+          "spread": 0.00232586,
+          "score": 0.00442584
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00136961,
-          "spread": 0.00237223,
-          "score": 0.00273921
+          "bias": 0.00137305,
+          "spread": 0.00237819,
+          "score": 0.0027461
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.11354624,
-          "spread": 0.06646546,
-          "score": 0.13156901
+          "bias": -0.11375656,
+          "spread": 0.06676104,
+          "score": 0.13189993
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00036183,
-          "spread": 0.0006267,
-          "score": 0.00072366
+          "bias": 0.00036526,
+          "spread": 0.00063265,
+          "score": 0.00073052
         },
         {
           "profile": "cp_0pct",
@@ -865,198 +865,198 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00969048,
-          "spread": 0.00736412,
-          "score": 0.0121711
+          "bias": 0.00942527,
+          "spread": 0.00772499,
+          "score": 0.01218652
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00315475,
-          "spread": 0.00502881,
-          "score": 0.00593645
+          "bias": 0.002888,
+          "spread": 0.00490993,
+          "score": 0.00569631
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00435877,
-          "spread": 0.00672609,
-          "score": 0.00801493
+          "bias": 0.00408992,
+          "spread": 0.00636283,
+          "score": 0.00756393
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00114791,
-          "spread": 0.00333989,
-          "score": 0.00353165
+          "bias": 0.00095978,
+          "spread": 0.00334688,
+          "score": 0.00348178
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.00114791,
-          "spread": 0.00333989,
-          "score": 0.00353165
+          "bias": 0.00095978,
+          "spread": 0.00334688,
+          "score": 0.00348178
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00227016,
-          "spread": 0.0032837,
-          "score": 0.00399203
+          "bias": -0.00245744,
+          "spread": 0.00332727,
+          "score": 0.00413639
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00017945,
-          "spread": 0.0024082,
-          "score": 0.00241488
+          "bias": -8.46e-06,
+          "spread": 0.00241526,
+          "score": 0.00241528
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00015711,
-          "spread": 0.0040542,
-          "score": 0.00405724
+          "bias": -3.063e-05,
+          "spread": 0.00411361,
+          "score": 0.00411373
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00398434,
-          "spread": 0.00469482,
-          "score": 0.00615762
+          "bias": 0.00379517,
+          "spread": 0.00458493,
+          "score": 0.00595189
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00984079,
-          "spread": 0.00660396,
-          "score": 0.01185131
+          "bias": 0.00965042,
+          "spread": 0.00655296,
+          "score": 0.01166499
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00119361,
-          "spread": 0.01223235,
-          "score": 0.01229045
+          "bias": 0.00100522,
+          "spread": 0.01234562,
+          "score": 0.01238647
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.05196499,
-          "spread": 0.04379656,
-          "score": 0.06795954
+          "bias": 0.05176876,
+          "spread": 0.04398425,
+          "score": 0.06793099
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.37437931,
-          "spread": 0.39366729,
-          "score": 0.54326218
+          "bias": 0.37418958,
+          "spread": 0.393914,
+          "score": 0.5433103
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.43961748,
-          "spread": 0.68082491,
-          "score": 0.8104234
+          "bias": 0.43925467,
+          "spread": 0.68040778,
+          "score": 0.80987618
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.10361101,
-          "spread": 0.09147877,
-          "score": 0.1382158
+          "bias": -0.10377105,
+          "spread": 0.0915633,
+          "score": 0.13839172
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00120616,
-          "spread": 0.00277209,
-          "score": 0.00302313
+          "bias": 0.00101777,
+          "spread": 0.00284186,
+          "score": 0.00301862
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00155942,
-          "spread": 0.00256534,
-          "score": 0.00300212
+          "bias": 0.0013705,
+          "spread": 0.00246004,
+          "score": 0.00281604
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00214135,
-          "spread": 0.00211971,
-          "score": 0.00301307
+          "bias": 0.00195228,
+          "spread": 0.0019741,
+          "score": 0.00277641
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00069421,
-          "spread": 0.00090552,
-          "score": 0.00114101
+          "bias": 0.00050557,
+          "spread": 0.00074136,
+          "score": 0.00089734
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00159071,
-          "spread": 0.00335535,
-          "score": 0.00371332
+          "bias": 0.00140173,
+          "spread": 0.00325895,
+          "score": 0.00354762
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.12400607,
-          "spread": 0.07021904,
-          "score": 0.14250691
+          "bias": -0.12418597,
+          "spread": 0.07005689,
+          "score": 0.14258374
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00286131,
-          "spread": 0.01172776,
-          "score": 0.01207176
+          "bias": 0.00273776,
+          "spread": 0.01161851,
+          "score": 0.01193671
         },
         {
           "profile": "cp_0pct",
@@ -1081,36 +1081,36 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00151711,
-          "spread": 0.00714809,
-          "score": 0.00730731
+          "bias": 0.00132848,
+          "spread": 0.00721195,
+          "score": 0.00733329
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00101636,
-          "spread": 0.00687475,
-          "score": 0.00694948
+          "bias": 0.00082782,
+          "spread": 0.0069248,
+          "score": 0.0069741
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00095207,
-          "spread": 0.0072653,
-          "score": 0.00732742
+          "bias": 0.00076363,
+          "spread": 0.0072862,
+          "score": 0.00732611
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 1,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00501482,
-          "spread": 0.00909108,
-          "score": 0.01038249
+          "bias": -0.00384907,
+          "spread": 0.01034629,
+          "score": 0.01103907
         },
         {
           "profile": "cp_minus_10pct",
@@ -1126,126 +1126,126 @@
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.01224268,
-          "spread": 0.01075626,
-          "score": 0.01629663
+          "bias": -0.01113107,
+          "spread": 0.01031484,
+          "score": 0.01517553
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00848537,
-          "spread": 0.01141673,
-          "score": 0.01422474
+          "bias": -0.00733369,
+          "spread": 0.01090355,
+          "score": 0.01314041
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.0058273,
-          "spread": 0.01084657,
-          "score": 0.01231282
+          "bias": -0.00467814,
+          "spread": 0.00938016,
+          "score": 0.01048201
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -3.948e-05,
-          "spread": 0.01502656,
-          "score": 0.01502661
+          "bias": 0.00117978,
+          "spread": 0.01879995,
+          "score": 0.01883693
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.0105389,
-          "spread": 0.03322406,
-          "score": 0.03485551
+          "bias": 0.01185055,
+          "spread": 0.03718078,
+          "score": 0.03902366
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.03063751,
-          "spread": 0.02580052,
-          "score": 0.04005401
+          "bias": 0.03172498,
+          "spread": 0.02103543,
+          "score": 0.03806525
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.30672274,
-          "spread": 0.54929566,
-          "score": 0.62913001
+          "bias": 0.30555648,
+          "spread": 0.54136619,
+          "score": 0.62164468
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.00825423,
-          "spread": 0.11033988,
-          "score": 0.11064818
+          "bias": 0.00940955,
+          "spread": 0.11028238,
+          "score": 0.11068307
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.0638973,
-          "spread": 0.09868056,
-          "score": 0.11756155
+          "bias": 0.06506305,
+          "spread": 0.10149519,
+          "score": 0.120559
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.06000267,
-          "spread": 0.13890544,
-          "score": 0.15131107
+          "bias": -0.06005661,
+          "spread": 0.1361023,
+          "score": 0.14876368
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00241458,
-          "spread": 0.01965757,
-          "score": 0.01980531
+          "bias": 0.00367068,
+          "spread": 0.02047109,
+          "score": 0.02079758
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.0015484,
-          "spread": 0.01631979,
-          "score": 0.01639308
+          "bias": -0.00019521,
+          "spread": 0.01860744,
+          "score": 0.01860847
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00557877,
-          "spread": 0.00725785,
-          "score": 0.00915418
+          "bias": 0.0049595,
+          "spread": 0.0107849,
+          "score": 0.01187059
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00693428,
-          "spread": 0.01170431,
-          "score": 0.01360423
+          "bias": 0.00819054,
+          "spread": 0.01388008,
+          "score": 0.0161165
         },
         {
           "profile": "cp_minus_10pct",
@@ -1261,9 +1261,9 @@
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.07806877,
-          "spread": 0.07267703,
-          "score": 0.10666154
+          "bias": -0.07649903,
+          "spread": 0.07298395,
+          "score": 0.10572965
         },
         {
           "profile": "cp_minus_10pct",
@@ -1297,171 +1297,171 @@
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00886516,
-          "spread": 0.01710289,
-          "score": 0.01926396
+          "bias": -0.00775334,
+          "spread": 0.01259719,
+          "score": 0.014792
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00495189,
-          "spread": 0.01439284,
-          "score": 0.01522087
+          "bias": -0.00378958,
+          "spread": 0.0125679,
+          "score": 0.01312681
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.01180111,
-          "spread": 0.01298908,
-          "score": 0.01754943
+          "bias": -0.01056026,
+          "spread": 0.01650938,
+          "score": 0.01959792
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 2,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00044265,
-          "spread": 0.00486339,
-          "score": 0.0048835
+          "bias": -5.91e-06,
+          "spread": 0.00177786,
+          "score": 0.00177787
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.03393016,
+          "bias": 0.02865895,
           "spread": 0.0,
-          "score": 0.03393016
+          "score": 0.02865895
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.01098663,
-          "spread": 0.00650399,
-          "score": 0.01276745
+          "bias": 0.01051591,
+          "spread": 0.00852081,
+          "score": 0.01353471
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00174811,
-          "spread": 0.00565101,
-          "score": 0.00591522
+          "bias": -0.00220613,
+          "spread": 0.00275503,
+          "score": 0.00352948
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00095632,
-          "spread": 0.00705315,
-          "score": 0.00711768
+          "bias": -0.00139856,
+          "spread": 0.00367355,
+          "score": 0.00393077
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00473768,
-          "spread": 0.00153389,
-          "score": 0.0049798
+          "bias": 0.00432491,
+          "spread": 0.00442502,
+          "score": 0.00618754
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00461084,
-          "spread": 0.0105941,
-          "score": 0.011554
+          "bias": 0.00420457,
+          "spread": 0.01088353,
+          "score": 0.01166746
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.0059253,
-          "spread": 0.03926464,
-          "score": 0.0397092
+          "bias": 0.00539714,
+          "spread": 0.03605263,
+          "score": 0.03645437
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.08034964,
-          "spread": 0.13584032,
-          "score": 0.15782477
+          "bias": 0.0795603,
+          "spread": 0.13289277,
+          "score": 0.15488812
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.48189684,
-          "spread": 1.12082606,
-          "score": 1.22003099
+          "bias": 0.47777474,
+          "spread": 1.11158461,
+          "score": 1.20991283
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.33128796,
-          "spread": 0.94727464,
-          "score": 1.00353423
+          "bias": 0.33054501,
+          "spread": 0.94808336,
+          "score": 1.00405282
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.08448587,
-          "spread": 0.11170671,
-          "score": 0.14005803
+          "bias": -0.08463702,
+          "spread": 0.11013724,
+          "score": 0.13890154
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00454938,
-          "spread": 0.01364188,
-          "score": 0.01438047
+          "bias": 0.00412232,
+          "spread": 0.01251367,
+          "score": 0.01317519
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00237444,
-          "spread": 0.0039669,
-          "score": 0.00462323
+          "bias": -0.00281697,
+          "spread": 0.00329746,
+          "score": 0.00433689
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00575524,
-          "spread": 0.00290607,
-          "score": 0.00644733
+          "bias": 0.00532433,
+          "spread": 0.00658366,
+          "score": 0.00846718
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00331092,
-          "spread": 0.00553225,
-          "score": 0.00644732
+          "bias": 0.00277537,
+          "spread": 0.00460466,
+          "score": 0.00537639
         },
         {
           "profile": "cp_minus_10pct",
@@ -1477,9 +1477,9 @@
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.02552172,
-          "spread": 0.06176549,
-          "score": 0.06683064
+          "bias": -0.02577671,
+          "spread": 0.06145049,
+          "score": 0.06663784
         },
         {
           "profile": "cp_minus_10pct",
@@ -1513,171 +1513,171 @@
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00596279,
-          "spread": 0.01337536,
-          "score": 0.01464428
+          "bias": -0.00639992,
+          "spread": 0.0104292,
+          "score": 0.01223631
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00191905,
-          "spread": 0.00614622,
-          "score": 0.00643885
+          "bias": 0.00150918,
+          "spread": 0.00485887,
+          "score": 0.00508786
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00213153,
-          "spread": 0.0064594,
-          "score": 0.006802
+          "bias": -0.00254314,
+          "spread": 0.00464942,
+          "score": 0.00529949
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00134073,
-          "spread": 0.00213654,
-          "score": 0.00252238
+          "bias": 0.00199414,
+          "spread": 0.00175822,
+          "score": 0.00265856
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": -0.01723172,
-          "spread": 0.04583144,
-          "score": 0.0489638
+          "bias": -0.01662761,
+          "spread": 0.04697211,
+          "score": 0.04982826
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.01116482,
-          "spread": 0.01176756,
-          "score": 0.01622124
+          "bias": -0.01049677,
+          "spread": 0.01256439,
+          "score": 0.01637212
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -3.699e-05,
-          "spread": 0.00340331,
-          "score": 0.00340351
+          "bias": 0.00062669,
+          "spread": 0.00374279,
+          "score": 0.00379489
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00052369,
-          "spread": 0.00247888,
-          "score": 0.0025336
+          "bias": 0.00012487,
+          "spread": 0.00245731,
+          "score": 0.00246048
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00468933,
-          "spread": 0.00954652,
-          "score": 0.01063607
+          "bias": 0.00532273,
+          "spread": 0.00890493,
+          "score": 0.01037445
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00952595,
-          "spread": 0.01640502,
-          "score": 0.0189702
+          "bias": 0.01014956,
+          "spread": 0.01568982,
+          "score": 0.01868646
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.0188272,
-          "spread": 0.03851814,
-          "score": 0.0428732
+          "bias": -0.01824447,
+          "spread": 0.03792599,
+          "score": 0.04208612
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.08844033,
-          "spread": 0.08843976,
-          "score": 0.12507312
+          "bias": 0.0891861,
+          "spread": 0.08933041,
+          "score": 0.12623027
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.12638283,
-          "spread": 0.39049289,
-          "score": 0.41043552
+          "bias": 0.12722954,
+          "spread": 0.39074165,
+          "score": 0.41093356
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.08614982,
-          "spread": 0.26549983,
-          "score": 0.27912712
+          "bias": -0.08554026,
+          "spread": 0.265961,
+          "score": 0.27937858
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.0723448,
-          "spread": 0.18836647,
-          "score": 0.20178131
+          "bias": -0.07155602,
+          "spread": 0.18894835,
+          "score": 0.20204391
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00472542,
-          "spread": 0.00994961,
-          "score": 0.01101474
+          "bias": 0.00539682,
+          "spread": 0.01076889,
+          "score": 0.01204552
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00118748,
-          "spread": 0.00846502,
-          "score": 0.0085479
+          "bias": -0.00047277,
+          "spread": 0.00934836,
+          "score": 0.0093603
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00646794,
-          "spread": 0.01012507,
-          "score": 0.01201463
+          "bias": 0.00720038,
+          "spread": 0.01102817,
+          "score": 0.01317065
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00065225,
-          "spread": 0.00223079,
-          "score": 0.00232419
+          "bias": 0.00075521,
+          "spread": 0.00279431,
+          "score": 0.00289456
         },
         {
           "profile": "cp_minus_10pct",
@@ -1693,9 +1693,9 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.05070941,
-          "spread": 0.07318243,
-          "score": 0.08903434
+          "bias": -0.05023622,
+          "spread": 0.07268888,
+          "score": 0.08835921
         },
         {
           "profile": "cp_minus_10pct",
@@ -1729,198 +1729,198 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00024246,
-          "spread": 0.0175952,
-          "score": 0.01759687
+          "bias": 0.00039028,
+          "spread": 0.01685309,
+          "score": 0.01685761
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00306991,
-          "spread": 0.01087722,
-          "score": 0.01130214
+          "bias": -0.00243372,
+          "spread": 0.01013017,
+          "score": 0.01041841
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00020693,
-          "spread": 0.00810986,
-          "score": 0.0081125
+          "bias": 0.00084796,
+          "spread": 0.00735538,
+          "score": 0.0074041
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00418225,
-          "spread": 0.00178571,
-          "score": 0.00454752
+          "bias": 0.00393485,
+          "spread": 0.00173969,
+          "score": 0.00430227
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.03722706,
-          "spread": 0.00461658,
-          "score": 0.03751222
+          "bias": 0.03650596,
+          "spread": 0.00472934,
+          "score": 0.03681102
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00110973,
-          "spread": 0.00687626,
-          "score": 0.00696523
+          "bias": 0.00086244,
+          "spread": 0.00727424,
+          "score": 0.00732519
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00144456,
-          "spread": 0.00147999,
-          "score": 0.00206812
+          "bias": 0.00119381,
+          "spread": 0.00103158,
+          "score": 0.00157776
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.0021806,
-          "spread": 0.00271443,
-          "score": 0.00348183
+          "bias": 0.00193485,
+          "spread": 0.00233102,
+          "score": 0.0030294
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.0105824,
-          "spread": 0.00544087,
-          "score": 0.01189917
+          "bias": 0.01034117,
+          "spread": 0.00579968,
+          "score": 0.01185648
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01602369,
-          "spread": 0.00532306,
-          "score": 0.01688471
+          "bias": 0.01578272,
+          "spread": 0.00556512,
+          "score": 0.01673514
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.01533729,
-          "spread": 0.01243233,
-          "score": 0.01974323
+          "bias": 0.01509943,
+          "spread": 0.01253685,
+          "score": 0.01962563
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.08294855,
-          "spread": 0.06763538,
-          "score": 0.10702806
+          "bias": 0.08266184,
+          "spread": 0.06712638,
+          "score": 0.10648441
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.04738599,
-          "spread": 0.35008831,
-          "score": 0.3532807
+          "bias": 0.04713599,
+          "spread": 0.35043617,
+          "score": 0.35359201
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.11330722,
-          "spread": 0.36779921,
-          "score": 0.38485684
+          "bias": -0.11349276,
+          "spread": 0.3678401,
+          "score": 0.38495058
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.03962063,
-          "spread": 0.17311704,
-          "score": 0.17759309
+          "bias": -0.0398477,
+          "spread": 0.17322516,
+          "score": 0.17774925
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00484145,
-          "spread": 0.00423425,
-          "score": 0.00643184
+          "bias": 0.00459658,
+          "spread": 0.00425564,
+          "score": 0.00626411
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00064382,
-          "spread": 0.00480998,
-          "score": 0.00485287
+          "bias": -0.00090332,
+          "spread": 0.00511762,
+          "score": 0.00519673
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00363597,
-          "spread": 0.00357965,
-          "score": 0.00510237
+          "bias": 0.00337181,
+          "spread": 0.00411521,
+          "score": 0.00532015
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00218426,
-          "spread": 0.00026938,
-          "score": 0.0022008
+          "bias": 0.00191846,
+          "spread": 0.00048359,
+          "score": 0.00197847
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00252881,
-          "spread": 0.0024311,
-          "score": 0.00350787
+          "bias": 0.00253225,
+          "spread": 0.00243456,
+          "score": 0.00351275
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.05530105,
-          "spread": 0.03036177,
-          "score": 0.06308758
+          "bias": -0.05547736,
+          "spread": 0.03051969,
+          "score": 0.06331815
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00597259,
-          "spread": 0.00519295,
-          "score": 0.00791446
+          "bias": 0.00597601,
+          "spread": 0.00519317,
+          "score": 0.00791718
         },
         {
           "profile": "cp_minus_10pct",
@@ -1945,198 +1945,198 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00894666,
-          "spread": 0.00757995,
-          "score": 0.01172596
+          "bias": 0.00870795,
+          "spread": 0.0078863,
+          "score": 0.01174828
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00288945,
-          "spread": 0.00506077,
-          "score": 0.00582754
+          "bias": 0.00264926,
+          "spread": 0.00498491,
+          "score": 0.00564516
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00559829,
-          "spread": 0.00594802,
-          "score": 0.00816821
+          "bias": 0.00535591,
+          "spread": 0.00566839,
+          "score": 0.00779849
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00115185,
-          "spread": 0.00314342,
-          "score": 0.00334782
+          "bias": 0.00097754,
+          "spread": 0.00314893,
+          "score": 0.00329717
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": -0.00761767,
-          "spread": 0.05319564,
-          "score": 0.05373831
+          "bias": -0.00779199,
+          "spread": 0.05333077,
+          "score": 0.053897
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00123415,
-          "spread": 0.00490307,
-          "score": 0.00505601
+          "bias": 0.0010625,
+          "spread": 0.00492228,
+          "score": 0.00503565
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00055843,
-          "spread": 0.00225181,
-          "score": 0.00232002
+          "bias": -0.00073497,
+          "spread": 0.00227514,
+          "score": 0.0023909
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00047751,
-          "spread": 0.00395629,
-          "score": 0.003985
+          "bias": -0.00065174,
+          "spread": 0.00401019,
+          "score": 0.00406281
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00599929,
-          "spread": 0.00407075,
-          "score": 0.00725
+          "bias": 0.00582694,
+          "spread": 0.00395536,
+          "score": 0.00704259
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01247258,
-          "spread": 0.00558814,
-          "score": 0.01366721
+          "bias": 0.01230225,
+          "spread": 0.0055467,
+          "score": 0.01349486
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00718812,
-          "spread": 0.01115189,
-          "score": 0.01326777
+          "bias": 0.00702351,
+          "spread": 0.01124733,
+          "score": 0.01326017
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.05504582,
-          "spread": 0.0399913,
-          "score": 0.0680393
+          "bias": 0.05487994,
+          "spread": 0.0401757,
+          "score": 0.06801393
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.34068611,
-          "spread": 0.32185845,
-          "score": 0.46867887
+          "bias": 0.34052245,
+          "spread": 0.32206677,
+          "score": 0.46870305
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.08505467,
-          "spread": 0.98968656,
-          "score": 0.99333468
+          "bias": 0.08474781,
+          "spread": 0.98931103,
+          "score": 0.99293429
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.08485712,
-          "spread": 0.08811283,
-          "score": 0.12232989
+          "bias": -0.08502469,
+          "spread": 0.08820205,
+          "score": 0.12251041
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00470364,
-          "spread": 0.00202454,
-          "score": 0.00512084
+          "bias": 0.00452955,
+          "spread": 0.00219414,
+          "score": 0.005033
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00252129,
-          "spread": 0.00299195,
-          "score": 0.00391263
+          "bias": -0.00270601,
+          "spread": 0.00293256,
+          "score": 0.00399029
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.0003183,
-          "spread": 0.00201614,
-          "score": 0.00204111
+          "bias": 0.00013167,
+          "spread": 0.00183011,
+          "score": 0.00183484
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00046224,
-          "spread": 0.00168233,
-          "score": 0.00174468
+          "bias": -0.00064817,
+          "spread": 0.00154807,
+          "score": 0.00167828
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00185323,
-          "spread": 0.00529107,
-          "score": 0.00560623
+          "bias": 0.00166749,
+          "spread": 0.00518623,
+          "score": 0.00544771
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.06918067,
-          "spread": 0.03128142,
-          "score": 0.07592425
+          "bias": -0.06933853,
+          "spread": 0.03116918,
+          "score": 0.07602203
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00637258,
-          "spread": 0.01400496,
-          "score": 0.01538664
+          "bias": 0.00625176,
+          "spread": 0.01389056,
+          "score": 0.0152326
         },
         {
           "profile": "cp_minus_10pct",
@@ -2161,36 +2161,36 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00150032,
-          "spread": 0.00729049,
-          "score": 0.00744327
+          "bias": 0.00133335,
+          "spread": 0.00734006,
+          "score": 0.00746018
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.0002125,
-          "spread": 0.00680629,
-          "score": 0.00680961
+          "bias": 4.587e-05,
+          "spread": 0.00683775,
+          "score": 0.00683791
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.0021475,
-          "spread": 0.00678806,
-          "score": 0.00711966
+          "bias": 0.00197953,
+          "spread": 0.00678731,
+          "score": 0.00707009
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00604154,
-          "spread": 0.01055613,
-          "score": 0.01216273
+          "bias": -0.00469195,
+          "spread": 0.01194394,
+          "score": 0.01283247
         },
         {
           "profile": "cp_plus_10pct",
@@ -2206,126 +2206,126 @@
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.01315747,
-          "spread": 0.02852693,
-          "score": 0.03141504
+          "bias": -0.01183134,
+          "spread": 0.02753973,
+          "score": 0.02997362
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.01177883,
-          "spread": 0.0185783,
-          "score": 0.0219976
+          "bias": -0.01047858,
+          "spread": 0.01762605,
+          "score": 0.02050557
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00678789,
-          "spread": 0.0098621,
-          "score": 0.01197232
+          "bias": -0.00547459,
+          "spread": 0.00902007,
+          "score": 0.01055143
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.0020751,
-          "spread": 0.01620303,
-          "score": 0.01633536
+          "bias": -0.00063854,
+          "spread": 0.02137087,
+          "score": 0.02138041
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00889415,
-          "spread": 0.03888923,
-          "score": 0.03989333
+          "bias": 0.01044726,
+          "spread": 0.04400131,
+          "score": 0.04522456
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.02515727,
-          "spread": 0.01759747,
-          "score": 0.03070113
+          "bias": 0.02645095,
+          "spread": 0.01221752,
+          "score": 0.02913624
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.37656574,
-          "spread": 0.75682527,
-          "score": 0.84533203
+          "bias": 0.37481256,
+          "spread": 0.74580223,
+          "score": 0.83468882
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.0539565,
-          "spread": 0.07101565,
-          "score": 0.08918815
+          "bias": 0.05526518,
+          "spread": 0.0694333,
+          "score": 0.08874245
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.07495366,
-          "spread": 0.10976303,
-          "score": 0.13291341
+          "bias": -0.07360408,
+          "spread": 0.107069,
+          "score": 0.12992817
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.06037622,
-          "spread": 0.08801493,
-          "score": 0.10673292
+          "bias": 0.06058593,
+          "spread": 0.08668893,
+          "score": 0.10576212
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00154462,
-          "spread": 0.01564615,
-          "score": 0.01572221
+          "bias": -0.00010262,
+          "spread": 0.01704862,
+          "score": 0.01704893
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.01273256,
-          "spread": 0.01712177,
-          "score": 0.02133713
+          "bias": 0.01415025,
+          "spread": 0.02027281,
+          "score": 0.02472279
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00517819,
-          "spread": 0.00701694,
-          "score": 0.00872072
+          "bias": 0.00454491,
+          "spread": 0.00952352,
+          "score": 0.01055242
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00468173,
-          "spread": 0.00841721,
-          "score": 0.00963162
+          "bias": 0.00593232,
+          "spread": 0.01058305,
+          "score": 0.01213233
         },
         {
           "profile": "cp_plus_10pct",
@@ -2341,9 +2341,9 @@
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.2269713,
-          "spread": 0.22117219,
-          "score": 0.31691183
+          "bias": -0.22540485,
+          "spread": 0.22408614,
+          "score": 0.3178395
         },
         {
           "profile": "cp_plus_10pct",
@@ -2377,171 +2377,171 @@
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00876836,
-          "spread": 0.02177186,
-          "score": 0.02347121
+          "bias": -0.00740667,
+          "spread": 0.01663434,
+          "score": 0.01820879
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.0043661,
-          "spread": 0.01529442,
-          "score": 0.01590541
+          "bias": -0.00293838,
+          "spread": 0.01317137,
+          "score": 0.01349515
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.01824157,
-          "spread": 0.01474993,
-          "score": 0.0234588
+          "bias": -0.01674733,
+          "spread": 0.01850757,
+          "score": 0.02496003
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 2,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.0003606,
-          "spread": 0.00564041,
-          "score": 0.00565192
+          "bias": -0.000143,
+          "spread": 0.00210294,
+          "score": 0.00210779
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": -0.01800805,
+          "bias": -0.02410521,
           "spread": 0.0,
-          "score": 0.01800805
+          "score": 0.02410521
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00157322,
-          "spread": 0.00590996,
-          "score": 0.00611577
+          "bias": 0.00112329,
+          "spread": 0.00539854,
+          "score": 0.00551417
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00649161,
-          "spread": 0.00803883,
-          "score": 0.01033266
+          "bias": 0.00598755,
+          "spread": 0.00492891,
+          "score": 0.00775531
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.0022193,
-          "spread": 0.00542093,
-          "score": 0.00585762
+          "bias": -0.00273527,
+          "spread": 0.00184098,
+          "score": 0.00329711
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00204945,
-          "spread": 0.00722553,
-          "score": 0.00751057
+          "bias": -0.00254773,
+          "spread": 0.00847217,
+          "score": 0.00884695
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": -0.00819376,
-          "spread": 0.01493015,
-          "score": 0.01703077
+          "bias": -0.00869157,
+          "spread": 0.01618636,
+          "score": 0.01837231
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.01214767,
-          "spread": 0.04042336,
-          "score": 0.04220917
+          "bias": -0.01281785,
+          "spread": 0.03652753,
+          "score": 0.03871121
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.05797451,
-          "spread": 0.18055122,
-          "score": 0.18963066
+          "bias": 0.05697448,
+          "spread": 0.17676222,
+          "score": 0.18571745
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.55956574,
-          "spread": 1.25891634,
-          "score": 1.37767346
+          "bias": 0.55560599,
+          "spread": 1.25014731,
+          "score": 1.36805201
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.58682211,
-          "spread": 1.38770025,
-          "score": 1.50667587
+          "bias": -0.58740532,
+          "spread": 1.38642467,
+          "score": 1.50572852
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.05927014,
-          "spread": 0.17362776,
-          "score": 0.18346539
+          "bias": -0.05952708,
+          "spread": 0.17237241,
+          "score": 0.18236151
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00131667,
-          "spread": 0.00808126,
-          "score": 0.00818782
+          "bias": 0.00081631,
+          "spread": 0.00504223,
+          "score": 0.00510788
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00915274,
-          "spread": 0.00304398,
-          "score": 0.00964565
+          "bias": 0.00870059,
+          "spread": 0.00354589,
+          "score": 0.00939541
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.0121763,
-          "spread": 0.00698466,
-          "score": 0.01403737
+          "bias": 0.01174878,
+          "spread": 0.00978823,
+          "score": 0.01529193
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00227728,
-          "spread": 0.00414682,
-          "score": 0.00473097
+          "bias": 0.00174157,
+          "spread": 0.00321896,
+          "score": 0.00365989
         },
         {
           "profile": "cp_plus_10pct",
@@ -2557,9 +2557,9 @@
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.11394909,
-          "spread": 0.12441176,
-          "score": 0.16870886
+          "bias": -0.11436811,
+          "spread": 0.1258265,
+          "score": 0.17003638
         },
         {
           "profile": "cp_plus_10pct",
@@ -2593,171 +2593,171 @@
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.01017839,
-          "spread": 0.0187558,
-          "score": 0.02133962
+          "bias": -0.01070192,
+          "spread": 0.01629203,
+          "score": 0.0194926
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00146992,
-          "spread": 0.00527274,
-          "score": 0.0054738
+          "bias": 0.00097016,
+          "spread": 0.00260805,
+          "score": 0.00278265
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00654679,
-          "spread": 0.00855949,
-          "score": 0.01077615
+          "bias": -0.00705348,
+          "spread": 0.00539847,
+          "score": 0.00888229
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00137479,
-          "spread": 0.00241035,
-          "score": 0.00277486
+          "bias": 0.00212598,
+          "spread": 0.00200595,
+          "score": 0.00292295
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.02362693,
-          "spread": 0.04956016,
-          "score": 0.05490393
+          "bias": 0.02432769,
+          "spread": 0.04824485,
+          "score": 0.05403149
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00752838,
-          "spread": 0.01309689,
-          "score": 0.01510646
+          "bias": -0.00678365,
+          "spread": 0.01397744,
+          "score": 0.01553663
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00717892,
-          "spread": 0.00462602,
-          "score": 0.00854031
+          "bias": 0.00792635,
+          "spread": 0.00474793,
+          "score": 0.00923958
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00239148,
-          "spread": 0.00185008,
-          "score": 0.00302357
+          "bias": -0.00163901,
+          "spread": 0.00092577,
+          "score": 0.00188239
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00226828,
-          "spread": 0.01153174,
-          "score": 0.01175271
+          "bias": -0.0015104,
+          "spread": 0.0107487,
+          "score": 0.0108543
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": -0.00033763,
-          "spread": 0.02421819,
-          "score": 0.02422054
+          "bias": 0.00041885,
+          "spread": 0.02340324,
+          "score": 0.02340698
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.03211586,
-          "spread": 0.04904209,
-          "score": 0.05862214
+          "bias": -0.03139311,
+          "spread": 0.04830336,
+          "score": 0.05760852
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.08609015,
-          "spread": 0.12229098,
-          "score": 0.14955467
+          "bias": 0.0870453,
+          "spread": 0.12343032,
+          "score": 0.15103618
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.2637422,
-          "spread": 0.41265365,
-          "score": 0.48973767
+          "bias": 0.2647784,
+          "spread": 0.41353729,
+          "score": 0.49104042
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.02555113,
-          "spread": 0.34298784,
-          "score": 0.34393825
+          "bias": 0.02631242,
+          "spread": 0.34255724,
+          "score": 0.34356631
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.15236211,
-          "spread": 0.19532295,
-          "score": 0.24772014
+          "bias": -0.15160465,
+          "spread": 0.19594565,
+          "score": 0.24774718
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00174937,
-          "spread": 0.00488448,
-          "score": 0.0051883
+          "bias": -0.00096757,
+          "spread": 0.00562117,
+          "score": 0.00570384
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.01013887,
-          "spread": 0.00882258,
-          "score": 0.01344004
+          "bias": 0.01088502,
+          "spread": 0.00973044,
+          "score": 0.01460017
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.01128934,
-          "spread": 0.01304546,
-          "score": 0.01725205
+          "bias": 0.01202921,
+          "spread": 0.01393978,
+          "score": 0.01841248
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00185811,
-          "spread": 0.00640594,
-          "score": 0.00666998
+          "bias": 0.00196343,
+          "spread": 0.00697011,
+          "score": 0.00724138
         },
         {
           "profile": "cp_plus_10pct",
@@ -2773,9 +2773,9 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.13996786,
-          "spread": 0.15773505,
-          "score": 0.21088231
+          "bias": -0.13931806,
+          "spread": 0.15706699,
+          "score": 0.20995133
         },
         {
           "profile": "cp_plus_10pct",
@@ -2809,198 +2809,198 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00080708,
-          "spread": 0.01825128,
-          "score": 0.01826912
+          "bias": 0.00158444,
+          "spread": 0.01735787,
+          "score": 0.01743003
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00256626,
-          "spread": 0.00945253,
-          "score": 0.00979469
+          "bias": -0.00178427,
+          "spread": 0.00855715,
+          "score": 0.0087412
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00398075,
-          "spread": 0.00780345,
-          "score": 0.00876015
+          "bias": -0.00319842,
+          "spread": 0.00694432,
+          "score": 0.00764548
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00457547,
-          "spread": 0.00205215,
-          "score": 0.00501461
+          "bias": 0.00429025,
+          "spread": 0.00199037,
+          "score": 0.00472946
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": -0.02650066,
-          "spread": 0.00053702,
-          "score": 0.0265061
+          "bias": -0.02733038,
+          "spread": 0.00040759,
+          "score": 0.02733342
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00227638,
-          "spread": 0.00986092,
-          "score": 0.01012026
+          "bias": -0.00255399,
+          "spread": 0.01005694,
+          "score": 0.01037617
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00581942,
-          "spread": 0.00258988,
-          "score": 0.0063697
+          "bias": 0.00553741,
+          "spread": 0.00253475,
+          "score": 0.00608999
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00241532,
-          "spread": 0.00193715,
-          "score": 0.00309618
+          "bias": 0.00212834,
+          "spread": 0.00171649,
+          "score": 0.00273426
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00558352,
-          "spread": 0.00682675,
-          "score": 0.00881931
+          "bias": 0.00529424,
+          "spread": 0.00708546,
+          "score": 0.00884493
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01028672,
-          "spread": 0.00878575,
-          "score": 0.01352797
+          "bias": 0.00999188,
+          "spread": 0.00875746,
+          "score": 0.01328649
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.0102467,
-          "spread": 0.01499992,
-          "score": 0.0181657
+          "bias": 0.00995047,
+          "spread": 0.01508469,
+          "score": 0.01807096
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.07556166,
-          "spread": 0.08457475,
-          "score": 0.11341276
+          "bias": 0.07519876,
+          "spread": 0.08392379,
+          "score": 0.11268565
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.17906305,
-          "spread": 0.1481549,
-          "score": 0.23240794
+          "bias": 0.17891076,
+          "spread": 0.14836137,
+          "score": 0.23242237
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.02634082,
-          "spread": 0.50544443,
-          "score": 0.50613033
+          "bias": -0.0264906,
+          "spread": 0.50542915,
+          "score": 0.50612289
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.11121012,
-          "spread": 0.15069998,
-          "score": 0.18729168
+          "bias": -0.11143518,
+          "spread": 0.15069907,
+          "score": 0.18742467
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00110307,
-          "spread": 0.00316256,
-          "score": 0.00334941
+          "bias": -0.00139031,
+          "spread": 0.00330379,
+          "score": 0.00358441
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00956147,
-          "spread": 0.00371826,
-          "score": 0.01025901
+          "bias": 0.00928992,
+          "spread": 0.00407704,
+          "score": 0.01014519
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00820904,
-          "spread": 0.00436785,
-          "score": 0.00929873
+          "bias": 0.00794194,
+          "spread": 0.00468697,
+          "score": 0.00922182
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00455452,
-          "spread": 0.00386591,
-          "score": 0.00597402
+          "bias": 0.00428741,
+          "spread": 0.00396771,
+          "score": 0.00584163
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": -9.778e-05,
-          "spread": 0.00342619,
-          "score": 0.00342759
+          "bias": -9.463e-05,
+          "spread": 0.00343065,
+          "score": 0.00343196
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.17581003,
-          "spread": 0.1182412,
-          "score": 0.21187295
+          "bias": -0.17605219,
+          "spread": 0.11858627,
+          "score": 0.21226653
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00513268,
-          "spread": 0.00534076,
-          "score": 0.0074073
+          "bias": -0.00512954,
+          "spread": 0.00534205,
+          "score": 0.00740605
         },
         {
           "profile": "cp_plus_10pct",
@@ -3025,198 +3025,198 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.01015016,
-          "spread": 0.0091512,
-          "score": 0.01366639
+          "bias": 0.00985825,
+          "spread": 0.00956424,
+          "score": 0.01373535
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00403849,
-          "spread": 0.00433888,
-          "score": 0.0059275
+          "bias": 0.00374439,
+          "spread": 0.00423365,
+          "score": 0.00565192
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00296652,
-          "spread": 0.00707519,
-          "score": 0.00767193
+          "bias": 0.00267047,
+          "spread": 0.00663475,
+          "score": 0.00715201
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00114412,
-          "spread": 0.00353644,
-          "score": 0.00371691
+          "bias": 0.00094456,
+          "spread": 0.00354445,
+          "score": 0.00366815
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.00991364,
-          "spread": 0.04857429,
-          "score": 0.04957562
+          "bias": 0.00971409,
+          "spread": 0.04841127,
+          "score": 0.04937625
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00650031,
-          "spread": 0.00156636,
-          "score": 0.00668636
+          "bias": -0.00670118,
+          "spread": 0.00167178,
+          "score": 0.00690657
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.000855,
-          "spread": 0.00255201,
-          "score": 0.00269143
+          "bias": 0.00065821,
+          "spread": 0.00255107,
+          "score": 0.00263461
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00065072,
-          "spread": 0.0042328,
-          "score": 0.00428253
+          "bias": 0.00045186,
+          "spread": 0.0042961,
+          "score": 0.0043198
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00224771,
-          "spread": 0.00539659,
-          "score": 0.00584597
+          "bias": 0.00204379,
+          "spread": 0.00528983,
+          "score": 0.00567093
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00735666,
-          "spread": 0.00765538,
-          "score": 0.01061722
+          "bias": 0.00714932,
+          "spread": 0.00759208,
+          "score": 0.01042844
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00282425,
-          "spread": 0.01515655,
-          "score": 0.01541743
+          "bias": -0.00302996,
+          "spread": 0.01528507,
+          "score": 0.01558249
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.05148816,
-          "spread": 0.05211119,
-          "score": 0.07325713
+          "bias": 0.05127752,
+          "spread": 0.0523248,
+          "score": 0.07326165
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.41293776,
-          "spread": 0.46189709,
-          "score": 0.61956962
+          "bias": 0.41272246,
+          "spread": 0.46218289,
+          "score": 0.61963929
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.78623224,
-          "spread": 0.81223859,
-          "score": 1.13043915
+          "bias": 0.78581652,
+          "spread": 0.81202171,
+          "score": 1.12999419
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.12673658,
-          "spread": 0.11609313,
-          "score": 0.17187139
+          "bias": -0.12688772,
+          "spread": 0.11616809,
+          "score": 0.17203348
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00245583,
-          "spread": 0.00414125,
-          "score": 0.00481467
+          "bias": -0.00265643,
+          "spread": 0.00414965,
+          "score": 0.00492709
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00544503,
-          "spread": 0.0024832,
-          "score": 0.00598454
+          "bias": 0.00525397,
+          "spread": 0.00233223,
+          "score": 0.00574835
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00345875,
-          "spread": 0.00249175,
-          "score": 0.00426284
+          "bias": 0.00326977,
+          "spread": 0.00239038,
+          "score": 0.00405034
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00133069,
-          "spread": 0.00102921,
-          "score": 0.00168226
+          "bias": 0.00114216,
+          "spread": 0.00096137,
+          "score": 0.0014929
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00067691,
-          "spread": 0.0018322,
-          "score": 0.00195324
+          "bias": 0.00048834,
+          "spread": 0.00178031,
+          "score": 0.00184607
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.17608435,
-          "spread": 0.11218495,
-          "score": 0.20878496
+          "bias": -0.17628527,
+          "spread": 0.11198741,
+          "score": 0.20884845
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00183514,
-          "spread": 0.01060477,
-          "score": 0.01076238
+          "bias": -0.00195877,
+          "spread": 0.01052302,
+          "score": 0.01070377
         },
         {
           "profile": "cp_plus_10pct",
@@ -3241,36 +3241,36 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00232474,
-          "spread": 0.00772591,
-          "score": 0.00806809
+          "bias": 0.00211588,
+          "spread": 0.00779494,
+          "score": 0.008077
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00146797,
-          "spread": 0.00705313,
-          "score": 0.00720428
+          "bias": 0.00126096,
+          "spread": 0.00711571,
+          "score": 0.00722657
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00015515,
-          "spread": 0.00762341,
-          "score": 0.00762499
+          "bias": -0.00036179,
+          "spread": 0.00767475,
+          "score": 0.00768327
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 1,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00568163,
-          "spread": 0.0100431,
-          "score": 0.01153884
+          "bias": -0.00439617,
+          "spread": 0.01138418,
+          "score": 0.01220352
         },
         {
           "profile": "cp_plus_3pct",
@@ -3286,126 +3286,126 @@
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.01315547,
-          "spread": 0.01750782,
-          "score": 0.02189955
+          "bias": -0.0119045,
+          "spread": 0.01641695,
+          "score": 0.02027889
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.0107483,
-          "spread": 0.01588643,
-          "score": 0.01918084
+          "bias": -0.00950126,
+          "spread": 0.01497505,
+          "score": 0.01773488
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00631092,
-          "spread": 0.01003108,
-          "score": 0.01185117
+          "bias": -0.00505324,
+          "spread": 0.00906611,
+          "score": 0.01037929
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00114023,
-          "spread": 0.01589535,
-          "score": 0.01593619
+          "bias": 0.00021936,
+          "spread": 0.02046972,
+          "score": 0.02047089
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00915887,
-          "spread": 0.03632492,
-          "score": 0.03746178
+          "bias": 0.01062367,
+          "spread": 0.041,
+          "score": 0.04235401
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.02875476,
-          "spread": 0.02035436,
-          "score": 0.03522977
+          "bias": 0.02997211,
+          "spread": 0.01458547,
+          "score": 0.03333262
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.35333888,
-          "spread": 0.69432505,
-          "score": 0.77906075
+          "bias": 0.35172262,
+          "spread": 0.68430453,
+          "score": 0.76940333
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.04295883,
-          "spread": 0.05709694,
-          "score": 0.07145293
+          "bias": 0.04421058,
+          "spread": 0.05556986,
+          "score": 0.07101116
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.02635527,
-          "spread": 0.03761242,
-          "score": 0.04592706
+          "bias": -0.02506981,
+          "spread": 0.03559301,
+          "score": 0.0435357
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.01077001,
-          "spread": 0.09407371,
-          "score": 0.0946882
+          "bias": 0.01092556,
+          "spread": 0.09237206,
+          "score": 0.09301595
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.001066,
-          "spread": 0.01726563,
-          "score": 0.0172985
+          "bias": 0.0024454,
+          "spread": 0.01845628,
+          "score": 0.01861758
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.0090542,
-          "spread": 0.01758544,
-          "score": 0.01977944
+          "bias": 0.01045876,
+          "spread": 0.02071901,
+          "score": 0.02320912
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00501732,
-          "spread": 0.00708605,
-          "score": 0.00868249
+          "bias": 0.00439218,
+          "spread": 0.01023117,
+          "score": 0.01113409
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00546753,
-          "spread": 0.00956225,
-          "score": 0.01101501
+          "bias": 0.00672007,
+          "spread": 0.0117317,
+          "score": 0.01352006
         },
         {
           "profile": "cp_plus_3pct",
@@ -3421,9 +3421,9 @@
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.17074409,
-          "spread": 0.16384509,
-          "score": 0.23664056
+          "bias": -0.16921733,
+          "spread": 0.16596429,
+          "score": 0.23702036
         },
         {
           "profile": "cp_plus_3pct",
@@ -3457,171 +3457,171 @@
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00982797,
-          "spread": 0.0212703,
-          "score": 0.02343106
+          "bias": -0.00856405,
+          "spread": 0.01612098,
+          "score": 0.01825456
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00513185,
-          "spread": 0.01546382,
-          "score": 0.01629312
+          "bias": -0.00380029,
+          "spread": 0.013311,
+          "score": 0.01384287
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.01644368,
-          "spread": 0.01425705,
-          "score": 0.02176368
+          "bias": -0.01503693,
+          "spread": 0.0180019,
+          "score": 0.02345586
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00038958,
-          "spread": 0.00536804,
-          "score": 0.00538215
+          "bias": -9.481e-05,
+          "spread": 0.00198906,
+          "score": 0.00199132
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.00017032,
+          "bias": -0.00563693,
           "spread": 0.0,
-          "score": 0.00017032
+          "score": 0.00563693
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00448897,
-          "spread": 0.00327465,
-          "score": 0.00555645
+          "bias": 0.00403418,
+          "spread": 0.00482131,
+          "score": 0.00628646
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00348424,
-          "spread": 0.00644256,
-          "score": 0.00732438
+          "bias": 0.00299665,
+          "spread": 0.00280111,
+          "score": 0.00410196
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.0017404,
-          "spread": 0.0062089,
-          "score": 0.00644821
+          "bias": -0.00223153,
+          "spread": 0.00257462,
+          "score": 0.00340711
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00039129,
-          "spread": 0.00451747,
-          "score": 0.00453439
+          "bias": -7.599e-05,
+          "spread": 0.00644377,
+          "score": 0.00644422
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": -0.00392525,
-          "spread": 0.01380187,
-          "score": 0.01434919
+          "bias": -0.00438893,
+          "spread": 0.01486293,
+          "score": 0.0154974
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00679505,
-          "spread": 0.03924455,
-          "score": 0.03982847
+          "bias": -0.00741036,
+          "spread": 0.03565876,
+          "score": 0.03642061
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.06907202,
-          "spread": 0.162945,
-          "score": 0.17698027
+          "bias": 0.0681238,
+          "spread": 0.15929001,
+          "score": 0.17324595
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.54021744,
-          "spread": 1.21438733,
-          "score": 1.32912432
+          "bias": 0.53615497,
+          "spread": 1.20532024,
+          "score": 1.31918878
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.24747673,
-          "spread": 0.54119802,
-          "score": 0.59509665
+          "bias": -0.24808964,
+          "spread": 0.54010193,
+          "score": 0.59435559
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.03215046,
-          "spread": 0.13498696,
-          "score": 0.13876286
+          "bias": -0.03227703,
+          "spread": 0.13394449,
+          "score": 0.13777857
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00270791,
-          "spread": 0.01050771,
-          "score": 0.01085103
+          "bias": 0.00223178,
+          "spread": 0.00847151,
+          "score": 0.00876055
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00493222,
-          "spread": 0.00371496,
-          "score": 0.00617477
+          "bias": 0.00448531,
+          "spread": 0.00422648,
+          "score": 0.00616288
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00946682,
-          "spread": 0.0057677,
-          "score": 0.01108544
+          "bias": 0.00903769,
+          "spread": 0.00864944,
+          "score": 0.0125097
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00228919,
-          "spread": 0.00402572,
-          "score": 0.00463107
+          "bias": 0.00175427,
+          "spread": 0.00309921,
+          "score": 0.00356126
         },
         {
           "profile": "cp_plus_3pct",
@@ -3637,9 +3637,9 @@
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.08231498,
-          "spread": 0.10584851,
-          "score": 0.13408827
+          "bias": -0.08268063,
+          "spread": 0.10667318,
+          "score": 0.1349639
         },
         {
           "profile": "cp_plus_3pct",
@@ -3673,171 +3673,171 @@
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00925067,
-          "spread": 0.01623981,
-          "score": 0.01868974
+          "bias": -0.0097422,
+          "spread": 0.01365506,
+          "score": 0.01677413
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00196349,
-          "spread": 0.00466508,
-          "score": 0.00506145
+          "bias": 0.00149624,
+          "spread": 0.0024431,
+          "score": 0.00286487
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00460766,
-          "spread": 0.00805392,
-          "score": 0.00927881
+          "bias": -0.00508158,
+          "spread": 0.00542516,
+          "score": 0.00743336
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00136341,
-          "spread": 0.00231393,
-          "score": 0.00268573
+          "bias": 0.00207983,
+          "spread": 0.00191886,
+          "score": 0.00282979
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.0093264,
-          "spread": 0.0161731,
-          "score": 0.01866951
+          "bias": 0.00999333,
+          "spread": 0.01491879,
+          "score": 0.01795653
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00815,
-          "spread": 0.01212394,
-          "score": 0.01460864
+          "bias": -0.00743106,
+          "spread": 0.01301777,
+          "score": 0.01498943
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00456248,
-          "spread": 0.00395133,
-          "score": 0.00603566
+          "bias": 0.00527989,
+          "spread": 0.00412656,
+          "score": 0.00670118
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00145666,
-          "spread": 0.00146365,
-          "score": 0.00206497
+          "bias": -0.00074092,
+          "spread": 0.00077031,
+          "score": 0.00106881
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00023099,
-          "spread": 0.01060525,
-          "score": 0.01060776
+          "bias": 0.00048246,
+          "spread": 0.00986633,
+          "score": 0.00987812
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00311785,
-          "spread": 0.0207634,
-          "score": 0.02099619
+          "bias": 0.00382816,
+          "spread": 0.01998145,
+          "score": 0.02034485
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.02837009,
-          "spread": 0.04815151,
-          "score": 0.05588766
+          "bias": -0.02769804,
+          "spread": 0.04748526,
+          "score": 0.05497301
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.08245004,
-          "spread": 0.10047517,
-          "score": 0.12997411
+          "bias": 0.08332488,
+          "spread": 0.10152053,
+          "score": 0.13133718
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.21600857,
-          "spread": 0.38612106,
-          "score": 0.4424355
+          "bias": 0.21699704,
+          "spread": 0.38683321,
+          "score": 0.44353991
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.01707768,
-          "spread": 0.1409623,
-          "score": 0.14199302
+          "bias": -0.01637192,
+          "spread": 0.14071456,
+          "score": 0.14166378
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.14762292,
-          "spread": 0.18974688,
-          "score": 0.24040882
+          "bias": -0.1469163,
+          "spread": 0.19036642,
+          "score": 0.24046574
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00077978,
-          "spread": 0.00585846,
-          "score": 0.00591013
+          "bias": 0.00152194,
+          "spread": 0.00671352,
+          "score": 0.00688387
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00691031,
-          "spread": 0.00815771,
-          "score": 0.01069115
+          "bias": 0.00764462,
+          "spread": 0.00905606,
+          "score": 0.01185126
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.01008349,
-          "spread": 0.0113212,
-          "score": 0.01516069
+          "bias": 0.01081963,
+          "spread": 0.01221931,
+          "score": 0.01632102
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00168652,
-          "spread": 0.00435875,
-          "score": 0.00467366
+          "bias": 0.00178992,
+          "spread": 0.00491239,
+          "score": 0.00522832
         },
         {
           "profile": "cp_plus_3pct",
@@ -3853,9 +3853,9 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.10734297,
-          "spread": 0.13021817,
-          "score": 0.16875806
+          "bias": -0.10674433,
+          "spread": 0.1296133,
+          "score": 0.16791057
         },
         {
           "profile": "cp_plus_3pct",
@@ -3889,198 +3889,198 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -3.394e-05,
-          "spread": 0.016776,
-          "score": 0.01677604
+          "bias": 0.00069539,
+          "spread": 0.01592819,
+          "score": 0.01594336
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00340328,
-          "spread": 0.00922481,
-          "score": 0.00983257
+          "bias": -0.00267247,
+          "spread": 0.00838137,
+          "score": 0.00879713
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00253841,
-          "spread": 0.00771319,
-          "score": 0.00812015
+          "bias": -0.00180633,
+          "spread": 0.00688155,
+          "score": 0.00711467
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00443746,
-          "spread": 0.00195932,
-          "score": 0.00485077
+          "bias": 0.0041658,
+          "spread": 0.0019026,
+          "score": 0.00457971
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": -0.00419631,
-          "spread": 0.00126739,
-          "score": 0.00438353
+          "bias": -0.00498778,
+          "spread": 0.00139039,
+          "score": 0.00517795
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00125783,
-          "spread": 0.00882422,
-          "score": 0.00891342
+          "bias": -0.00152457,
+          "spread": 0.00906666,
+          "score": 0.00919394
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00442293,
-          "spread": 0.00182889,
-          "score": 0.00478614
+          "bias": 0.00415217,
+          "spread": 0.00166809,
+          "score": 0.00447471
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.0023726,
-          "spread": 0.00218227,
-          "score": 0.0032236
+          "bias": 0.00210046,
+          "spread": 0.0019221,
+          "score": 0.00284717
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00712826,
-          "spread": 0.0062564,
-          "score": 0.00948444
+          "bias": 0.00685607,
+          "spread": 0.00653411,
+          "score": 0.00947102
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01200202,
-          "spread": 0.00824529,
-          "score": 0.01456136
+          "bias": 0.0117261,
+          "spread": 0.00824527,
+          "score": 0.01433478
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.0118926,
-          "spread": 0.01383698,
-          "score": 0.01824544
+          "bias": 0.01161672,
+          "spread": 0.01389687,
+          "score": 0.01811273
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.07627726,
-          "spread": 0.07724377,
-          "score": 0.10855791
+          "bias": 0.07594199,
+          "spread": 0.07663768,
+          "score": 0.10789124
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.23502045,
-          "spread": 0.06549226,
-          "score": 0.24397509
+          "bias": 0.23474401,
+          "spread": 0.06581688,
+          "score": 0.24379625
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.07199009,
-          "spread": 0.38200234,
-          "score": 0.38872659
+          "bias": 0.07183687,
+          "spread": 0.38219821,
+          "score": 0.38889074
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.08542429,
-          "spread": 0.14077034,
-          "score": 0.16466207
+          "bias": -0.0856476,
+          "spread": 0.14083605,
+          "score": 0.16483418
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00096588,
-          "spread": 0.00320421,
-          "score": 0.00334662
+          "bias": 0.000694,
+          "spread": 0.00336234,
+          "score": 0.00343321
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00620701,
-          "spread": 0.00434584,
-          "score": 0.00757715
+          "bias": 0.00594007,
+          "spread": 0.004697,
+          "score": 0.00757273
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.0070037,
-          "spread": 0.00394883,
-          "score": 0.00804022
+          "bias": 0.0067378,
+          "spread": 0.00434097,
+          "score": 0.00801511
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00393723,
-          "spread": 0.00258257,
-          "score": 0.00470865
+          "bias": 0.0036708,
+          "spread": 0.0026814,
+          "score": 0.00454584
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00076265,
-          "spread": 0.00228925,
-          "score": 0.00241294
+          "bias": 0.00076609,
+          "spread": 0.00229501,
+          "score": 0.0024195
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.13503354,
-          "spread": 0.08325248,
-          "score": 0.1586349
+          "bias": -0.13525279,
+          "spread": 0.08355395,
+          "score": 0.15897981
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00163125,
-          "spread": 0.00157234,
-          "score": 0.00226566
+          "bias": -0.00162782,
+          "spread": 0.00157318,
+          "score": 0.00226378
         },
         {
           "profile": "cp_plus_3pct",
@@ -4105,198 +4105,198 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00895324,
-          "spread": 0.00791612,
-          "score": 0.01195096
+          "bias": 0.00868027,
+          "spread": 0.00829367,
+          "score": 0.0120055
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00367902,
-          "spread": 0.00472195,
-          "score": 0.00598598
+          "bias": 0.00340415,
+          "spread": 0.00463935,
+          "score": 0.00575429
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00431854,
-          "spread": 0.00680793,
-          "score": 0.00806212
+          "bias": 0.0040414,
+          "spread": 0.00641583,
+          "score": 0.0075826
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00114635,
-          "spread": 0.00339926,
-          "score": 0.00358735
+          "bias": 0.00095838,
+          "spread": 0.00340711,
+          "score": 0.00353933
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.0037772,
-          "spread": 0.01315697,
-          "score": 0.01368843
+          "bias": 0.00358924,
+          "spread": 0.01298084,
+          "score": 0.01346792
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00372718,
-          "spread": 0.00218923,
-          "score": 0.00432257
+          "bias": -0.00391493,
+          "spread": 0.00223992,
+          "score": 0.00451042
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00029198,
-          "spread": 0.00245536,
-          "score": 0.00247266
+          "bias": 0.00010496,
+          "spread": 0.0024606,
+          "score": 0.00246283
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00036033,
-          "spread": 0.00412119,
-          "score": 0.00413692
+          "bias": 0.00017286,
+          "spread": 0.00418572,
+          "score": 0.00418929
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00350616,
-          "spread": 0.00505564,
-          "score": 0.00615245
+          "bias": 0.00331609,
+          "spread": 0.00494467,
+          "score": 0.00595367
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00912605,
-          "spread": 0.00691414,
-          "score": 0.01144946
+          "bias": 0.00893451,
+          "spread": 0.00686407,
+          "score": 0.01126681
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00075617,
-          "spread": 0.01308583,
-          "score": 0.01310766
+          "bias": 0.0005676,
+          "spread": 0.01321388,
+          "score": 0.01322606
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.05327346,
-          "spread": 0.04618211,
-          "score": 0.07050425
+          "bias": 0.05308157,
+          "spread": 0.04638832,
+          "score": 0.07049489
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.38960461,
-          "spread": 0.41924769,
-          "score": 0.57232891
+          "bias": 0.38941422,
+          "spread": 0.41951419,
+          "score": 0.57239461
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.54295983,
-          "spread": 0.67069861,
-          "score": 0.86292641
+          "bias": 0.54258562,
+          "spread": 0.67031848,
+          "score": 0.86239552
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.11591051,
-          "spread": 0.09247767,
-          "score": 0.14828137
+          "bias": -0.1160618,
+          "spread": 0.09257598,
+          "score": 0.14846094
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00022562,
-          "spread": 0.00308694,
-          "score": 0.00309517
+          "bias": 3.714e-05,
+          "spread": 0.00314493,
+          "score": 0.00314515
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00265481,
-          "spread": 0.00247048,
-          "score": 0.00362648
+          "bias": 0.00246877,
+          "spread": 0.00235425,
+          "score": 0.00341135
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00242673,
-          "spread": 0.00222316,
-          "score": 0.00329111
+          "bias": 0.00224106,
+          "spread": 0.00208432,
+          "score": 0.00306051
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00079047,
-          "spread": 0.0009978,
-          "score": 0.00127297
+          "bias": 0.0006053,
+          "spread": 0.00086439,
+          "score": 0.00105525
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00127691,
-          "spread": 0.0027559,
-          "score": 0.00303734
+          "bias": 0.00109137,
+          "spread": 0.0026612,
+          "score": 0.0028763
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.13867452,
-          "spread": 0.08177455,
-          "score": 0.16098975
+          "bias": -0.13885615,
+          "spread": 0.08159701,
+          "score": 0.1610562
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00105014,
-          "spread": 0.01205876,
-          "score": 0.0121044
+          "bias": 0.0009294,
+          "spread": 0.01197098,
+          "score": 0.012007
         },
         {
           "profile": "cp_plus_3pct",
@@ -4321,36 +4321,36 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00148064,
-          "spread": 0.00752839,
-          "score": 0.00767261
+          "bias": 0.00129039,
+          "spread": 0.00758716,
+          "score": 0.00769611
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00102792,
-          "spread": 0.00694896,
-          "score": 0.00702457
+          "bias": 0.0008376,
+          "spread": 0.0069967,
+          "score": 0.00704666
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00077954,
-          "spread": 0.00738644,
-          "score": 0.00742746
+          "bias": 0.00058924,
+          "spread": 0.00741597,
+          "score": 0.00743934
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 1,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00556888,
-          "spread": 0.0099739,
-          "score": 0.01142327
+          "bias": -0.00429532,
+          "spread": 0.01132593,
+          "score": 0.01211307
         },
         {
           "profile": "rated_plus_5pct",
@@ -4366,126 +4366,126 @@
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.01289789,
-          "spread": 0.00846594,
-          "score": 0.01542815
+          "bias": -0.01166879,
+          "spread": 0.00760779,
+          "score": 0.01392979
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.01007844,
-          "spread": 0.01380967,
-          "score": 0.01709626
+          "bias": -0.00883167,
+          "spread": 0.01299189,
+          "score": 0.01570947
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00658765,
-          "spread": 0.01126084,
-          "score": 0.01304621
+          "bias": -0.00533724,
+          "spread": 0.00988126,
+          "score": 0.01123056
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 3.775e-05,
-          "spread": 0.01608132,
-          "score": 0.01608136
+          "bias": 0.00137867,
+          "spread": 0.02047982,
+          "score": 0.02052618
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01124825,
-          "spread": 0.03594243,
-          "score": 0.03766141
+          "bias": 0.01268878,
+          "spread": 0.04054369,
+          "score": 0.04248289
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.03053361,
-          "spread": 0.02316792,
-          "score": 0.03832824
+          "bias": 0.03172024,
+          "spread": 0.01799025,
+          "score": 0.03646674
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.35264613,
-          "spread": 0.67299757,
-          "score": 0.75979275
+          "bias": 0.35107608,
+          "spread": 0.66333972,
+          "score": 0.75051583
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.04643265,
-          "spread": 0.05692117,
-          "score": 0.07345754
+          "bias": 0.04767943,
+          "spread": 0.05578568,
+          "score": 0.07338508
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.00819991,
-          "spread": 0.01277066,
-          "score": 0.01517657
+          "bias": 0.00947347,
+          "spread": 0.0138056,
+          "score": 0.01674339
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.00324452,
-          "spread": 0.08175568,
-          "score": 0.08182003
+          "bias": -0.00306368,
+          "spread": 0.08018205,
+          "score": 0.08024056
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00359966,
-          "spread": 0.01886135,
-          "score": 0.01920177
+          "bias": 0.00498047,
+          "spread": 0.02014487,
+          "score": 0.0207514
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00475625,
-          "spread": 0.01705226,
-          "score": 0.01770315
+          "bias": 0.00620483,
+          "spread": 0.01994082,
+          "score": 0.02088387
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.01855692,
-          "spread": 0.03119639,
-          "score": 0.0362984
+          "bias": -0.01921282,
+          "spread": 0.03165789,
+          "score": 0.03703181
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.030373,
-          "spread": 0.03325879,
-          "score": 0.04504072
+          "bias": -0.0290539,
+          "spread": 0.03554355,
+          "score": 0.04590722
         },
         {
           "profile": "rated_plus_5pct",
@@ -4501,9 +4501,9 @@
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.13957078,
-          "spread": 0.14427113,
-          "score": 0.20073406
+          "bias": -0.13798168,
+          "spread": 0.14622756,
+          "score": 0.20105085
         },
         {
           "profile": "rated_plus_5pct",
@@ -4537,171 +4537,171 @@
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00894436,
-          "spread": 0.01689006,
-          "score": 0.01911218
+          "bias": -0.00769699,
+          "spread": 0.01170382,
+          "score": 0.01400796
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00275039,
-          "spread": 0.01520935,
-          "score": 0.01545603
+          "bias": -0.00145192,
+          "spread": 0.01310958,
+          "score": 0.01318973
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.01209561,
-          "spread": 0.01311884,
-          "score": 0.01784399
+          "bias": -0.01071575,
+          "spread": 0.01720706,
+          "score": 0.02027091
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 2,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00041786,
-          "spread": 0.00533179,
-          "score": 0.00534813
+          "bias": -6.768e-05,
+          "spread": 0.00197783,
+          "score": 0.00197899
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.02149576,
+          "bias": 0.01573559,
           "spread": 0.0,
-          "score": 0.02149576
+          "score": 0.01573559
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00909011,
-          "spread": 0.00654999,
-          "score": 0.01120413
+          "bias": 0.00860206,
+          "spread": 0.00813336,
+          "score": 0.01183837
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00068268,
-          "spread": 0.00594326,
-          "score": 0.00598234
+          "bias": 0.00018983,
+          "spread": 0.00213707,
+          "score": 0.00214548
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00124245,
-          "spread": 0.0070082,
-          "score": 0.00711748
+          "bias": -0.00172647,
+          "spread": 0.00341232,
+          "score": 0.00382422
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00262419,
-          "spread": 0.00278699,
-          "score": 0.00382802
+          "bias": 0.00216844,
+          "spread": 0.00535884,
+          "score": 0.00578094
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00013252,
-          "spread": 0.0133952,
-          "score": 0.01339586
+          "bias": -0.00031951,
+          "spread": 0.01420288,
+          "score": 0.01420647
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00169578,
-          "spread": 0.04210453,
-          "score": 0.04213867
+          "bias": 0.00108924,
+          "spread": 0.03862968,
+          "score": 0.03864504
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.07333648,
-          "spread": 0.14929805,
-          "score": 0.16633744
+          "bias": 0.072443,
+          "spread": 0.14583978,
+          "score": 0.16284112
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.4882196,
-          "spread": 1.096562,
-          "score": 1.20033603
+          "bias": 0.48443694,
+          "spread": 1.08792974,
+          "score": 1.19091153
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.09095479,
-          "spread": 0.18638214,
-          "score": 0.20739112
+          "bias": -0.09159584,
+          "spread": 0.18544454,
+          "score": 0.206832
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.08155984,
-          "spread": 0.11260811,
-          "score": 0.1390417
+          "bias": -0.08180123,
+          "spread": 0.11021072,
+          "score": 0.13725103
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00583718,
-          "spread": 0.01211701,
-          "score": 0.0134497
+          "bias": 0.00537171,
+          "spread": 0.01077731,
+          "score": 0.01204183
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00310665,
-          "spread": 0.00425346,
-          "score": 0.00526718
+          "bias": 0.00264656,
+          "spread": 0.00536499,
+          "score": 0.00598226
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.0099272,
-          "spread": 0.00548776,
-          "score": 0.01134305
+          "bias": 0.00948237,
+          "spread": 0.00918408,
+          "score": 0.01320086
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.03388324,
-          "spread": 0.02705885,
-          "score": 0.04336191
+          "bias": -0.0344461,
+          "spread": 0.02608395,
+          "score": 0.04320771
         },
         {
           "profile": "rated_plus_5pct",
@@ -4717,9 +4717,9 @@
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.0644845,
-          "spread": 0.10534034,
-          "score": 0.12351048
+          "bias": -0.06480862,
+          "spread": 0.10600789,
+          "score": 0.12424907
         },
         {
           "profile": "rated_plus_5pct",
@@ -4753,171 +4753,171 @@
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.0054092,
-          "spread": 0.01467961,
-          "score": 0.0156445
+          "bias": -0.0058892,
+          "spread": 0.01173543,
+          "score": 0.01313023
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00330579,
-          "spread": 0.00623283,
-          "score": 0.00705523
+          "bias": 0.00284877,
+          "spread": 0.00395359,
+          "score": 0.00487302
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00191414,
-          "spread": 0.00735389,
-          "score": 0.00759893
+          "bias": -0.00237072,
+          "spread": 0.00523507,
+          "score": 0.00574685
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00138896,
-          "spread": 0.00231509,
-          "score": 0.00269979
+          "bias": 0.00210248,
+          "spread": 0.00191524,
+          "score": 0.00284404
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.01821258,
-          "spread": 0.00307466,
-          "score": 0.01847029
+          "bias": 0.01887461,
+          "spread": 0.00182765,
+          "score": 0.01896289
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00947169,
-          "spread": 0.0132848,
-          "score": 0.0163156
+          "bias": -0.00874719,
+          "spread": 0.01415732,
+          "score": 0.0166416
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00188512,
-          "spread": 0.0035837,
-          "score": 0.00404927
+          "bias": 0.00260535,
+          "spread": 0.00387762,
+          "score": 0.0046716
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00101903,
-          "spread": 0.00192669,
-          "score": 0.00217958
+          "bias": -0.00030891,
+          "spread": 0.00173394,
+          "score": 0.00176125
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00295491,
-          "spread": 0.01026796,
-          "score": 0.01068468
+          "bias": 0.00365485,
+          "spread": 0.00952956,
+          "score": 0.01020639
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00855126,
-          "spread": 0.01849163,
-          "score": 0.02037313
+          "bias": 0.00924583,
+          "spread": 0.01768662,
+          "score": 0.0199575
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.02446899,
-          "spread": 0.04096321,
-          "score": 0.04771495
+          "bias": -0.02381221,
+          "spread": 0.04030351,
+          "score": 0.04681233
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.08701918,
-          "spread": 0.10963875,
-          "score": 0.13997498
+          "bias": 0.08787258,
+          "spread": 0.11065361,
+          "score": 0.14130043
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.19481839,
-          "spread": 0.37567217,
-          "score": 0.42318292
+          "bias": 0.19576612,
+          "spread": 0.37626554,
+          "score": 0.42414636
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.01631716,
-          "spread": 0.05972684,
-          "score": 0.06191563
+          "bias": -0.01562161,
+          "spread": 0.05983304,
+          "score": 0.06183872
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.0586742,
-          "spread": 0.14834797,
-          "score": 0.15952987
+          "bias": -0.05790434,
+          "spread": 0.14894848,
+          "score": 0.1598079
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.0045,
-          "spread": 0.00868889,
-          "score": 0.00978503
+          "bias": 0.00523741,
+          "spread": 0.00956084,
+          "score": 0.01090138
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00363762,
-          "spread": 0.00794015,
-          "score": 0.00873374
+          "bias": 0.00439854,
+          "spread": 0.00888198,
+          "score": 0.00991145
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.01028658,
-          "spread": 0.01045967,
-          "score": 0.01467032
+          "bias": 0.0110598,
+          "spread": 0.01141504,
+          "score": 0.0158941
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.02325363,
-          "spread": 0.02635452,
-          "score": 0.03514672
+          "bias": -0.02314529,
+          "spread": 0.0265222,
+          "score": 0.0352013
         },
         {
           "profile": "rated_plus_5pct",
@@ -4933,9 +4933,9 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.09634471,
-          "spread": 0.10897946,
-          "score": 0.14546074
+          "bias": -0.09577588,
+          "spread": 0.10841197,
+          "score": 0.14465882
         },
         {
           "profile": "rated_plus_5pct",
@@ -4969,198 +4969,198 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00225066,
-          "spread": 0.01763,
-          "score": 0.01777308
+          "bias": 0.00295891,
+          "spread": 0.01682362,
+          "score": 0.01708184
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00165677,
-          "spread": 0.01060994,
-          "score": 0.01073851
+          "bias": -0.00094611,
+          "spread": 0.00976477,
+          "score": 0.0098105
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00033264,
-          "spread": 0.00820544,
-          "score": 0.00821218
+          "bias": 0.0010468,
+          "spread": 0.00734972,
+          "score": 0.0074239
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00446299,
-          "spread": 0.00193873,
-          "score": 0.0048659
+          "bias": 0.00419323,
+          "spread": 0.00188561,
+          "score": 0.00459769
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.02053612,
-          "spread": 0.00230878,
-          "score": 0.02066549
+          "bias": 0.0197497,
+          "spread": 0.00243129,
+          "score": 0.01989879
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00012301,
-          "spread": 0.00719517,
-          "score": 0.00719622
+          "bias": -0.00039059,
+          "spread": 0.00756681,
+          "score": 0.00757688
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00276849,
-          "spread": 0.0015796,
-          "score": 0.00318742
+          "bias": 0.00249706,
+          "spread": 0.00122747,
+          "score": 0.00278244
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00233664,
-          "spread": 0.00260934,
-          "score": 0.00350265
+          "bias": 0.00206773,
+          "spread": 0.0022421,
+          "score": 0.00305
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.01004388,
-          "spread": 0.0057077,
-          "score": 0.01155237
+          "bias": 0.00977751,
+          "spread": 0.00605682,
+          "score": 0.01150151
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01500004,
-          "spread": 0.00661009,
-          "score": 0.0163919
+          "bias": 0.01473213,
+          "spread": 0.00675971,
+          "score": 0.01620892
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.01388121,
-          "spread": 0.01484041,
-          "score": 0.02032057
+          "bias": 0.01361497,
+          "spread": 0.01497136,
+          "score": 0.02023633
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.08083976,
-          "spread": 0.07564091,
-          "score": 0.1107096
+          "bias": 0.08051504,
+          "spread": 0.0750574,
+          "score": 0.110074
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.19739002,
-          "spread": 0.11168786,
-          "score": 0.22679726
+          "bias": 0.19711611,
+          "spread": 0.11208386,
+          "score": 0.22675439
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.02699408,
-          "spread": 0.36908456,
-          "score": 0.37007039
+          "bias": 0.02683944,
+          "spread": 0.36925137,
+          "score": 0.37022551
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.0861745,
-          "spread": 0.17585216,
-          "score": 0.19583163
+          "bias": -0.08639565,
+          "spread": 0.17589661,
+          "score": 0.19596894
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00414319,
-          "spread": 0.0037962,
-          "score": 0.00561936
+          "bias": 0.00387497,
+          "spread": 0.00393216,
+          "score": 0.00552062
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00265164,
-          "spread": 0.00528384,
-          "score": 0.00591186
+          "bias": 0.00237629,
+          "spread": 0.00561962,
+          "score": 0.00610138
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.0058205,
-          "spread": 0.00412395,
-          "score": 0.00713339
+          "bias": 0.00554271,
+          "spread": 0.00463418,
+          "score": 0.00722476
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.0031815,
-          "spread": 0.00127448,
-          "score": 0.00342728
+          "bias": 0.00290251,
+          "spread": 0.00142285,
+          "score": 0.0032325
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": -0.03526707,
-          "spread": 0.02341804,
-          "score": 0.04233404
+          "bias": -0.03526346,
+          "spread": 0.02342429,
+          "score": 0.04233449
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.11430998,
-          "spread": 0.06954034,
-          "score": 0.13380071
+          "bias": -0.11451977,
+          "spread": 0.06982557,
+          "score": 0.13412825
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.03435447,
-          "spread": 0.02180616,
-          "score": 0.04069076
+          "bias": -0.03435088,
+          "spread": 0.02181234,
+          "score": 0.04069104
         },
         {
           "profile": "rated_plus_5pct",
@@ -5185,198 +5185,198 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00991178,
-          "spread": 0.00829485,
-          "score": 0.0129247
+          "bias": 0.00964691,
+          "spread": 0.00866008,
+          "score": 0.01296379
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00380414,
-          "spread": 0.00533879,
-          "score": 0.00655547
+          "bias": 0.00353734,
+          "spread": 0.00524422,
+          "score": 0.00632571
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00558413,
-          "spread": 0.00674545,
-          "score": 0.00875692
+          "bias": 0.00531519,
+          "spread": 0.00642228,
+          "score": 0.00833648
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00118574,
-          "spread": 0.00340433,
-          "score": 0.00360492
+          "bias": 0.00099426,
+          "spread": 0.00341076,
+          "score": 0.00355272
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.02119027,
-          "spread": 0.002646,
-          "score": 0.02135483
+          "bias": 0.02099879,
+          "spread": 0.00269301,
+          "score": 0.02117077
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00068742,
-          "spread": 0.00440209,
-          "score": 0.00445544
+          "bias": -0.00087713,
+          "spread": 0.0044382,
+          "score": 0.00452405
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00026337,
-          "spread": 0.00253967,
-          "score": 0.00255329
+          "bias": -0.00045586,
+          "spread": 0.00256007,
+          "score": 0.00260034
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00012835,
-          "spread": 0.00413221,
-          "score": 0.0041342
+          "bias": -0.00031952,
+          "spread": 0.00419036,
+          "score": 0.00420252
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00527507,
-          "spread": 0.00469658,
-          "score": 0.00706288
+          "bias": 0.00508403,
+          "spread": 0.00457575,
+          "score": 0.00683994
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01171574,
-          "spread": 0.00646127,
-          "score": 0.01337933
+          "bias": 0.01152479,
+          "spread": 0.0064072,
+          "score": 0.01318609
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00337463,
-          "spread": 0.01265757,
-          "score": 0.0130997
+          "bias": 0.00318753,
+          "spread": 0.01276391,
+          "score": 0.0131559
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.05548249,
-          "spread": 0.04651099,
-          "score": 0.07239875
+          "bias": 0.05529321,
+          "spread": 0.04671306,
+          "score": 0.07238404
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.3736913,
-          "spread": 0.38530635,
-          "score": 0.53675522
+          "bias": 0.37350008,
+          "spread": 0.38555007,
+          "score": 0.53679714
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.44629413,
-          "spread": 0.68491463,
-          "score": 0.81748792
+          "bias": 0.44593237,
+          "spread": 0.68449859,
+          "score": 0.81694185
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.10984504,
-          "spread": 0.1020589,
-          "score": 0.14993983
+          "bias": -0.1099995,
+          "spread": 0.10215362,
+          "score": 0.15011746
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00320692,
-          "spread": 0.00226221,
-          "score": 0.00392454
+          "bias": 0.00301541,
+          "spread": 0.00238445,
+          "score": 0.00384425
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00022652,
-          "spread": 0.00284568,
-          "score": 0.00285468
+          "bias": -0.00042359,
+          "spread": 0.00275791,
+          "score": 0.00279025
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00121891,
-          "spread": 0.00215006,
-          "score": 0.00247154
+          "bias": 0.00102089,
+          "spread": 0.0019714,
+          "score": 0.00222005
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 2.109e-05,
-          "spread": 0.00139165,
-          "score": 0.00139181
+          "bias": -0.00017653,
+          "spread": 0.0012588,
+          "score": 0.00127111
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00164596,
-          "spread": 0.004337,
-          "score": 0.00463883
+          "bias": 0.00144805,
+          "spread": 0.00424195,
+          "score": 0.0044823
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.12409537,
-          "spread": 0.07071082,
-          "score": 0.14282745
+          "bias": -0.12427359,
+          "spread": 0.07054733,
+          "score": 0.14290154
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00793813,
-          "spread": 0.02582734,
-          "score": 0.02701972
+          "bias": -0.00806724,
+          "spread": 0.02570924,
+          "score": 0.02694522
         },
         {
           "profile": "rated_plus_5pct",
@@ -5401,36 +5401,36 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00190974,
-          "spread": 0.00780579,
-          "score": 0.00803601
+          "bias": 0.00172168,
+          "spread": 0.00786299,
+          "score": 0.00804927
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00088789,
-          "spread": 0.00728803,
-          "score": 0.00734191
+          "bias": 0.00069988,
+          "spread": 0.00733048,
+          "score": 0.00736382
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00183409,
-          "spread": 0.00750336,
-          "score": 0.00772427
+          "bias": 0.00164564,
+          "spread": 0.00751717,
+          "score": 0.00769519
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 1,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00579568,
-          "spread": 0.01023763,
-          "score": 0.01176432
+          "bias": -0.00449322,
+          "spread": 0.01159818,
+          "score": 0.01243812
         },
         {
           "profile": "ti_dependent_cp",
@@ -5446,126 +5446,126 @@
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.0305893,
-          "spread": 0.03399556,
-          "score": 0.04573186
+          "bias": -0.029291,
+          "spread": 0.03298612,
+          "score": 0.04411402
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.01612096,
-          "spread": 0.01934357,
-          "score": 0.02518053
+          "bias": -0.01484242,
+          "spread": 0.01832033,
+          "score": 0.02357821
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00742374,
-          "spread": 0.01066915,
-          "score": 0.0129978
+          "bias": -0.00614768,
+          "spread": 0.00938804,
+          "score": 0.01122182
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00453326,
-          "spread": 0.01704392,
-          "score": 0.01763649
+          "bias": 0.00590672,
+          "spread": 0.02141137,
+          "score": 0.02221117
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.0229007,
-          "spread": 0.03714277,
-          "score": 0.04363516
+          "bias": 0.02436666,
+          "spread": 0.04178736,
+          "score": 0.04837269
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.0517879,
-          "spread": 0.02091167,
-          "score": 0.05585055
+          "bias": 0.05301154,
+          "spread": 0.0156848,
+          "score": 0.05528324
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.37598916,
-          "spread": 0.67698561,
-          "score": 0.77438838
+          "bias": 0.37443203,
+          "spread": 0.66720104,
+          "score": 0.76508599
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.07444869,
-          "spread": 0.05232376,
-          "score": 0.09099661
+          "bias": 0.0757256,
+          "spread": 0.05097468,
+          "score": 0.09128408
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.03796194,
-          "spread": 0.0125278,
-          "score": 0.03997568
+          "bias": 0.0392644,
+          "spread": 0.01300724,
+          "score": 0.0413628
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.041219,
-          "spread": 0.08163636,
-          "score": 0.09145218
+          "bias": 0.04159974,
+          "spread": 0.08268686,
+          "score": 0.09256163
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00156928,
-          "spread": 0.01553968,
-          "score": 0.01561872
+          "bias": -0.00018376,
+          "spread": 0.01674286,
+          "score": 0.01674386
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00919727,
-          "spread": 0.01664891,
-          "score": 0.01902041
+          "bias": 0.01059966,
+          "spread": 0.01970684,
+          "score": 0.0223766
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00512078,
-          "spread": 0.0072704,
-          "score": 0.00889276
+          "bias": 0.00449367,
+          "spread": 0.01026122,
+          "score": 0.01120204
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00529656,
-          "spread": 0.00932285,
-          "score": 0.01072236
+          "bias": 0.00654899,
+          "spread": 0.01149209,
+          "score": 0.01322714
         },
         {
           "profile": "ti_dependent_cp",
@@ -5581,9 +5581,9 @@
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.16078739,
-          "spread": 0.17472698,
-          "score": 0.23744916
+          "bias": -0.15918759,
+          "spread": 0.17707094,
+          "score": 0.23810671
         },
         {
           "profile": "ti_dependent_cp",
@@ -5617,171 +5617,171 @@
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00591674,
-          "spread": 0.01958846,
-          "score": 0.02046254
+          "bias": -0.00460363,
+          "spread": 0.0142841,
+          "score": 0.01500762
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00380158,
-          "spread": 0.0150533,
-          "score": 0.01552591
+          "bias": -0.00243502,
+          "spread": 0.01274172,
+          "score": 0.01297231
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.01690147,
-          "spread": 0.01418452,
-          "score": 0.02206491
+          "bias": -0.01547638,
+          "spread": 0.01800484,
+          "score": 0.02374221
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 2,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00040254,
-          "spread": 0.00550132,
-          "score": 0.00551603
+          "bias": -9.884e-05,
+          "spread": 0.00204178,
+          "score": 0.00204418
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": -0.04119399,
+          "bias": -0.04716425,
           "spread": 0.0,
-          "score": 0.04119399
+          "score": 0.04716425
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00934051,
-          "spread": 0.01446033,
-          "score": 0.01721471
+          "bias": -0.00978033,
+          "spread": 0.01469618,
+          "score": 0.01765312
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00165253,
-          "spread": 0.00862205,
-          "score": 0.00877898
+          "bias": 0.0011501,
+          "spread": 0.00545533,
+          "score": 0.00557524
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00285987,
-          "spread": 0.00676258,
-          "score": 0.00734243
+          "bias": -0.00336726,
+          "spread": 0.00329624,
+          "score": 0.00471208
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00493026,
-          "spread": 0.00735033,
-          "score": 0.00885069
+          "bias": 0.00445386,
+          "spread": 0.00863633,
+          "score": 0.00971716
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01085199,
-          "spread": 0.01214242,
-          "score": 0.01628509
+          "bias": 0.01038358,
+          "spread": 0.01294574,
+          "score": 0.01659551
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.01661925,
-          "spread": 0.0392764,
-          "score": 0.0426478
+          "bias": 0.01601196,
+          "spread": 0.03562196,
+          "score": 0.03905517
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.09333203,
-          "spread": 0.16493701,
-          "score": 0.18951276
+          "bias": 0.09239758,
+          "spread": 0.1614083,
+          "score": 0.18598374
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.54684342,
-          "spread": 1.18834487,
-          "score": 1.30812892
+          "bias": 0.54279712,
+          "spread": 1.17918857,
+          "score": 1.29811956
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.06746429,
-          "spread": 0.1978012,
-          "score": 0.20898982
+          "bias": -0.06812682,
+          "spread": 0.19686628,
+          "score": 0.2083209
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.06020858,
-          "spread": 0.11586327,
-          "score": 0.13057324
+          "bias": -0.06037958,
+          "spread": 0.11418162,
+          "score": 0.12916322
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00016569,
-          "spread": 0.00965182,
-          "score": 0.00965325
+          "bias": -0.00033267,
+          "spread": 0.00745274,
+          "score": 0.00746016
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00500951,
-          "spread": 0.00369348,
-          "score": 0.0062239
+          "bias": 0.00455452,
+          "spread": 0.00319229,
+          "score": 0.00556186
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00935194,
-          "spread": 0.00609582,
-          "score": 0.01116323
+          "bias": 0.00892108,
+          "spread": 0.00875805,
+          "score": 0.01250156
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00197811,
-          "spread": 0.00354809,
-          "score": 0.00406224
+          "bias": 0.00144354,
+          "spread": 0.00262221,
+          "score": 0.00299329
         },
         {
           "profile": "ti_dependent_cp",
@@ -5797,9 +5797,9 @@
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.07916917,
-          "spread": 0.11389531,
-          "score": 0.13870796
+          "bias": -0.07953607,
+          "spread": 0.11480347,
+          "score": 0.13966325
         },
         {
           "profile": "ti_dependent_cp",
@@ -5833,171 +5833,171 @@
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00546366,
-          "spread": 0.01608929,
-          "score": 0.01699167
+          "bias": -0.00597756,
+          "spread": 0.01304314,
+          "score": 0.01434764
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00422401,
-          "spread": 0.00547637,
-          "score": 0.00691613
+          "bias": 0.00373419,
+          "spread": 0.00331847,
+          "score": 0.00499564
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00511055,
-          "spread": 0.00740402,
-          "score": 0.00899652
+          "bias": -0.00561157,
+          "spread": 0.00432208,
+          "score": 0.00708309
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00137974,
-          "spread": 0.00236671,
-          "score": 0.00273952
+          "bias": 0.00211391,
+          "spread": 0.00196807,
+          "score": 0.00288824
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": -0.00160525,
-          "spread": 0.04695774,
-          "score": 0.04698517
+          "bias": -0.0009176,
+          "spread": 0.04567132,
+          "score": 0.04568054
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.01307559,
-          "spread": 0.01467539,
-          "score": 0.01965549
+          "bias": -0.01233355,
+          "spread": 0.01557147,
+          "score": 0.01986422
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00290152,
-          "spread": 0.00492107,
-          "score": 0.00571277
+          "bias": 0.00363975,
+          "spread": 0.00503558,
+          "score": 0.00621328
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00265385,
-          "spread": 0.00119345,
-          "score": 0.00290986
+          "bias": -0.0019207,
+          "spread": 0.00055592,
+          "score": 0.00199954
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.0041781,
-          "spread": 0.00998021,
-          "score": 0.01081948
+          "bias": 0.00490286,
+          "spread": 0.00928382,
+          "score": 0.01049893
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.0166191,
-          "spread": 0.02046464,
-          "score": 0.02636278
+          "bias": 0.01733028,
+          "spread": 0.0197398,
+          "score": 0.02626782
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00879348,
-          "spread": 0.04424513,
-          "score": 0.0451105
+          "bias": -0.00812821,
+          "spread": 0.04360157,
+          "score": 0.04435273
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.10199877,
-          "spread": 0.10869598,
-          "score": 0.14905893
+          "bias": 0.1028641,
+          "spread": 0.10973773,
+          "score": 0.15041075
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.23303424,
-          "spread": 0.41493286,
-          "score": 0.47589309
+          "bias": 0.23402518,
+          "spread": 0.41557463,
+          "score": 0.47693822
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.00890264,
-          "spread": 0.0626253,
-          "score": 0.06325492
+          "bias": 0.00961845,
+          "spread": 0.06278823,
+          "score": 0.06352068
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.16094759,
-          "spread": 0.12472715,
-          "score": 0.20361972
+          "bias": -0.16026419,
+          "spread": 0.12535572,
+          "score": 0.20346662
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00102914,
-          "spread": 0.0052149,
-          "score": 0.00531548
+          "bias": -0.00026612,
+          "spread": 0.00608941,
+          "score": 0.00609523
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00720969,
-          "spread": 0.00794211,
-          "score": 0.01072645
+          "bias": 0.00794936,
+          "spread": 0.00882565,
+          "score": 0.0118779
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00993999,
-          "spread": 0.01153979,
-          "score": 0.01523057
+          "bias": 0.01067687,
+          "spread": 0.01242406,
+          "score": 0.01638148
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00186184,
-          "spread": 0.00432796,
-          "score": 0.00471144
+          "bias": 0.00196548,
+          "spread": 0.00487542,
+          "score": 0.00525669
         },
         {
           "profile": "ti_dependent_cp",
@@ -6013,9 +6013,9 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.11227088,
-          "spread": 0.1342482,
-          "score": 0.17500666
+          "bias": -0.11166331,
+          "spread": 0.13366102,
+          "score": 0.17416648
         },
         {
           "profile": "ti_dependent_cp",
@@ -6049,198 +6049,198 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00236653,
-          "spread": 0.01913387,
-          "score": 0.01927966
+          "bias": 0.00311769,
+          "spread": 0.01825051,
+          "score": 0.01851489
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00171734,
-          "spread": 0.01000018,
-          "score": 0.01014657
+          "bias": -0.00096135,
+          "spread": 0.00913554,
+          "score": 0.00918599
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00278571,
-          "spread": 0.00726765,
-          "score": 0.00778325
+          "bias": -0.00202697,
+          "spread": 0.0064394,
+          "score": 0.00675088
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00450206,
-          "spread": 0.00200664,
-          "score": 0.00492902
+          "bias": 0.00422315,
+          "spread": 0.00194556,
+          "score": 0.00464975
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": -0.05174671,
-          "spread": 0.00393016,
-          "score": 0.05189574
+          "bias": -0.05255749,
+          "spread": 0.00380106,
+          "score": 0.05269476
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00717826,
-          "spread": 0.01148773,
-          "score": 0.01354604
+          "bias": -0.00745628,
+          "spread": 0.01163973,
+          "score": 0.01382315
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00220182,
-          "spread": 0.00184079,
-          "score": 0.00286993
+          "bias": 0.00192296,
+          "spread": 0.00168365,
+          "score": 0.00255587
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00180108,
-          "spread": 0.00225713,
-          "score": 0.00288765
+          "bias": 0.00152164,
+          "spread": 0.00187396,
+          "score": 0.00241394
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.01170843,
-          "spread": 0.00514224,
-          "score": 0.01278788
+          "bias": 0.01143167,
+          "spread": 0.00537307,
+          "score": 0.01263143
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.02561283,
-          "spread": 0.00694758,
-          "score": 0.02653839
+          "bias": 0.02533736,
+          "spread": 0.00687609,
+          "score": 0.02625381
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.03320671,
-          "spread": 0.01392755,
-          "score": 0.03600919
+          "bias": 0.0329332,
+          "spread": 0.01392472,
+          "score": 0.03575603
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.10266824,
-          "spread": 0.08266351,
-          "score": 0.13181056
+          "bias": 0.10232865,
+          "spread": 0.08207308,
+          "score": 0.131176
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.22021299,
-          "spread": 0.10643567,
-          "score": 0.244586
+          "bias": 0.21995914,
+          "spread": 0.10686041,
+          "score": 0.24454278
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.0044087,
-          "spread": 0.44623051,
-          "score": 0.44625229
+          "bias": 0.00429213,
+          "spread": 0.44634414,
+          "score": 0.44636477
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.08600661,
-          "spread": 0.15661971,
-          "score": 0.17868092
+          "bias": -0.08626928,
+          "spread": 0.15666783,
+          "score": 0.17884965
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00085488,
-          "spread": 0.00293253,
-          "score": 0.0030546
+          "bias": -0.00113673,
+          "spread": 0.00300444,
+          "score": 0.00321229
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00660691,
-          "spread": 0.00384629,
-          "score": 0.00764494
+          "bias": 0.00633672,
+          "spread": 0.00422115,
+          "score": 0.00761394
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00651918,
-          "spread": 0.00402588,
-          "score": 0.00766208
+          "bias": 0.00625233,
+          "spread": 0.00440663,
+          "score": 0.00764918
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00363031,
-          "spread": 0.00322644,
-          "score": 0.00485686
+          "bias": 0.00336285,
+          "spread": 0.00330421,
+          "score": 0.0047145
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00076378,
-          "spread": 0.00253982,
-          "score": 0.00265218
+          "bias": 0.00076723,
+          "spread": 0.00254555,
+          "score": 0.00265866
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.13561918,
-          "spread": 0.09240991,
-          "score": 0.16411019
+          "bias": -0.13584109,
+          "spread": 0.09271975,
+          "score": 0.1644681
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00346702,
-          "spread": 0.00316474,
-          "score": 0.00469423
+          "bias": -0.00346358,
+          "spread": 0.00316557,
+          "score": 0.00469225
         },
         {
           "profile": "ti_dependent_cp",
@@ -6265,198 +6265,198 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.01068245,
-          "spread": 0.00808683,
-          "score": 0.01339819
+          "bias": 0.01040497,
+          "spread": 0.00852296,
+          "score": 0.01345007
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00510606,
-          "spread": 0.00442408,
-          "score": 0.00675606
+          "bias": 0.00482193,
+          "spread": 0.00438809,
+          "score": 0.00651969
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00435363,
-          "spread": 0.00688645,
-          "score": 0.00814722
+          "bias": 0.00406499,
+          "spread": 0.00644874,
+          "score": 0.00762302
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00114913,
-          "spread": 0.00346553,
-          "score": 0.00365108
+          "bias": 0.00095651,
+          "spread": 0.00347279,
+          "score": 0.0036021
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": -0.01246608,
-          "spread": 0.04776898,
-          "score": 0.0493688
+          "bias": -0.01265869,
+          "spread": 0.04761336,
+          "score": 0.04926738
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00944123,
-          "spread": 0.00210166,
-          "score": 0.00967232
+          "bias": -0.00963875,
+          "spread": 0.00225509,
+          "score": 0.00989904
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00169875,
-          "spread": 0.00269823,
-          "score": 0.00318845
+          "bias": -0.00189127,
+          "spread": 0.00274196,
+          "score": 0.00333095
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -5.218e-05,
-          "spread": 0.00412116,
-          "score": 0.00412149
+          "bias": -0.00024443,
+          "spread": 0.00419764,
+          "score": 0.00420475
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00732484,
-          "spread": 0.00442396,
-          "score": 0.00855715
+          "bias": 0.00713146,
+          "spread": 0.00430496,
+          "score": 0.00833009
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.02139537,
-          "spread": 0.0063981,
-          "score": 0.02233154
+          "bias": 0.02120276,
+          "spread": 0.00635915,
+          "score": 0.02213585
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.02031971,
-          "spread": 0.01293879,
-          "score": 0.02408948
+          "bias": 0.02013219,
+          "spread": 0.01308518,
+          "score": 0.02401097
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.0709351,
-          "spread": 0.04588684,
-          "score": 0.08448308
+          "bias": 0.07074516,
+          "spread": 0.04609495,
+          "score": 0.08443709
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.41097484,
-          "spread": 0.41280025,
-          "score": 0.58249839
+          "bias": 0.41078634,
+          "spread": 0.41306187,
+          "score": 0.58255088
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.4725847,
-          "spread": 0.69511153,
-          "score": 0.84054526
+          "bias": 0.47221778,
+          "spread": 0.69468487,
+          "score": 0.83998613
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.1044143,
-          "spread": 0.08870986,
-          "score": 0.13701017
+          "bias": -0.10456965,
+          "spread": 0.08880717,
+          "score": 0.13719157
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.0014935,
-          "spread": 0.00367088,
-          "score": 0.00396306
+          "bias": -0.00168679,
+          "spread": 0.00370505,
+          "score": 0.00407095
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.0035689,
-          "spread": 0.00224659,
-          "score": 0.00421713
+          "bias": 0.00338103,
+          "spread": 0.00209823,
+          "score": 0.00397919
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00266061,
-          "spread": 0.00221509,
-          "score": 0.003462
+          "bias": 0.00247363,
+          "spread": 0.0020943,
+          "score": 0.00324113
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00097284,
-          "spread": 0.00079809,
-          "score": 0.00125832
+          "bias": 0.00078638,
+          "spread": 0.00068415,
+          "score": 0.00104233
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00089008,
-          "spread": 0.00222988,
-          "score": 0.00240096
+          "bias": 0.00070327,
+          "spread": 0.00216544,
+          "score": 0.00227678
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.14100351,
-          "spread": 0.08830591,
-          "score": 0.16637284
+          "bias": -0.14118961,
+          "spread": 0.08812326,
+          "score": 0.16643382
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00087729,
-          "spread": 0.0118906,
-          "score": 0.01192292
+          "bias": -0.00099851,
+          "spread": 0.01182165,
+          "score": 0.01186374
         },
         {
           "profile": "ti_dependent_cp",
@@ -6481,36 +6481,36 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00292882,
-          "spread": 0.00774207,
-          "score": 0.00827753
+          "bias": 0.00273192,
+          "spread": 0.00782019,
+          "score": 0.00828365
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00217204,
-          "spread": 0.00689809,
-          "score": 0.00723197
+          "bias": 0.00197473,
+          "spread": 0.00694991,
+          "score": 0.00722501
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00049926,
-          "spread": 0.00740506,
-          "score": 0.00742187
+          "bias": 0.00030227,
+          "spread": 0.00744437,
+          "score": 0.0074505
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00576117,
-          "spread": 0.01021458,
-          "score": 0.01172727
+          "bias": -0.00444582,
+          "spread": 0.01157795,
+          "score": 0.01240219
         },
         {
           "profile": "ws_dependent_cp",
@@ -6526,126 +6526,126 @@
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.01757764,
-          "spread": 0.02059181,
-          "score": 0.0270739
+          "bias": -0.01628035,
+          "spread": 0.01899937,
+          "score": 0.02502051
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.011678,
-          "spread": 0.01767152,
-          "score": 0.02118156
+          "bias": -0.01040086,
+          "spread": 0.01643281,
+          "score": 0.01944775
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00660563,
-          "spread": 0.00985821,
-          "score": 0.0118667
+          "bias": -0.00532441,
+          "spread": 0.00882232,
+          "score": 0.0103045
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00071799,
-          "spread": 0.01751422,
-          "score": 0.01752893
+          "bias": 0.00067371,
+          "spread": 0.0223277,
+          "score": 0.02233786
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00996829,
-          "spread": 0.03941595,
-          "score": 0.04065691
+          "bias": 0.0114688,
+          "spread": 0.04454705,
+          "score": 0.04599971
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.02760476,
-          "spread": 0.01433547,
-          "score": 0.03110512
+          "bias": 0.02887811,
+          "spread": 0.00860625,
+          "score": 0.03013325
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.34935334,
-          "spread": 0.69642743,
-          "score": 0.77913986
+          "bias": 0.34783297,
+          "spread": 0.68591215,
+          "score": 0.76906648
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.03639874,
-          "spread": 0.06867144,
-          "score": 0.07772152
+          "bias": 0.03766493,
+          "spread": 0.06712955,
+          "score": 0.07697418
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.09604807,
-          "spread": 0.10745482,
-          "score": 0.14412415
+          "bias": -0.09473271,
+          "spread": 0.10582113,
+          "score": 0.14202957
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.07520685,
-          "spread": 0.08206966,
-          "score": 0.11131711
+          "bias": 0.07538168,
+          "spread": 0.08007617,
+          "score": 0.10997541
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00344459,
-          "spread": 0.01771928,
-          "score": 0.01805098
+          "bias": 0.00481636,
+          "spread": 0.01878715,
+          "score": 0.0193947
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00875915,
-          "spread": 0.01878457,
-          "score": 0.02072638
+          "bias": 0.01015752,
+          "spread": 0.02160886,
+          "score": 0.02387714
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00540114,
-          "spread": 0.00660409,
-          "score": 0.00853149
+          "bias": 0.00477311,
+          "spread": 0.00949784,
+          "score": 0.01062975
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00554853,
-          "spread": 0.00961034,
-          "score": 0.01109707
+          "bias": 0.00680147,
+          "spread": 0.01178049,
+          "score": 0.01360294
         },
         {
           "profile": "ws_dependent_cp",
@@ -6661,9 +6661,9 @@
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.220221,
-          "spread": 0.22977746,
-          "score": 0.31826871
+          "bias": -0.21860836,
+          "spread": 0.23266635,
+          "score": 0.3192542
         },
         {
           "profile": "ws_dependent_cp",
@@ -6697,171 +6697,171 @@
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.01192855,
-          "spread": 0.02009793,
-          "score": 0.02337129
+          "bias": -0.0105687,
+          "spread": 0.0149341,
+          "score": 0.01829549
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00674657,
-          "spread": 0.01514127,
-          "score": 0.01657632
+          "bias": -0.0053517,
+          "spread": 0.01371258,
+          "score": 0.0147199
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.01693939,
-          "spread": 0.01386759,
-          "score": 0.02189185
+          "bias": -0.01551468,
+          "spread": 0.01762058,
+          "score": 0.02347744
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00039283,
-          "spread": 0.00544186,
-          "score": 0.00545602
+          "bias": -9.121e-05,
+          "spread": 0.00202294,
+          "score": 0.002025
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.0207169,
+          "bias": 0.01484423,
           "spread": 0.0,
-          "score": 0.0207169
+          "score": 0.01484423
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00182977,
-          "spread": 0.01089273,
-          "score": 0.01104534
+          "bias": -0.00226971,
+          "spread": 0.01141855,
+          "score": 0.01164195
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00395413,
-          "spread": 0.00768367,
-          "score": 0.00864141
+          "bias": 0.00346888,
+          "spread": 0.00436974,
+          "score": 0.00557923
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00177237,
-          "spread": 0.00587289,
-          "score": 0.0061345
+          "bias": -0.00226548,
+          "spread": 0.00210531,
+          "score": 0.00309269
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00026472,
-          "spread": 0.00720617,
-          "score": 0.00721103
+          "bias": -0.00021051,
+          "spread": 0.0088409,
+          "score": 0.00884341
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": -0.00415187,
-          "spread": 0.01641956,
-          "score": 0.01693635
+          "bias": -0.00463607,
+          "spread": 0.01768049,
+          "score": 0.01827821
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00395999,
-          "spread": 0.04006272,
-          "score": 0.04025795
+          "bias": -0.00461601,
+          "spread": 0.0363593,
+          "score": 0.03665115
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.0658755,
-          "spread": 0.16271972,
-          "score": 0.17554854
+          "bias": 0.06488621,
+          "spread": 0.15889154,
+          "score": 0.17162967
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.55275017,
-          "spread": 1.24596182,
-          "score": 1.36306772
+          "bias": 0.54876901,
+          "spread": 1.2371949,
+          "score": 1.35343956
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.58629904,
-          "spread": 1.33781165,
-          "score": 1.46064594
+          "bias": -0.58685538,
+          "spread": 1.33662038,
+          "score": 1.4597785
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.0136498,
-          "spread": 0.15981595,
-          "score": 0.16039781
+          "bias": -0.01378846,
+          "spread": 0.15894199,
+          "score": 0.15953896
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00513592,
-          "spread": 0.01023765,
-          "score": 0.0114537
+          "bias": 0.00466715,
+          "spread": 0.00843745,
+          "score": 0.00964224
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.005033,
-          "spread": 0.00427677,
-          "score": 0.00660469
+          "bias": 0.00458856,
+          "spread": 0.00470529,
+          "score": 0.00657227
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00984687,
-          "spread": 0.00625955,
-          "score": 0.01166803
+          "bias": 0.00942057,
+          "spread": 0.00917839,
+          "score": 0.01315257
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00193712,
-          "spread": 0.00335519,
-          "score": 0.00387424
+          "bias": 0.00140428,
+          "spread": 0.00243228,
+          "score": 0.00280856
         },
         {
           "profile": "ws_dependent_cp",
@@ -6877,9 +6877,9 @@
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.10521498,
-          "spread": 0.13112854,
-          "score": 0.16812164
+          "bias": -0.10566018,
+          "spread": 0.1322597,
+          "score": 0.1692829
         },
         {
           "profile": "ws_dependent_cp",
@@ -6913,171 +6913,171 @@
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.01023407,
-          "spread": 0.01592088,
-          "score": 0.01892645
+          "bias": -0.01075831,
+          "spread": 0.01262876,
+          "score": 0.01658996
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00021675,
-          "spread": 0.00649624,
-          "score": 0.00649985
+          "bias": -0.00026836,
+          "spread": 0.00464856,
+          "score": 0.0046563
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00499582,
-          "spread": 0.00807243,
-          "score": 0.00949328
+          "bias": -0.00547332,
+          "spread": 0.00536398,
+          "score": 0.00766352
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00138709,
-          "spread": 0.00236699,
-          "score": 0.00274348
+          "bias": 0.00211218,
+          "spread": 0.00196026,
+          "score": 0.00288165
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.02605638,
-          "spread": 0.01345874,
-          "score": 0.02932699
+          "bias": 0.02672912,
+          "spread": 0.01219057,
+          "score": 0.02937781
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00738239,
-          "spread": 0.01086444,
-          "score": 0.01313529
+          "bias": -0.00665397,
+          "spread": 0.01176917,
+          "score": 0.01351994
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00564015,
-          "spread": 0.00436533,
-          "score": 0.00713214
+          "bias": 0.00636407,
+          "spread": 0.00439359,
+          "score": 0.00773337
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00168392,
-          "spread": 0.00131156,
-          "score": 0.00213443
+          "bias": -0.00095967,
+          "spread": 0.00058189,
+          "score": 0.00112231
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00088145,
-          "spread": 0.01075023,
-          "score": 0.01078631
+          "bias": -0.00015409,
+          "spread": 0.01002896,
+          "score": 0.01003014
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00258348,
-          "spread": 0.02297799,
-          "score": 0.02312277
+          "bias": 0.00331457,
+          "spread": 0.02221505,
+          "score": 0.02246096
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.02821146,
-          "spread": 0.04476783,
-          "score": 0.05291545
+          "bias": -0.02750792,
+          "spread": 0.04405037,
+          "score": 0.05193381
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.07928645,
-          "spread": 0.11921801,
-          "score": 0.14317568
+          "bias": 0.08021576,
+          "spread": 0.12032911,
+          "score": 0.14461557
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.25281926,
-          "spread": 0.40476432,
-          "score": 0.47723342
+          "bias": 0.25382586,
+          "spread": 0.40560716,
+          "score": 0.4784817
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.00829701,
-          "spread": 0.32546137,
-          "score": 0.32556711
+          "bias": 0.0090335,
+          "spread": 0.32503475,
+          "score": 0.32516026
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.12588086,
-          "spread": 0.2315992,
-          "score": 0.26359852
+          "bias": -0.12509396,
+          "spread": 0.23218253,
+          "score": 0.26373704
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00286508,
-          "spread": 0.00654821,
-          "score": 0.00714757
+          "bias": 0.00360286,
+          "spread": 0.00739185,
+          "score": 0.00822314
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00714898,
-          "spread": 0.00889916,
-          "score": 0.01141504
+          "bias": 0.00788247,
+          "spread": 0.00980029,
+          "score": 0.01257692
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.0110761,
-          "spread": 0.01183247,
-          "score": 0.01620763
+          "bias": 0.01181497,
+          "spread": 0.01273419,
+          "score": 0.01737104
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00223968,
-          "spread": 0.00485853,
-          "score": 0.00534991
+          "bias": 0.00234498,
+          "spread": 0.00540574,
+          "score": 0.00589245
         },
         {
           "profile": "ws_dependent_cp",
@@ -7093,9 +7093,9 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.13986662,
-          "spread": 0.1544022,
-          "score": 0.20833317
+          "bias": -0.13921367,
+          "spread": 0.15372678,
+          "score": 0.20739423
         },
         {
           "profile": "ws_dependent_cp",
@@ -7129,198 +7129,198 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00266165,
-          "spread": 0.01835771,
-          "score": 0.01854966
+          "bias": -0.00188911,
+          "spread": 0.01751038,
+          "score": 0.01761199
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00493749,
-          "spread": 0.01074569,
-          "score": 0.01182577
+          "bias": -0.00417922,
+          "spread": 0.00988616,
+          "score": 0.01073322
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00344563,
-          "spread": 0.00826027,
-          "score": 0.00895011
+          "bias": -0.00270409,
+          "spread": 0.007404,
+          "score": 0.00788234
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00450881,
-          "spread": 0.0019924,
-          "score": 0.0049294
+          "bias": 0.00423473,
+          "spread": 0.00193694,
+          "score": 0.00465668
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": -0.0179209,
-          "spread": 0.02133788,
-          "score": 0.0278651
+          "bias": -0.01872095,
+          "spread": 0.02121519,
+          "score": 0.02829414
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00317454,
-          "spread": 0.01188696,
-          "score": 0.01230356
+          "bias": -0.00344471,
+          "spread": 0.012124,
+          "score": 0.01260386
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00484217,
-          "spread": 0.00233075,
-          "score": 0.00537392
+          "bias": 0.00456975,
+          "spread": 0.00226621,
+          "score": 0.00510081
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00252922,
-          "spread": 0.0023232,
-          "score": 0.00343427
+          "bias": 0.00225458,
+          "spread": 0.00205121,
+          "score": 0.00304805
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00687617,
-          "spread": 0.00656909,
-          "score": 0.00950971
+          "bias": 0.00659964,
+          "spread": 0.00681803,
+          "score": 0.00948898
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01282272,
-          "spread": 0.0080833,
-          "score": 0.0151579
+          "bias": 0.01254,
+          "spread": 0.00801556,
+          "score": 0.0148829
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.01356674,
-          "spread": 0.01469049,
-          "score": 0.01999667
+          "bias": 0.01328199,
+          "spread": 0.01479393,
+          "score": 0.01988144
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.07608757,
-          "spread": 0.07976925,
-          "score": 0.11023816
+          "bias": 0.07573596,
+          "spread": 0.07913015,
+          "score": 0.10953317
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.13879978,
-          "spread": 0.21453297,
-          "score": 0.25551864
+          "bias": 0.13867394,
+          "spread": 0.21466137,
+          "score": 0.25555815
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.00152207,
-          "spread": 0.45041908,
-          "score": 0.45042166
+          "bias": -0.00170369,
+          "spread": 0.4504575,
+          "score": 0.45046072
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.10430663,
-          "spread": 0.14298267,
-          "score": 0.17698564
+          "bias": -0.10453418,
+          "spread": 0.14296843,
+          "score": 0.17710835
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00353271,
-          "spread": 0.00276589,
-          "score": 0.00448667
+          "bias": 0.00326303,
+          "spread": 0.00287071,
+          "score": 0.00434607
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00666932,
-          "spread": 0.00490026,
-          "score": 0.00827601
+          "bias": 0.00640373,
+          "spread": 0.00521623,
+          "score": 0.00825934
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00713499,
-          "spread": 0.00414649,
-          "score": 0.00825236
+          "bias": 0.00686936,
+          "spread": 0.0045361,
+          "score": 0.00823191
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00475334,
-          "spread": 0.00281176,
-          "score": 0.0055227
+          "bias": 0.00448682,
+          "spread": 0.00286592,
+          "score": 0.00532401
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00154389,
-          "spread": 0.00267409,
-          "score": 0.00308778
+          "bias": 0.00154734,
+          "spread": 0.00268006,
+          "score": 0.00309467
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.17773994,
-          "spread": 0.11831149,
-          "score": 0.21351603
+          "bias": -0.17798184,
+          "spread": 0.11864721,
+          "score": 0.21390347
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00067931,
-          "spread": 0.0011766,
-          "score": 0.00135862
+          "bias": 0.00068275,
+          "spread": 0.00118255,
+          "score": 0.00136549
         },
         {
           "profile": "ws_dependent_cp",
@@ -7345,198 +7345,198 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00664822,
-          "spread": 0.00884916,
-          "score": 0.01106826
+          "bias": 0.00635893,
+          "spread": 0.00922321,
+          "score": 0.01120284
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.001708,
-          "spread": 0.00507256,
-          "score": 0.0053524
+          "bias": 0.00142349,
+          "spread": 0.00503486,
+          "score": 0.00523222
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00351774,
-          "spread": 0.00723001,
-          "score": 0.00804037
+          "bias": 0.00323773,
+          "spread": 0.00686762,
+          "score": 0.00759257
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.001185,
-          "spread": 0.0034466,
-          "score": 0.00364462
+          "bias": 0.00099354,
+          "spread": 0.00345196,
+          "score": 0.0035921
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.00039802,
-          "spread": 0.02991569,
-          "score": 0.02991834
+          "bias": 0.00020655,
+          "spread": 0.02985669,
+          "score": 0.02985741
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00328812,
-          "spread": 0.0019835,
-          "score": 0.00384005
+          "bias": -0.00348234,
+          "spread": 0.00190951,
+          "score": 0.00397151
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00022213,
-          "spread": 0.00257766,
-          "score": 0.00258721
+          "bias": 3.214e-05,
+          "spread": 0.00258294,
+          "score": 0.00258314
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00036981,
-          "spread": 0.00408111,
-          "score": 0.00409784
+          "bias": 0.00017911,
+          "spread": 0.00415438,
+          "score": 0.00415824
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00368817,
-          "spread": 0.00545285,
-          "score": 0.00658302
+          "bias": 0.0034939,
+          "spread": 0.00533426,
+          "score": 0.00637665
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01032838,
-          "spread": 0.00689988,
-          "score": 0.0124211
+          "bias": 0.01013099,
+          "spread": 0.00684044,
+          "score": 0.0122241
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00290124,
-          "spread": 0.01385051,
-          "score": 0.0141511
+          "bias": 0.00270452,
+          "spread": 0.01400112,
+          "score": 0.01425993
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.0541513,
-          "spread": 0.04847203,
-          "score": 0.07267669
+          "bias": 0.05394884,
+          "spread": 0.04867815,
+          "score": 0.07266388
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.40250784,
-          "spread": 0.44737262,
-          "score": 0.60179301
+          "bias": 0.40230291,
+          "spread": 0.44765289,
+          "score": 0.60186439
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.71361694,
-          "spread": 0.74393195,
-          "score": 1.0308656
+          "bias": 0.71321959,
+          "spread": 0.74368734,
+          "score": 1.03041402
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.13042886,
-          "spread": 0.10563538,
-          "score": 0.16784076
+          "bias": -0.13057782,
+          "spread": 0.10571876,
+          "score": 0.168009
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00240437,
-          "spread": 0.00287827,
-          "score": 0.00375039
+          "bias": 0.0022158,
+          "spread": 0.00292752,
+          "score": 0.00367153
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00305625,
-          "spread": 0.00268369,
-          "score": 0.00406729
+          "bias": 0.00286932,
+          "spread": 0.00257733,
+          "score": 0.00385689
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00275929,
-          "spread": 0.00243764,
-          "score": 0.00368181
+          "bias": 0.00257242,
+          "spread": 0.00231668,
+          "score": 0.00346184
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00139895,
-          "spread": 0.00102308,
-          "score": 0.00173314
+          "bias": 0.00121248,
+          "spread": 0.00088424,
+          "score": 0.00150066
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00218725,
-          "spread": 0.00297554,
-          "score": 0.00369295
+          "bias": 0.00200045,
+          "spread": 0.00286688,
+          "score": 0.00349582
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.17855832,
-          "spread": 0.11193077,
-          "score": 0.21074053
+          "bias": -0.17875431,
+          "spread": 0.11172951,
+          "score": 0.21079987
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00332773,
-          "spread": 0.01202088,
-          "score": 0.01247298
+          "bias": 0.00320647,
+          "spread": 0.01191755,
+          "score": 0.01234137
         },
         {
           "profile": "ws_dependent_cp",
@@ -7561,33 +7561,33 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00103729,
-          "spread": 0.00805827,
-          "score": 0.00812475
+          "bias": -0.00124044,
+          "spread": 0.00811623,
+          "score": 0.00821048
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00065312,
-          "spread": 0.00743765,
-          "score": 0.00746627
+          "bias": -0.00085185,
+          "spread": 0.00748358,
+          "score": 0.00753191
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00032666,
-          "spread": 0.00777162,
-          "score": 0.00777848
+          "bias": -0.00052048,
+          "spread": 0.00779137,
+          "score": 0.00780874
         }
       ]
     },
     "toggle": {
-      "recorded_utc": "2026-07-08T13:07:31Z",
-      "git_commit": "09f3b06-dirty",
+      "recorded_utc": "2026-07-10T11:14:14Z",
+      "git_commit": "ac9f2c7-dirty",
       "n_replicates": 4,
       "seed": 0,
       "campaign_months": [
@@ -7612,9 +7612,9 @@
           "campaign_months": 1,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00555726,
-          "spread": 0.00491433,
-          "score": 0.00741848
+          "bias": -0.00304697,
+          "spread": 0.00227074,
+          "score": 0.00380004
         },
         {
           "profile": "cp_0pct",
@@ -7630,117 +7630,117 @@
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00854218,
-          "spread": 0.00258257,
-          "score": 0.00892404
+          "bias": -0.00603062,
+          "spread": 0.00229119,
+          "score": 0.00645119
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00608136,
-          "spread": 0.00224869,
-          "score": 0.0064838
+          "bias": -0.0035632,
+          "spread": 0.00208776,
+          "score": 0.00412978
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00451501,
-          "spread": 0.00679228,
-          "score": 0.008156
+          "bias": -0.00200749,
+          "spread": 0.00404419,
+          "score": 0.00451503
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00520719,
-          "spread": 0.00725422,
-          "score": 0.00892964
+          "bias": -0.0027007,
+          "spread": 0.00492454,
+          "score": 0.00561649
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": -0.00660855,
-          "spread": 0.00351323,
-          "score": 0.00748437
+          "bias": -0.00408929,
+          "spread": 0.00406321,
+          "score": 0.00576472
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.03207282,
-          "spread": 0.0489486,
-          "score": 0.05852035
+          "bias": -0.02972971,
+          "spread": 0.0469716,
+          "score": 0.05558945
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.00555726,
-          "spread": 0.00491433,
-          "score": 0.00741848
+          "bias": -0.00304697,
+          "spread": 0.00227074,
+          "score": 0.00380004
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": -0.00555726,
-          "spread": 0.00491433,
-          "score": 0.00741848
+          "bias": -0.00304697,
+          "spread": 0.00227074,
+          "score": 0.00380004
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.00555726,
-          "spread": 0.00491433,
-          "score": 0.00741848
+          "bias": -0.00304697,
+          "spread": 0.00227074,
+          "score": 0.00380004
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.00665186,
-          "spread": 0.05601843,
-          "score": 0.05641198
+          "bias": -0.00387851,
+          "spread": 0.0540593,
+          "score": 0.05419826
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00667319,
-          "spread": 0.00975321,
-          "score": 0.01181764
+          "bias": -0.00379711,
+          "spread": 0.00882851,
+          "score": 0.00961044
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00099963,
-          "spread": 0.01053117,
-          "score": 0.01057851
+          "bias": 0.00201843,
+          "spread": 0.00857283,
+          "score": 0.00880724
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00167349,
-          "spread": 0.00289857,
-          "score": 0.00334698
+          "bias": -0.00108133,
+          "spread": 0.00187293,
+          "score": 0.00216267
         },
         {
           "profile": "cp_0pct",
@@ -7765,9 +7765,9 @@
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.00525868,
-          "spread": 0.06341937,
-          "score": 0.06363702
+          "bias": -0.00246131,
+          "spread": 0.06226831,
+          "score": 0.06231693
         },
         {
           "profile": "cp_0pct",
@@ -7801,36 +7801,36 @@
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00593797,
-          "spread": 0.01816215,
-          "score": 0.01910819
+          "bias": -0.00305798,
+          "spread": 0.01783782,
+          "score": 0.01809804
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00789732,
-          "spread": 0.00776733,
-          "score": 0.01107696
+          "bias": -0.00503511,
+          "spread": 0.00478497,
+          "score": 0.0069461
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00555236,
-          "spread": 0.00404525,
-          "score": 0.0068697
+          "bias": -0.00265898,
+          "spread": 0.00519882,
+          "score": 0.00583935
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 2,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00167815,
-          "spread": 0.00298766,
-          "score": 0.00342671
+          "bias": -0.00120784,
+          "spread": 0.00160438,
+          "score": 0.00200821
         },
         {
           "profile": "cp_0pct",
@@ -7846,117 +7846,117 @@
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00037392,
-          "spread": 0.00180566,
-          "score": 0.00184397
+          "bias": 9.926e-05,
+          "spread": 0.00118466,
+          "score": 0.00118881
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00448994,
-          "spread": 0.00211709,
-          "score": 0.00496403
+          "bias": -0.00401615,
+          "spread": 0.00277899,
+          "score": 0.00488388
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00181531,
-          "spread": 0.0048812,
-          "score": 0.00520782
+          "bias": 0.0022845,
+          "spread": 0.0034432,
+          "score": 0.00413214
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00310547,
-          "spread": 0.00703932,
-          "score": 0.00769389
+          "bias": -0.00264162,
+          "spread": 0.00562238,
+          "score": 0.00621203
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": -0.00644217,
-          "spread": 0.00718768,
-          "score": 0.00965216
+          "bias": -0.00596764,
+          "spread": 0.00762973,
+          "score": 0.00968636
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.02502376,
-          "spread": 0.07486508,
-          "score": 0.07893649
+          "bias": -0.02463284,
+          "spread": 0.07404246,
+          "score": 0.07803245
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.09505343,
-          "spread": 0.18227348,
-          "score": 0.20556939
+          "bias": 0.09532865,
+          "spread": 0.18060757,
+          "score": 0.20422205
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": -0.00631329,
-          "spread": 0.00811635,
-          "score": 0.01028264
+          "bias": -0.00584547,
+          "spread": 0.0076784,
+          "score": 0.00965025
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.00167815,
-          "spread": 0.00298766,
-          "score": 0.00342671
+          "bias": -0.00120784,
+          "spread": 0.00160438,
+          "score": 0.00200821
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.01990818,
-          "spread": 0.01843146,
-          "score": 0.02713032
+          "bias": 0.02043367,
+          "spread": 0.0189057,
+          "score": 0.02783811
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00379461,
-          "spread": 0.0029617,
-          "score": 0.0048136
+          "bias": -0.00329246,
+          "spread": 0.0018614,
+          "score": 0.00378221
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00160216,
-          "spread": 0.0048158,
-          "score": 0.00507532
+          "bias": -0.00110208,
+          "spread": 0.00339167,
+          "score": 0.00356623
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.0028309,
-          "spread": 0.00406114,
-          "score": 0.00495044
+          "bias": -0.00232987,
+          "spread": 0.0028243,
+          "score": 0.00366127
         },
         {
           "profile": "cp_0pct",
@@ -7981,9 +7981,9 @@
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.00712918,
-          "spread": 0.05453523,
-          "score": 0.05499924
+          "bias": 0.0075743,
+          "spread": 0.05336965,
+          "score": 0.05390445
         },
         {
           "profile": "cp_0pct",
@@ -8017,36 +8017,36 @@
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 6.3e-05,
-          "spread": 0.01217825,
-          "score": 0.01217841
+          "bias": 0.00056585,
+          "spread": 0.01187027,
+          "score": 0.01188375
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00091075,
-          "spread": 0.00479557,
-          "score": 0.00488129
+          "bias": -0.00040927,
+          "spread": 0.00366992,
+          "score": 0.00369267
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00026725,
-          "spread": 0.00247988,
-          "score": 0.00249423
+          "bias": 0.00023926,
+          "spread": 0.00245137,
+          "score": 0.00246302
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00109247,
-          "spread": 0.00203933,
-          "score": 0.00231352
+          "bias": 0.00178909,
+          "spread": 0.00181329,
+          "score": 0.00254733
         },
         {
           "profile": "cp_0pct",
@@ -8062,126 +8062,126 @@
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00073143,
-          "spread": 0.01045936,
-          "score": 0.01048491
+          "bias": 0.00142621,
+          "spread": 0.01027522,
+          "score": 0.01037372
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00100744,
-          "spread": 0.00264446,
-          "score": 0.00282986
+          "bias": -0.00031219,
+          "spread": 0.00251287,
+          "score": 0.00253219
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00298486,
-          "spread": 0.00299647,
-          "score": 0.00422944
+          "bias": 0.00368241,
+          "spread": 0.00270804,
+          "score": 0.00457095
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00064048,
-          "spread": 0.00538697,
-          "score": 0.00542491
+          "bias": 0.00133637,
+          "spread": 0.00523013,
+          "score": 0.00539816
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00180376,
-          "spread": 0.00646884,
-          "score": 0.00671561
+          "bias": 0.00250136,
+          "spread": 0.00647983,
+          "score": 0.00694586
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00877237,
-          "spread": 0.03348075,
-          "score": 0.03461091
+          "bias": -0.00808372,
+          "spread": 0.03346457,
+          "score": 0.03442708
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.00529553,
-          "spread": 0.03353415,
-          "score": 0.03394969
+          "bias": 0.00598177,
+          "spread": 0.03312938,
+          "score": 0.03366508
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": -0.1548114,
-          "spread": 0.27164374,
-          "score": 0.31266099
+          "bias": -0.15431934,
+          "spread": 0.27164332,
+          "score": 0.31241727
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.00109247,
-          "spread": 0.00203933,
-          "score": 0.00231352
+          "bias": 0.00178909,
+          "spread": 0.00181329,
+          "score": 0.00254733
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.00125386,
-          "spread": 0.02350618,
-          "score": 0.0235396
+          "bias": 0.00198675,
+          "spread": 0.02378039,
+          "score": 0.02386323
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00131209,
-          "spread": 0.00106754,
-          "score": 0.00169152
+          "bias": -0.00058745,
+          "spread": 0.0006386,
+          "score": 0.0008677
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00056096,
-          "spread": 0.00315139,
-          "score": 0.00320092
+          "bias": 0.00128589,
+          "spread": 0.00265788,
+          "score": 0.0029526
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 6.197e-05,
-          "spread": 0.00410225,
-          "score": 0.00410272
+          "bias": 0.00078656,
+          "spread": 0.0037421,
+          "score": 0.00382387
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00062363,
-          "spread": 0.00108017,
-          "score": 0.00124727
+          "bias": -0.00040369,
+          "spread": 0.00069922,
+          "score": 0.00080739
         },
         {
           "profile": "cp_0pct",
@@ -8197,9 +8197,9 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.00841854,
-          "spread": 0.0362672,
-          "score": 0.03723146
+          "bias": 0.00913948,
+          "spread": 0.03598354,
+          "score": 0.03712607
         },
         {
           "profile": "cp_0pct",
@@ -8233,189 +8233,189 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -4.478e-05,
-          "spread": 0.01293028,
-          "score": 0.01293036
+          "bias": 0.00067984,
+          "spread": 0.01283909,
+          "score": 0.01285708
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00488225,
-          "spread": 0.00507183,
-          "score": 0.00703987
+          "bias": 0.00561164,
+          "spread": 0.00505495,
+          "score": 0.00755268
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00076327,
-          "spread": 0.0039741,
-          "score": 0.00404673
+          "bias": 0.00148998,
+          "spread": 0.00402376,
+          "score": 0.00429076
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00153161,
-          "spread": 0.00154332,
-          "score": 0.00217432
+          "bias": 0.00149479,
+          "spread": 0.00150792,
+          "score": 0.00212326
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.00235001,
-          "spread": 0.00181394,
-          "score": 0.00296866
+          "bias": 0.0022366,
+          "spread": 0.00184051,
+          "score": 0.00289653
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00039128,
-          "spread": 0.01141579,
-          "score": 0.0114225
+          "bias": 0.00035351,
+          "spread": 0.01132538,
+          "score": 0.01133089
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00035277,
-          "spread": 0.00168249,
-          "score": 0.00171907
+          "bias": 0.00031592,
+          "spread": 0.00160758,
+          "score": 0.00163833
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00299429,
-          "spread": 0.00131465,
-          "score": 0.00327018
+          "bias": 0.00295747,
+          "spread": 0.00132267,
+          "score": 0.00323977
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00057428,
-          "spread": 0.00222472,
-          "score": 0.00229765
+          "bias": -0.00061097,
+          "spread": 0.00222722,
+          "score": 0.0023095
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00140993,
-          "spread": 0.01026565,
-          "score": 0.01036202
+          "bias": 0.00137316,
+          "spread": 0.01026518,
+          "score": 0.01035662
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00349407,
-          "spread": 0.02065543,
-          "score": 0.02094887
+          "bias": 0.00345684,
+          "spread": 0.02063452,
+          "score": 0.02092207
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.0361877,
-          "spread": 0.03055484,
-          "score": 0.04736188
+          "bias": -0.03622114,
+          "spread": 0.03061605,
+          "score": 0.04742692
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.05408209,
-          "spread": 0.17338282,
-          "score": 0.18162179
+          "bias": 0.05402819,
+          "spread": 0.17329936,
+          "score": 0.18152607
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.00153161,
-          "spread": 0.00154332,
-          "score": 0.00217432
+          "bias": 0.00149479,
+          "spread": 0.00150792,
+          "score": 0.00212326
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.00345852,
-          "spread": 0.01462605,
-          "score": 0.0150294
+          "bias": 0.00342309,
+          "spread": 0.01471553,
+          "score": 0.01510842
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00115779,
-          "spread": 0.00128684,
-          "score": 0.00173102
+          "bias": 0.00112113,
+          "spread": 0.00126619,
+          "score": 0.00169121
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00064171,
-          "spread": 0.00232911,
-          "score": 0.0024159
+          "bias": 0.00060485,
+          "spread": 0.00222229,
+          "score": 0.00230313
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00024906,
-          "spread": 0.00276377,
-          "score": 0.00277497
+          "bias": 0.00021221,
+          "spread": 0.00267239,
+          "score": 0.0026808
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00056791,
-          "spread": 0.00231979,
-          "score": 0.0023883
+          "bias": 0.00053106,
+          "spread": 0.00221394,
+          "score": 0.00227675
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 9.614e-05,
-          "spread": 0.00016652,
-          "score": 0.00019228
+          "bias": 7.543e-05,
+          "spread": 0.00013066,
+          "score": 0.00015087
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.00831306,
-          "spread": 0.02798172,
-          "score": 0.02919047
+          "bias": -0.00835053,
+          "spread": 0.02793809,
+          "score": 0.02915936
         },
         {
           "profile": "cp_0pct",
@@ -8449,198 +8449,198 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00297115,
-          "spread": 0.0053148,
-          "score": 0.00608892
+          "bias": 0.00293446,
+          "spread": 0.00531529,
+          "score": 0.00607152
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00043659,
-          "spread": 0.00297499,
-          "score": 0.00300686
+          "bias": 0.00040016,
+          "spread": 0.00303578,
+          "score": 0.00306204
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00274702,
-          "spread": 0.00516232,
-          "score": 0.00584771
+          "bias": 0.00271029,
+          "spread": 0.00515475,
+          "score": 0.00582384
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.0007862,
-          "spread": 0.00171218,
-          "score": 0.00188405
+          "bias": 0.00066443,
+          "spread": 0.00179042,
+          "score": 0.00190973
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.00136543,
-          "spread": 0.00160209,
-          "score": 0.00210501
+          "bias": 0.00129467,
+          "spread": 0.00163869,
+          "score": 0.00208842
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00209517,
-          "spread": 0.00430115,
-          "score": 0.00478431
+          "bias": 0.00197323,
+          "spread": 0.00433457,
+          "score": 0.00476258
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00099102,
-          "spread": 0.00155434,
-          "score": 0.00184339
+          "bias": 0.00086925,
+          "spread": 0.00165401,
+          "score": 0.00186851
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00035771,
-          "spread": 0.00130418,
-          "score": 0.00135234
+          "bias": 0.00023591,
+          "spread": 0.00134821,
+          "score": 0.0013687
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.0005329,
-          "spread": 0.00273945,
-          "score": 0.0027908
+          "bias": 0.00041124,
+          "spread": 0.00282115,
+          "score": 0.00285096
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00538877,
-          "spread": 0.00736276,
-          "score": 0.00912409
+          "bias": 0.00526658,
+          "spread": 0.00740042,
+          "score": 0.00908312
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00380856,
-          "spread": 0.02999761,
-          "score": 0.03023841
+          "bias": -0.00392663,
+          "spread": 0.03010079,
+          "score": 0.03035583
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.01341685,
-          "spread": 0.02004463,
-          "score": 0.02412051
+          "bias": -0.01353554,
+          "spread": 0.02011898,
+          "score": 0.02424839
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.03431081,
-          "spread": 0.23056244,
-          "score": 0.23310142
+          "bias": 0.03415007,
+          "spread": 0.23038242,
+          "score": 0.23289974
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.10064593,
-          "spread": 0.12955433,
-          "score": 0.16405465
+          "bias": -0.10076942,
+          "spread": 0.12946095,
+          "score": 0.16405674
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.0067243,
-          "spread": 0.03876545,
-          "score": 0.03934433
+          "bias": -0.00684663,
+          "spread": 0.03874155,
+          "score": 0.03934189
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00015222,
-          "spread": 0.00244182,
-          "score": 0.00244656
+          "bias": -0.00027456,
+          "spread": 0.00248188,
+          "score": 0.00249702
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00124048,
-          "spread": 0.00063618,
-          "score": 0.0013941
+          "bias": 0.00111798,
+          "spread": 0.00078669,
+          "score": 0.00136703
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00056824,
-          "spread": 0.00143652,
-          "score": 0.00154483
+          "bias": -0.00069042,
+          "spread": 0.00157445,
+          "score": 0.00171917
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.0004671,
-          "spread": 0.00101511,
-          "score": 0.00111742
+          "bias": 0.00034477,
+          "spread": 0.00117374,
+          "score": 0.00122332
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": -0.00031793,
-          "spread": 0.00148923,
-          "score": 0.00152279
+          "bias": -0.00044034,
+          "spread": 0.00149146,
+          "score": 0.0015551
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.00196803,
-          "spread": 0.02152768,
-          "score": 0.02161745
+          "bias": 0.00184895,
+          "spread": 0.02169329,
+          "score": 0.02177194
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00085396,
-          "spread": 0.00228378,
-          "score": 0.00243821
+          "bias": -0.00089623,
+          "spread": 0.0024239,
+          "score": 0.00258428
         },
         {
           "profile": "cp_0pct",
@@ -8665,36 +8665,36 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00137435,
-          "spread": 0.00621371,
-          "score": 0.00636388
+          "bias": 0.00125258,
+          "spread": 0.00633141,
+          "score": 0.00645413
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00285544,
-          "spread": 0.00317819,
-          "score": 0.00427252
+          "bias": 0.00273303,
+          "spread": 0.00328759,
+          "score": 0.00427524
         },
         {
           "profile": "cp_0pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00048749,
-          "spread": 0.00308945,
-          "score": 0.00312768
+          "bias": 0.00036481,
+          "spread": 0.00303664,
+          "score": 0.00305847
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 1,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00507537,
-          "spread": 0.00450642,
-          "score": 0.00678728
+          "bias": -0.00275742,
+          "spread": 0.00206798,
+          "score": 0.00344672
         },
         {
           "profile": "cp_minus_10pct",
@@ -8710,117 +8710,117 @@
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00499391,
-          "spread": 0.01375917,
-          "score": 0.01463741
+          "bias": -0.00269173,
+          "spread": 0.01340259,
+          "score": 0.01367022
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00721926,
-          "spread": 0.0011793,
-          "score": 0.00731495
+          "bias": -0.00488225,
+          "spread": 0.00264693,
+          "score": 0.00555361
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00476991,
-          "spread": 0.00761916,
-          "score": 0.00898909
+          "bias": -0.00244764,
+          "spread": 0.00509015,
+          "score": 0.00564806
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00234172,
-          "spread": 0.00690072,
-          "score": 0.00728722
+          "bias": -4.423e-05,
+          "spread": 0.00485533,
+          "score": 0.00485553
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": -0.00421,
-          "spread": 0.00414075,
-          "score": 0.00590507
+          "bias": -0.0019145,
+          "spread": 0.00636169,
+          "score": 0.00664353
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00398258,
-          "spread": 0.06245687,
-          "score": 0.06258372
+          "bias": 0.00611396,
+          "spread": 0.06051498,
+          "score": 0.06082305
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.04086111,
-          "spread": 0.18498537,
-          "score": 0.18944449
+          "bias": -0.03854316,
+          "spread": 0.18737272,
+          "score": 0.19129588
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": -1.32397735,
-          "spread": 2.22321078,
-          "score": 2.58758231
+          "bias": -1.3216594,
+          "spread": 2.2227762,
+          "score": 2.58602352
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 1.99522174,
-          "spread": 3.58522966,
-          "score": 4.10302102
+          "bias": 1.99753969,
+          "spread": 3.58508454,
+          "score": 4.10402193
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.00563065,
-          "spread": 0.054523,
-          "score": 0.05481297
+          "bias": -0.00284043,
+          "spread": 0.05285787,
+          "score": 0.05293413
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00424526,
-          "spread": 0.00992942,
-          "score": 0.01079887
+          "bias": -0.00158171,
+          "spread": 0.0092076,
+          "score": 0.00934246
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00191455,
-          "spread": 0.01296664,
-          "score": 0.01310722
+          "bias": 0.00292983,
+          "spread": 0.01116042,
+          "score": 0.01153859
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00107473,
-          "spread": 0.00348257,
-          "score": 0.00364463
+          "bias": -0.00048312,
+          "spread": 0.00246021,
+          "score": 0.0025072
         },
         {
           "profile": "cp_minus_10pct",
@@ -8845,9 +8845,9 @@
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.03390598,
-          "spread": 0.06876383,
-          "score": 0.07666863
+          "bias": 0.03637764,
+          "spread": 0.06641095,
+          "score": 0.07572151
         },
         {
           "profile": "cp_minus_10pct",
@@ -8881,36 +8881,36 @@
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00622885,
-          "spread": 0.01874137,
-          "score": 0.01974937
+          "bias": -0.00365165,
+          "spread": 0.01811613,
+          "score": 0.0184805
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00950934,
-          "spread": 0.00925142,
-          "score": 0.01326711
+          "bias": -0.00695012,
+          "spread": 0.00673638,
+          "score": 0.00967899
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00446816,
-          "spread": 0.00368922,
-          "score": 0.00579438
+          "bias": -0.00186612,
+          "spread": 0.00445903,
+          "score": 0.00483377
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 2,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00149097,
-          "spread": 0.00276259,
-          "score": 0.00313925
+          "bias": -0.00105359,
+          "spread": 0.00149011,
+          "score": 0.00182496
         },
         {
           "profile": "cp_minus_10pct",
@@ -8926,117 +8926,117 @@
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00917701,
-          "spread": 0.01062145,
-          "score": 0.01403683
+          "bias": 0.00960016,
+          "spread": 0.01059603,
+          "score": 0.01429822
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00577329,
-          "spread": 0.00227033,
-          "score": 0.00620365
+          "bias": -0.00532438,
+          "spread": 0.00308218,
+          "score": 0.00615214
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00138499,
-          "spread": 0.00534011,
-          "score": 0.00551679
+          "bias": 0.00182503,
+          "spread": 0.00401921,
+          "score": 0.00441416
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 9.1e-07,
-          "spread": 0.00680675,
-          "score": 0.00680675
+          "bias": 0.00042811,
+          "spread": 0.00553347,
+          "score": 0.00555001
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": -0.00204889,
-          "spread": 0.00641047,
-          "score": 0.00672994
+          "bias": -0.00161606,
+          "spread": 0.00672945,
+          "score": 0.00692078
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.01527326,
-          "spread": 0.06194481,
-          "score": 0.06379994
+          "bias": -0.01491462,
+          "spread": 0.06120685,
+          "score": 0.06299782
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.12072078,
-          "spread": 0.16356336,
-          "score": 0.20328916
+          "bias": 0.1209829,
+          "spread": 0.16224911,
+          "score": 0.20238981
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": -0.1714385,
-          "spread": 0.20733368,
-          "score": 0.26903236
+          "bias": -0.17101305,
+          "spread": 0.20708456,
+          "score": 0.26856932
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.27550006,
-          "spread": 0.38871942,
-          "score": 0.47644839
+          "bias": -0.27506269,
+          "spread": 0.38849602,
+          "score": 0.47601327
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.0255841,
-          "spread": 0.02440216,
-          "score": 0.03535551
+          "bias": 0.02611872,
+          "spread": 0.02501441,
+          "score": 0.03616501
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00132058,
-          "spread": 0.00422899,
-          "score": 0.00443039
+          "bias": -0.00084868,
+          "spread": 0.00349403,
+          "score": 0.00359562
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.0063318,
-          "spread": 0.00531823,
-          "score": 0.00826893
+          "bias": -0.00583871,
+          "spread": 0.00390156,
+          "score": 0.0070223
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00452121,
-          "spread": 0.00446615,
-          "score": 0.00635514
+          "bias": -0.00402261,
+          "spread": 0.00305322,
+          "score": 0.00505011
         },
         {
           "profile": "cp_minus_10pct",
@@ -9061,9 +9061,9 @@
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.02436518,
-          "spread": 0.05242084,
-          "score": 0.05780663
+          "bias": 0.02478512,
+          "spread": 0.05130201,
+          "score": 0.05697542
         },
         {
           "profile": "cp_minus_10pct",
@@ -9097,36 +9097,36 @@
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00021562,
-          "spread": 0.01207646,
-          "score": 0.01207838
+          "bias": 0.00066752,
+          "spread": 0.01177442,
+          "score": 0.01179333
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00132489,
-          "spread": 0.00481218,
-          "score": 0.00499123
+          "bias": -0.00087385,
+          "spread": 0.00393046,
+          "score": 0.00402642
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00098091,
-          "spread": 0.00241275,
-          "score": 0.00260453
+          "bias": 0.00143948,
+          "spread": 0.00293126,
+          "score": 0.00326564
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00109301,
-          "spread": 0.00192617,
-          "score": 0.00221468
+          "bias": 0.00174337,
+          "spread": 0.00172362,
+          "score": 0.00245157
         },
         {
           "profile": "cp_minus_10pct",
@@ -9142,126 +9142,126 @@
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00146605,
-          "spread": 0.00925575,
-          "score": 0.00937114
+          "bias": -0.00081505,
+          "spread": 0.00911784,
+          "score": 0.00915419
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00235733,
-          "spread": 0.00228774,
-          "score": 0.00328493
+          "bias": -0.00169805,
+          "spread": 0.00226412,
+          "score": 0.00283013
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00280399,
-          "spread": 0.00335633,
-          "score": 0.00437348
+          "bias": 0.00345546,
+          "spread": 0.00300985,
+          "score": 0.00458251
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00328413,
-          "spread": 0.00467682,
-          "score": 0.00571473
+          "bias": 0.00392195,
+          "spread": 0.00449938,
+          "score": 0.00596876
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00482793,
-          "spread": 0.00597507,
-          "score": 0.00768182
+          "bias": 0.00546062,
+          "spread": 0.00593613,
+          "score": 0.00806573
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00584852,
-          "spread": 0.03298585,
-          "score": 0.03350032
+          "bias": -0.00522893,
+          "spread": 0.03295275,
+          "score": 0.03336503
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.01668992,
-          "spread": 0.0406862,
-          "score": 0.04397636
+          "bias": 0.0172945,
+          "spread": 0.04035191,
+          "score": 0.0439019
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.15920985,
-          "spread": 0.27612565,
-          "score": 0.3187368
+          "bias": 0.15955561,
+          "spread": 0.27602388,
+          "score": 0.31882154
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.33860231,
-          "spread": 0.49449524,
-          "score": 0.59931383
+          "bias": -0.33795195,
+          "spread": 0.49418775,
+          "score": 0.59869279
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.01373438,
-          "spread": 0.01967239,
-          "score": 0.02399242
+          "bias": 0.0144783,
+          "spread": 0.02007536,
+          "score": 0.02475159
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00169823,
-          "spread": 0.00192317,
-          "score": 0.00256565
+          "bias": 0.0023762,
+          "spread": 0.00159398,
+          "score": 0.00286132
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00427691,
-          "spread": 0.00285569,
-          "score": 0.00514266
+          "bias": -0.00356071,
+          "spread": 0.00241853,
+          "score": 0.00430441
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00134713,
-          "spread": 0.00346691,
-          "score": 0.00371944
+          "bias": -0.0006235,
+          "spread": 0.00314033,
+          "score": 0.00320162
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00042544,
-          "spread": 0.0017426,
-          "score": 0.00179378
+          "bias": -0.00020581,
+          "spread": 0.00138311,
+          "score": 0.00139834
         },
         {
           "profile": "cp_minus_10pct",
@@ -9277,9 +9277,9 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.02688248,
-          "spread": 0.04312597,
-          "score": 0.05081847
+          "bias": 0.02751631,
+          "spread": 0.0427747,
+          "score": 0.05086082
         },
         {
           "profile": "cp_minus_10pct",
@@ -9313,189 +9313,189 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.000323,
-          "spread": 0.01202633,
-          "score": 0.01203066
+          "bias": 0.00097581,
+          "spread": 0.01195965,
+          "score": 0.01199939
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00397318,
-          "spread": 0.00449348,
-          "score": 0.00599812
+          "bias": 0.00462953,
+          "spread": 0.00446148,
+          "score": 0.00642941
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00165524,
-          "spread": 0.00401505,
-          "score": 0.00434286
+          "bias": 0.0023109,
+          "spread": 0.00407399,
+          "score": 0.00468377
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00153465,
-          "spread": 0.00144272,
-          "score": 0.00210632
+          "bias": 0.00150011,
+          "spread": 0.00141091,
+          "score": 0.00205937
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.04035882,
-          "spread": 0.01000038,
-          "score": 0.04157935
+          "bias": 0.04025334,
+          "spread": 0.01002506,
+          "score": 0.04148293
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00161126,
-          "spread": 0.01150017,
-          "score": 0.01161249
+          "bias": 0.00157502,
+          "spread": 0.0114258,
+          "score": 0.01153385
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.0006136,
-          "spread": 0.00159073,
-          "score": 0.00170497
+          "bias": -0.00064853,
+          "spread": 0.00156348,
+          "score": 0.00169265
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00285043,
-          "spread": 0.00107992,
-          "score": 0.00304814
+          "bias": 0.00281625,
+          "spread": 0.00102494,
+          "score": 0.00299696
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00136524,
-          "spread": 0.00195698,
-          "score": 0.00238614
+          "bias": 0.00133173,
+          "spread": 0.00193999,
+          "score": 0.00235309
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00508674,
-          "spread": 0.00893921,
-          "score": 0.01028515
+          "bias": 0.00505329,
+          "spread": 0.00891889,
+          "score": 0.01025096
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.0065207,
-          "spread": 0.01853386,
-          "score": 0.01964748
+          "bias": 0.00648734,
+          "spread": 0.01851621,
+          "score": 0.01961977
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.01801613,
-          "spread": 0.03406112,
-          "score": 0.03853233
+          "bias": -0.018046,
+          "spread": 0.0340999,
+          "score": 0.03858058
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": -0.01772958,
-          "spread": 0.28552573,
-          "score": 0.28607566
+          "bias": -0.01778217,
+          "spread": 0.28555196,
+          "score": 0.2861051
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.09360749,
-          "spread": 0.11471668,
-          "score": 0.14806174
+          "bias": -0.09364203,
+          "spread": 0.11463957,
+          "score": 0.14802385
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.00751962,
-          "spread": 0.01479795,
-          "score": 0.01659891
+          "bias": 0.0074845,
+          "spread": 0.01491804,
+          "score": 0.01669029
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00400088,
-          "spread": 0.00199015,
-          "score": 0.00446852
+          "bias": 0.0039673,
+          "spread": 0.00197638,
+          "score": 0.00443233
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00377145,
-          "spread": 0.002052,
-          "score": 0.00429355
+          "bias": -0.00380749,
+          "spread": 0.00193924,
+          "score": 0.00427289
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00133816,
-          "spread": 0.00257645,
-          "score": 0.00290323
+          "bias": -0.00137492,
+          "spread": 0.00247626,
+          "score": 0.00283236
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 9.1e-05,
-          "spread": 0.00228297,
-          "score": 0.00228478
+          "bias": 5.42e-05,
+          "spread": 0.002173,
+          "score": 0.00217367
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00169442,
-          "spread": 0.00204958,
-          "score": 0.0026593
+          "bias": 0.00167374,
+          "spread": 0.00205042,
+          "score": 0.00264682
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.02940018,
-          "spread": 0.04724771,
-          "score": 0.05564815
+          "bias": 0.02936824,
+          "spread": 0.04718324,
+          "score": 0.05557654
         },
         {
           "profile": "cp_minus_10pct",
@@ -9529,198 +9529,198 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00300491,
-          "spread": 0.00477069,
-          "score": 0.00563817
+          "bias": 0.00297187,
+          "spread": 0.00477096,
+          "score": 0.00562086
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 4.687e-05,
-          "spread": 0.00279457,
-          "score": 0.00279496
+          "bias": 1.41e-05,
+          "spread": 0.00284851,
+          "score": 0.00284855
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00351336,
-          "spread": 0.00498562,
-          "score": 0.00609919
+          "bias": 0.00348023,
+          "spread": 0.00497459,
+          "score": 0.00607112
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00081861,
-          "spread": 0.00161825,
-          "score": 0.00181352
+          "bias": 0.00070418,
+          "spread": 0.00169029,
+          "score": 0.0018311
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.01375606,
-          "spread": 0.05117808,
-          "score": 0.05299457
+          "bias": 0.01368951,
+          "spread": 0.05131834,
+          "score": 0.05311285
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00119462,
-          "spread": 0.00479995,
-          "score": 0.00494638
+          "bias": 0.00108167,
+          "spread": 0.00485569,
+          "score": 0.00497471
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 2.454e-05,
-          "spread": 0.00144275,
-          "score": 0.00144296
+          "bias": -9.147e-05,
+          "spread": 0.00150048,
+          "score": 0.00150327
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00037881,
-          "spread": 0.00123509,
-          "score": 0.00129188
+          "bias": 0.00026414,
+          "spread": 0.00132828,
+          "score": 0.00135429
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00244855,
-          "spread": 0.0024929,
-          "score": 0.00349427
+          "bias": 0.00233636,
+          "spread": 0.002585,
+          "score": 0.00348437
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00898849,
-          "spread": 0.00744594,
-          "score": 0.01167197
+          "bias": 0.00887723,
+          "spread": 0.00749428,
+          "score": 0.01161764
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00017716,
-          "spread": 0.02487837,
-          "score": 0.02487901
+          "bias": -0.00028338,
+          "spread": 0.02497057,
+          "score": 0.02497217
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.00505683,
-          "spread": 0.02017909,
-          "score": 0.02080306
+          "bias": -0.00516334,
+          "spread": 0.02020939,
+          "score": 0.02085856
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.03445762,
-          "spread": 0.2013837,
-          "score": 0.20431036
+          "bias": 0.03431906,
+          "spread": 0.20122926,
+          "score": 0.20413479
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.58643104,
-          "spread": 0.54929485,
-          "score": 0.80350867
+          "bias": -0.58653317,
+          "spread": 0.54917965,
+          "score": 0.80350447
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.001833,
-          "spread": 0.04356545,
-          "score": 0.04360399
+          "bias": -0.00195578,
+          "spread": 0.04354783,
+          "score": 0.04359172
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00308202,
-          "spread": 0.00189955,
-          "score": 0.00362038
+          "bias": 0.00296777,
+          "spread": 0.00195655,
+          "score": 0.00355468
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00281769,
-          "spread": 0.00071337,
-          "score": 0.00290659
+          "bias": -0.00293868,
+          "spread": 0.00084936,
+          "score": 0.00305896
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00203143,
-          "spread": 0.0013246,
-          "score": 0.00242514
+          "bias": -0.00215331,
+          "spread": 0.0014599,
+          "score": 0.00260155
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -2.801e-05,
-          "spread": 0.00110866,
-          "score": 0.00110902
+          "bias": -0.00015023,
+          "spread": 0.00125899,
+          "score": 0.00126792
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00103838,
-          "spread": 0.00036696,
-          "score": 0.00110132
+          "bias": 0.00091611,
+          "spread": 0.00028754,
+          "score": 0.00096017
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.02594694,
-          "spread": 0.03792878,
-          "score": 0.04595472
+          "bias": 0.02584166,
+          "spread": 0.03805987,
+          "score": 0.04600375
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": 0.00374583,
-          "spread": 0.00383116,
-          "score": 0.00535808
+          "bias": 0.00370367,
+          "spread": 0.00388038,
+          "score": 0.00536419
         },
         {
           "profile": "cp_minus_10pct",
@@ -9745,36 +9745,36 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00205575,
-          "spread": 0.00517599,
-          "score": 0.00556929
+          "bias": 0.00194597,
+          "spread": 0.00528782,
+          "score": 0.00563452
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00224602,
-          "spread": 0.00322905,
-          "score": 0.00393337
+          "bias": 0.00213595,
+          "spread": 0.00333886,
+          "score": 0.00396362
         },
         {
           "profile": "cp_minus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00151856,
-          "spread": 0.00300965,
-          "score": 0.00337106
+          "bias": 0.00140792,
+          "spread": 0.00295375,
+          "score": 0.00327213
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00603945,
-          "spread": 0.0053219,
-          "score": 0.00804969
+          "bias": -0.00333653,
+          "spread": 0.00247365,
+          "score": 0.00415348
         },
         {
           "profile": "cp_plus_10pct",
@@ -9790,117 +9790,117 @@
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.01050764,
-          "spread": 0.01487169,
-          "score": 0.01820928
+          "bias": -0.00778153,
+          "spread": 0.01521842,
+          "score": 0.01709247
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00520793,
-          "spread": 0.00416893,
-          "score": 0.00667102
+          "bias": -0.00250881,
+          "spread": 0.00312478,
+          "score": 0.0040073
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00413503,
-          "spread": 0.0060418,
-          "score": 0.00732132
+          "bias": -0.00144196,
+          "spread": 0.00304512,
+          "score": 0.00336927
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00862137,
-          "spread": 0.00714664,
-          "score": 0.01119833
+          "bias": -0.00590577,
+          "spread": 0.00454347,
+          "score": 0.00745126
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": -0.01024604,
-          "spread": 0.00518371,
-          "score": 0.01148269
+          "bias": -0.00750515,
+          "spread": 0.00304867,
+          "score": 0.00810072
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.0688304,
-          "spread": 0.03847626,
-          "score": 0.07885459
+          "bias": -0.06627971,
+          "spread": 0.03676389,
+          "score": 0.07579303
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.02974629,
-          "spread": 0.1943186,
-          "score": 0.1965822
+          "bias": 0.03244921,
+          "spread": 0.19152299,
+          "score": 0.19425243
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 1.31286254,
-          "spread": 2.21952573,
-          "score": 2.57874049
+          "bias": 1.31556546,
+          "spread": 2.22001983,
+          "score": 2.58054268
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -2.00633656,
-          "spread": 3.58484177,
-          "score": 4.10809894
+          "bias": -2.00363364,
+          "spread": 3.58505821,
+          "score": 4.10696848
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.01676706,
-          "spread": 0.06779056,
-          "score": 0.06983334
+          "bias": -0.01402023,
+          "spread": 0.0661991,
+          "score": 0.06766748
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00838933,
-          "spread": 0.00998036,
-          "score": 0.01303796
+          "bias": -0.00529432,
+          "spread": 0.00926318,
+          "score": 0.01066941
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00027134,
-          "spread": 0.01510156,
-          "score": 0.01510399
+          "bias": 0.0007514,
+          "spread": 0.01406544,
+          "score": 0.01408549
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00199422,
-          "spread": 0.00184921,
-          "score": 0.00271966
+          "bias": -0.00140086,
+          "spread": 0.00083462,
+          "score": 0.00163064
         },
         {
           "profile": "cp_plus_10pct",
@@ -9925,9 +9925,9 @@
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.04257952,
-          "spread": 0.08565782,
-          "score": 0.09565708
+          "bias": -0.03946087,
+          "spread": 0.08612829,
+          "score": 0.09473776
         },
         {
           "profile": "cp_plus_10pct",
@@ -9961,36 +9961,36 @@
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00570293,
-          "spread": 0.01690292,
-          "score": 0.01783906
+          "bias": -0.00252289,
+          "spread": 0.01674148,
+          "score": 0.01693051
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00758806,
-          "spread": 0.00657672,
-          "score": 0.01004151
+          "bias": -0.00442531,
+          "spread": 0.00325611,
+          "score": 0.00549415
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00606272,
-          "spread": 0.00447217,
-          "score": 0.00753372
+          "bias": -0.00287432,
+          "spread": 0.0061349,
+          "score": 0.00677486
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 2,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00186534,
-          "spread": 0.00321318,
-          "score": 0.00371538
+          "bias": -0.00136228,
+          "spread": 0.00171967,
+          "score": 0.00219387
         },
         {
           "profile": "cp_plus_10pct",
@@ -10006,117 +10006,117 @@
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00881201,
-          "spread": 0.01421908,
-          "score": 0.01672823
+          "bias": -0.00828764,
+          "spread": 0.01420388,
+          "score": 0.01644491
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00283621,
-          "spread": 0.00215035,
-          "score": 0.00355923
+          "bias": -0.00233726,
+          "spread": 0.00268356,
+          "score": 0.00355869
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.0019264,
-          "spread": 0.00459726,
-          "score": 0.00498456
+          "bias": 0.00242415,
+          "spread": 0.00303474,
+          "score": 0.00388409
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00645576,
-          "spread": 0.00675631,
-          "score": 0.00934476
+          "bias": -0.0059548,
+          "spread": 0.00520244,
+          "score": 0.00790728
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": -0.01038237,
-          "spread": 0.00889251,
-          "score": 0.01367005
+          "bias": -0.00986812,
+          "spread": 0.0091707,
+          "score": 0.0134715
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.03459064,
-          "spread": 0.08664887,
-          "score": 0.09329812
+          "bias": -0.03416613,
+          "spread": 0.08574233,
+          "score": 0.09229881
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.07135446,
-          "spread": 0.2107669,
-          "score": 0.22251774
+          "bias": 0.07164096,
+          "spread": 0.20883935,
+          "score": 0.22078565
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.15812331,
-          "spread": 0.21668884,
-          "score": 0.26824808
+          "bias": 0.15863292,
+          "spread": 0.21690396,
+          "score": 0.26872241
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.27214375,
-          "spread": 0.38833403,
-          "score": 0.4741999
+          "bias": 0.27264682,
+          "spread": 0.38856544,
+          "score": 0.47467819
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.01703663,
-          "spread": 0.02573858,
-          "score": 0.03086619
+          "bias": 0.01756127,
+          "spread": 0.02611496,
+          "score": 0.03147045
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00674016,
-          "spread": 0.00302733,
-          "score": 0.00738881
+          "bias": -0.00620912,
+          "spread": 0.00152973,
+          "score": 0.00639478
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00308275,
-          "spread": 0.00499547,
-          "score": 0.0058701
+          "bias": 0.00358914,
+          "spread": 0.00371404,
+          "score": 0.00516489
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00102656,
-          "spread": 0.00399939,
-          "score": 0.00412904
+          "bias": -0.00052382,
+          "spread": 0.00289459,
+          "score": 0.0029416
         },
         {
           "profile": "cp_plus_10pct",
@@ -10141,9 +10141,9 @@
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.00844312,
-          "spread": 0.05986743,
-          "score": 0.06045986
+          "bias": -0.0079712,
+          "spread": 0.05877818,
+          "score": 0.05931622
         },
         {
           "profile": "cp_plus_10pct",
@@ -10177,36 +10177,36 @@
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00089566,
-          "spread": 0.01397102,
-          "score": 0.0139997
+          "bias": 0.00144943,
+          "spread": 0.01367915,
+          "score": 0.01375573
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00088125,
-          "spread": 0.00532605,
-          "score": 0.00539846
+          "bias": -0.00032972,
+          "spread": 0.00411145,
+          "score": 0.00412465
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00146924,
-          "spread": 0.00281002,
-          "score": 0.00317095
+          "bias": -0.00091363,
+          "spread": 0.00267169,
+          "score": 0.00282359
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00109193,
-          "spread": 0.00215355,
-          "score": 0.00241456
+          "bias": 0.00183538,
+          "spread": 0.00190476,
+          "score": 0.00264514
         },
         {
           "profile": "cp_plus_10pct",
@@ -10222,126 +10222,126 @@
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00315561,
-          "spread": 0.01162236,
-          "score": 0.01204314
+          "bias": 0.00389503,
+          "spread": 0.01140587,
+          "score": 0.0120526
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00015412,
-          "spread": 0.00314956,
-          "score": 0.00315332
+          "bias": 0.00088589,
+          "spread": 0.00297375,
+          "score": 0.0031029
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00305776,
-          "spread": 0.00292532,
-          "score": 0.00423171
+          "bias": 0.00380185,
+          "spread": 0.00273848,
+          "score": 0.00468544
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00141693,
-          "spread": 0.00577928,
-          "score": 0.00595045
+          "bias": -0.00066219,
+          "spread": 0.00559361,
+          "score": 0.00563267
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": -0.00042926,
-          "spread": 0.00629118,
-          "score": 0.00630581
+          "bias": 0.00033374,
+          "spread": 0.00625227,
+          "score": 0.00626117
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.01044832,
-          "spread": 0.03427753,
-          "score": 0.03583457
+          "bias": -0.00968853,
+          "spread": 0.0343034,
+          "score": 0.03564535
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.00606458,
-          "spread": 0.03482255,
-          "score": 0.0353467
+          "bias": -0.00529904,
+          "spread": 0.03435849,
+          "score": 0.03476472
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": -0.51037459,
-          "spread": 0.87892263,
-          "score": 1.01635979
+          "bias": -0.50978757,
+          "spread": 0.8788146,
+          "score": 1.01597168
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.1304416,
-          "spread": 0.14661915,
-          "score": 0.19624522
+          "bias": 0.13090959,
+          "spread": 0.14646365,
+          "score": 0.19644063
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.00390732,
-          "spread": 0.03131147,
-          "score": 0.03155432
+          "bias": -0.00317603,
+          "spread": 0.03158883,
+          "score": 0.0317481
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00414992,
-          "spread": 0.00131735,
-          "score": 0.00435399
+          "bias": -0.00337789,
+          "spread": 0.00121451,
+          "score": 0.00358959
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00518843,
-          "spread": 0.00362114,
-          "score": 0.00632712
+          "bias": 0.00592261,
+          "spread": 0.0031317,
+          "score": 0.00669962
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00181303,
-          "spread": 0.0039217,
-          "score": 0.00432051
+          "bias": 0.0025398,
+          "spread": 0.00354965,
+          "score": 0.0043647
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00083817,
-          "spread": 0.00072758,
-          "score": 0.00110991
+          "bias": -0.00061793,
+          "spread": 0.00052631,
+          "score": 0.00081169
         },
         {
           "profile": "cp_plus_10pct",
@@ -10357,9 +10357,9 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.00924612,
-          "spread": 0.03965478,
-          "score": 0.04071845
+          "bias": -0.00843807,
+          "spread": 0.03952625,
+          "score": 0.04041689
         },
         {
           "profile": "cp_plus_10pct",
@@ -10393,189 +10393,189 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00030927,
-          "spread": 0.01342848,
-          "score": 0.01343204
+          "bias": 0.00048834,
+          "spread": 0.01334914,
+          "score": 0.01335807
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00611462,
-          "spread": 0.00558366,
-          "score": 0.00828045
+          "bias": 0.00691787,
+          "spread": 0.00557521,
+          "score": 0.00888482
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00091886,
-          "spread": 0.00419345,
-          "score": 0.00429294
+          "bias": -0.00012124,
+          "spread": 0.00418397,
+          "score": 0.00418572
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00152858,
-          "spread": 0.00164407,
-          "score": 0.00224489
+          "bias": 0.00148935,
+          "spread": 0.00160515,
+          "score": 0.00218968
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": -0.0356588,
-          "spread": 0.0063725,
-          "score": 0.03622373
+          "bias": -0.03578036,
+          "spread": 0.00634382,
+          "score": 0.03633839
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00086998,
-          "spread": 0.01089088,
-          "score": 0.01092557
+          "bias": -0.00090928,
+          "spread": 0.01078805,
+          "score": 0.0108263
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00153526,
-          "spread": 0.00187957,
-          "score": 0.0024269
+          "bias": 0.00149641,
+          "spread": 0.00178002,
+          "score": 0.00232545
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00291676,
-          "spread": 0.00206024,
-          "score": 0.003571
+          "bias": 0.00287723,
+          "spread": 0.00211256,
+          "score": 0.0035695
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00230415,
-          "spread": 0.00263115,
-          "score": 0.00349744
+          "bias": -0.0023442,
+          "spread": 0.00262643,
+          "score": 0.00352043
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": -0.00064135,
-          "spread": 0.00948792,
-          "score": 0.00950957
+          "bias": -0.00068191,
+          "spread": 0.009474,
+          "score": 0.00949851
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00029102,
-          "spread": 0.02368483,
-          "score": 0.02368661
+          "bias": -0.00033226,
+          "spread": 0.02365863,
+          "score": 0.02366096
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.05296129,
-          "spread": 0.02899539,
-          "score": 0.06037906
+          "bias": -0.05299873,
+          "spread": 0.02907168,
+          "score": 0.06044856
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.11600997,
-          "spread": 0.35117785,
-          "score": 0.36984347
+          "bias": 0.1159549,
+          "spread": 0.35105652,
+          "score": 0.36971099
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.09667072,
-          "spread": 0.11446583,
-          "score": 0.14982541
+          "bias": 0.09663149,
+          "spread": 0.11455271,
+          "score": 0.14986651
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.00241904,
-          "spread": 0.01769988,
-          "score": 0.01786442
+          "bias": -0.00245358,
+          "spread": 0.01781818,
+          "score": 0.01798631
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00207792,
-          "spread": 0.00118363,
-          "score": 0.00239139
+          "bias": -0.00211773,
+          "spread": 0.00120108,
+          "score": 0.00243462
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00524984,
-          "spread": 0.00248665,
-          "score": 0.00580898
+          "bias": 0.00521205,
+          "spread": 0.002382,
+          "score": 0.00573056
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00167362,
-          "spread": 0.00295136,
-          "score": 0.00339286
+          "bias": 0.00163658,
+          "spread": 0.00286814,
+          "score": 0.00330221
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.0009583,
-          "spread": 0.00242978,
-          "score": 0.00261193
+          "bias": 0.0009213,
+          "spread": 0.00233448,
+          "score": 0.0025097
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": -0.00158098,
-          "spread": 0.00206184,
-          "score": 0.0025982
+          "bias": -0.0016017,
+          "spread": 0.00205821,
+          "score": 0.002608
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.04102636,
-          "spread": 0.04615402,
-          "score": 0.06175238
+          "bias": -0.04107031,
+          "spread": 0.04617071,
+          "score": 0.06179405
         },
         {
           "profile": "cp_plus_10pct",
@@ -10609,198 +10609,198 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00245345,
-          "spread": 0.00591631,
-          "score": 0.00640485
+          "bias": 0.00241305,
+          "spread": 0.00592774,
+          "score": 0.00640007
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00106813,
-          "spread": 0.002901,
-          "score": 0.00309139
+          "bias": 0.00102793,
+          "spread": 0.00297751,
+          "score": 0.00314996
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00175141,
-          "spread": 0.00552304,
-          "score": 0.00579408
+          "bias": 0.00171092,
+          "spread": 0.00550985,
+          "score": 0.00576937
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00075376,
-          "spread": 0.00180629,
-          "score": 0.00195726
+          "bias": 0.00062468,
+          "spread": 0.00189078,
+          "score": 0.0019913
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": -0.01102522,
-          "spread": 0.04940131,
-          "score": 0.05061664
+          "bias": -0.01110017,
+          "spread": 0.04924011,
+          "score": 0.05047576
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00227483,
-          "spread": 0.00409979,
-          "score": 0.00468862
+          "bias": 0.00214416,
+          "spread": 0.00412831,
+          "score": 0.00465192
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00188545,
-          "spread": 0.00165134,
-          "score": 0.00250637
+          "bias": 0.00175794,
+          "spread": 0.00179026,
+          "score": 0.00250906
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00039176,
-          "spread": 0.00170059,
-          "score": 0.00174513
+          "bias": 0.00026283,
+          "spread": 0.00167907,
+          "score": 0.00169952
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00136973,
-          "spread": 0.00343363,
-          "score": 0.00369676
+          "bias": -0.00150079,
+          "spread": 0.00350859,
+          "score": 0.00381609
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00179732,
-          "spread": 0.0073426,
-          "score": 0.00755937
+          "bias": 0.00166434,
+          "spread": 0.00738138,
+          "score": 0.00756669
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.01015019,
-          "spread": 0.03415352,
-          "score": 0.03562989
+          "bias": -0.0102798,
+          "spread": 0.03426853,
+          "score": 0.03577718
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.0211943,
-          "spread": 0.02326746,
-          "score": 0.03147338
+          "bias": -0.02132594,
+          "spread": 0.02334229,
+          "score": 0.03161737
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.02150415,
-          "spread": 0.26320595,
-          "score": 0.26408294
+          "bias": 0.02132214,
+          "spread": 0.263002,
+          "score": 0.2638649
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.58000457,
-          "spread": 0.67009365,
-          "score": 0.88624534
+          "bias": 0.57988229,
+          "spread": 0.67024434,
+          "score": 0.88627927
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.01458565,
-          "spread": 0.04314657,
-          "score": 0.04554522
+          "bias": -0.0147072,
+          "spread": 0.04312157,
+          "score": 0.04556064
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00364804,
-          "spread": 0.00288959,
-          "score": 0.00465381
+          "bias": -0.00377845,
+          "spread": 0.00289769,
+          "score": 0.00476165
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00525082,
-          "spread": 0.00089039,
-          "score": 0.00532578
+          "bias": 0.00512688,
+          "spread": 0.00101551,
+          "score": 0.00522649
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00061404,
-          "spread": 0.00136949,
-          "score": 0.00150085
+          "bias": 0.00049162,
+          "spread": 0.00150672,
+          "score": 0.0015849
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00085478,
-          "spread": 0.00098524,
-          "score": 0.00130436
+          "bias": 0.00073238,
+          "spread": 0.00113373,
+          "score": 0.00134971
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": -0.00200849,
-          "spread": 0.0030809,
-          "score": 0.00367776
+          "bias": -0.00213095,
+          "spread": 0.00308917,
+          "score": 0.00375286
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.02524338,
-          "spread": 0.02165946,
-          "score": 0.033262
+          "bias": -0.02537676,
+          "spread": 0.02167908,
+          "score": 0.03337608
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00536946,
-          "spread": 0.00423133,
-          "score": 0.00683632
+          "bias": -0.00541191,
+          "spread": 0.00432499,
+          "score": 0.0069278
         },
         {
           "profile": "cp_plus_10pct",
@@ -10825,36 +10825,36 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00121731,
-          "spread": 0.00673497,
-          "score": 0.0068441
+          "bias": 0.00108327,
+          "spread": 0.00685938,
+          "score": 0.0069444
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00334366,
-          "spread": 0.00326858,
-          "score": 0.00467586
+          "bias": 0.00320891,
+          "spread": 0.00337453,
+          "score": 0.00465666
         },
         {
           "profile": "cp_plus_10pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00064558,
-          "spread": 0.0028609,
-          "score": 0.00293284
+          "bias": -0.00078014,
+          "spread": 0.00283923,
+          "score": 0.00294446
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 1,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00570211,
-          "spread": 0.00503629,
-          "score": 0.00760777
+          "bias": -0.00313355,
+          "spread": 0.00233166,
+          "score": 0.00390586
         },
         {
           "profile": "cp_plus_3pct",
@@ -10870,117 +10870,117 @@
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00853385,
-          "spread": 0.00522728,
-          "score": 0.01000755
+          "bias": -0.00595354,
+          "spread": 0.00583936,
+          "score": 0.00833923
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00577662,
-          "spread": 0.00269471,
-          "score": 0.00637423
+          "bias": -0.0032031,
+          "spread": 0.0023631,
+          "score": 0.00398046
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00444985,
-          "spread": 0.00664623,
-          "score": 0.00799834
+          "bias": -0.00188656,
+          "spread": 0.00381876,
+          "score": 0.00425934
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00622801,
-          "spread": 0.00724356,
-          "score": 0.00955287
+          "bias": -0.00365827,
+          "spread": 0.00484998,
+          "score": 0.00607497
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": -0.0075629,
-          "spread": 0.00422495,
-          "score": 0.00866301
+          "bias": -0.00497894,
+          "spread": 0.00324992,
+          "score": 0.00594575
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.04347856,
-          "spread": 0.0462047,
-          "score": 0.06344494
+          "bias": -0.04107508,
+          "spread": 0.04426963,
+          "score": 0.06039009
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.00503362,
-          "spread": 0.06157958,
-          "score": 0.06178497
+          "bias": 0.00760218,
+          "spread": 0.05891622,
+          "score": 0.05940467
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.38996849,
-          "spread": 0.66458221,
-          "score": 0.77054846
+          "bias": 0.39253705,
+          "spread": 0.66504363,
+          "score": 0.7722489
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.60579124,
-          "spread": 1.07532692,
-          "score": 1.23422486
+          "bias": -0.60322268,
+          "spread": 1.0755106,
+          "score": 1.23312637
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.014784,
-          "spread": 0.06941923,
-          "score": 0.07097603
+          "bias": -0.01201291,
+          "spread": 0.06820977,
+          "score": 0.06925953
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00726967,
-          "spread": 0.00956051,
-          "score": 0.01201047
+          "bias": -0.00432734,
+          "spread": 0.00871078,
+          "score": 0.00972644
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00085593,
-          "spread": 0.01142044,
-          "score": 0.01145247
+          "bias": 0.00187661,
+          "spread": 0.00974741,
+          "score": 0.00992641
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00183006,
-          "spread": 0.00268577,
-          "score": 0.00325
+          "bias": -0.00123769,
+          "spread": 0.00166015,
+          "score": 0.00207074
         },
         {
           "profile": "cp_plus_3pct",
@@ -11005,9 +11005,9 @@
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.014486,
-          "spread": 0.06219812,
-          "score": 0.06386275
+          "bias": -0.01160818,
+          "spread": 0.06112455,
+          "score": 0.06221704
         },
         {
           "profile": "cp_plus_3pct",
@@ -11041,36 +11041,36 @@
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00538367,
-          "spread": 0.01872168,
-          "score": 0.01948038
+          "bias": -0.00241164,
+          "spread": 0.01846956,
+          "score": 0.01862634
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00811276,
-          "spread": 0.00730391,
-          "score": 0.01091623
+          "bias": -0.00516041,
+          "spread": 0.00425103,
+          "score": 0.00668589
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00557507,
-          "spread": 0.00463935,
-          "score": 0.00725292
+          "bias": -0.00259278,
+          "spread": 0.00577687,
+          "score": 0.00633204
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00173431,
-          "spread": 0.00305527,
-          "score": 0.00351319
+          "bias": -0.00125429,
+          "spread": 0.00163879,
+          "score": 0.00206371
         },
         {
           "profile": "cp_plus_3pct",
@@ -11086,117 +11086,117 @@
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00319283,
-          "spread": 0.00503106,
-          "score": 0.00595867
+          "bias": -0.00270574,
+          "spread": 0.0046138,
+          "score": 0.00534866
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00402428,
-          "spread": 0.00219911,
-          "score": 0.00458595
+          "bias": -0.00354299,
+          "spread": 0.00284011,
+          "score": 0.00454082
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00189036,
-          "spread": 0.00501339,
-          "score": 0.00535794
+          "bias": 0.00236772,
+          "spread": 0.00354191,
+          "score": 0.00426042
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.0041108,
-          "spread": 0.00644857,
-          "score": 0.0076474
+          "bias": -0.00363519,
+          "spread": 0.00499951,
+          "score": 0.0061814
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": -0.00712542,
-          "spread": 0.00716812,
-          "score": 0.0101071
+          "bias": -0.00663945,
+          "spread": 0.00750421,
+          "score": 0.01001976
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.03028645,
-          "spread": 0.07825554,
-          "score": 0.08391185
+          "bias": -0.02988388,
+          "spread": 0.07744871,
+          "score": 0.08301415
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.07904704,
-          "spread": 0.17959607,
-          "score": 0.19622228
+          "bias": 0.07933665,
+          "spread": 0.17786857,
+          "score": 0.19476019
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.04304639,
-          "spread": 0.06832226,
-          "score": 0.08075223
+          "bias": 0.04352664,
+          "spread": 0.06848837,
+          "score": 0.0811494
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.08046842,
-          "spread": 0.11640007,
-          "score": 0.14150669
+          "bias": 0.08094844,
+          "spread": 0.11660399,
+          "score": 0.14194766
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.02078212,
-          "spread": 0.01925928,
-          "score": 0.02833401
+          "bias": 0.02130685,
+          "spread": 0.01966362,
+          "score": 0.02899379
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00460553,
-          "spread": 0.0030068,
-          "score": 0.00550016
+          "bias": -0.00409491,
+          "spread": 0.0017592,
+          "score": 0.00445679
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00039148,
-          "spread": 0.00494304,
-          "score": 0.00495852
+          "bias": 0.00010999,
+          "spread": 0.00351599,
+          "score": 0.00351771
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00220616,
-          "spread": 0.00437909,
-          "score": 0.00490343
+          "bias": -0.00170527,
+          "spread": 0.0031288,
+          "score": 0.00356333
         },
         {
           "profile": "cp_plus_3pct",
@@ -11221,9 +11221,9 @@
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.00122657,
-          "spread": 0.05446568,
-          "score": 0.05447948
+          "bias": 0.00168416,
+          "spread": 0.05338983,
+          "score": 0.05341638
         },
         {
           "profile": "cp_plus_3pct",
@@ -11257,36 +11257,36 @@
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00073275,
-          "spread": 0.01224441,
-          "score": 0.01226632
+          "bias": 0.00124968,
+          "spread": 0.01181821,
+          "score": 0.0118841
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00107788,
-          "spread": 0.00484117,
-          "score": 0.00495972
+          "bias": -0.00056122,
+          "spread": 0.00376035,
+          "score": 0.003802
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00057168,
-          "spread": 0.00217459,
-          "score": 0.00224848
+          "bias": -5.01e-05,
+          "spread": 0.00230388,
+          "score": 0.00230443
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00109231,
-          "spread": 0.00207349,
-          "score": 0.00234361
+          "bias": 0.00180344,
+          "spread": 0.00184108,
+          "score": 0.0025772
         },
         {
           "profile": "cp_plus_3pct",
@@ -11302,126 +11302,126 @@
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00106644,
-          "spread": 0.01040561,
-          "score": 0.01046012
+          "bias": 0.00177471,
+          "spread": 0.01019535,
+          "score": 0.01034866
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00065281,
-          "spread": 0.00273101,
-          "score": 0.00280795
+          "bias": 5.388e-05,
+          "spread": 0.00258863,
+          "score": 0.0025892
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00301307,
-          "spread": 0.0029964,
-          "score": 0.00424936
+          "bias": 0.00372499,
+          "spread": 0.00271986,
+          "score": 0.00461229
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00012597,
-          "spread": 0.00511524,
-          "score": 0.00511679
+          "bias": 0.00084021,
+          "spread": 0.00497091,
+          "score": 0.00504142
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00040568,
-          "spread": 0.00624477,
-          "score": 0.00625794
+          "bias": 0.00112275,
+          "spread": 0.00622561,
+          "score": 0.00632604
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00838578,
-          "spread": 0.03295904,
-          "score": 0.03400911
+          "bias": -0.00767396,
+          "spread": 0.03297726,
+          "score": 0.03385837
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.00225583,
-          "spread": 0.04078184,
-          "score": 0.04084418
+          "bias": 0.00296341,
+          "spread": 0.04035455,
+          "score": 0.04046321
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": -0.25641146,
-          "spread": 0.4518962,
-          "score": 0.51957388
+          "bias": -0.25588602,
+          "spread": 0.45185522,
+          "score": 0.51927911
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.10300091,
-          "spread": 0.14834932,
-          "score": 0.18060096
+          "bias": 0.10371203,
+          "spread": 0.14868319,
+          "score": 0.18128121
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.00104875,
-          "spread": 0.02461906,
-          "score": 0.02464139
+          "bias": 0.00178235,
+          "spread": 0.02489525,
+          "score": 0.02495897
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00231611,
-          "spread": 0.00099292,
-          "score": 0.00251997
+          "bias": -0.00157674,
+          "spread": 0.00082157,
+          "score": 0.00177795
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00184623,
-          "spread": 0.00344283,
-          "score": 0.00390662
+          "bias": 0.00257426,
+          "spread": 0.00295054,
+          "score": 0.00391567
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00055692,
-          "spread": 0.00413339,
-          "score": 0.00417074
+          "bias": 0.00128263,
+          "spread": 0.00378193,
+          "score": 0.00399351
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00064048,
-          "spread": 0.00084411,
-          "score": 0.00105959
+          "bias": -0.00042041,
+          "spread": 0.00047419,
+          "score": 0.00063372
         },
         {
           "profile": "cp_plus_3pct",
@@ -11437,9 +11437,9 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.00496958,
-          "spread": 0.03686192,
-          "score": 0.0371954
+          "bias": 0.00571835,
+          "spread": 0.03661734,
+          "score": 0.03706115
         },
         {
           "profile": "cp_plus_3pct",
@@ -11473,189 +11473,189 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00019147,
-          "spread": 0.01307715,
-          "score": 0.01307856
+          "bias": 0.00093873,
+          "spread": 0.01299216,
+          "score": 0.01302603
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00534842,
-          "spread": 0.00523344,
-          "score": 0.00748295
+          "bias": 0.00610057,
+          "spread": 0.0052274,
+          "score": 0.00803385
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00037341,
-          "spread": 0.00430131,
-          "score": 0.00431749
+          "bias": 0.00112183,
+          "spread": 0.00430409,
+          "score": 0.00444788
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.0015307,
-          "spread": 0.00157353,
-          "score": 0.00219523
+          "bias": 0.00149319,
+          "spread": 0.00153705,
+          "score": 0.00214293
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": -0.00905263,
-          "spread": 0.00064199,
-          "score": 0.00907537
+          "bias": -0.00916842,
+          "spread": 0.00061486,
+          "score": 0.00918901
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 3.808e-05,
-          "spread": 0.01057964,
-          "score": 0.01057971
+          "bias": -4e-08,
+          "spread": 0.01048642,
+          "score": 0.01048642
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00068513,
-          "spread": 0.0017286,
-          "score": 0.00185942
+          "bias": 0.00064771,
+          "spread": 0.001644,
+          "score": 0.00176699
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00290525,
-          "spread": 0.00152411,
-          "score": 0.00328076
+          "bias": 0.00286766,
+          "spread": 0.00155158,
+          "score": 0.0032605
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00081263,
-          "spread": 0.00229753,
-          "score": 0.002437
+          "bias": -0.00085031,
+          "spread": 0.0022944,
+          "score": 0.0024469
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00091192,
-          "spread": 0.00979873,
-          "score": 0.00984107
+          "bias": 0.00087403,
+          "spread": 0.00979251,
+          "score": 0.00983144
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00233391,
-          "spread": 0.02190811,
-          "score": 0.02203208
+          "bias": 0.00229533,
+          "spread": 0.02187739,
+          "score": 0.02199747
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.04302372,
-          "spread": 0.02978741,
-          "score": 0.05232906
+          "bias": -0.04305837,
+          "spread": 0.02984954,
+          "score": 0.05239292
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.0721999,
-          "spread": 0.20361228,
-          "score": 0.21603422
+          "bias": 0.07214597,
+          "spread": 0.20350405,
+          "score": 0.2159142
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.03007334,
-          "spread": 0.03428337,
-          "score": 0.04560433
+          "bias": 0.03003583,
+          "spread": 0.0343655,
+          "score": 0.04564142
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.00389619,
-          "spread": 0.01546617,
-          "score": 0.01594938
+          "bias": -0.00393115,
+          "spread": 0.01556321,
+          "score": 0.01605202
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00022757,
-          "spread": 0.00110158,
-          "score": 0.00112484
+          "bias": 0.00019001,
+          "spread": 0.00109551,
+          "score": 0.00111186
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00222205,
-          "spread": 0.00224794,
-          "score": 0.00316081
+          "bias": 0.00218495,
+          "spread": 0.00214094,
+          "score": 0.00305902
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00063661,
-          "spread": 0.00275202,
-          "score": 0.0028247
+          "bias": 0.00059974,
+          "spread": 0.00266373,
+          "score": 0.00273041
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00074072,
-          "spread": 0.00239267,
-          "score": 0.0025047
+          "bias": 0.00070385,
+          "spread": 0.0022916,
+          "score": 0.00239726
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": -0.00040458,
-          "spread": 0.00064311,
-          "score": 0.00075979
+          "bias": -0.0004253,
+          "spread": 0.00063351,
+          "score": 0.00076303
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.01894063,
-          "spread": 0.03254489,
-          "score": 0.03765525
+          "bias": -0.01898022,
+          "spread": 0.03251579,
+          "score": 0.03765004
         },
         {
           "profile": "cp_plus_3pct",
@@ -11689,198 +11689,198 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00245485,
-          "spread": 0.00545276,
-          "score": 0.00597987
+          "bias": 0.00241707,
+          "spread": 0.00545277,
+          "score": 0.00596447
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00075806,
-          "spread": 0.00273887,
-          "score": 0.00284184
+          "bias": 0.00072053,
+          "spread": 0.00281057,
+          "score": 0.00290146
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00237576,
-          "spread": 0.00554981,
-          "score": 0.00603694
+          "bias": 0.00233793,
+          "spread": 0.00553932,
+          "score": 0.00601249
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00077647,
-          "spread": 0.0017404,
-          "score": 0.00190575
+          "bias": 0.00065256,
+          "spread": 0.00182047,
+          "score": 0.00193389
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": -0.00235176,
-          "spread": 0.01425535,
-          "score": 0.01444804
+          "bias": -0.00242373,
+          "spread": 0.01409664,
+          "score": 0.01430349
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00170224,
-          "spread": 0.00433603,
-          "score": 0.0046582
+          "bias": 0.00157786,
+          "spread": 0.0043806,
+          "score": 0.0046561
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00128971,
-          "spread": 0.00148068,
-          "score": 0.00196361
+          "bias": 0.00116626,
+          "spread": 0.00159555,
+          "score": 0.00197634
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00035437,
-          "spread": 0.00141615,
-          "score": 0.00145981
+          "bias": 0.00023048,
+          "spread": 0.00143504,
+          "score": 0.00145343
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -2.761e-05,
-          "spread": 0.00306257,
-          "score": 0.0030627
+          "bias": -0.00015202,
+          "spread": 0.00314093,
+          "score": 0.00314461
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00431188,
-          "spread": 0.00737273,
-          "score": 0.00854105
+          "bias": 0.00418658,
+          "spread": 0.00741873,
+          "score": 0.00851851
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.0058545,
-          "spread": 0.03081722,
-          "score": 0.03136839
+          "bias": -0.00597604,
+          "spread": 0.03092246,
+          "score": 0.03149463
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.01396387,
-          "spread": 0.01965514,
-          "score": 0.02411046
+          "bias": -0.01408692,
+          "spread": 0.01971757,
+          "score": 0.0242327
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.026257,
-          "spread": 0.243101,
-          "score": 0.24451488
+          "bias": 0.0260898,
+          "spread": 0.24291311,
+          "score": 0.24431016
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.10893246,
-          "spread": 0.14961516,
-          "score": 0.18507019
+          "bias": 0.10881068,
+          "spread": 0.14973692,
+          "score": 0.18509702
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.01028444,
-          "spread": 0.04818128,
-          "score": 0.04926668
+          "bias": -0.01040747,
+          "spread": 0.04813731,
+          "score": 0.04924953
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.0012544,
-          "spread": 0.00252328,
-          "score": 0.00281789
+          "bias": -0.00137908,
+          "spread": 0.00255669,
+          "score": 0.00290491
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00249411,
-          "spread": 0.00075281,
-          "score": 0.00260524
+          "bias": 0.00237123,
+          "spread": 0.00088796,
+          "score": 0.00253204
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00024052,
-          "spread": 0.00144458,
-          "score": 0.00146446
+          "bias": -0.00036271,
+          "spread": 0.00157329,
+          "score": 0.00161456
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00060524,
-          "spread": 0.00099793,
-          "score": 0.00116712
+          "bias": 0.00048294,
+          "spread": 0.0011507,
+          "score": 0.00124794
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": -0.0009048,
-          "spread": 0.0019767,
-          "score": 0.00217394
+          "bias": -0.00102716,
+          "spread": 0.00198107,
+          "score": 0.00223152
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.00414451,
-          "spread": 0.01889925,
-          "score": 0.01934834
+          "bias": -0.00426772,
+          "spread": 0.01906211,
+          "score": 0.01953401
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00221619,
-          "spread": 0.00247844,
-          "score": 0.00332478
+          "bias": -0.00225851,
+          "spread": 0.00261183,
+          "score": 0.0034529
         },
         {
           "profile": "cp_plus_3pct",
@@ -11905,36 +11905,36 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00131701,
-          "spread": 0.00615466,
-          "score": 0.00629399
+          "bias": 0.00119151,
+          "spread": 0.00627163,
+          "score": 0.00638382
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00319149,
-          "spread": 0.00318034,
-          "score": 0.00450557
+          "bias": 0.0030654,
+          "spread": 0.00329204,
+          "score": 0.00449825
         },
         {
           "profile": "cp_plus_3pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 6.79e-05,
-          "spread": 0.00307645,
-          "score": 0.0030772
+          "bias": -5.827e-05,
+          "spread": 0.00303274,
+          "score": 0.0030333
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 1,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00561549,
-          "spread": 0.00496701,
-          "score": 0.007497
+          "bias": -0.00307527,
+          "spread": 0.00229989,
+          "score": 0.00384015
         },
         {
           "profile": "rated_plus_5pct",
@@ -11950,117 +11950,117 @@
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00673717,
-          "spread": 0.00663401,
-          "score": 0.00945514
+          "bias": -0.00420223,
+          "spread": 0.0062948,
+          "score": 0.00756857
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00699078,
-          "spread": 0.00204094,
-          "score": 0.00728261
+          "bias": -0.00443767,
+          "spread": 0.00244753,
+          "score": 0.00506787
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00483314,
-          "spread": 0.00733603,
-          "score": 0.00878502
+          "bias": -0.00229181,
+          "spread": 0.00455308,
+          "score": 0.00509735
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00398177,
-          "spread": 0.00769281,
-          "score": 0.00866221
+          "bias": -0.00145418,
+          "spread": 0.00539077,
+          "score": 0.00558346
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": -0.00507686,
-          "spread": 0.00266905,
-          "score": 0.0057357
+          "bias": -0.0025452,
+          "spread": 0.00380481,
+          "score": 0.00457762
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.02098164,
-          "spread": 0.05659131,
-          "score": 0.06035566
+          "bias": -0.01862482,
+          "spread": 0.05467744,
+          "score": 0.0577625
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.00814056,
-          "spread": 0.00779428,
-          "score": 0.01127029
+          "bias": 0.01068078,
+          "spread": 0.00561578,
+          "score": 0.01206715
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.00814027,
-          "spread": 0.00778183,
-          "score": 0.01126148
+          "bias": 0.01068049,
+          "spread": 0.00560014,
+          "score": 0.01205962
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.00814057,
-          "spread": 0.00780229,
-          "score": 0.01127584
+          "bias": 0.01068079,
+          "spread": 0.00562239,
+          "score": 0.01207024
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.00085809,
-          "spread": 0.06352774,
-          "score": 0.06353353
+          "bias": 0.00194522,
+          "spread": 0.06170427,
+          "score": 0.06173492
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00015835,
-          "spread": 0.01123872,
-          "score": 0.01123984
+          "bias": 0.00311609,
+          "spread": 0.0109151,
+          "score": 0.01135119
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00751143,
-          "spread": 0.02252137,
-          "score": 0.02374097
+          "bias": -0.00643577,
+          "spread": 0.02209367,
+          "score": 0.02301194
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.03754144,
-          "spread": 0.02044011,
-          "score": 0.04274527
+          "bias": -0.03691403,
+          "spread": 0.02152682,
+          "score": 0.0427323
         },
         {
           "profile": "rated_plus_5pct",
@@ -12085,9 +12085,9 @@
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.00029071,
-          "spread": 0.06235168,
-          "score": 0.06235236
+          "bias": 0.0031384,
+          "spread": 0.06137755,
+          "score": 0.06145774
         },
         {
           "profile": "rated_plus_5pct",
@@ -12121,36 +12121,36 @@
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -8.023e-05,
-          "spread": 0.01861284,
-          "score": 0.01861301
+          "bias": 0.00283919,
+          "spread": 0.01843793,
+          "score": 0.01865525
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00391149,
-          "spread": 0.0069744,
-          "score": 0.00799638
+          "bias": -0.00101578,
+          "spread": 0.00393653,
+          "score": 0.00406547
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.0003763,
-          "spread": 0.00485884,
-          "score": 0.00487339
+          "bias": 0.00331099,
+          "spread": 0.00643359,
+          "score": 0.00723559
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 2,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00169296,
-          "spread": 0.00302663,
-          "score": 0.00346794
+          "bias": -0.00121577,
+          "spread": 0.00162635,
+          "score": 0.00203054
         },
         {
           "profile": "rated_plus_5pct",
@@ -12166,117 +12166,117 @@
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00479628,
-          "spread": 0.00454419,
-          "score": 0.00660711
+          "bias": 0.00526774,
+          "spread": 0.00426934,
+          "score": 0.00678059
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00542221,
-          "spread": 0.00261283,
-          "score": 0.00601891
+          "bias": -0.0049373,
+          "spread": 0.00336305,
+          "score": 0.00597387
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00183732,
-          "spread": 0.00558396,
-          "score": 0.00587847
+          "bias": 0.00231503,
+          "spread": 0.00414426,
+          "score": 0.00474703
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00187089,
-          "spread": 0.0069045,
-          "score": 0.00715349
+          "bias": -0.00140194,
+          "spread": 0.00549265,
+          "score": 0.00566874
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": -0.00470224,
-          "spread": 0.00694953,
-          "score": 0.00839089
+          "bias": -0.00422567,
+          "spread": 0.00745317,
+          "score": 0.00856774
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.02201602,
-          "spread": 0.07652441,
-          "score": 0.07962845
+          "bias": -0.02162875,
+          "spread": 0.07565641,
+          "score": 0.07868732
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.10440512,
-          "spread": 0.19036735,
-          "score": 0.21711784
+          "bias": 0.10467537,
+          "spread": 0.18869237,
+          "score": 0.21578171
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.00554183,
-          "spread": 0.01227853,
-          "score": 0.01347124
+          "bias": 0.00601471,
+          "spread": 0.01196072,
+          "score": 0.01338789
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.01355158,
-          "spread": 0.00447692,
-          "score": 0.01427194
+          "bias": 0.01402877,
+          "spread": 0.00364196,
+          "score": 0.01449381
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.03049141,
-          "spread": 0.02583212,
-          "score": 0.03996279
+          "bias": 0.03103399,
+          "spread": 0.02656553,
+          "score": 0.04085139
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.0002187,
-          "spread": 0.00286783,
-          "score": 0.00287616
+          "bias": 0.00029712,
+          "spread": 0.00196666,
+          "score": 0.00198898
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00150456,
-          "spread": 0.00522543,
-          "score": 0.00543772
+          "bias": -0.00097972,
+          "spread": 0.00380049,
+          "score": 0.00392474
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00145335,
-          "spread": 0.00379004,
-          "score": 0.00405914
+          "bias": -0.00092505,
+          "spread": 0.00234208,
+          "score": 0.00251814
         },
         {
           "profile": "rated_plus_5pct",
@@ -12301,9 +12301,9 @@
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.0104415,
-          "spread": 0.05688689,
-          "score": 0.05783722
+          "bias": 0.01088959,
+          "spread": 0.05576744,
+          "score": 0.05682068
         },
         {
           "profile": "rated_plus_5pct",
@@ -12337,36 +12337,36 @@
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00198584,
-          "spread": 0.01350972,
-          "score": 0.01365489
+          "bias": 0.00249158,
+          "spread": 0.01326517,
+          "score": 0.01349714
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.0010968,
-          "spread": 0.00547688,
-          "score": 0.00558562
+          "bias": 0.00160126,
+          "spread": 0.00462031,
+          "score": 0.00488991
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00248595,
-          "spread": 0.00177993,
-          "score": 0.00305746
+          "bias": 0.00299696,
+          "spread": 0.00237308,
+          "score": 0.00382274
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00111984,
-          "spread": 0.0020758,
-          "score": 0.0023586
+          "bias": 0.00182857,
+          "spread": 0.00184696,
+          "score": 0.00259902
         },
         {
           "profile": "rated_plus_5pct",
@@ -12382,126 +12382,126 @@
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00076508,
-          "spread": 0.0111403,
-          "score": 0.01116654
+          "bias": -5.792e-05,
+          "spread": 0.01093483,
+          "score": 0.01093498
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00166058,
-          "spread": 0.00248235,
-          "score": 0.00298657
+          "bias": -0.00094815,
+          "spread": 0.00241152,
+          "score": 0.00259122
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.0029619,
-          "spread": 0.00322118,
-          "score": 0.00437594
+          "bias": 0.00367168,
+          "spread": 0.00289191,
+          "score": 0.00467379
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00205856,
-          "spread": 0.0053676,
-          "score": 0.00574881
+          "bias": 0.00276065,
+          "spread": 0.0051828,
+          "score": 0.00587219
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00447798,
-          "spread": 0.00692627,
-          "score": 0.00824776
+          "bias": 0.00517859,
+          "spread": 0.00679696,
+          "score": 0.00854497
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00582665,
-          "spread": 0.03583524,
-          "score": 0.03630585
+          "bias": -0.00513462,
+          "spread": 0.03580853,
+          "score": 0.03617479
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.00937227,
-          "spread": 0.03443791,
-          "score": 0.03569046
+          "bias": 0.01006131,
+          "spread": 0.03402565,
+          "score": 0.03548204
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": -0.14537272,
-          "spread": 0.27736183,
-          "score": 0.31314982
+          "bias": -0.14487544,
+          "spread": 0.27736529,
+          "score": 0.31292235
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.0171565,
-          "spread": 0.00131362,
-          "score": 0.01720671
+          "bias": 0.01786523,
+          "spread": 0.00127408,
+          "score": 0.0179106
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.00730949,
-          "spread": 0.02197462,
-          "score": 0.02315843
+          "bias": 0.00805041,
+          "spread": 0.02233232,
+          "score": 0.02373903
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00182017,
-          "spread": 0.00120412,
-          "score": 0.00218241
+          "bias": 0.00256119,
+          "spread": 0.00096563,
+          "score": 0.00273718
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00024138,
-          "spread": 0.00294515,
-          "score": 0.00295503
+          "bias": 0.00100189,
+          "spread": 0.00248246,
+          "score": 0.00267701
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00109231,
-          "spread": 0.00363812,
-          "score": 0.00379856
+          "bias": 0.00185588,
+          "spread": 0.00328251,
+          "score": 0.00377083
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.03747212,
-          "spread": 0.02044059,
-          "score": 0.04268463
+          "bias": -0.03724103,
+          "spread": 0.02084082,
+          "score": 0.04267592
         },
         {
           "profile": "rated_plus_5pct",
@@ -12517,9 +12517,9 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.01377771,
-          "spread": 0.0382645,
-          "score": 0.04066937
+          "bias": 0.01450401,
+          "spread": 0.03797855,
+          "score": 0.04065386
         },
         {
           "profile": "rated_plus_5pct",
@@ -12553,189 +12553,189 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00157774,
-          "spread": 0.01391952,
-          "score": 0.01400865
+          "bias": 0.00230564,
+          "spread": 0.01383644,
+          "score": 0.01402723
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.0066774,
-          "spread": 0.00571219,
-          "score": 0.00878731
+          "bias": 0.0074105,
+          "spread": 0.00574977,
+          "score": 0.00937952
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.0029807,
-          "spread": 0.00446965,
-          "score": 0.00537237
+          "bias": 0.00371174,
+          "spread": 0.0045875,
+          "score": 0.00590103
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00157317,
-          "spread": 0.00157137,
-          "score": 0.00222352
+          "bias": 0.00153565,
+          "spread": 0.00153524,
+          "score": 0.00217144
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.0175834,
-          "spread": 0.00201412,
-          "score": 0.01769838
+          "bias": 0.01746827,
+          "spread": 0.00204107,
+          "score": 0.01758711
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00138184,
-          "spread": 0.01172119,
-          "score": 0.01180236
+          "bias": 0.00134296,
+          "spread": 0.01163356,
+          "score": 0.01171082
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -2.622e-05,
-          "spread": 0.00156253,
-          "score": 0.00156275
+          "bias": -6.395e-05,
+          "spread": 0.00150589,
+          "score": 0.00150725
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00306714,
-          "spread": 0.00120196,
-          "score": 0.00329425
+          "bias": 0.00302981,
+          "spread": 0.00119117,
+          "score": 0.00325556
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00018967,
-          "spread": 0.00229941,
-          "score": 0.00230721
+          "bias": 0.00015272,
+          "spread": 0.00228698,
+          "score": 0.00229208
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.0033729,
-          "spread": 0.01045491,
-          "score": 0.01098551
+          "bias": 0.00333586,
+          "spread": 0.01044218,
+          "score": 0.01096207
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00290846,
-          "spread": 0.01933122,
-          "score": 0.01954879
+          "bias": 0.00287128,
+          "spread": 0.01931356,
+          "score": 0.01952583
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.03601828,
-          "spread": 0.03011744,
-          "score": 0.04695079
+          "bias": -0.03605152,
+          "spread": 0.03018667,
+          "score": 0.04702071
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.0613419,
-          "spread": 0.1690647,
-          "score": 0.17984911
+          "bias": 0.06128782,
+          "spread": 0.16897922,
+          "score": 0.17975031
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.01852055,
-          "spread": 0.0031945,
-          "score": 0.01879403
+          "bias": 0.01848303,
+          "spread": 0.00315369,
+          "score": 0.01875015
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.00512072,
-          "spread": 0.01570464,
-          "score": 0.0165184
+          "bias": 0.00508559,
+          "spread": 0.01581006,
+          "score": 0.01660787
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00320913,
-          "spread": 0.00161684,
-          "score": 0.00359343
+          "bias": 0.00317218,
+          "spread": 0.0016102,
+          "score": 0.00355746
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00087112,
-          "spread": 0.001907,
-          "score": 0.00209654
+          "bias": -0.00090938,
+          "spread": 0.00179325,
+          "score": 0.00201065
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00022056,
-          "spread": 0.00252601,
-          "score": 0.00253562
+          "bias": 0.00018193,
+          "spread": 0.00242782,
+          "score": 0.00243463
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00112159,
-          "spread": 0.00221687,
-          "score": 0.00248444
+          "bias": 0.00108293,
+          "spread": 0.00210181,
+          "score": 0.00236439
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": -0.03608785,
-          "spread": 0.02195866,
-          "score": 0.04224353
+          "bias": -0.0361096,
+          "spread": 0.02192102,
+          "score": 0.04224257
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.00426888,
-          "spread": 0.02683228,
-          "score": 0.02716974
+          "bias": -0.00430683,
+          "spread": 0.0267748,
+          "score": 0.02711898
         },
         {
           "profile": "rated_plus_5pct",
@@ -12769,198 +12769,198 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00355718,
-          "spread": 0.00506221,
-          "score": 0.00618704
+          "bias": 0.00352053,
+          "spread": 0.00507436,
+          "score": 0.00617602
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00096428,
-          "spread": 0.00316888,
-          "score": 0.00331234
+          "bias": 0.0009279,
+          "spread": 0.00324253,
+          "score": 0.00337269
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00383457,
-          "spread": 0.00537181,
-          "score": 0.00660002
+          "bias": 0.00379779,
+          "spread": 0.00536231,
+          "score": 0.00657097
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00082033,
-          "spread": 0.00174765,
-          "score": 0.0019306
+          "bias": 0.00069615,
+          "spread": 0.00182659,
+          "score": 0.00195475
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": 0.02165923,
-          "spread": 0.00050763,
-          "score": 0.02166518
+          "bias": 0.02158701,
+          "spread": 0.00062022,
+          "score": 0.02159592
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00149312,
-          "spread": 0.00476782,
-          "score": 0.00499615
+          "bias": 0.00136967,
+          "spread": 0.00482071,
+          "score": 0.00501151
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00050667,
-          "spread": 0.00151979,
-          "score": 0.00160202
+          "bias": 0.00038173,
+          "spread": 0.00160548,
+          "score": 0.00165024
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00036178,
-          "spread": 0.00130919,
-          "score": 0.00135826
+          "bias": 0.00023748,
+          "spread": 0.00137844,
+          "score": 0.00139875
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00173033,
-          "spread": 0.0028166,
-          "score": 0.00330564
+          "bias": 0.00160732,
+          "spread": 0.00290897,
+          "score": 0.00332349
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00766319,
-          "spread": 0.00760194,
-          "score": 0.01079416
+          "bias": 0.00754032,
+          "spread": 0.0076532,
+          "score": 0.01074374
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00296738,
-          "spread": 0.02923648,
-          "score": 0.02938669
+          "bias": -0.00308571,
+          "spread": 0.02933897,
+          "score": 0.0295008
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.01009669,
-          "spread": 0.02083591,
-          "score": 0.02315337
+          "bias": -0.01021604,
+          "spread": 0.02089885,
+          "score": 0.02326219
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.03359304,
-          "spread": 0.23182303,
-          "score": 0.23424434
+          "bias": 0.0334323,
+          "spread": 0.23164287,
+          "score": 0.23404303
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.07630034,
-          "spread": 0.11048249,
-          "score": 0.13426884
+          "bias": -0.07642293,
+          "spread": 0.11039858,
+          "score": 0.13426954
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.01223974,
-          "spread": 0.04069808,
-          "score": 0.04249877
+          "bias": -0.0123625,
+          "spread": 0.04065077,
+          "score": 0.04248901
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00161652,
-          "spread": 0.00243459,
-          "score": 0.00292239
+          "bias": 0.00149208,
+          "spread": 0.00247653,
+          "score": 0.00289128
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00047705,
-          "spread": 0.00082502,
-          "score": 0.00095301
+          "bias": -0.00060494,
+          "spread": 0.00096994,
+          "score": 0.00114312
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00103696,
-          "spread": 0.00153428,
-          "score": 0.00185184
+          "bias": -0.0011651,
+          "spread": 0.00167345,
+          "score": 0.00203909
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00047279,
-          "spread": 0.00129472,
-          "score": 0.00137835
+          "bias": 0.00034442,
+          "spread": 0.00144642,
+          "score": 0.00148687
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00044566,
-          "spread": 0.00082174,
-          "score": 0.00093481
+          "bias": 0.00031725,
+          "spread": 0.00083458,
+          "score": 0.00089285
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.00382566,
-          "spread": 0.02064012,
-          "score": 0.02099167
+          "bias": 0.00370621,
+          "spread": 0.0208059,
+          "score": 0.02113342
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.02351643,
-          "spread": 0.02259581,
-          "score": 0.03261277
+          "bias": -0.02356071,
+          "spread": 0.02256018,
+          "score": 0.03262006
         },
         {
           "profile": "rated_plus_5pct",
@@ -12985,36 +12985,36 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00188696,
-          "spread": 0.0057346,
-          "score": 0.00603708
+          "bias": 0.00176497,
+          "spread": 0.00585288,
+          "score": 0.00611321
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00312134,
-          "spread": 0.00327989,
-          "score": 0.00452775
+          "bias": 0.00299889,
+          "spread": 0.0033929,
+          "score": 0.00452825
         },
         {
           "profile": "rated_plus_5pct",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00115023,
-          "spread": 0.00337879,
-          "score": 0.00356921
+          "bias": 0.00102742,
+          "spread": 0.00332198,
+          "score": 0.00347723
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 1,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00581636,
-          "spread": 0.00515516,
-          "score": 0.00777211
+          "bias": -0.00319522,
+          "spread": 0.00238377,
+          "score": 0.00398646
         },
         {
           "profile": "ti_dependent_cp",
@@ -13030,117 +13030,117 @@
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.02742901,
-          "spread": 0.02306132,
-          "score": 0.03583539
+          "bias": -0.02475536,
+          "spread": 0.02287865,
+          "score": 0.03370846
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.0086316,
-          "spread": 0.0045907,
-          "score": 0.00977646
+          "bias": -0.00597209,
+          "spread": 0.00277251,
+          "score": 0.00658428
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00546251,
-          "spread": 0.00664793,
-          "score": 0.0086043
+          "bias": -0.00284287,
+          "spread": 0.00375529,
+          "score": 0.00471
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00327895,
-          "spread": 0.00813782,
-          "score": 0.00877358
+          "bias": -0.00068262,
+          "spread": 0.00586698,
+          "score": 0.00590656
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00507508,
-          "spread": 0.0067922,
-          "score": 0.00847882
+          "bias": 0.00764937,
+          "spread": 0.00479065,
+          "score": 0.0090257
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.00431771,
-          "spread": 0.05852366,
-          "score": 0.05868271
+          "bias": 0.00672593,
+          "spread": 0.05639275,
+          "score": 0.05679243
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.03808611,
-          "spread": 0.00906957,
-          "score": 0.0391511
+          "bias": 0.04070724,
+          "spread": 0.0078607,
+          "score": 0.04145926
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.03808611,
-          "spread": 0.00906957,
-          "score": 0.0391511
+          "bias": 0.04070724,
+          "spread": 0.0078607,
+          "score": 0.04145926
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.03808611,
-          "spread": 0.00906957,
-          "score": 0.0391511
+          "bias": 0.04070724,
+          "spread": 0.0078607,
+          "score": 0.04145926
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.01965577,
-          "spread": 0.06163829,
-          "score": 0.06469643
+          "bias": -0.0168938,
+          "spread": 0.06031265,
+          "score": 0.06263399
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.008212,
-          "spread": 0.00974432,
-          "score": 0.01274319
+          "bias": -0.00521086,
+          "spread": 0.00900116,
+          "score": 0.01040067
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -8.05e-05,
-          "spread": 0.0129627,
-          "score": 0.01296295
+          "bias": 0.00094003,
+          "spread": 0.01163979,
+          "score": 0.01167768
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00203369,
-          "spread": 0.00247751,
-          "score": 0.0032053
+          "bias": -0.00144112,
+          "spread": 0.00145728,
+          "score": 0.00204951
         },
         {
           "profile": "ti_dependent_cp",
@@ -13165,9 +13165,9 @@
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.01499305,
-          "spread": 0.06032155,
-          "score": 0.06215691
+          "bias": -0.01204836,
+          "spread": 0.05961402,
+          "score": 0.06081936
         },
         {
           "profile": "ti_dependent_cp",
@@ -13201,36 +13201,36 @@
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00493962,
-          "spread": 0.01706626,
-          "score": 0.01776674
+          "bias": -0.0018839,
+          "spread": 0.0169706,
+          "score": 0.01707485
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.0077666,
-          "spread": 0.00798188,
-          "score": 0.01113689
+          "bias": -0.00472671,
+          "spread": 0.00471717,
+          "score": 0.00667784
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00547664,
-          "spread": 0.00448003,
-          "score": 0.00707561
+          "bias": -0.00241803,
+          "spread": 0.00601468,
+          "score": 0.00648253
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 2,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00177698,
-          "spread": 0.00313123,
-          "score": 0.00360032
+          "bias": -0.00129,
+          "spread": 0.00167909,
+          "score": 0.00211741
         },
         {
           "profile": "ti_dependent_cp",
@@ -13246,117 +13246,117 @@
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.02486969,
-          "spread": 0.02536616,
-          "score": 0.03552385
+          "bias": -0.02435963,
+          "spread": 0.02508437,
+          "score": 0.03496594
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00575804,
-          "spread": 0.00222531,
-          "score": 0.00617309
+          "bias": -0.00526507,
+          "spread": 0.0025222,
+          "score": 0.00583802
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00112286,
-          "spread": 0.0051868,
-          "score": 0.00530695
+          "bias": 0.00160853,
+          "spread": 0.00367129,
+          "score": 0.00400821
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00101532,
-          "spread": 0.00717875,
-          "score": 0.00725019
+          "bias": -0.00053596,
+          "spread": 0.00569485,
+          "score": 0.00572001
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.0043009,
-          "spread": 0.00476265,
-          "score": 0.00641721
+          "bias": 0.00478334,
+          "spread": 0.00462228,
+          "score": 0.00665175
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00622365,
-          "spread": 0.07871528,
-          "score": 0.07896093
+          "bias": -0.00583272,
+          "spread": 0.07780393,
+          "score": 0.07802225
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.11952667,
-          "spread": 0.17308874,
-          "score": 0.21034813
+          "bias": 0.11983152,
+          "spread": 0.17143549,
+          "score": 0.20916434
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.0310431,
-          "spread": 0.02110872,
-          "score": 0.03754001
+          "bias": 0.03152478,
+          "spread": 0.02074932,
+          "score": 0.03774051
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.04088511,
-          "spread": 0.00715243,
-          "score": 0.04150601
+          "bias": 0.04137209,
+          "spread": 0.00609443,
+          "score": 0.04181856
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.02151148,
-          "spread": 0.02121685,
-          "score": 0.03021422
+          "bias": 0.02203969,
+          "spread": 0.02171799,
+          "score": 0.03094219
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00595322,
-          "spread": 0.00309914,
-          "score": 0.0067116
+          "bias": -0.00543748,
+          "spread": 0.00174667,
+          "score": 0.00571113
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00093787,
-          "spread": 0.00557124,
-          "score": 0.00564962
+          "bias": 0.00144017,
+          "spread": 0.00418861,
+          "score": 0.00442928
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00186108,
-          "spread": 0.00432889,
-          "score": 0.004712
+          "bias": -0.0013594,
+          "spread": 0.003147,
+          "score": 0.00342806
         },
         {
           "profile": "ti_dependent_cp",
@@ -13381,9 +13381,9 @@
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.0107068,
-          "spread": 0.05751592,
-          "score": 0.05850399
+          "bias": 0.01116098,
+          "spread": 0.05631046,
+          "score": 0.05740588
         },
         {
           "profile": "ti_dependent_cp",
@@ -13417,36 +13417,36 @@
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00115613,
-          "spread": 0.01324401,
-          "score": 0.01329438
+          "bias": 0.00168534,
+          "spread": 0.01298232,
+          "score": 0.01309126
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00088988,
-          "spread": 0.004908,
-          "score": 0.00498802
+          "bias": -0.00036062,
+          "spread": 0.00378958,
+          "score": 0.0038067
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00075869,
-          "spread": 0.00274513,
-          "score": 0.00284805
+          "bias": -0.00022775,
+          "spread": 0.00277272,
+          "score": 0.00278206
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.0011033,
-          "spread": 0.00212144,
-          "score": 0.00239119
+          "bias": 0.00182771,
+          "spread": 0.00188064,
+          "score": 0.00262247
         },
         {
           "profile": "ti_dependent_cp",
@@ -13462,126 +13462,126 @@
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00579401,
-          "spread": 0.01375559,
-          "score": 0.01492605
+          "bias": -0.00506057,
+          "spread": 0.01359523,
+          "score": 0.01450653
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00253478,
-          "spread": 0.00286559,
-          "score": 0.0038258
+          "bias": -0.00181062,
+          "spread": 0.00268371,
+          "score": 0.00323738
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00239864,
-          "spread": 0.00319087,
-          "score": 0.00399189
+          "bias": 0.00312481,
+          "spread": 0.00291169,
+          "score": 0.00427111
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00363155,
-          "spread": 0.0059236,
-          "score": 0.00694818
+          "bias": 0.0043532,
+          "spread": 0.00566136,
+          "score": 0.00714152
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01267331,
-          "spread": 0.00564746,
-          "score": 0.01387467
+          "bias": 0.01338798,
+          "spread": 0.0054098,
+          "score": 0.01443967
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.0075656,
-          "spread": 0.02957395,
-          "score": 0.03052633
+          "bias": 0.0082657,
+          "spread": 0.02954072,
+          "score": 0.03067533
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.02414625,
-          "spread": 0.04141152,
-          "score": 0.047937
+          "bias": 0.02484159,
+          "spread": 0.04097693,
+          "score": 0.04791882
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": -0.12753408,
-          "spread": 0.28316924,
-          "score": 0.31056362
+          "bias": -0.12702879,
+          "spread": 0.28316338,
+          "score": 0.31035111
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.04314064,
-          "spread": 0.00572961,
-          "score": 0.04351946
+          "bias": 0.04386505,
+          "spread": 0.00531919,
+          "score": 0.04418638
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.00035981,
-          "spread": 0.02319203,
-          "score": 0.02319482
+          "bias": 0.00109247,
+          "spread": 0.02347459,
+          "score": 0.0235
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00362242,
-          "spread": 0.00122484,
-          "score": 0.00382389
+          "bias": -0.00286856,
+          "spread": 0.00099081,
+          "score": 0.00303486
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00345094,
-          "spread": 0.00365081,
-          "score": 0.00502368
+          "bias": 0.00418174,
+          "spread": 0.00315575,
+          "score": 0.00523887
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00115835,
-          "spread": 0.00409175,
-          "score": 0.00425256
+          "bias": 0.00188446,
+          "spread": 0.00375203,
+          "score": 0.00419868
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00063443,
-          "spread": 0.00071071,
-          "score": 0.00095268
+          "bias": -0.00041425,
+          "spread": 0.00036013,
+          "score": 0.00054891
         },
         {
           "profile": "ti_dependent_cp",
@@ -13597,9 +13597,9 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": 0.00845515,
-          "spread": 0.03697759,
-          "score": 0.03793194
+          "bias": 0.00921022,
+          "spread": 0.03671797,
+          "score": 0.03785548
         },
         {
           "profile": "ti_dependent_cp",
@@ -13633,189 +13633,189 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00094072,
-          "spread": 0.0128405,
-          "score": 0.01287491
+          "bias": 0.00170584,
+          "spread": 0.01277074,
+          "score": 0.01288416
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00556334,
-          "spread": 0.00532112,
-          "score": 0.00769838
+          "bias": 0.00633649,
+          "spread": 0.00533382,
+          "score": 0.00828256
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -8.78e-05,
-          "spread": 0.0042106,
-          "score": 0.00421151
+          "bias": 0.00068099,
+          "spread": 0.00420477,
+          "score": 0.00425955
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00153122,
-          "spread": 0.00161557,
-          "score": 0.00222592
+          "bias": 0.00149274,
+          "spread": 0.00157831,
+          "score": 0.0021724
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": -0.06080087,
-          "spread": 0.00954969,
-          "score": 0.06154626
+          "bias": -0.06091945,
+          "spread": 0.00952155,
+          "score": 0.06165906
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00408036,
-          "spread": 0.01162063,
-          "score": 0.01231619
+          "bias": -0.00411951,
+          "spread": 0.01151784,
+          "score": 0.01223237
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00128435,
-          "spread": 0.00201779,
-          "score": 0.00239187
+          "bias": -0.00132276,
+          "spread": 0.00191204,
+          "score": 0.00232499
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.0023585,
-          "spread": 0.00141243,
-          "score": 0.00274909
+          "bias": 0.00232,
+          "spread": 0.00143364,
+          "score": 0.00272722
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.0028193,
-          "spread": 0.00234789,
-          "score": 0.00366893
+          "bias": 0.00278105,
+          "spread": 0.00231529,
+          "score": 0.00361868
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01285202,
-          "spread": 0.00836467,
-          "score": 0.01533435
+          "bias": 0.01281398,
+          "spread": 0.0083279,
+          "score": 0.01528241
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.02046988,
-          "spread": 0.02208509,
-          "score": 0.03011257
+          "bias": 0.02043173,
+          "spread": 0.02205106,
+          "score": 0.03006169
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.01753212,
-          "spread": 0.02735064,
-          "score": 0.03248742
+          "bias": -0.01756649,
+          "spread": 0.02741144,
+          "score": 0.03255716
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.07390378,
-          "spread": 0.16856457,
-          "score": 0.18405375
+          "bias": 0.07384845,
+          "spread": 0.1684744,
+          "score": 0.18394895
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.04291997,
-          "spread": 0.00478849,
-          "score": 0.04318626
+          "bias": 0.04288149,
+          "spread": 0.00474671,
+          "score": 0.0431434
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.00126594,
-          "spread": 0.01863747,
-          "score": 0.01868042
+          "bias": -0.00130036,
+          "spread": 0.01875255,
+          "score": 0.01879758
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00133329,
-          "spread": 0.00091385,
-          "score": 0.00161641
+          "bias": -0.00137204,
+          "spread": 0.00093365,
+          "score": 0.00165958
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00327386,
-          "spread": 0.002535,
-          "score": 0.00414058
+          "bias": 0.00323641,
+          "spread": 0.00242796,
+          "score": 0.0040459
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00101319,
-          "spread": 0.00277772,
-          "score": 0.00295673
+          "bias": 0.0009763,
+          "spread": 0.00269141,
+          "score": 0.00286301
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00076117,
-          "spread": 0.00229052,
-          "score": 0.00241369
+          "bias": 0.00072431,
+          "spread": 0.00219193,
+          "score": 0.0023085
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": -0.0006193,
-          "spread": 0.0007541,
-          "score": 0.00097581
+          "bias": -0.00064002,
+          "spread": 0.00075377,
+          "score": 0.00098883
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.01226876,
-          "spread": 0.03189475,
-          "score": 0.03417305
+          "bias": -0.01230979,
+          "spread": 0.03187957,
+          "score": 0.03417364
         },
         {
           "profile": "ti_dependent_cp",
@@ -13849,198 +13849,198 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00320425,
-          "spread": 0.00543306,
-          "score": 0.00630756
+          "bias": 0.00316498,
+          "spread": 0.00543784,
+          "score": 0.00629184
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00096819,
-          "spread": 0.00294431,
-          "score": 0.00309941
+          "bias": 0.00092912,
+          "spread": 0.0030107,
+          "score": 0.00315081
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00243873,
-          "spread": 0.00548611,
-          "score": 0.00600373
+          "bias": 0.00239937,
+          "spread": 0.00547424,
+          "score": 0.00597698
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.0007696,
-          "spread": 0.00177635,
-          "score": 0.0019359
+          "bias": 0.00064339,
+          "spread": 0.00185831,
+          "score": 0.00196653
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": -0.03269808,
-          "spread": 0.04941493,
-          "score": 0.05925368
+          "bias": -0.03277143,
+          "spread": 0.04926054,
+          "score": 0.05916559
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00106241,
-          "spread": 0.00412038,
-          "score": 0.00425515
+          "bias": -0.00119266,
+          "spread": 0.00416769,
+          "score": 0.00433498
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00033888,
-          "spread": 0.00161301,
-          "score": 0.00164822
+          "bias": -0.00046526,
+          "spread": 0.00176175,
+          "score": 0.00182215
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00022736,
-          "spread": 0.00143491,
-          "score": 0.00145281
+          "bias": -0.00035358,
+          "spread": 0.00145449,
+          "score": 0.00149685
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": 0.00337426,
-          "spread": 0.0029378,
-          "score": 0.00447396
+          "bias": 0.00324845,
+          "spread": 0.0030419,
+          "score": 0.00445034
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.01510599,
-          "spread": 0.00818971,
-          "score": 0.0171832
+          "bias": 0.01498089,
+          "spread": 0.00823602,
+          "score": 0.01709558
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": 0.01102584,
-          "spread": 0.02999397,
-          "score": 0.03195633
+          "bias": 0.01090586,
+          "spread": 0.03009587,
+          "score": 0.03201092
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.00273735,
-          "spread": 0.02022156,
-          "score": 0.02040599
+          "bias": 0.00261645,
+          "spread": 0.02028448,
+          "score": 0.02045253
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.04002344,
-          "spread": 0.23279517,
-          "score": 0.23621064
+          "bias": 0.03986128,
+          "spread": 0.23261266,
+          "score": 0.23600333
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -0.07547839,
-          "spread": 0.13709352,
-          "score": 0.15649799
+          "bias": -0.07560467,
+          "spread": 0.13700399,
+          "score": 0.15648054
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.00754971,
-          "spread": 0.04082219,
-          "score": 0.04151445
+          "bias": -0.00767167,
+          "spread": 0.04080503,
+          "score": 0.04151994
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00276143,
-          "spread": 0.00260984,
-          "score": 0.00379958
+          "bias": -0.00288868,
+          "spread": 0.00262743,
+          "score": 0.00390485
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00359343,
-          "spread": 0.00100574,
-          "score": 0.00373152
+          "bias": 0.00347009,
+          "spread": 0.00113902,
+          "score": 0.00365224
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 4.392e-05,
-          "spread": 0.00151049,
-          "score": 0.00151113
+          "bias": -7.84e-05,
+          "spread": 0.00165121,
+          "score": 0.00165307
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00069236,
-          "spread": 0.00107306,
-          "score": 0.00127703
+          "bias": 0.00056996,
+          "spread": 0.00122632,
+          "score": 0.00135229
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": -0.00119453,
-          "spread": 0.00240677,
-          "score": 0.0026869
+          "bias": -0.00131702,
+          "spread": 0.00241653,
+          "score": 0.00275212
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.00078411,
-          "spread": 0.02024698,
-          "score": 0.02026216
+          "bias": -0.00090961,
+          "spread": 0.02039511,
+          "score": 0.02041538
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.0043106,
-          "spread": 0.00340769,
-          "score": 0.00549487
+          "bias": -0.004353,
+          "spread": 0.00351579,
+          "score": 0.00559548
         },
         {
           "profile": "ti_dependent_cp",
@@ -14065,36 +14065,36 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00198235,
-          "spread": 0.00620726,
-          "score": 0.00651612
+          "bias": 0.00185323,
+          "spread": 0.0063282,
+          "score": 0.00659398
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00353915,
-          "spread": 0.0031831,
-          "score": 0.00476001
+          "bias": 0.00340924,
+          "spread": 0.00329585,
+          "score": 0.00474189
         },
         {
           "profile": "ti_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -5.098e-05,
-          "spread": 0.00292221,
-          "score": 0.00292265
+          "bias": -0.00018088,
+          "spread": 0.00287832,
+          "score": 0.002884
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00577906,
-          "spread": 0.00511711,
-          "score": 0.00771896
+          "bias": -0.00316969,
+          "spread": 0.00237343,
+          "score": 0.00395981
         },
         {
           "profile": "ws_dependent_cp",
@@ -14110,117 +14110,117 @@
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.01174297,
-          "spread": 0.00976875,
-          "score": 0.01527501
+          "bias": -0.00909153,
+          "spread": 0.01093173,
+          "score": 0.01421825
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00571369,
-          "spread": 0.00317985,
-          "score": 0.00653894
+          "bias": -0.00309656,
+          "spread": 0.00214699,
+          "score": 0.00376806
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": -0.00402897,
-          "spread": 0.00649183,
-          "score": 0.00764045
+          "bias": -0.00143054,
+          "spread": 0.00363628,
+          "score": 0.00390755
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00696767,
-          "spread": 0.00645774,
-          "score": 0.00950005
+          "bias": -0.00435727,
+          "spread": 0.00389701,
+          "score": 0.00584572
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": -0.00893404,
-          "spread": 0.00477166,
-          "score": 0.01012847
+          "bias": -0.00630021,
+          "spread": 0.00323325,
+          "score": 0.00708142
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.07157369,
-          "spread": 0.03363677,
-          "score": 0.07908366
+          "bias": -0.0690891,
+          "spread": 0.03213417,
+          "score": 0.07619651
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.01188424,
-          "spread": 0.18075445,
-          "score": 0.18114471
+          "bias": 0.01449361,
+          "spread": 0.17802125,
+          "score": 0.17861028
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 1.28732249,
-          "spread": 2.21173535,
-          "score": 2.55909602
+          "bias": 1.28993186,
+          "spread": 2.21221084,
+          "score": 2.56082038
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": -2.03072304,
-          "spread": 3.58793004,
-          "score": 4.12275127
+          "bias": -2.02811367,
+          "spread": 3.58814665,
+          "score": 4.12165519
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.01841801,
-          "spread": 0.05652544,
-          "score": 0.05945039
+          "bias": -0.01564084,
+          "spread": 0.05533282,
+          "score": 0.05750093
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00480753,
-          "spread": 0.00996684,
-          "score": 0.01106573
+          "bias": -0.00188527,
+          "spread": 0.00929847,
+          "score": 0.00948766
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00174327,
-          "spread": 0.0108223,
-          "score": 0.01096181
+          "bias": 0.00276324,
+          "spread": 0.00889826,
+          "score": 0.00931743
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00165075,
-          "spread": 0.00285919,
-          "score": 0.0033015
+          "bias": -0.00105854,
+          "spread": 0.00183345,
+          "score": 0.00211709
         },
         {
           "profile": "ws_dependent_cp",
@@ -14245,9 +14245,9 @@
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.04615541,
-          "spread": 0.08384239,
-          "score": 0.0957072
+          "bias": -0.04306459,
+          "spread": 0.08415911,
+          "score": 0.09453737
         },
         {
           "profile": "ws_dependent_cp",
@@ -14281,36 +14281,36 @@
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00822283,
-          "spread": 0.01920844,
-          "score": 0.02089448
+          "bias": -0.0050717,
+          "spread": 0.01904013,
+          "score": 0.01970403
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00969731,
-          "spread": 0.00831789,
-          "score": 0.01277596
+          "bias": -0.00663953,
+          "spread": 0.0051345,
+          "score": 0.00839324
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 1,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00653559,
-          "spread": 0.00415433,
-          "score": 0.00774418
+          "bias": -0.00351989,
+          "spread": 0.00529935,
+          "score": 0.00636182
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": -0.00175491,
-          "spread": 0.00309495,
-          "score": 0.00355787
+          "bias": -0.00126705,
+          "spread": 0.00166538,
+          "score": 0.00209258
         },
         {
           "profile": "ws_dependent_cp",
@@ -14326,117 +14326,117 @@
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": -0.00814327,
-          "spread": 0.01464793,
-          "score": 0.01675932
+          "bias": -0.00763642,
+          "spread": 0.01463878,
+          "score": 0.01651087
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.0039941,
-          "spread": 0.0022259,
-          "score": 0.00457247
+          "bias": -0.00350567,
+          "spread": 0.00277728,
+          "score": 0.00447247
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00235856,
-          "spread": 0.004833,
-          "score": 0.00537779
+          "bias": 0.00284194,
+          "spread": 0.00334086,
+          "score": 0.00438612
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00520759,
-          "spread": 0.005991,
-          "score": 0.00793796
+          "bias": -0.00472493,
+          "spread": 0.00449398,
+          "score": 0.0065208
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": -0.00968718,
-          "spread": 0.00794984,
-          "score": 0.01253162
+          "bias": -0.00919414,
+          "spread": 0.00823191,
+          "score": 0.01234085
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.03253975,
-          "spread": 0.08798125,
-          "score": 0.09380584
+          "bias": -0.03212832,
+          "spread": 0.0870391,
+          "score": 0.09277949
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": 0.05468174,
-          "spread": 0.20892042,
-          "score": 0.21595795
+          "bias": 0.05495255,
+          "spread": 0.20704202,
+          "score": 0.2142106
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.13860007,
-          "spread": 0.20194126,
-          "score": 0.24492907
+          "bias": 0.13909671,
+          "spread": 0.20217877,
+          "score": 0.24540609
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.2417389,
-          "spread": 0.36441397,
-          "score": 0.43730451
+          "bias": 0.24222677,
+          "spread": 0.3647096,
+          "score": 0.43782063
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.01594594,
-          "spread": 0.02127409,
-          "score": 0.02658684
+          "bias": 0.01647143,
+          "spread": 0.02177919,
+          "score": 0.02730644
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": -0.00217099,
-          "spread": 0.00321512,
-          "score": 0.00387945
+          "bias": -0.00166229,
+          "spread": 0.00227642,
+          "score": 0.00281874
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": -0.00017076,
-          "spread": 0.00480293,
-          "score": 0.00480596
+          "bias": 0.00033015,
+          "spread": 0.00340086,
+          "score": 0.00341685
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00223335,
-          "spread": 0.00434244,
-          "score": 0.0048831
+          "bias": -0.00173242,
+          "spread": 0.0030841,
+          "score": 0.00353737
         },
         {
           "profile": "ws_dependent_cp",
@@ -14461,9 +14461,9 @@
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.01013735,
-          "spread": 0.06103319,
-          "score": 0.06186935
+          "bias": -0.00966759,
+          "spread": 0.05994207,
+          "score": 0.06071667
         },
         {
           "profile": "ws_dependent_cp",
@@ -14497,36 +14497,36 @@
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00126089,
-          "spread": 0.01416916,
-          "score": 0.01422515
+          "bias": -0.00071206,
+          "spread": 0.01380538,
+          "score": 0.01382373
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00243968,
-          "spread": 0.00540776,
-          "score": 0.00593262
+          "bias": -0.00190441,
+          "spread": 0.00424775,
+          "score": 0.00465512
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 2,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00121723,
-          "spread": 0.0021567,
-          "score": 0.00247649
+          "bias": -0.00068876,
+          "spread": 0.00242545,
+          "score": 0.00252135
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00111163,
-          "spread": 0.0020918,
-          "score": 0.00236883
+          "bias": 0.00183177,
+          "spread": 0.00185713,
+          "score": 0.00260851
         },
         {
           "profile": "ws_dependent_cp",
@@ -14542,126 +14542,126 @@
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00153855,
-          "spread": 0.0108509,
-          "score": 0.01095944
+          "bias": 0.00225943,
+          "spread": 0.01065978,
+          "score": 0.0108966
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": -0.00039634,
-          "spread": 0.00276257,
-          "score": 0.00279086
+          "bias": 0.00031659,
+          "spread": 0.00263833,
+          "score": 0.00265726
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00332722,
-          "spread": 0.00304477,
-          "score": 0.0045101
+          "bias": 0.00404717,
+          "spread": 0.00278167,
+          "score": 0.00491093
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00107709,
-          "spread": 0.0050679,
-          "score": 0.00518109
+          "bias": -0.00035033,
+          "spread": 0.00492994,
+          "score": 0.00494237
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": -0.00012332,
-          "spread": 0.0063422,
-          "score": 0.0063434
+          "bias": 0.00061265,
+          "spread": 0.00643347,
+          "score": 0.00646258
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.01308967,
-          "spread": 0.03553554,
-          "score": 0.0378697
+          "bias": -0.01235258,
+          "spread": 0.03550026,
+          "score": 0.03758796
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.01975826,
-          "spread": 0.03887462,
-          "score": 0.04360762
+          "bias": -0.01901073,
+          "spread": 0.03850148,
+          "score": 0.04293916
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": -0.51525338,
-          "spread": 0.87938982,
-          "score": 1.01922152
+          "bias": -0.51467807,
+          "spread": 0.87928925,
+          "score": 1.018844
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.10818731,
-          "spread": 0.12876622,
-          "score": 0.16818214
+          "bias": 0.10864042,
+          "spread": 0.12864951,
+          "score": 0.16838479
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.00201656,
-          "spread": 0.03149731,
-          "score": 0.0315618
+          "bias": 0.00275133,
+          "spread": 0.03173854,
+          "score": 0.03185757
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.0001639,
-          "spread": 0.00106951,
-          "score": 0.001082
+          "bias": 0.00089878,
+          "spread": 0.00061758,
+          "score": 0.00109051
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00188018,
-          "spread": 0.00343407,
-          "score": 0.00391509
+          "bias": 0.00260649,
+          "spread": 0.00294133,
+          "score": 0.00393004
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00073754,
-          "spread": 0.00423589,
-          "score": 0.00429962
+          "bias": 0.00146313,
+          "spread": 0.00387558,
+          "score": 0.00414257
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": -0.00040548,
-          "spread": 0.00070232,
-          "score": 0.00081096
+          "bias": -0.00018535,
+          "spread": 0.00032103,
+          "score": 0.0003707
         },
         {
           "profile": "ws_dependent_cp",
@@ -14677,9 +14677,9 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.00867661,
-          "spread": 0.04013474,
-          "score": 0.04106192
+          "bias": -0.00786884,
+          "spread": 0.03997928,
+          "score": 0.04074631
         },
         {
           "profile": "ws_dependent_cp",
@@ -14713,189 +14713,189 @@
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00197373,
-          "spread": 0.01434168,
-          "score": 0.01447686
+          "bias": -0.00118141,
+          "spread": 0.01425253,
+          "score": 0.01430141
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00436844,
-          "spread": 0.00594697,
-          "score": 0.00737901
+          "bias": 0.00514871,
+          "spread": 0.00595654,
+          "score": 0.00787334
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 3,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00064094,
-          "spread": 0.00422538,
-          "score": 0.00427371
+          "bias": 0.00011627,
+          "spread": 0.00427499,
+          "score": 0.00427657
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00156512,
-          "spread": 0.00160974,
-          "score": 0.00224519
+          "bias": 0.0015272,
+          "spread": 0.00157221,
+          "score": 0.00219185
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": -0.06328166,
-          "spread": 0.01265777,
-          "score": 0.06453517
+          "bias": -0.06339915,
+          "spread": 0.01263023,
+          "score": 0.064645
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00047125,
-          "spread": 0.01094098,
-          "score": 0.01095112
+          "bias": 0.00043267,
+          "spread": 0.01084268,
+          "score": 0.01085131
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00094329,
-          "spread": 0.001707,
-          "score": 0.0019503
+          "bias": 0.0009055,
+          "spread": 0.00162398,
+          "score": 0.00185937
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00319677,
-          "spread": 0.00158767,
-          "score": 0.00356931
+          "bias": 0.00315873,
+          "spread": 0.00162039,
+          "score": 0.0035501
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00173092,
-          "spread": 0.00264969,
-          "score": 0.00316496
+          "bias": -0.0017692,
+          "spread": 0.00264782,
+          "score": 0.0031845
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": -0.00079849,
-          "spread": 0.0098074,
-          "score": 0.00983985
+          "bias": -0.00083714,
+          "spread": 0.00981081,
+          "score": 0.00984646
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00023778,
-          "spread": 0.02721129,
-          "score": 0.02721233
+          "bias": -0.00027746,
+          "spread": 0.02718317,
+          "score": 0.02718459
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.06188952,
-          "spread": 0.03093521,
-          "score": 0.06919032
+          "bias": -0.06192551,
+          "spread": 0.03102387,
+          "score": 0.06926218
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.09462763,
-          "spread": 0.31717433,
-          "score": 0.33098934
+          "bias": 0.09457428,
+          "spread": 0.31705354,
+          "score": 0.33085834
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.07667768,
-          "spread": 0.09103134,
-          "score": 0.11902173
+          "bias": 0.07663976,
+          "spread": 0.09112932,
+          "score": 0.11907227
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": 0.00034261,
-          "spread": 0.01660054,
-          "score": 0.01660408
+          "bias": 0.00030743,
+          "spread": 0.0166999,
+          "score": 0.01670272
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00264299,
-          "spread": 0.00128796,
-          "score": 0.00294011
+          "bias": 0.00260559,
+          "spread": 0.00130365,
+          "score": 0.00291352
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00218292,
-          "spread": 0.00216147,
-          "score": 0.00307199
+          "bias": 0.00214581,
+          "spread": 0.00205514,
+          "score": 0.00297121
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": 0.00074208,
-          "spread": 0.00263765,
-          "score": 0.00274005
+          "bias": 0.00070501,
+          "spread": 0.00254554,
+          "score": 0.00264137
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00120913,
-          "spread": 0.00246258,
-          "score": 0.00274341
+          "bias": 0.00117203,
+          "spread": 0.00235772,
+          "score": 0.00263296
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 0.00024169,
-          "spread": 0.00041862,
-          "score": 0.00048338
+          "bias": 0.00022097,
+          "spread": 0.00038273,
+          "score": 0.00044194
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.04417091,
-          "spread": 0.05011062,
-          "score": 0.06679928
+          "bias": -0.04421448,
+          "spread": 0.05013468,
+          "score": 0.06684614
         },
         {
           "profile": "ws_dependent_cp",
@@ -14929,198 +14929,198 @@
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": 0.00052873,
-          "spread": 0.00570452,
-          "score": 0.00572898
+          "bias": 0.00048847,
+          "spread": 0.00571146,
+          "score": 0.00573231
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": -0.00068926,
-          "spread": 0.00320598,
-          "score": 0.00327924
+          "bias": -0.0007284,
+          "spread": 0.0032732,
+          "score": 0.00335327
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 6,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": 0.00171268,
-          "spread": 0.0056037,
-          "score": 0.00585958
+          "bias": 0.00167419,
+          "spread": 0.00559164,
+          "score": 0.00583689
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "overall",
           "condition_bin": "overall",
-          "bias": 0.00081161,
-          "spread": 0.00176902,
-          "score": 0.00194632
+          "bias": 0.00068624,
+          "spread": 0.00184784,
+          "score": 0.00197115
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.0, 0.05]",
-          "bias": -0.0374423,
-          "spread": 0.04703681,
-          "score": 0.06011978
+          "bias": -0.03751528,
+          "spread": 0.04689154,
+          "score": 0.06005175
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.05, 0.1]",
-          "bias": 0.00224415,
-          "spread": 0.00374172,
-          "score": 0.0043631
+          "bias": 0.00211717,
+          "spread": 0.00376708,
+          "score": 0.00432126
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.1, 0.15]",
-          "bias": 0.00139376,
-          "spread": 0.00142309,
-          "score": 0.00199192
+          "bias": 0.00126914,
+          "spread": 0.00152782,
+          "score": 0.00198619
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.15, 0.2]",
-          "bias": 0.00060698,
-          "spread": 0.00152907,
-          "score": 0.00164514
+          "bias": 0.00048177,
+          "spread": 0.00154787,
+          "score": 0.00162112
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.2, 0.25]",
-          "bias": -0.00037788,
-          "spread": 0.00319549,
-          "score": 0.00321776
+          "bias": -0.00050415,
+          "spread": 0.00328479,
+          "score": 0.00332325
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.25, 0.3]",
-          "bias": 0.00275718,
-          "spread": 0.00690574,
-          "score": 0.00743581
+          "bias": 0.00262919,
+          "spread": 0.00694652,
+          "score": 0.00742744
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.3, 0.35]",
-          "bias": -0.00936288,
-          "spread": 0.03322585,
-          "score": 0.03451986
+          "bias": -0.00948848,
+          "spread": 0.03334168,
+          "score": 0.03466553
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.35, 0.4]",
-          "bias": -0.02151993,
-          "spread": 0.02091784,
-          "score": 0.03001106
+          "bias": -0.02164829,
+          "spread": 0.02098857,
+          "score": 0.03015242
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.4, 0.45]",
-          "bias": 0.01730795,
-          "spread": 0.25591884,
-          "score": 0.25650345
+          "bias": 0.01713203,
+          "spread": 0.25572165,
+          "score": 0.25629489
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ti",
           "condition_bin": "(0.45, 0.5]",
-          "bias": 0.5043107,
-          "spread": 0.57955308,
-          "score": 0.76825195
+          "bias": 0.50419046,
+          "spread": 0.57969357,
+          "score": 0.76827902
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(0.0, 2.0]",
-          "bias": -0.00578604,
-          "spread": 0.04229151,
-          "score": 0.04268548
+          "bias": -0.0059087,
+          "spread": 0.04226353,
+          "score": 0.04267457
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(10.0, 12.0]",
-          "bias": 0.00096816,
-          "spread": 0.00248853,
-          "score": 0.00267023
+          "bias": 0.00084419,
+          "spread": 0.00250789,
+          "score": 0.00264616
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(12.0, 14.0]",
-          "bias": 0.00244761,
-          "spread": 0.00071362,
-          "score": 0.00254952
+          "bias": 0.002325,
+          "spread": 0.0008599,
+          "score": 0.00247892
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(14.0, 16.0]",
-          "bias": -0.00010456,
-          "spread": 0.00132061,
-          "score": 0.00132474
+          "bias": -0.00022679,
+          "spread": 0.0014535,
+          "score": 0.00147109
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(16.0, 18.0]",
-          "bias": 0.00093696,
-          "spread": 0.00109996,
-          "score": 0.00144492
+          "bias": 0.00081458,
+          "spread": 0.00124408,
+          "score": 0.00148704
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(18.0, 20.0]",
-          "bias": 5.649e-05,
-          "spread": 0.0016046,
-          "score": 0.0016056
+          "bias": -6.595e-05,
+          "spread": 0.00160338,
+          "score": 0.00160473
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(2.0, 4.0]",
-          "bias": -0.02618156,
-          "spread": 0.02015505,
-          "score": 0.03304089
+          "bias": -0.02631475,
+          "spread": 0.02018131,
+          "score": 0.0331625
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(20.0, 22.0]",
-          "bias": -0.00061484,
-          "spread": 0.00190444,
-          "score": 0.00200123
+          "bias": -0.00065711,
+          "spread": 0.00204492,
+          "score": 0.00214791
         },
         {
           "profile": "ws_dependent_cp",
@@ -15145,27 +15145,27 @@
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(4.0, 6.0]",
-          "bias": -0.00098403,
-          "spread": 0.0069983,
-          "score": 0.00706714
+          "bias": -0.00111706,
+          "spread": 0.0071314,
+          "score": 0.00721836
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(6.0, 8.0]",
-          "bias": 0.00170148,
-          "spread": 0.00333035,
-          "score": 0.00373982
+          "bias": 0.00157062,
+          "spread": 0.0034408,
+          "score": 0.00378232
         },
         {
           "profile": "ws_dependent_cp",
           "campaign_months": 12,
           "condition": "ws",
           "condition_bin": "(8.0, 10.0]",
-          "bias": -0.00054711,
-          "spread": 0.00323314,
-          "score": 0.0032791
+          "bias": -0.00067486,
+          "spread": 0.00318414,
+          "score": 0.00325487
         }
       ]
     }

--- a/docs/v1/findings.md
+++ b/docs/v1/findings.md
@@ -7,6 +7,116 @@ from, not just conclusions.
 
 ---
 
+## F20 — the headline training window self-configures: an adaptive time-decay half-life (2 × campaign duration) is the new default, subsuming the fixed 548 d; big short-campaign wins, tied long, in both modes (Issue 15 deliverable 2)
+
+*2026-07-10 — Issue 15's mechanism-justified fallback after F19 ruled out the `double_ratio` path. New
+`PowerModelMethod` default `adaptive_time_decay: bool = True`; the headline fit's time-decay half-life
+is now `_TIME_DECAY_CAMPAIGN_MULTIPLE (=2.0) × campaign_duration_days` via a new
+`_effective_half_life`. `time_decay_half_life_days` is demoted to an **expert override** (default flipped
+548.0 → `None`, used only when `adaptive_time_decay=False`; a guard forbids setting both). Conditional
+two-direction fits stay unweighted (F16). A/B'd via `study_power_model_compare.py` (plain run =
+adaptive-default vs the fixed-548 committed benchmark), placebo `cp_0pct` both modes for the coarse `k`
+sweep, then the full 7-profile both-mode sweep for the ship.*
+
+### Mechanism — a scale-free "trust window", not a lookup
+The best fixed half-life is regime-dependent (F16: ~90 d helps short campaigns in **both** modes; ≥1 yr
+is safe long; 548 d fixed was a compromise). Making the half-life **proportional to the campaign's own
+duration** — `k × campaign_days` — gives a short half-life for a short campaign (down-weight the stale
+pre-campaign era that dominates a sliver campaign → less bias *and*, in toggle, less spread) and a long
+one for a long campaign (use the plentiful recent data). One dimensionless `k` = "trust pre-campaign
+data within ~k campaign-durations". A scale-free multiple is chosen over a length→half-life lookup
+precisely to avoid benchmark overfitting: it is mechanism-anchored and generalises to any campaign
+length or dataset span, including F16's "20 yr of SCADA, 1-month campaign" case by construction.
+`k=2` → 1mo≈60 d, 3mo≈182 d, 12mo≈730 d (≈ today's 548 d regime at 12 months, so a strict
+generalisation of the accepted default).
+
+### Coarse `k` sweep (placebo `cp_0pct`, both modes, overall score pp; all vs fixed-548 benchmark)
+All three adaptive `k` beat fixed-548 on pooled mean in **both** modes (prepost 0.55 → ~0.50, toggle
+0.34 → ~0.25). Per-length the best `k` is scattered across {1.5, 2, 3} — the signature of a flat region
+where finer tuning would fit placebo noise. **k=2 chosen**: best prepost pooled mean (0.493), 2nd toggle
+(0.248, a hair behind k1.5's 0.232), and it wins the headline **toggle-1mo** case (0.380 vs k1.5 0.400,
+k3 0.482). It is the middle of the bracket (least overfit-prone) and matches the a-priori mechanism
+anchor; chasing k1.5's toggle-2mo edge would cost prepost-1mo/6mo. `k` lives as the module constant
+`_TIME_DECAY_CAMPAIGN_MULTIPLE`, **not** a user knob, so it is documented without inviting per-dataset
+tuning.
+
+### Full 7-profile sweep verdict (overall P50, pooled per length, dScore pp; <0 = adaptive better)
+| mo | prepost Δ | toggle Δ | cells worse >0.1pp |
+| --- | --- | --- | --- |
+| 1 | +0.067 | **−0.368** (all 7) | 0 |
+| 2 | **−0.338** (all 7) | **−0.144** (all 7) | 0 |
+| 3 | +0.014 | +0.024 | 0 |
+| 6 | −0.027 | −0.005 | 0 |
+| 12 | −0.005 | +0.003 | 0 |
+
+Pooled mean score **prepost 0.559 → 0.501, toggle 0.350 → 0.252**. **Zero cells regress by >0.1 pp**
+anywhere; the only positive deltas (prepost-1mo +0.067, 3mo +0.01–0.02) are uniform across profiles and
+inside the 0.1 pp materiality band — i.e. tied. The prepost-1mo +0.067 is a spread effect (the shortest
+prepost campaign wants maximal baseline; a 60 d half-life thins it) and neither a longer `k=3` (+0.084)
+nor shorter `k=1.5` (+0.114) helps it — an inherent short-prepost tension the adaptive rule accepts to
+buy the large toggle short-campaign gains. Conditional decomposition (re-levels to the now-adaptive
+headline; the two-direction shape is unweighted and unchanged) is neutral-to-better: prepost mean
+|bias| −0.87 pp (46 better/17 worse of 69), toggle −0.10 pp (32/32), no cell flagged a material
+regression. Benchmark JSON regenerated on the new default.
+
+### Decisions / follow-ups
+- `adaptive_time_decay=True` is the shipped default; the fixed half-life is the expert escape hatch.
+- **`toggle_campaign_only` demotion not yet decided** — the adaptive half-life is a *soft* campaign-only
+  at short campaigns, so whether `toggle_campaign_only` is now redundant is a separate confirmation
+  (tracked, not done here).
+- The temporary `double_ratio` `rho_off_scope` knob (F19) is still present; removing it (shipping
+  era-local as `double_ratio`'s behaviour) is the remaining knob-cleanup deliverable.
+- `inspect_short_campaigns.py`'s `hl90`/`hl365` arms updated to set `adaptive_time_decay=False`.
+
+---
+
+## F19 — the era-local `double_ratio` gate: no `double_ratio` variant beats the counterfactual default, so the self-configuring toggle default is not an estimator swap (Issue 15 deliverable 1)
+
+*2026-07-10 — Issue 15's first, gated step. New temporary A/B knob `PowerModelMethod.rho_off_scope`
+(`"campaign"` default / `"all"`): `double_ratio`'s calibration ratio `rho_off = Σy_off/Σpred_off` is now
+measured over the **campaign-window off rows only** (era-local), the fold models still training on all
+off rows; `"all"` reproduces the pre-Issue-15 behaviour. New `_rho_off_mask` + threaded campaign mask;
+to be removed with the knob cleanup. A/B'd on the toggle `cp_0pct` placebo at 1/2/3/6/12 months via
+`study_power_model_compare.py --method-overrides`.*
+
+### Result — era-local fixes the 1-month bias but does not dominate
+Toggle `cp_0pct` placebo, score = √(bias²+spread²) pp (cf = counterfactual default = the committed
+benchmark; gl = global-`rho_off` DR; el = era-local `rho_off` DR):
+
+| mo | bias cf/gl/el | spread cf/gl/el | score cf/gl/el |
+| --- | --- | --- | --- |
+| 1 | −0.56 / −0.71 / **+0.04** | 0.49 / 0.69 / 0.81 | **0.74** / 0.99 / 0.81 |
+| 2 | −0.17 / −0.24 / −0.22 | 0.30 / 0.50 / **0.25** | 0.34 / 0.56 / **0.34** |
+| 3 | +0.11 / **−0.01** / +0.41 | 0.20 / 0.31 / 0.34 | **0.23** / 0.31 / 0.53 |
+| 6 | +0.15 / **+0.07** / +0.16 | 0.15 / 0.22 / 0.26 | **0.22** / 0.24 / 0.31 |
+| 12 | +0.08 / −0.03 / −0.01 | 0.17 / 0.24 / **0.11** | 0.19 / 0.25 / **0.11** |
+
+Era-local fixes `double_ratio`'s 1-month **bias** (−0.71 → +0.04) by keeping `rho_off` in the ON
+window's era, but the campaign-window off set is tiny (**2150 of 101532 rows at 1mo**), so `rho_off`
+becomes a noisy ±0.5 % multiplier (1.004/1.009/0.994 across replicates vs the stable global 0.99934)
+and **spread balloons**. On the composite score it does **not** dominate: the plain counterfactual
+default is best-or-tied at 1/2/3/6 months; era-local only wins at 12mo; global-`rho_off` DR is dominated
+almost everywhere. Prepost is untouched (the overrides are toggle-only). Verified on current code, not
+just F16's recorded numbers.
+
+### Root cause — a well-calibrated model leaves `double_ratio` nothing to do
+`double_ratio` = `rho_on/rho_off − 1`; its value is cancelling model *miscalibration* shared between
+the on/off sides. But with **all-data training the model is already well-calibrated** (logged
+`rho_off = 0.99934` ≈ 1), so the ratio-of-ratios only **injects estimation noise** — visible in the
+spreads (global-DR spread exceeds the plain counterfactual sum's at every length ≥2mo). `double_ratio`
+only earns its keep when the model *is* miscalibrated — i.e. campaign-only / small fits — but F16 found
+campaign-only `double_ratio` overcorrects and its 3-month spread balloons. It is boxed between "nothing
+to correct" (all-data) and "too noisy to correct" (campaign-only); a smoother `rho_off` does not free it.
+
+### Decision
+No `double_ratio` variant beats the counterfactual default on score → the self-configuring toggle
+default is **not** an estimator swap. The mechanism-justified lever is the training window
+(drift-vs-shrinkage; F16's crossover), pursued as the adaptive time-decay half-life (**F20**). Era-local
+`rho_off` is kept as `double_ratio`'s behaviour (a strict fix to the opt-in); the `rho_off_scope` knob is
+temporary and slated for removal in the knob-cleanup deliverable.
+
+---
+
 ## F18 — the frozen reference dir regenerated on current code and verified; the compare default repointed at it; a clean four-method bias/spread read (F17 stale-reference follow-up)
 
 *2026-07-09 — the F17 stale-reference flag closed out. A full overnight run

--- a/docs/v1/findings.md
+++ b/docs/v1/findings.md
@@ -430,7 +430,7 @@ display item; estimates unchanged). Candidates A/B'd per the Issue 9 protocol:
   quantile-0.5 — estimate the median and bias the energy sum. The F5 shrinkage is a
   *regularisation* artefact, not a loss artefact; changing objective does not fix it. Legitimate
   within the mean family: Tweedie / variance-weighted L2 (efficiency candidates, untried).
-  Quantile objectives are out of scope for the point estimate (they return in Issue 17/WS4).
+  Quantile objectives are out of scope for the point estimate (they return in Issue 19/WS4).
 - **Tune on uplift metrics, never on prediction RMSE.** More regularisation can improve held-out
   RMSE while worsening shrinkage. Yardsticks: placebo bias on the harness, per-bin residual
   flatness, the predicted-vs-actual **calibration slope** (target ≈ 1) on a time-blocked held-out

--- a/docs/v1/issues.md
+++ b/docs/v1/issues.md
@@ -10,12 +10,12 @@ conditional P50, then extending the measurement to AEP uplift and starting the
 uncertainty (Phase 3 / WS4) work.
 
 Suggested order of execution: #1 → #2 → #3 → #4 → #5 (done), then
-#9 → #10 → #11 → #12 → #13 → #14 → #15 (done) → #18 → #19 → #16 → #17. (#9–#12 are
+#9 → #10 → #11 → #12 → #13 → #14 → #15 (done) → #16 → #17 → #18 → #19. (#9–#12 are
 independent input-data and model trials sharing one evaluation protocol — many ideas,
 each tested one by one; #14 is small and independent, so it can be pulled earlier — and
-#15's adaptive rule wants #14's hardened conditional scoring in place; #18/#19 are the
+#15's adaptive rule wants #14's hardened conditional scoring in place; #16/#17 are the
 `power_model` hygiene + consistency follow-ups that fall out of #15 and are best done
-before the AEP/uncertainty work builds on the conditional path; #17 builds on #16's AEP
+before the AEP/uncertainty work builds on the conditional path; #19 builds on #18's AEP
 machinery, so it goes last.) (Issue 4 was originally a data contract + method-selector
 issue; it has been re-scoped to a naive energy-ratio method — see Issue 4 below for why.)
 
@@ -391,7 +391,7 @@ early stopping, and identical whether the fit has ~13k training rows (3-month to
   shrinkage-free, valuable as a cross-check on the tree models' conditional bias even if
   its overall accuracy is worse.
 - **Quantile objectives are out of scope for the point estimate** (median ≠ mean under
-  skew → biased energy). Quantile models return in Issue 17 / WS4 for conformal OOD
+  skew → biased energy). Quantile models return in Issue 19 / WS4 for conformal OOD
   filtering and diagnostics — not as the uplift estimator.
 
 **Done when:** a findings entry records the verdict per candidate against the uplift
@@ -618,96 +618,7 @@ the dominance of the single configuration); benchmark regenerated.
 
 ---
 
-## Issue 16 — AEP uplift: long-term extrapolation design + harness scoring (WS1/WS4)
-
-**Goal:** turn the campaign conditional uplift into an **AEP uplift** — the long-term
-annual energy benefit, PR #100's third metric — and score it in the harness against known
-ground truth. The core idea: choose the condition axes from the nature of the upgrade
-(wind speed only for most upgrades; add wind direction etc. for complex upgrades like
-wake steering), estimate the **long-term MWh distribution** over those condition bins,
-and take the energy-weighted sum of the conditional uplift:
-`AEP uplift = Σ_b E_b^LT · (1+u_b) / Σ_b E_b^LT − 1`.
-
-**Scope**
-- **Upgrade-nature-driven condition axes.** A config on the method/driver naming the
-  binning axes for extrapolation (default `("ws",)`; wake steering `("ws", "wd")`, …).
-  Generalise the Issue 8 conditional machinery to produce `u_b` on those axes (today it
-  emits ws and TI *marginals*; direction and joint axes need the same treatment).
-- **Long-term energy distribution `E_b^LT`.** Two candidate sources, decided in design:
-  (a) long on-site SCADA history binned on measured conditions (simple, but needs years
-  of history and stationary sensors); (b) long-term ERA5 (10–20 y) driven through the
-  campaign-learned relation between ERA5 and the test turbine's conditions/energy — e.g.
-  the baseline counterfactual model evaluated over the long-term ERA5 record, or an
-  ERA5-cell occupancy map × per-cell mean energy from the campaign. (b) is preferred
-  (works for any site, matches the WS4 density-ratio framing).
-- **The axis-consistency question (design decision).** Conditional uplift is binned on
-  test-measured ws/TI, but the long-term record is ERA5 — either learn the ERA5→test-axis
-  transfer on the campaign overlap, or run the AEP path end-to-end on the ERA5 axis
-  (matching, uplift bins and long-term weights all on the same treatment-invariant axis).
-  Sketch both in a short design note section before coding; the ERA5-axis route avoids a
-  post-treatment reporting axis entirely and is likely cleaner for AEP.
-- **Coverage fallback.** Long-term bins with no measured `u_b` (or floored by Issue 14)
-  take Issue 14's imputed values (bfill-then-0 on the ws axis — the 0-at-rated prior
-  matters even more here, since long-term energy concentrates in high-ws bins that an
-  overall-uplift fallback would over-credit); report the coverage fraction (share of
-  long-term energy in bins with a measured uplift) as a headline diagnostic.
-- **Harness truth + scoring.** The generator knows the true uplift function, so the true
-  AEP uplift per replicate is the injected profile applied over the **full multi-year
-  dataset** (not just the campaign window); score `estimate − truth` with the same
-  bias/spread/score metrics and campaign-length sweep. Include a naive extrapolation
-  baseline (`AEP uplift = campaign overall uplift`) — the bar to beat, which only a
-  condition-dependent profile can separate from the real thing.
-- **A direction-dependent (wake-steering-shaped) profile** in the generator, so the
-  "bin by direction" path is actually exercised (listed in Issue 1, never implemented).
-
-**Done when:** the design decision (axis strategy) is recorded; the harness emits AEP
-truth and scores; `power_model` produces an AEP estimate on at least the ws axis and
-beats the naive extrapolation baseline on condition-dependent profiles.
-
----
-
-## Issue 17 — Uncertainty: campaign & AEP P50 uncertainty with harness coverage scoring (WS4)
-
-**Goal:** start Phase 3 — report an uncertainty (σ / P95) on the campaign overall P50 and
-the AEP P50, and verify it in the harness per PR #100: the campaign-uplift P95 should sit
-below the true uplift ~95% of the time. (P50 accuracy work stays the priority; this issue
-establishes the machinery and a first honest number, not the final uncertainty model.)
-
-**Scope**
-- **Method-side estimator: circular block bootstrap** over time blocks of the baseline
-  and upgraded rows (block length ≥ the residual autocorrelation scale, likely ~1 day).
-  Two variants to compare on a small grid: *cheap* (fix the fitted model, resample the
-  (actual, counterfactual) pairs → distribution of the energy ratio) and *full* (refit the
-  model per resample — captures model-fit noise, ~50–100× the cost). Emit σ and empirical
-  quantiles; P95 = P50 − 1.645σ under normality or the empirical quantile, whichever the
-  data supports.
-- **Seam extension (additive).** Optional uncertainty fields on `MethodOutput`
-  (e.g. `sigma_overall`, `p95_overall`, per-bin σ) — `None` for methods that don't emit
-  them, no breaking change to existing methods.
-- **Harness scoring.** Coverage = fraction of (replicate × campaign) cases with
-  `truth ≥ P95` (target 0.95), plus a calibration read at 2–3 more quantiles using the
-  replicate ensemble, plus mean interval width — so a method cannot win coverage by
-  inflating σ. Validate first on the placebo (truth 0), where miscalibration is most
-  visible.
-- **Why not quantile regression for P95:** per-row predictive quantiles describe
-  single-timestamp scatter and do not aggregate into a quantile of the campaign *ratio*
-  without independence assumptions the autocorrelated 10-min data violates — hence the
-  block bootstrap. Quantile models stay on the WS4 list for conformal OOD filtering and
-  diagnostics.
-- **AEP P95.** Combine the campaign sampling uncertainty (bootstrap above) with the
-  long-term-distribution uncertainty (resample ERA5 *years* to get the inter-annual
-  variability of `E_b^LT`). Document explicitly what is in and out of scope of the
-  reported number (e.g. model-form error and sensor drift are out, for now).
-- Cross-check the block bootstrap design against v0's existing bootstrap (`wind_up`
-  uncertainty machinery) — same idea, method-appropriate implementation; no v0 import.
-
-**Done when:** `power_model` emits σ/P95 for campaign and AEP uplift; the harness reports
-coverage and interval width per profile × campaign length; observed coverage is within an
-agreed tolerance of nominal on the placebo and the standard profiles.
-
----
-
-## Issue 18 — Prune the historic opt-ins: orient `power_model` to the winning configuration (power_model)
+## Issue 16 — Prune the historic opt-ins: orient `power_model` to the winning configuration (power_model)
 
 **Goal:** the accumulated development knobs on `PowerModelMethod` are almost all opt-ins that
 **lost their A/B and are off in the shipped default**. Remove the dead ones so the code presents
@@ -760,7 +671,7 @@ findings entry records the pruned set and the `toggle_campaign_only` verdict.
 
 ---
 
-## Issue 19 — Make the conditional estimator consistent with the headline (power_model)
+## Issue 17 — Make the conditional estimator consistent with the headline (power_model)
 
 **Goal:** the per-bin conditional uplift and the overall headline currently use **different data and
 weighting**, an asymmetry that grew up historically (F8/F15/F16) and is now partly obsolete. Reconcile
@@ -808,9 +719,98 @@ changes; findings entry records the verdict.
 
 ---
 
+## Issue 18 — AEP uplift: long-term extrapolation design + harness scoring (WS1/WS4)
+
+**Goal:** turn the campaign conditional uplift into an **AEP uplift** — the long-term
+annual energy benefit, PR #100's third metric — and score it in the harness against known
+ground truth. The core idea: choose the condition axes from the nature of the upgrade
+(wind speed only for most upgrades; add wind direction etc. for complex upgrades like
+wake steering), estimate the **long-term MWh distribution** over those condition bins,
+and take the energy-weighted sum of the conditional uplift:
+`AEP uplift = Σ_b E_b^LT · (1+u_b) / Σ_b E_b^LT − 1`.
+
+**Scope**
+- **Upgrade-nature-driven condition axes.** A config on the method/driver naming the
+  binning axes for extrapolation (default `("ws",)`; wake steering `("ws", "wd")`, …).
+  Generalise the Issue 8 conditional machinery to produce `u_b` on those axes (today it
+  emits ws and TI *marginals*; direction and joint axes need the same treatment).
+- **Long-term energy distribution `E_b^LT`.** Two candidate sources, decided in design:
+  (a) long on-site SCADA history binned on measured conditions (simple, but needs years
+  of history and stationary sensors); (b) long-term ERA5 (10–20 y) driven through the
+  campaign-learned relation between ERA5 and the test turbine's conditions/energy — e.g.
+  the baseline counterfactual model evaluated over the long-term ERA5 record, or an
+  ERA5-cell occupancy map × per-cell mean energy from the campaign. (b) is preferred
+  (works for any site, matches the WS4 density-ratio framing).
+- **The axis-consistency question (design decision).** Conditional uplift is binned on
+  test-measured ws/TI, but the long-term record is ERA5 — either learn the ERA5→test-axis
+  transfer on the campaign overlap, or run the AEP path end-to-end on the ERA5 axis
+  (matching, uplift bins and long-term weights all on the same treatment-invariant axis).
+  Sketch both in a short design note section before coding; the ERA5-axis route avoids a
+  post-treatment reporting axis entirely and is likely cleaner for AEP.
+- **Coverage fallback.** Long-term bins with no measured `u_b` (or floored by Issue 14)
+  take Issue 14's imputed values (bfill-then-0 on the ws axis — the 0-at-rated prior
+  matters even more here, since long-term energy concentrates in high-ws bins that an
+  overall-uplift fallback would over-credit); report the coverage fraction (share of
+  long-term energy in bins with a measured uplift) as a headline diagnostic.
+- **Harness truth + scoring.** The generator knows the true uplift function, so the true
+  AEP uplift per replicate is the injected profile applied over the **full multi-year
+  dataset** (not just the campaign window); score `estimate − truth` with the same
+  bias/spread/score metrics and campaign-length sweep. Include a naive extrapolation
+  baseline (`AEP uplift = campaign overall uplift`) — the bar to beat, which only a
+  condition-dependent profile can separate from the real thing.
+- **A direction-dependent (wake-steering-shaped) profile** in the generator, so the
+  "bin by direction" path is actually exercised (listed in Issue 1, never implemented).
+
+**Done when:** the design decision (axis strategy) is recorded; the harness emits AEP
+truth and scores; `power_model` produces an AEP estimate on at least the ws axis and
+beats the naive extrapolation baseline on condition-dependent profiles.
+
+---
+
+## Issue 19 — Uncertainty: campaign & AEP P50 uncertainty with harness coverage scoring (WS4)
+
+**Goal:** start Phase 3 — report an uncertainty (σ / P95) on the campaign overall P50 and
+the AEP P50, and verify it in the harness per PR #100: the campaign-uplift P95 should sit
+below the true uplift ~95% of the time. (P50 accuracy work stays the priority; this issue
+establishes the machinery and a first honest number, not the final uncertainty model.)
+
+**Scope**
+- **Method-side estimator: circular block bootstrap** over time blocks of the baseline
+  and upgraded rows (block length ≥ the residual autocorrelation scale, likely ~1 day).
+  Two variants to compare on a small grid: *cheap* (fix the fitted model, resample the
+  (actual, counterfactual) pairs → distribution of the energy ratio) and *full* (refit the
+  model per resample — captures model-fit noise, ~50–100× the cost). Emit σ and empirical
+  quantiles; P95 = P50 − 1.645σ under normality or the empirical quantile, whichever the
+  data supports.
+- **Seam extension (additive).** Optional uncertainty fields on `MethodOutput`
+  (e.g. `sigma_overall`, `p95_overall`, per-bin σ) — `None` for methods that don't emit
+  them, no breaking change to existing methods.
+- **Harness scoring.** Coverage = fraction of (replicate × campaign) cases with
+  `truth ≥ P95` (target 0.95), plus a calibration read at 2–3 more quantiles using the
+  replicate ensemble, plus mean interval width — so a method cannot win coverage by
+  inflating σ. Validate first on the placebo (truth 0), where miscalibration is most
+  visible.
+- **Why not quantile regression for P95:** per-row predictive quantiles describe
+  single-timestamp scatter and do not aggregate into a quantile of the campaign *ratio*
+  without independence assumptions the autocorrelated 10-min data violates — hence the
+  block bootstrap. Quantile models stay on the WS4 list for conformal OOD filtering and
+  diagnostics.
+- **AEP P95.** Combine the campaign sampling uncertainty (bootstrap above) with the
+  long-term-distribution uncertainty (resample ERA5 *years* to get the inter-annual
+  variability of `E_b^LT`). Document explicitly what is in and out of scope of the
+  reported number (e.g. model-form error and sensor drift are out, for now).
+- Cross-check the block bootstrap design against v0's existing bootstrap (`wind_up`
+  uncertainty machinery) — same idea, method-appropriate implementation; no v0 import.
+
+**Done when:** `power_model` emits σ/P95 for campaign and AEP uplift; the harness reports
+coverage and interval width per profile × campaign length; observed coverage is within an
+agreed tolerance of nominal on the placebo and the standard profiles.
+
+---
+
 ## Not in the first wave (tracked for later phases)
 
-- Uncertainty / P95 model beyond Issue 17's first cut: conformal OOD filtering,
+- Uncertainty / P95 model beyond Issue 19's first cut: conformal OOD filtering,
   density-ratio long-term weighting in place of hard CEM subsampling (WS4, Phase 3).
   Density-ratio weighting also reclaims the short-campaign matched-set size the CEM
   subsample throws away (F7 follow-up).

--- a/docs/v1/issues.md
+++ b/docs/v1/issues.md
@@ -10,13 +10,14 @@ conditional P50, then extending the measurement to AEP uplift and starting the
 uncertainty (Phase 3 / WS4) work.
 
 Suggested order of execution: #1 → #2 → #3 → #4 → #5 (done), then
-#9 → #10 → #11 → #12 → #13 (done) → #14 → #15 → #16 → #17. (#9–#12 are independent
-input-data and model trials sharing one evaluation protocol — many ideas, each tested
-one by one; #14 is small and independent, so it can be pulled earlier — and #15's
-adaptive rule wants #14's hardened conditional scoring in place; #17 builds on #16's
-AEP machinery, so it goes last.) (Issue 4 was originally a data contract +
-method-selector issue; it has been re-scoped to a naive energy-ratio method — see
-Issue 4 below for why.)
+#9 → #10 → #11 → #12 → #13 → #14 → #15 (done) → #18 → #19 → #16 → #17. (#9–#12 are
+independent input-data and model trials sharing one evaluation protocol — many ideas,
+each tested one by one; #14 is small and independent, so it can be pulled earlier — and
+#15's adaptive rule wants #14's hardened conditional scoring in place; #18/#19 are the
+`power_model` hygiene + consistency follow-ups that fall out of #15 and are best done
+before the AEP/uncertainty work builds on the conditional path; #17 builds on #16's AEP
+machinery, so it goes last.) (Issue 4 was originally a data contract + method-selector
+issue; it has been re-scoped to a naive energy-ratio method — see Issue 4 below for why.)
 
 ---
 
@@ -593,7 +594,7 @@ configuration is regime-dependent, with a crossover near ~3 months.
   one estimator may dominate everywhere and become the toggle default outright — no
   selection machinery needed. Test at 1, 2, 3, 6, 12 months in both framings.
 - **Adaptive training window / half-life as fallback.** If no single configuration
-  dominates: derive the switch (or a blended weight) from the campaign's own observables
+  dominates: derive a blended weight from the campaign's own observables
   — campaign length, campaign-row count vs pre-campaign-row count — never from the
   benchmark truth. Prefer a smooth blend (e.g. weight the campaign-only and all-data
   estimates by a logistic in log(campaign rows)) over a hard threshold, so estimates
@@ -703,6 +704,107 @@ establishes the machinery and a first honest number, not the final uncertainty m
 **Done when:** `power_model` emits σ/P95 for campaign and AEP uplift; the harness reports
 coverage and interval width per profile × campaign length; observed coverage is within an
 agreed tolerance of nominal on the placebo and the standard profiles.
+
+---
+
+## Issue 18 — Prune the historic opt-ins: orient `power_model` to the winning configuration (power_model)
+
+**Goal:** the accumulated development knobs on `PowerModelMethod` are almost all opt-ins that
+**lost their A/B and are off in the shipped default**. Remove the dead ones so the code presents
+only the successful approach — smaller surface, less overfit temptation, easier to reason about.
+This is code hygiene, not a methodology change: the default configuration is unchanged, so the
+committed benchmark must come out **bit-identical** (the acceptance test). Also finishes the
+Issue 15 knob cleanup.
+
+**The removal set (each off/absent in the default; findings verdict in brackets)**
+- `calibrate_slope` [F14 — toggle overcorrects; OOF-vs-final shrinkage gap is structural],
+  `calibrate_residuals` [F15 — OOF residuals don't transfer to a refit model in level or shape].
+- `early_stopping` [F14 — neutral even in its target 3mo-toggle regime, +15% runtime],
+  `n_seed_ensemble` [F14 — spread is weather-sampling not seed noise, +75% runtime].
+- `toggle_estimator="double_ratio"` **and** the temporary `rho_off_scope` knob [F16/F19 — never
+  beats the counterfactual default on score; boxed between "nothing to correct" (all-data →
+  `rho_off`≈1) and "too noisy to correct" (campaign-only)]. Removing `double_ratio` makes
+  `toggle_estimator` a single-value knob → drop it entirely; the counterfactual is the sole
+  headline estimator.
+- `time_features` (+ `latitude`, `longitude`) [F11 — all rejected: prepost drift import, calendar
+  proxy], `era5_derivations` (+ `hub_height_m`) [F10 — all rejected *as model features*].
+
+**Keep (with rationale, so it isn't re-litigated)**
+- The **injectable `model_factory` seam** (roadmap Phase-2 learners) *may* stay, but drop the dead
+  `hgb`/`linear` registry entries and the calibration/early-stop/seed plumbing in `fitting.py`,
+  keeping only the shared `time_block_folds`. Decide seam-stays-vs-goes on whether any driver needs
+  it; if nothing uses it, remove it too.
+- **`era5_derived.py` and `time_features.py` stay as utilities** — CEM matching / the inspection
+  scripts use the derivations even though the *feature knobs* are removed. Only the model-feature
+  wiring and the method-surface knobs go.
+- Settled defaults stay: `era5_exclude=CURATED_ERA5_EXCLUDE` (F13), `availability_feature=False`
+  (F13), `reference_stat_cols` (schema), `matching_vars`/`matching_bin_edges` (F6), the adaptive
+  time-decay default and its `time_decay_half_life_days` expert override (F20).
+
+**`toggle_campaign_only` — confirm then likely remove.** The adaptive half-life (F20) is a *soft*
+campaign-only at short campaigns, so `toggle_campaign_only=True` is probably now redundant for
+`power_model`. One cheap A/B (adaptive vs adaptive+campaign-only, toggle 1–3mo, both placebo and a
+recovery profile) settles it; remove the knob if redundant, keep with fresh evidence if not.
+(`naive_ratio` keeps its own campaign-only restriction — a different method, untouched.)
+
+**Scope**
+- Delete the dead knobs, their config-validation branches, their `_config_params` entries, their
+  plumbing, and their unit tests; thin `fitting.py`; update any driver/inspection script that set a
+  removed knob (e.g. `inspect_short_campaigns.py`'s `double_ratio*` arms).
+- Re-run `study_power_model_compare.py` on the default config and assert the benchmark is
+  bit-identical (no `--update-baseline` needed — nothing should change).
+
+**Done when:** the removed knobs are gone with their tests; `poe all-fast` green; a default-config
+run of `study_power_model_compare.py` reproduces the committed benchmark bit-identically; a short
+findings entry records the pruned set and the `toggle_campaign_only` verdict.
+
+---
+
+## Issue 19 — Make the conditional estimator consistent with the headline (power_model)
+
+**Goal:** the per-bin conditional uplift and the overall headline currently use **different data and
+weighting**, an asymmetry that grew up historically (F8/F15/F16) and is now partly obsolete. Reconcile
+them — either unify the data/weighting path, or keep the asymmetry only where fresh evidence still
+demands it and document why.
+
+**The current asymmetry (`method.py:_estimate_conditional`)**
+| aspect | headline (overall) | conditional (per-bin) |
+| --- | --- | --- |
+| training data | **all** baseline | campaign-window rows **only** (F15) |
+| recency weighting | **adaptive half-life** (F20) | **none** (F16) |
+| estimator | single full-window fit | two-direction CEM-matched cross-prediction, re-levelled to the headline |
+
+The re-level (F8/F14) keeps the *aggregate* consistent; the *inputs* diverge.
+
+**Why this is an investigation, not a one-liner**
+- **The missing half-life is downstream of the campaign-only matching.** The conditional already
+  excludes pre-campaign rows, so a decay weight has little to act on — adding the half-life is only
+  meaningful *if* the conditional also starts using pre-campaign data like the headline.
+- **F15 localised the all-data damage to the *matching*, not the fits** (matching pre-campaign rows
+  against campaign on-rows reads reference/era drift as per-bin uplift). So naive unification
+  (feed it all-data + decay) is known to fail; genuine unification needs *weighted or restricted*
+  matching — design work.
+- **But the narrow version is now unblocked:** Issue 14 deferred lifting the "weights are
+  headline-fit-only" restriction until the per-bin count floor existed ("the floor should make the
+  conditional path robust enough to lift that restriction"); the floor shipped in **F17**. So
+  re-trialling recency weighting on the conditional path is ready.
+
+**Scope (per the Issue 9 A/B protocol, one change at a time)**
+- **Re-trial recency weighting on the conditional fits** now the F17 count floor is in place — the
+  specific F14/F16-flagged item. Watch the sparse extreme-TI/ws tail bins that destabilised before
+  the floor.
+- **Trial unifying the training window**: let the conditional use all-data with the adaptive half-life
+  *and* an appropriately weighted/restricted CEM match, vs today's campaign-only match. The win
+  condition is the F15 drift bias staying cancelled while the extra data cuts per-bin spread.
+- **Preserve the exact energy-aggregation identity** (measured + pinned-imputed bins aggregate to the
+  headline) throughout — it is the one consistency property already correct and must not regress.
+- Evaluate on the conditional benchmark (`conditional_benchmark_comparison`) across profiles and
+  campaign lengths; gate on conditional |bias| no worse (ideally better) and overall P50 unchanged.
+
+**Done when:** either the conditional and headline share one data/weighting path (with the energy
+identity intact and conditional |bias| no worse), **or** each surviving asymmetry is deliberately
+documented with fresh post-floor evidence for why it must remain; benchmark regenerated if any default
+changes; findings entry records the verdict.
 
 ---
 

--- a/tests/benchmarking/baselines/test_power_model_method.py
+++ b/tests/benchmarking/baselines/test_power_model_method.py
@@ -20,6 +20,7 @@ from benchmarking.baselines.rlearner.nuisance import make_outcome_model
 if TYPE_CHECKING:
     from pathlib import Path
 from benchmarking.baselines.power_model.method import (
+    _TIME_DECAY_CAMPAIGN_MULTIPLE,
     _clip_predictions,
     _combine_uplift,
     _implied_shrinkage,
@@ -239,17 +240,53 @@ class TestModelFundamentals:
 
     def test_time_decay_weights_recover_uplift(self) -> None:
         mi, _ = _prepost_case()
-        out = _fundamentals_method(model_params=_FAST_PARAMS, time_decay_half_life_days=30.0).estimate(mi)
+        out = _fundamentals_method(
+            model_params=_FAST_PARAMS, adaptive_time_decay=False, time_decay_half_life_days=30.0
+        ).estimate(mi)
         assert out.p50_overall == pytest.approx(0.05, abs=0.02)
 
     def test_time_decay_weight_values(self) -> None:
-        method = _fundamentals_method(time_decay_half_life_days=10.0)
+        # the expert fixed-half-life path (adaptive_time_decay=False)
+        method = _fundamentals_method(adaptive_time_decay=False, time_decay_half_life_days=10.0)
         index = pd.date_range("2019-01-01", periods=5, freq="10D", tz="UTC")
         # campaign interval [index[2], index[3]]: inside weighs 1, outside decays both ways
         weights = method._time_decay_weights(index, campaign_start=index[2], campaign_end=index[3])  # noqa: SLF001
         np.testing.assert_allclose(weights, [0.25, 0.5, 1.0, 1.0, 0.5])
-        no_decay = _fundamentals_method(time_decay_half_life_days=None)
+        no_decay = _fundamentals_method(adaptive_time_decay=False, time_decay_half_life_days=None)
         assert no_decay._time_decay_weights(index, campaign_start=index[2], campaign_end=index[3]) is None  # noqa: SLF001
+
+    def test_adaptive_time_decay_half_life_scales_with_campaign_duration(self) -> None:
+        # the self-configuring default: half_life = k * campaign_duration_days, in both modes
+        method = _fundamentals_method()  # adaptive_time_decay defaults to True
+        assert method.adaptive_time_decay is True
+        start = pd.Timestamp("2019-04-01", tz="UTC")
+        for duration_days in (30.0, 90.0, 365.0):
+            end = start + pd.Timedelta(days=duration_days)
+            hl = method._effective_half_life(campaign_start=start, campaign_end=end)  # noqa: SLF001
+            assert hl == pytest.approx(_TIME_DECAY_CAMPAIGN_MULTIPLE * duration_days)
+
+    def test_adaptive_time_decay_weight_values(self) -> None:
+        method = _fundamentals_method()  # adaptive default
+        index = pd.date_range("2019-01-01", periods=5, freq="10D", tz="UTC")
+        start, end = index[2], index[3]  # 10-day campaign -> half_life = k * 10
+        hl = _TIME_DECAY_CAMPAIGN_MULTIPLE * 10.0
+        days_outside = np.array([20.0, 10.0, 0.0, 0.0, 10.0])  # distance to [index[2], index[3]]
+        expected = 0.5 ** (days_outside / hl)
+        weights = method._time_decay_weights(index, campaign_start=start, campaign_end=end)  # noqa: SLF001
+        np.testing.assert_allclose(weights, expected)
+
+    def test_effective_half_life_fixed_and_off(self) -> None:
+        start = pd.Timestamp("2019-04-01", tz="UTC")
+        end = start + pd.Timedelta(days=90)
+        fixed = _fundamentals_method(adaptive_time_decay=False, time_decay_half_life_days=42.0)
+        assert fixed._effective_half_life(campaign_start=start, campaign_end=end) == 42.0  # noqa: SLF001
+        off = _fundamentals_method(adaptive_time_decay=False, time_decay_half_life_days=None)
+        assert off._effective_half_life(campaign_start=start, campaign_end=end) is None  # noqa: SLF001
+
+    def test_adaptive_with_explicit_half_life_conflict_raises(self) -> None:
+        mi, _ = _prepost_case(n=200)
+        with pytest.raises(ValueError, match="adaptive_time_decay"):
+            _fundamentals_method(adaptive_time_decay=True, time_decay_half_life_days=90.0).estimate(mi)
 
     def test_issue13_config_conflicts_raise(self) -> None:
         mi, _ = _prepost_case(n=200)
@@ -261,7 +298,7 @@ class TestModelFundamentals:
         with pytest.raises(ValueError, match="out-of-fold basis"):
             _fundamentals_method(calibrate_residuals=True, n_seed_ensemble=2, era5_hourly_df=era5).estimate(mi)
         with pytest.raises(ValueError, match="must be positive"):
-            _fundamentals_method(time_decay_half_life_days=0.0).estimate(mi)
+            _fundamentals_method(adaptive_time_decay=False, time_decay_half_life_days=0.0).estimate(mi)
 
     def test_campaign_mask_bites_only_for_started_toggle(self) -> None:
         index = pd.date_range("2019-01-01", periods=4, freq="10D", tz="UTC")
@@ -311,6 +348,54 @@ class TestModelFundamentals:
         mi = MethodInput(scada_df=scada, test_wtg="T1", upgrade_timing=schedule, turbine_col=_TURBINE)
         with pytest.raises(ValueError, match=r"double_ratio.*off rows"):
             method.estimate(mi)
+
+    def test_double_ratio_era_local_rho_off_beats_all_under_era_drift(self) -> None:
+        # A pre-campaign era effect the references do not explain (Issue 15 mechanism): the
+        # double-ratio cancels the model's miscalibration between the on/off sides, but rho_off
+        # measured over *all* off rows straddles the stale pre-campaign era while the ON window is
+        # a campaign-only sliver, so it subtracts the wrong era's miscalibration. Measuring rho_off
+        # on the campaign-window off rows only (rho_off_scope="campaign") keeps the placebo at ~0.
+        n = 6000
+        idx = pd.date_range("2019-01-01", periods=n, freq="10min", tz="UTC")
+        start = idx[n // 2]  # first half pre-campaign off; second half interleaved toggle
+        within = (((idx - start) // (pd.Timedelta(hours=4) / 2)).astype(int) % 2) == 1
+        treated = np.asarray((idx >= start) & within)
+        schedule = ToggleSchedule(period=pd.Timedelta(hours=4), start=start)
+        scada = _toy_scada(n, uplift=0.0, treated=treated)  # placebo: true uplift is 0
+        # inflate the test turbine's pre-campaign power by 20% — a level shift the reference
+        # features cannot see, i.e. a stale-era miscalibration the model averages over
+        pre = (scada.index < start) & (scada[_TURBINE] == "T1")
+        scada.loc[pre, _POWER] *= 1.20
+        mi = MethodInput(scada_df=scada, test_wtg="T1", upgrade_timing=schedule, turbine_col=_TURBINE)
+        era_local = _fundamentals_method(
+            model_params=_FAST_PARAMS, toggle_estimator="double_ratio", rho_off_scope="campaign"
+        ).estimate(mi)
+        all_scope = _fundamentals_method(
+            model_params=_FAST_PARAMS, toggle_estimator="double_ratio", rho_off_scope="all"
+        ).estimate(mi)
+        assert era_local.p50_overall == pytest.approx(0.0, abs=0.02)
+        assert all_scope.p50_overall < -0.04  # the stale pre-campaign era biases the all-rows rho_off
+
+    def test_double_ratio_rho_off_scope_moot_when_campaign_only(self) -> None:
+        # with toggle_campaign_only the pre-campaign rows are dropped, so every off row is already
+        # in-campaign and the two scopes must give bit-identical results.
+        n = 4000
+        idx = pd.date_range("2019-01-01", periods=n, freq="10min", tz="UTC")
+        start = idx[n // 2]
+        within = (((idx - start) // (pd.Timedelta(hours=4) / 2)).astype(int) % 2) == 1
+        treated = np.asarray((idx >= start) & within)
+        schedule = ToggleSchedule(period=pd.Timedelta(hours=4), start=start)
+        scada = _toy_scada(n, uplift=0.04, treated=treated)
+        mi = MethodInput(scada_df=scada, test_wtg="T1", upgrade_timing=schedule, turbine_col=_TURBINE)
+        common = {"model_params": _FAST_PARAMS, "toggle_estimator": "double_ratio", "toggle_campaign_only": True}
+        campaign = _fundamentals_method(**common, rho_off_scope="campaign").estimate(mi)
+        all_scope = _fundamentals_method(**common, rho_off_scope="all").estimate(mi)
+        assert campaign.p50_overall == pytest.approx(all_scope.p50_overall, abs=1e-9)
+
+    def test_rho_off_scope_guard(self) -> None:
+        mi, _ = _prepost_case(n=200)
+        with pytest.raises(ValueError, match="rho_off_scope"):
+            _fundamentals_method(rho_off_scope="nope").estimate(mi)
 
     def test_toggle_all_data_with_conditional_recovers_uplift(self) -> None:
         n = 4000


### PR DESCRIPTION
Main change is to calculate half life based on campaign window (see `findings.md`). End result is that power_model beats v0 and naive_ratio in almost all cases now