### PR TITLE
Cleanup: drop stale R-learner refs, strip finding numbers, retire spe…

### DIFF
--- a/benchmarking/baselines/block_bootstrap.py
+++ b/benchmarking/baselines/block_bootstrap.py
@@ -10,8 +10,6 @@ ratio re-formed, rather than linearised.
 
 Block sums come from prefix sums over the records (doubled end-to-end so a wrapped block is still
 two lookups), so a resample is a gather-and-subtract rather than a pass over the data.
-
-Rationale for the design and for the block length: findings F28.
 """
 
 from __future__ import annotations
@@ -43,7 +41,7 @@ _SIGMA_PERCENTILES = (100.0 * norm.cdf(-1.0), 100.0 * norm.cdf(1.0))
 _MIN_FALLBACK_DF = 1
 # Fewest records a segment needs before its own scatter is worth measuring, for `relative_scatter`.
 _MIN_RECORDS_PER_SIDE = 3
-# Records per side over which the report ramps linearly from the fallback to the bootstrap (F33):
+# Records per side over which the report ramps linearly from the fallback to the bootstrap:
 # pure fallback at/below LO, pure bootstrap at/above HI.
 _BLEND_LO_RECORDS = 3
 _BLEND_HI_RECORDS = 7
@@ -125,7 +123,7 @@ def relative_scatter(
 
 
 def _fallback_sigma(*, n_on: int, n_off: int, s_rel: float) -> float:
-    """Return a t-inflated per-record-scatter uncertainty for one cell (F33).
+    """Return a t-inflated per-record-scatter uncertainty for one cell.
 
     ``s_rel * sqrt(1/n_on + 1/n_off)`` is the standard ratio-estimator error under multiplicative
     per-record noise, propagated through ``rho_up / rho_base``. The ``scipy.stats.t`` multiplier is
@@ -171,7 +169,7 @@ def bootstrap_ratio_uplift(
         the used records are covered rather than closed up
     :param campaign_end: the campaign's last timestamp
     :param timebase: analysis timebase; sets the candidate block-start grid
-    :param block_hours: block length (F28). A length at or beyond the campaign leaves one block, which
+    :param block_hours: block length. A length at or beyond the campaign leaves one block, which
         nothing can vary, so every cell reports NaN rather than a spurious near-zero sigma.
     :param n_resamples: resamples to draw
     :param seed: RNG seed, so a reported sigma is reproducible
@@ -233,7 +231,7 @@ def bootstrap_ratio_uplift(
 
 
 def _bootstrap_weight(n_min: int) -> float:
-    """Weight on the bootstrap for a cell with ``n_min`` records on its thinner side (F33)."""
+    """Weight on the bootstrap for a cell with ``n_min`` records on its thinner side."""
     span = _BLEND_HI_RECORDS - _BLEND_LO_RECORDS
     return float(np.clip((n_min - _BLEND_LO_RECORDS) / span, 0.0, 1.0))
 

--- a/benchmarking/baselines/era5_sync.py
+++ b/benchmarking/baselines/era5_sync.py
@@ -6,9 +6,9 @@ which are private there) but kept local so the methods stay v0-independent:
 
 1. :func:`upsample_era5_to_timebase` resamples ERA5 onto the analysis timebase and
    forward-fills within each hour. **Every raw column is passed through under its original
-   Open-Meteo name** (no renaming); for back-compat with the R-learner and the shared
-   diagnostics, neutral ``era5_ws`` / ``era5_wd`` *aliases* of wind speed / direction are
-   added alongside the raw columns.
+   Open-Meteo name** (no renaming); for the feature builders and the shared diagnostics,
+   neutral ``era5_ws`` / ``era5_wd`` *aliases* of wind speed / direction are added alongside
+   the raw columns.
 2. :func:`find_best_lag` sweeps the integer row-shift that maximises the correlation
    between ERA5 wind speed and a reference (wind-farm) wind speed, recovering the lag
    between the reanalysis and the site.
@@ -28,7 +28,7 @@ import pandas as pd
 _MIN_OVERLAP = 3
 
 # Neutral, source-agnostic aliases (no wind_up / v0 vocabulary) added alongside the raw columns
-# so the R-learner's ``era5_features`` and the shared diagnostics keep a stable ws/wd handle.
+# so the feature builders and the shared diagnostics keep a stable ws/wd handle.
 ERA5_WS = "era5_ws"
 ERA5_WD = "era5_wd"
 

--- a/benchmarking/baselines/example_prepost_study.py
+++ b/benchmarking/baselines/example_prepost_study.py
@@ -142,10 +142,10 @@ def run_prepost_study(
                 columns=HOT_COLUMNS,
                 baseline_rated_power_kw=HOT_RATED_POWER_KW,
                 era5_hourly_df=context.reanalysis_datasets[0].data,
-                # Removal-ablation accepted defaults (findings F13).
+                # Accepted defaults: no availability feature, curated ERA5 exclusions.
                 availability_feature=False,
                 era5_exclude=CURATED_ERA5_EXCLUDE,
-                # Issue 12 accepted default (findings F14): looser leaf capacity.
+                # Accepted default: looser leaf capacity.
                 model_params=dict(TUNED_MODEL_PARAMS),
                 out_dir=out_dir / "power_model_runs",
             )

--- a/benchmarking/baselines/example_toggle_study.py
+++ b/benchmarking/baselines/example_toggle_study.py
@@ -110,10 +110,10 @@ def run_toggle_study(
                 columns=HOT_COLUMNS,
                 baseline_rated_power_kw=HOT_RATED_POWER_KW,
                 era5_hourly_df=context.reanalysis_datasets[0].data,
-                # Removal-ablation accepted defaults (findings F13).
+                # Accepted defaults: no availability feature, curated ERA5 exclusions.
                 availability_feature=False,
                 era5_exclude=CURATED_ERA5_EXCLUDE,
-                # Issue 12 accepted default (findings F14): looser leaf capacity.
+                # Accepted default: looser leaf capacity.
                 model_params=dict(TUNED_MODEL_PARAMS),
                 out_dir=out_dir / "power_model_runs",
             )

--- a/benchmarking/baselines/filtering.py
+++ b/benchmarking/baselines/filtering.py
@@ -4,7 +4,7 @@ The outcome is the test turbine's power, so abnormal operation unrelated to the 
 downtime, curtailment, frozen/stuck sensors — would otherwise be attributed to the upgrade (a
 downward bias, worst when it clusters in the upgrade period). Every method must select the
 normally-operating test-turbine rows the same way, so this filter lives in one shared place
-(the R-learner and the naive ratio both use it; it has no ``wind_up`` dependency).
+(the benchmarking methods all use it; it has no ``wind_up`` dependency).
 
 Three checks:
 
@@ -19,7 +19,7 @@ The central rule is **filter on cause, not effect**: selection uses operational 
 power, never "power lower than expected" — that would drop genuine low-uplift records and bias the
 estimate. This is row selection, not a feature rule, so using the test turbine's own operational
 signals here does not violate the upgrade-invariant feature rule. References are deliberately not
-filtered (the R-learner learns their operating modes; the naive ratio keeps complete-case refs).
+filtered (the naive ratio keeps complete-case refs; the power model learns their operating modes).
 """
 
 from __future__ import annotations

--- a/benchmarking/baselines/hot_context.py
+++ b/benchmarking/baselines/hot_context.py
@@ -5,9 +5,8 @@ the harness's thin ``MethodInput`` does not carry: per-turbine metadata (lat/lon
 reanalysis, and the paths to the vendored asset and northing-corrections YAMLs. It is loaded
 once and reused across every campaign a method scores.
 
-This is a benchmarking helper, not a harness-enforced contract: future methods (e.g. the
-Issue 5 R-learner) reuse it by calling it from their own constructor. Keeping it here lets the
-harness seam stay thin until the Issue 4 contract has two real consumers to design against.
+This is a benchmarking helper, not a harness-enforced contract: methods reuse it by calling it
+from their own constructor, keeping the harness seam thin.
 """
 
 from __future__ import annotations

--- a/benchmarking/baselines/inspect_prepost_hard_case.py
+++ b/benchmarking/baselines/inspect_prepost_hard_case.py
@@ -1,13 +1,12 @@
 """Inspect one hard PREPOST case across every method, with plots on.
 
-A focused investigation driver (findings F1): replay the **exact** overnight prepost study
+A focused investigation driver: replay the **exact** overnight prepost study
 draws (same ``StudyConfig``/seed/profile), pin a single hard ``(test_wtg, campaign_months)``
 run, and execute naive + power_model (+ v0) on the **identical** ``MethodInput`` with
 ``save_plots=True``, each into its own subfolder of one timestamped run dir. The default case is
-``cp_0pct`` (placebo) on ``T07`` at 6 months — the prepost case where the cross-fit R-learner was
-badly biased (~-14%) while naive (~+2%) and v0 (~0%) are fine. The question here is whether the
-counterfactual power model, which forms the test-vs-reference contrast the R-learner lacked, also
-stays near zero — eyeball the per-method diagnostics side by side to confirm.
+``cp_0pct`` (placebo) on ``T07`` at 6 months — a hard prepost case where the baseline and upgraded
+periods do not share a weather distribution. The question here is whether the counterfactual power
+model stays near zero on it — eyeball the per-method diagnostics side by side to confirm.
 
 Because the draws are a deterministic function of ``(StudyConfig, seed)`` and the harness builds
 one ``MethodInput`` per ``(replicate, window)``, every method here sees the same data the
@@ -73,7 +72,7 @@ logger = logging.getLogger(__name__)
 N_REPLICATES = 4
 CAMPAIGN_MONTHS = [3, 6, 12]
 
-# The default hard case (see module docstring / findings F1).
+# The default hard case (see module docstring).
 DEFAULT_PROFILE = "cp_0pct"
 DEFAULT_TEST_WTG = "T07"
 DEFAULT_CAMPAIGN_MONTHS = 6
@@ -159,10 +158,10 @@ def _power_model(out_dir: Path, era5_hourly_df: pd.DataFrame, *, save_plots: boo
         columns=HOT_COLUMNS,
         baseline_rated_power_kw=HOT_RATED_POWER_KW,
         era5_hourly_df=era5_hourly_df,
-        # Removal-ablation accepted defaults (findings F13).
+        # Accepted defaults: no availability feature, curated ERA5 exclusions.
         availability_feature=False,
         era5_exclude=CURATED_ERA5_EXCLUDE,
-        # Issue 12 accepted default (findings F14): looser leaf capacity.
+        # Accepted default: looser leaf capacity.
         model_params=dict(TUNED_MODEL_PARAMS),
         out_dir=out_dir,
         save_plots=save_plots,

--- a/benchmarking/baselines/naive_ratio.py
+++ b/benchmarking/baselines/naive_ratio.py
@@ -180,7 +180,7 @@ class NaiveRatioMethod:
         Returns a bool Series on ``wide.index``. Every turbine (test and references) must be
         available (counter >= a full period) and have finite power — a down turbine on either side
         of the ratio is therefore excluded. The test turbine additionally goes through the shared
-        :class:`NormalOperationFilter` (the same downtime + finite-power logic the R-learner uses;
+        :class:`NormalOperationFilter` (the same downtime + finite-power logic the power model uses;
         the stuck filter is left off here as the ratio sums raw power rather than fitting a model).
         """
         turbines = [test, *refs]

--- a/benchmarking/baselines/old/__init__.py
+++ b/benchmarking/baselines/old/__init__.py
@@ -1,0 +1,6 @@
+"""Retired one-off and manual-inspection drivers.
+
+These scripts are kept for reference and reproducibility (some are cited in
+``docs/v1/findings.md``) but are no longer part of the active benchmarking flow. They are
+runnable as ``python -m benchmarking.baselines.old.<name>``.
+"""

--- a/benchmarking/baselines/old/inspect_era5_matching_importance.py
+++ b/benchmarking/baselines/old/inspect_era5_matching_importance.py
@@ -2,7 +2,7 @@
 
 The bias-cancellation correction (Issue 8) matches the baseline and upgraded periods on **ERA5-only**
 weather so a common per-bin multiplicative shrinkage cancels between the two train/predict directions
-(design + ``docs/v1/findings.md`` F5). CEM cell count explodes with dimension, so we can only afford to
+(design + ``docs/v1/findings.md``). CEM cell count explodes with dimension, so we can only afford to
 match on a *few* ERA5 variables — and they must be the ones that actually drive the test turbine's
 power, or the matched shrinkage factor is not the one that distorts the estimate.
 
@@ -24,13 +24,13 @@ Outputs (under ``<out-root>/inspection_era5_matching``):
   **gate**: if ERA5 predicts test power poorly the whole ranking is suspect, not just imprecise.
 * ``era5_matching_importance.csv`` — the merged ranking table.
 
-The chosen matching set + rationale (citing these metrics) is recorded as **F6** in
+The chosen matching set + rationale (citing these metrics) is recorded in
 ``docs/v1/findings.md`` and hard-coded as the method default; this script does not edit anything.
 
 Run from the repo root::
 
-    uv run python -m benchmarking.baselines.inspect_era5_matching_importance
-    uv run python -m benchmarking.baselines.inspect_era5_matching_importance --test-wtg T07
+    uv run python -m benchmarking.baselines.old.inspect_era5_matching_importance
+    uv run python -m benchmarking.baselines.old.inspect_era5_matching_importance --test-wtg T07
 """
 
 from __future__ import annotations
@@ -89,7 +89,7 @@ def add_shear_exponent(features: pd.DataFrame) -> pd.DataFrame:
     permutation discounts whichever is redundant — neither view then cleanly reflects the *shear* they
     jointly encode. The power-law exponent (see
     :func:`benchmarking.baselines.era5_derived.shear_exponent`, the shared Issue 9 utility) captures
-    that shear in a single column (a stability / turbulence proxy that directly attacks the F5 cause),
+    that shear in a single column (a stability / turbulence proxy that directly attacks the cause),
     so we keep ``wind_speed_100m`` as the magnitude and drop the now-redundant ``wind_speed_10m``.
     """
     alpha = shear_exponent(features["wind_speed_10m"], features["wind_speed_100m"])
@@ -276,7 +276,7 @@ def run(*, test_wtg: str, out_root: Path | None, seed: int) -> pd.DataFrame:
     )
     logger.info(
         "Suggested matching set (gain >= %.0f%% of top, capped at %d): %s — verify against the cell budget "
-        "(Component 2) before hard-coding as the F6 default.",
+        "(Component 2) before hard-coding as the default.",
         100 * _SELECTION_FLOOR_FRAC,
         _PREFERRED_N,
         _select_matching_vars(table),

--- a/benchmarking/baselines/old/inspect_naive.py
+++ b/benchmarking/baselines/old/inspect_naive.py
@@ -1,6 +1,6 @@
 """Manual inspection driver: run a few naive-ratio replicates (prepost and toggle) with plots on.
 
-A runnable companion to :mod:`benchmarking.baselines.inspect_v0_run`, but for
+A runnable companion to :mod:`benchmarking.baselines.old.inspect_v0_run`, but for
 :class:`benchmarking.baselines.naive_ratio.NaiveRatioMethod`. It runs a handful of replicates in
 each mode with ``save_plots=True``, each in its **own output directory**, so the naive method's
 diagnostics (the per-run data-stats / results CSVs and the scatter, ratio-timeseries and
@@ -13,7 +13,7 @@ Each replicate is built and scored exactly as :func:`benchmarking.harness.score_
 
 Run it::
 
-    uv run python -m benchmarking.baselines.inspect_naive
+    uv run python -m benchmarking.baselines.old.inspect_naive
 
 First run downloads and caches the Hill of Towie v2 SCADA (Zenodo). Each replicate's outputs land
 under ``<out_root>/inspection_naive/<mode>/replicate_<id>_<wtg>/naive_<wtg>_<dates>/`` (with a

--- a/benchmarking/baselines/old/inspect_short_campaigns.py
+++ b/benchmarking/baselines/old/inspect_short_campaigns.py
@@ -14,7 +14,7 @@ Which choices can even flip at short campaigns:
 
 Run from the repo root (defaults: both modes, all variants)::
 
-    uv run python -m benchmarking.baselines.inspect_short_campaigns
+    uv run python -m benchmarking.baselines.old.inspect_short_campaigns
 
 Outputs one ``results_<mode>_<variant>_<profile>.csv`` per run plus a combined
 ``short_campaign_summary.csv`` / log table of power_model bias/spread/score per

--- a/benchmarking/baselines/old/inspect_v0_run.py
+++ b/benchmarking/baselines/old/inspect_v0_run.py
@@ -12,7 +12,7 @@ Each replicate is built and scored exactly as :func:`benchmarking.harness.score_
 
 Run it::
 
-    uv run python -m benchmarking.baselines.inspect_v0_run
+    uv run python -m benchmarking.baselines.old.inspect_v0_run
 
 First run downloads and caches the Hill of Towie v2 SCADA (Zenodo) and ERA5 (Open-Meteo; needs
 the ``era5`` optional dependency group). Each replicate's plots land under

--- a/benchmarking/baselines/old/migrate_toggle_baseline_v2_to_v3.py
+++ b/benchmarking/baselines/old/migrate_toggle_baseline_v2_to_v3.py
@@ -1,4 +1,4 @@
-"""One-off: split the single v2 toggle benchmark into a portable + a per-platform v3 pair (F30).
+"""One-off: split the single v2 toggle benchmark into a portable + a per-platform v3 pair.
 
 The v2 file was recorded on a Windows laptop and holds both methods. ``power_model``'s cells are
 machine-specific, so they can only ever be re-derived on that machine — hence a split rather than a
@@ -7,7 +7,7 @@ become the shared baseline unchanged.
 
 Delete this script once both platform baselines are recorded and committed.
 
-    uv run python -m benchmarking.baselines.migrate_toggle_baseline_v2_to_v3
+    uv run python -m benchmarking.baselines.old.migrate_toggle_baseline_v2_to_v3
 """
 
 from __future__ import annotations

--- a/benchmarking/baselines/power_model/features.py
+++ b/benchmarking/baselines/power_model/features.py
@@ -2,8 +2,8 @@
 
 The discipline (design note §3): every model feature must be *upgrade-invariant* — derived from
 reference turbines (or ERA5), never the test turbine's own signals, which the upgrade distorts.
-Unlike the R-learner's *maximal* feature builder, this matrix is deliberately **curated** to
-features known to relate to the *cause* of the test turbine's power — weather and wakes:
+This matrix is deliberately **curated** to features known to relate to the *cause* of the test
+turbine's power — weather and wakes:
 
 * per **reference turbine**: active power (the primary stable weather-driven measurement) and the
   availability counter (whether the reference is operating, hence whether it is making a wake);

--- a/benchmarking/baselines/power_model/matching.py
+++ b/benchmarking/baselines/power_model/matching.py
@@ -4,7 +4,7 @@ The bias-cancellation correction trains/predicts in two symmetric directions and
 per-bin multiplicative shrinkage* cancelling between them — which only holds if the baseline and
 upgraded periods share a covariate distribution within each reporting bin. This module makes that
 matching explicit and model-free: bin the matching variables into cells, keep only cells present on
-*both* sides (the common-support guard — the exact failure that sank the R-learner in prepost, F1),
+*both* sides (the common-support guard),
 and seeded-subsample the larger side down to the smaller within every retained cell so the two sides
 carry equal weight per cell.
 

--- a/benchmarking/baselines/power_model/method.py
+++ b/benchmarking/baselines/power_model/method.py
@@ -10,7 +10,7 @@ in-sample leakage to correct for.
 The feature set is curated to the *causes* of test-turbine power — weather (all raw ERA5) and
 wakes (each reference's active power + availability). Expressing expected power *through the
 references* forms the test-vs-reference contrast that cancels common-mode seasonal/long-term
-drift (the lever the R-learner lacks; findings F1).
+drift.
 
 It is v0-independent — ERA5 is supplied as a plain hourly DataFrame (the driver fetches it), so
 this package imports nothing from ``wind_up``.
@@ -64,14 +64,14 @@ _MIN_HOLDOUT_ROWS = 20  # below this, report the in-sample fit (no point splitti
 # spread across the whole window (seasonally balanced) while staying contiguous at the block scale.
 _N_FOLDS = 5
 _N_BLOCKS = 25
-# Adaptive time-decay half-life = this multiple of the campaign's own duration (Issue 15 / F20): a
+# Adaptive time-decay half-life = this multiple of the campaign's own duration (Issue 15): a
 # scale-free "trust pre-campaign data within ~k campaign-durations" rule that gives a short half-life
 # for a short campaign (drift protection) and a long one for a long campaign (use the plentiful recent
-# data), reproducing F16's regime map with one mechanism-anchored constant. k=2 -> 1mo~60d, 12mo~730d.
+# data), reproducing the earlier regime map with one mechanism-anchored constant. k=2 -> 1mo~60d, 12mo~730d.
 _TIME_DECAY_CAMPAIGN_MULTIPLE = 2.0
 _MIN_TIME_DECAY_DURATION_DAYS = 1.0  # floor the campaign duration so the half-life can't degenerate to 0
 
-# The removal-ablation verdict (findings F13): raw Open-Meteo columns the curated feature set does
+# Removal-ablation verdict: raw Open-Meteo columns the curated feature set does
 # better without — redundant thermodynamic derivatives of temperature/humidity and the precipitation
 # trio. HoT drivers pass this (with availability_feature=False) as the accepted default; kept here,
 # not baked into ``era5_exclude``'s dataclass default, so a non-Open-Meteo ERA5 frame is not broken
@@ -84,29 +84,29 @@ CURATED_ERA5_EXCLUDE: tuple[str, ...] = (
     "snowfall",
 )
 
-# The Issue 12 capacity verdict (findings F14): loosening min_child_samples 200 -> 50 materially
+# Capacity verdict: loosening min_child_samples 200 -> 50 materially
 # improves prepost spread/score (placebo ALL Δscore -0.62 pp) at neutral overall P50; 20 overshoots
 # into overfit. A power_model-specific tuning — the common params in ``make_outcome_model`` are
 # unchanged; drivers pass this instead.
 TUNED_MODEL_PARAMS: dict[str, Any] = {"min_child_samples": 50}
 
 # Per-reporting-bin matched-count floor for the two-direction conditional combine (Issue 14). Below this
-# many matched rows *per side* in a ws/TI reporting bin, the combine overshoots — the F7/F9 sparse-extreme
+# many matched rows *per side* in a ws/TI reporting bin, the combine overshoots — the sparse-extreme
 # tail (e.g. TI (0.45,0.50] swinging -77 to +93 pp between replicates) — so the bin is marked uncovered and
 # filled by the physics-informed imputer instead of trusting its noisy shape. Compared against the raw
 # per-side matched count today; if the per-bin balance reweighting (A5) is adopted it becomes the Kish
-# ESS. The value is chosen on placebo/benchmark evidence across many bins (findings F17), not tuned to the
+# ESS. The value is chosen on placebo/benchmark evidence across many bins, not tuned to the
 # one known bad TI bin.
 _MIN_BIN_MATCHED_COUNT = 50
 
-# F6 matching set + bin widths for the bias-cancellation correction, verified on real HoT by the CEM
-# coverage sweep (docs/v1/findings.md F6). wind_speed_100m (dominant) is binned finest, wind_gusts_10m
+# Matching set + bin widths for the bias-cancellation correction, verified on real HoT by the CEM
+# coverage sweep (docs/v1/findings.md). wind_speed_100m (dominant) is binned finest, wind_gusts_10m
 # coarser, and wind_direction_100m in 20° sectors (a reanalysis direction — finer is finer than the
 # signal). Fixed sectors, no wraparound (adjacent sectors are just separate cells, per the CEM utility).
 _DEFAULT_MATCHING_VARS: tuple[str, ...] = ("wind_speed_100m", "wind_gusts_10m", "wind_direction_100m")
 # This method can report every condition axis: its ws/TI come from the test turbine's own measurements
 # (post-treatment, accepted per design-note §3) and its power axis is labelled by the counterfactual
-# prediction (F23). The default reports all three, preserving the behaviour of every existing caller.
+# prediction. The default reports all three, preserving the behaviour of every existing caller.
 _SUPPORTED_CONDITIONS: tuple[str, ...] = CONDITIONS
 _DEFAULT_MATCHING_BIN_EDGES: dict[str, list[float]] = {
     "wind_speed_100m": [float(x) for x in np.arange(0.0, 34.0, 2.0)],  # 0,2,…,32
@@ -126,7 +126,7 @@ def _combine_uplift(r_fwd: np.ndarray, r_rev: np.ndarray) -> np.ndarray:
     """Two-direction uplift ``sqrt((1+r_fwd)/(1+r_rev)) - 1`` (shrinkage cancels); NaN if either 1+r <= 0.
 
     Under a common per-bin multiplicative shrinkage the forward/reverse ratios are ``(1+u)/s`` and
-    ``1/(s(1+u))``, so their geometric contrast recovers ``u`` with ``s`` cancelled (design/F5).
+    ``1/(s(1+u))``, so their geometric contrast recovers ``u`` with ``s`` cancelled (by design).
     """
     a = 1.0 + np.asarray(r_fwd, dtype=float)
     b = 1.0 + np.asarray(r_rev, dtype=float)
@@ -168,7 +168,7 @@ def _condition_frame(
     keeps the reverse ratio free of a regression-to-the-mean tilt (see the power-frame note in
     ``_conditional_by_bin``). The forward/reverse energy ratios give the shrinkage-free per-bin
     shape; uncovered bins are imputed (``impute_uncovered_bins``) and the whole thing is re-leveled onto the
-    headline by full-upgraded energy so measured + imputed aggregate to ``one_plus_overall`` (F8/F14).
+    headline by full-upgraded energy so measured + imputed aggregate to ``one_plus_overall``.
     """
     fwd = energy_ratio_by_bin(fwd_cond, y_fwd, pred_fwd, bins=bins)
     rev = energy_ratio_by_bin(rev_cond, y_rev, pred_rev, bins=bins)
@@ -189,7 +189,7 @@ def _condition_frame(
     shape = 1.0 + _combine_uplift(r_fwd, r_rev)  # shrinkage-free shape (NaN if degenerate)
     sum_actual_full = merged["sum_actual_full"].to_numpy()
     # A bin is covered only if its shape is finite AND both directions have enough matched rows;
-    # below the floor the two-direction combine overshoots, so the bin is imputed instead (F7/F9).
+    # below the floor the two-direction combine overshoots, so the bin is imputed instead.
     per_side = np.minimum(merged["n_records_fwd"].to_numpy(), merged["n_records_rev"].to_numpy())
     measured = np.isfinite(shape) & (per_side >= _MIN_BIN_MATCHED_COUNT)
     imputed_shape = impute_uncovered_bins(shape, condition=name, measured=measured, one_plus_overall=one_plus_overall)
@@ -256,7 +256,7 @@ class PowerModelMethod:
     :param seed: seed for the baseline holdout split and the LightGBM ``random_state`` (a caller-supplied
         ``random_state`` in ``model_params`` still wins)
     :param model_params: LightGBM overrides passed to the outcome model; merged **over** the tuned
-        default ``TUNED_MODEL_PARAMS`` (``min_child_samples=50``, F14), so a bare method already carries
+        default ``TUNED_MODEL_PARAMS`` (``min_child_samples=50``), so a bare method already carries
         the accepted capacity and any key here wins
     :param timebase: analysis timebase; inferred from the data when ``None``
     :param conditions: which condition axes to report a per-bin conditional uplift over — any of
@@ -266,25 +266,25 @@ class PowerModelMethod:
         (its common per-bin shrinkage cancels), then re-levels onto the headline. That step
         **requires ERA5** (the matching axis is the ERA5 columns). Pass ``()`` to skip that
         cross-prediction — the expensive part — and return only the overall P50.
-    :param matching_vars: ERA5 columns matched on for the conditional step (default: the F6 set)
-    :param matching_bin_edges: per-variable CEM bin edges; the F6 defaults are used when ``None``
+    :param matching_vars: ERA5 columns matched on for the conditional step (default: the curated set)
+    :param matching_bin_edges: per-variable CEM bin edges; the curated defaults are used when ``None``
     :param reference_stat_cols: *extra* per-reference value columns to carry as features beyond the
         active-power minimum, which is always carried via the ``columns`` schema's ``active_power_min``
-        role (Issue 11 / F12 — the max/SD companions stay opt-in here; a repeat of the min is deduped)
+        role (Issue 11 — the max/SD companions stay opt-in here; a repeat of the min is deduped)
     :param era5_exclude: raw ERA5 columns to drop from the model features (removal-ablation knob;
         a dropped direction column also loses its sin/cos companions). Columns used as
         ``matching_vars`` cannot be excluded while any ``conditions`` are requested. Defaults to the
-        accepted ``CURATED_ERA5_EXCLUDE`` set (F13); the **untouched default** is drop-if-present (so a
+        accepted ``CURATED_ERA5_EXCLUDE`` set; the **untouched default** is drop-if-present (so a
         non-Open-Meteo ERA5 frame lacking those columns is not broken), while an **explicitly-set**
         value keeps the strict raise-on-unknown-column typo guard.
-    :param availability_feature: when ``False`` (the accepted default, F13), drop the per-reference
+    :param availability_feature: when ``False`` (the accepted default), drop the per-reference
         availability *feature*; the ``availability`` role itself stays required for the downtime filter
     :param adaptive_time_decay: when ``True`` (**default**, the Issue 15 self-configuring behaviour)
         the headline fit's time-decay half-life is set automatically to
         ``_TIME_DECAY_CAMPAIGN_MULTIPLE * campaign_duration_days`` — a short half-life for a short
         campaign (down-weight the stale pre-campaign era that dominates a sliver campaign) and a long
         one for a long campaign (use the plentiful recent data). This subsumes the fixed default:
-        the best half-life is regime-dependent (F16 — short helps 1-3-month campaigns in both modes,
+        the best half-life is regime-dependent (short helps 1-3-month campaigns in both modes,
         long is safe at 12 months), and a campaign-proportional half-life gets both ends right with no
         manual tuning. When ``True``, ``time_decay_half_life_days`` must be left ``None``.
     :param time_decay_half_life_days: **expert override** (used only when ``adaptive_time_decay=False``):
@@ -292,7 +292,7 @@ class PowerModelMethod:
         ``0.5 ** (days_outside_campaign / half_life)``. Rows inside the campaign interval (for toggle,
         the interleaved on and off rows) weigh 1; rows outside decay with their distance to it — so
         distant history informs the fit without dominating it (Issue 13's recency weighting; the
-        alternative to the rejected F11 drift *feature*). ``None`` disables the weighting entirely.
+        alternative to the rejected drift *feature*). ``None`` disables the weighting entirely.
         The default self-configuring behaviour is ``adaptive_time_decay=True`` (this left ``None``).
 
     The toggle headline is always the counterfactual energy ratio ``Σactual/Σprediction - 1``.
@@ -338,7 +338,7 @@ class PowerModelMethod:
         y = extract_outcome(
             scada, test_wtg=mi.test_wtg, turbine_col=mi.turbine_col, active_power_col=self.columns.active_power
         )
-        # The per-reference active-power minimum (Issue 11 / F12) is a standard feature carried by the
+        # The per-reference active-power minimum (Issue 11) is a standard feature carried by the
         # schema, so it is always present without per-driver ``reference_stat_cols`` config; extra
         # stat columns still append after it (deduped, so a caller repeating the min is harmless).
         extra_cols = tuple(dict.fromkeys(c for c in (self.columns.active_power_min, *self.reference_stat_cols) if c))
@@ -427,10 +427,10 @@ class PowerModelMethod:
             # pre-campaign baseline, only the interleaved campaign off rows qualify (the strict
             # ``campaign_baseline``): matching pre-campaign rows against campaign on rows would read
             # reference/era drift as per-bin uplift. The extra pre-campaign rows serve only the headline
-            # fit's training data. (F26 re-confirmed this post-floor: unifying onto ``training_baseline``
+            # fit's training data. (Re-confirmed post-floor: unifying onto ``training_baseline``
             # blew up tail-bin |bias|/spread — the added rows promote drift-contaminated bins past the count
             # floor from imputed to trusted.)
-            # No time-decay weights here either (F16, re-confirmed post-floor in F25): the matched contrast
+            # No time-decay weights here either (re-confirmed post-floor): the matched contrast
             # is already era-insensitive (its common shrinkage cancels), and weighting the direction fits
             # only churns the sparse extreme-condition tail bins (and slightly worsens ws spread) without
             # helping the populated bins — so the corrections are spent on the overall headline instead.
@@ -463,9 +463,9 @@ class PowerModelMethod:
         """Per-(ws, TI)-bin conditional uplift via a two-direction, ERA5-weather-matched cross-prediction.
 
         Match the baseline and upgraded periods on ERA5 weather, then fit/predict in both directions and
-        combine so the common per-bin shrinkage cancels (design/F5); the decomposition is re-leveled onto the
+        combine so the common per-bin shrinkage cancels (by design); the decomposition is re-leveled onto the
         already-computed overall headline (``overall_ratio``, from the single full fit ``fit``) so the per-bin
-        MWh partitions it (F8). Requires ERA5 — the matching axis is the synced ERA5 columns, which live in
+        MWh partitions it. Requires ERA5 — the matching axis is the synced ERA5 columns, which live in
         ``features`` (``era5_feature_frame`` passes them through). Returns the ``[condition, condition_bin,
         p50_uplift]`` frame (or ``None`` when no wind-speed column), and writes the per-run diagnostics.
         """
@@ -533,7 +533,7 @@ class PowerModelMethod:
 
         No calibration and no time-decay weights here: the two-direction combine cancels the common
         per-bin shrinkage by construction, and weighting the matched fits only churns sparse
-        extreme-condition bins (F16; re-confirmed post-floor in F25) — the corrections are spent on the
+        extreme-condition bins (re-confirmed post-floor) — the corrections are spent on the
         overall headline instead.
         """
         models = self._fit_models(features.iloc[train], y[train])
@@ -567,7 +567,7 @@ class PowerModelMethod:
         rated; ti: the overall uplift) so every bin carries a best estimate rather than a bare NaN. The
         re-level **weights** are the *full-upgraded* actual energy per bin (``actual_full`` over
         ``upgraded_pos``): imputed bins are pinned and one λ scales the measured bins so measured + imputed
-        together energy-aggregate to ``1 + overall_ratio`` exactly (F8, corrected for uncovered-bin energy).
+        together energy-aggregate to ``1 + overall_ratio`` exactly (corrected for uncovered-bin energy).
         The returned frame carries a ``covered`` flag (a per-run diagnostic — the harness seam only sees
         ``p50_uplift``).
         """
@@ -662,7 +662,7 @@ class PowerModelMethod:
             )
 
     def _default_bin_edges(self) -> dict[str, list[float]]:
-        """Per-variable CEM edges for ``matching_vars`` from the F6 defaults; raise on an unknown var."""
+        """Per-variable CEM edges for ``matching_vars`` from the curated defaults; raise on an unknown var."""
         missing = [v for v in self.matching_vars if v not in _DEFAULT_MATCHING_BIN_EDGES]
         if missing:
             msg = (
@@ -723,7 +723,7 @@ class PowerModelMethod:
         """Return the time-decay half-life (days) for this campaign, or ``None`` when decay is off.
 
         ``adaptive_time_decay`` (the default) sets it to ``_TIME_DECAY_CAMPAIGN_MULTIPLE`` times the
-        campaign's own duration (Issue 15 / F20); otherwise the fixed ``time_decay_half_life_days``
+        campaign's own duration (Issue 15); otherwise the fixed ``time_decay_half_life_days``
         expert override is used verbatim.
         """
         if not self.adaptive_time_decay:

--- a/benchmarking/baselines/study_overnight_prepost.py
+++ b/benchmarking/baselines/study_overnight_prepost.py
@@ -1,4 +1,4 @@
-"""Longer (overnight) PREPOST study: oracle + naive + R-learner + v0 over seven upgrade profiles.
+"""Longer (overnight) PREPOST study: oracle + naive + power_model + v0 over seven upgrade profiles.
 
 Run on a server from the repo root::
 
@@ -9,10 +9,10 @@ per-replicate results, per-method campaign-length curves, and each method's per-
 diagnostics) are written under ``WIND_UP_BENCHMARKING_OUTPUT_DIR`` (default
 ``~/temp/wind-up-benchmarking/prepost``). The first run downloads + caches the Hill of Towie
 SCADA (Zenodo) and ERA5 (Open-Meteo, needs the ``era5`` group); install the ``ml`` group too
-for the R-learner (lightgbm).
+for ``power_model`` (lightgbm).
 
 Tune runtime vs precision with the two constants below. v0 (a full wind_up run per campaign)
-and the R-learner are the cost; oracle and naive are ~free.
+and ``power_model`` are the cost; oracle and naive are ~free.
 """
 
 from __future__ import annotations

--- a/benchmarking/baselines/study_overnight_toggle.py
+++ b/benchmarking/baselines/study_overnight_toggle.py
@@ -1,4 +1,4 @@
-"""Longer (overnight) TOGGLE study: oracle + naive + R-learner + v0 over seven upgrade profiles.
+"""Longer (overnight) TOGGLE study: oracle + naive + power_model + v0 over seven upgrade profiles.
 
 Run on a server from the repo root::
 
@@ -7,9 +7,8 @@ Run on a server from the repo root::
 Same seven profiles and outputs as the prepost study (see
 :mod:`benchmarking.baselines.study_overnight_prepost`), but with a 20-min-on / 20-min-off
 toggle. Outputs go under ``WIND_UP_BENCHMARKING_OUTPUT_DIR/toggle`` (default
-``~/temp/wind-up-benchmarking/toggle``). The naive and R-learner methods fit the interleaved
-on/off campaign window only (``toggle_campaign_only`` default), so on and off share a wind
-distribution.
+``~/temp/wind-up-benchmarking/toggle``). The naive and power_model methods fit the interleaved
+on/off campaign window only, so on and off share a wind distribution.
 
 Tune runtime vs precision with the two constants below.
 """

--- a/benchmarking/baselines/study_power_model_compare.py
+++ b/benchmarking/baselines/study_power_model_compare.py
@@ -33,7 +33,7 @@ against where it stands today.
 
 **This benchmark is machine-specific: record and diff it on one machine only.** Every cell here is
 ``power_model``, and LightGBM's threaded float reduction order depends on the machine, so a benchmark
-recorded elsewhere reports a permanent false MOVED of ~0.7 pp — 14x the same-machine noise (F30).
+recorded elsewhere reports a permanent false MOVED of ~0.7 pp — 14x the same-machine noise.
 Unlike ``study_toggle_methods_compare``, which splits portable from machine-specific cells across
 files, this script keeps one file because it has no portable cells to split off. The committed
 benchmark is recorded on the Linux laptop; run it there. If that ever stops being true, the
@@ -199,11 +199,10 @@ def _make_power_model(
     protocol), e.g. ``{"matching_vars": ["wind_speed_100m"]}``; unknown field names fail loudly and
     JSON lists are coerced to the tuples the dataclass fields expect.
     """
-    # Only data-schema description is passed here now: the accepted behaviour defaults (F13
-    # availability_feature/era5_exclude, F14 min_child_samples) live on the PowerModelMethod class
-    # (Issue 14), so a bare method already *is* the benchmarked config. The Issue 11 / F12 reference
-    # active-power minimum is carried by HOT_COLUMNS' active_power_min role, so no specialist config
-    # is needed here either.
+    # Only data-schema description is passed here now: the accepted behaviour defaults
+    # (availability_feature/era5_exclude, min_child_samples) live on the PowerModelMethod class,
+    # so a bare method already *is* the benchmarked config. The reference active-power minimum is
+    # carried by HOT_COLUMNS' active_power_min role, so no specialist config is needed here either.
     kwargs: dict[str, Any] = {
         "columns": HOT_COLUMNS,
         "baseline_rated_power_kw": HOT_RATED_POWER_KW,
@@ -371,7 +370,7 @@ def _git_commit() -> str:
     modifications make a run irreproducible from its commit. Counting untracked files (a scratch
     script, a local CLAUDE.md) made ``--update-baseline`` impossible for anyone with a stray file, and
     is the likeliest reason the committed baseline is stamped ``e2e21b0-dirty`` despite reproducing
-    exactly (F30).
+    exactly.
     """
     repo = Path(__file__).resolve().parent
     try:

--- a/benchmarking/baselines/study_toggle_methods_compare.py
+++ b/benchmarking/baselines/study_toggle_methods_compare.py
@@ -21,7 +21,7 @@ methods' reproducibility differs by four orders of magnitude — measured, not a
 its ``seed``, because LightGBM's threaded float reduction order varies (~0.05 pp same-machine). The
 max observed delta is logged every run, so a cell just inside its band stays visible.
 
-**The benchmark is split across files because that reproducibility is also machine-dependent** (F30).
+**The benchmark is split across files because that reproducibility is also machine-dependent.**
 LightGBM's reduction order depends on the machine, so ``power_model`` scores ~0.7 pp against a
 benchmark recorded elsewhere — 14x its same-machine noise, and a permanent false MOVED. Its cells
 therefore live in a per-platform file (``..._baseline_<sys.platform>.json``), while
@@ -98,7 +98,7 @@ _LENGTH_COL = "campaign_weeks"
 _DEFAULT_OUTPUT_DIR = Path.home() / "temp" / "wind-up-benchmarking" / "toggle_methods_compare"
 _BASELINE_DIR = Path(__file__).resolve().parent
 _BASELINE_STEM = "study_toggle_methods_compare_baseline"
-# v3 splits the single file into a portable baseline plus one per platform (F30).
+# v3 splits the single file into a portable baseline plus one per platform.
 _BASELINE_SCHEMA = "toggle_methods_compare_baseline_v3"
 # Per-cell metrics recorded and **diffed**. spread/score: lower is better; bias: |bias| nearer 0 is better.
 _METRIC_COLS = ["bias", "spread", "score"]
@@ -113,7 +113,7 @@ _PP = 100.0  # fraction -> percentage points
 
 @dataclass(frozen=True)
 class MethodReproducibility:
-    """How reproducible a method is, and under what conditions (F30).
+    """How reproducible a method is, and under what conditions.
 
     :param band: how close a re-run must land to the benchmark to read "unchanged" (fraction)
     :param portable: whether its numbers survive a change of machine, and so whether its cells live
@@ -297,7 +297,7 @@ def _provenance(study: StudyConfig, lb: pd.DataFrame, *, git_commit: str) -> dic
     """Return the context needed to interpret a recorded baseline, including which machine made it.
 
     The machine fingerprint exists because a ``power_model`` MOVED against a baseline from another
-    machine is expected rather than a regression, and without this the file cannot say so (F30).
+    machine is expected rather than a regression, and without this the file cannot say so.
     """
     return {
         "schema": _BASELINE_SCHEMA,
@@ -447,7 +447,7 @@ def _warn_on_fingerprint_mismatch(prov: dict[str, Any], *, path: Path) -> None:
         detail = ", ".join(f"{k}: recorded {was!r}, now {now!r}" for k, (was, now) in differing.items())
         logger.warning(
             "%s holds machine-specific cells but was recorded on a machine unlike this one (%s). A MOVED "
-            "verdict may be that rather than your change — see F30.",
+            "verdict may be that rather than your change.",
             path.name,
             detail,
         )

--- a/benchmarking/baselines/study_toggle_specialist_uncertainty.py
+++ b/benchmarking/baselines/study_toggle_specialist_uncertainty.py
@@ -7,7 +7,7 @@ the *total* deviation from truth, bias included; a block bootstrap sees only sam
 where the method is biased the sigma will under-cover, and that is a finding rather than an
 unfairness (see :mod:`benchmarking.harness.calibration`).
 
-Three design points, each with evidence behind it in F28-F30:
+Three design points:
 
 **Replicates, not cells, are the evidence.** The three profiles reuse the same
 ``(turbine, treatment_start)`` draws, so their errors correlate 0.977-0.995; campaign lengths are
@@ -76,7 +76,7 @@ SEED = 0
 # evidence is scarcest: a 52-week campaign is 364d, so a 730d range holds only ~2 of them.
 TREATMENT_START_RANGE = (DEFAULT_START_DT, pd.Timestamp("2020-01-01", tz="UTC"))
 MIN_PRE_MONTHS_TOGGLE = 0
-# Brackets the default on both sides, because coverage degrades in both directions (F28) and a grid
+# Brackets the default on both sides, because coverage degrades in both directions and a grid
 # that only reached upwards would hide half of that. The bottom end (1h ~ 1.5 cycles of a 40-minute
 # toggle) over-covers; the top end starves the bootstrap of distinct blocks and biases sigma low.
 # 96h is dropped: at 1 week it is ~2 blocks and its verdict (coverage 0.438) is already recorded.
@@ -264,7 +264,7 @@ def _plot_coverage_by_length(table: pd.DataFrame, path: Path) -> None:
 def _plot_sigma_plateau(cases: pd.DataFrame, path: Path) -> None:
     """Mean headline sigma against block length, one line per campaign length.
 
-    There is no plateau to read here (F28): the curve is flat to falling. The measured RMS error is
+    There is no plateau to read here: the curve is flat to falling. The measured RMS error is
     drawn alongside as the level sigma should reach, which makes the long-block collapse legible.
     """
     headline = cases[cases["condition"] == "overall"]

--- a/benchmarking/baselines/toggle_specialist.py
+++ b/benchmarking/baselines/toggle_specialist.py
@@ -16,7 +16,7 @@ Every uplift — the headline and each power bin — comes with a non-optional 1
 a circular block bootstrap (:mod:`benchmarking.baselines.block_bootstrap`). It is computed after the
 uplift, from the uplift's own frozen row selection and bin assignment, and only when the uplift is
 finite, so it cannot change any uplift result. The bootstrap sees sampling variability only, so
-sigma under-covers where the method is biased (F29).
+sigma under-covers where the method is biased.
 
 Each run writes a per-run folder ``toggle_specialist_<test>_<upgradestart>_<lastdate>/``
 (v0-style naming) under ``out_dir`` (a temp dir by default), holding a per-segment data-stats CSV,
@@ -400,7 +400,7 @@ class ToggleSpecialistMethod:
         Returns a bool Series on ``wide.index``. Every turbine (test and references) must be
         available (counter >= a full period) and have finite power — a down turbine on either side
         of the ratio is therefore excluded. The test turbine additionally goes through the shared
-        :class:`NormalOperationFilter` (the same downtime + finite-power logic the R-learner uses;
+        :class:`NormalOperationFilter` (the same downtime + finite-power logic the power model uses;
         the stuck filter is left off here as the ratio sums raw power rather than fitting a model).
         """
         turbines = [test, *refs]

--- a/benchmarking/diagnostics/context.py
+++ b/benchmarking/diagnostics/context.py
@@ -3,8 +3,8 @@
 A method adapts its internals to a :class:`DiagnosticContext` (the test turbine, the long SCADA
 slice, per-timestamp treatment/used masks, the timebase, optional aligned ERA5) and the shared
 plotting functions take it from there. This keeps the plot code method-agnostic: it knows
-nothing about R-learner folds or the naive ratio, only the common picture of "which turbine,
-which rows, used or not, baseline or upgraded".
+nothing about a method's internal folds or reference selection, only the common picture of
+"which turbine, which rows, used or not, baseline or upgraded".
 
 The few computed views the plots need (the unique index, the test turbine's rows aligned to it,
 a wide per-turbine pivot, a reference-mean signal) live here so the plotting modules stay lean.
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 
     from benchmarking.synthetic import ColumnSchema
 
-# Column names the optional ``era5_df`` is expected to carry (the R-learner's ERA5 sync output).
+# Column names the optional ``era5_df`` is expected to carry (the shared ERA5 sync output).
 ERA5_WS_COL = "era5_ws"
 ERA5_WD_COL = "era5_wd"
 

--- a/benchmarking/diagnostics/histograms.py
+++ b/benchmarking/diagnostics/histograms.py
@@ -6,7 +6,7 @@ direction, temperature, turbulence, and the time-of-day / month structure — so
 see exactly where the two segments differ.
 
 Hour-of-day and month are derived from the timestamp index and are **diagnostics only**: they
-are deliberately not model features (the R-learner uses shuffled K-fold cross-fitting, which
+are deliberately not model features (the models use shuffled K-fold cross-fitting, which
 assumes no timestamp features — design-note §3/§4). Weather conditions use reference-derived
 (treatment-invariant) signals so the comparison is honest for the upgraded segment too.
 """

--- a/benchmarking/diagnostics/northing.py
+++ b/benchmarking/diagnostics/northing.py
@@ -1,6 +1,6 @@
 """Northing-error timeline (feedback 2026-06-26, item 15).
 
-The R-learner gets reference nacelle positions as raw features with **no** northing correction;
+Reference nacelle positions may enter a method as raw features with **no** northing correction;
 an offset or jumps in a turbine's yaw zero distorts the direction signal the model sees. This
 plots, per turbine, the **monthly circular mean** of (nacelle position - ERA5 wind direction) over
 time, so a drift or step in the offset stands out. Only rows where the turbine is generating

--- a/benchmarking/synthetic/schema.py
+++ b/benchmarking/synthetic/schema.py
@@ -32,8 +32,8 @@ class ColumnSchema:
     :param availability: a "ready to operate" counter (e.g. seconds available in the period).
         **Required**: the methods use it for downtime filtering, which must never be silently
         skipped, so every source must supply it.
-    :param active_power_min: the per-reference active-power **minimum** companion column (Issue 11 /
-        F12). Optional on the schema, but ``PowerModelMethod`` **requires** it — each reference's
+    :param active_power_min: the per-reference active-power **minimum** companion column.
+        Optional on the schema, but ``PowerModelMethod`` **requires** it — each reference's
         power minimum is a standard model feature, not a per-driver opt-in — and validates its
         presence on construction. Sources without it can still drive the lighter methods.
 

--- a/tests/benchmarking/baselines/test_block_bootstrap.py
+++ b/tests/benchmarking/baselines/test_block_bootstrap.py
@@ -227,7 +227,7 @@ class TestDegenerate:
 
 
 class TestTooFewRecordsToFallBackOn:
-    """A cell too sparse to bootstrap must still get an honest, wide sigma — not 0, and not NaN (F33).
+    """A cell too sparse to bootstrap must still get an honest, wide sigma — not 0, and not NaN.
 
     Resampling draws whole *blocks*, so if a cell's records sit in one block, every resample scales
     numerator and denominator together (rho = k*test / k*ref) and the ratio never moves: the bootstrap
@@ -273,7 +273,7 @@ class TestTooFewRecordsToFallBackOn:
 
     def test_a_well_populated_cell_reports_its_bootstrap_alone(self) -> None:
         """The load-bearing guarantee of the selection rule: no fallback contamination of the covered
-        regime (F32/F33). It reports the bootstrap *even when the fallback is larger* — a ``max`` would
+        regime. It reports the bootstrap *even when the fallback is larger* — a ``max`` would
         inflate it here, over-covering, and a max tuned on this farm could over-inflate on another.
         """
         cell = _run(self._sparse_case(1)).cells["overall"]
@@ -341,8 +341,8 @@ class TestPerfectDataMayReportZero:
 
     With noiseless, perfectly-matched data the uplift really is determined, so 0 is the correct
     answer and a model that cannot express it is mis-specified. There is no irreducible floor to
-    justify one either: F31 tested exactly that hypothesis over campaigns up to a year and found
-    sigma kept shrinking and kept tracking the error down to 0.135 pp.
+    justify one either: testing that hypothesis over campaigns up to a year found sigma kept
+    shrinking and kept tracking the error down to 0.135 pp.
 
     An earlier version NaN-ed a zero spread to trap the 1-record artefact. That punished this
     legitimate case to catch that one; the fallback traps the artefact without the collateral.

--- a/tests/benchmarking/baselines/test_power_model_method.py
+++ b/tests/benchmarking/baselines/test_power_model_method.py
@@ -431,7 +431,7 @@ class TestConditionalUplift:
 
 
 def _toy_era5(scada_idx: pd.DatetimeIndex, *, seed: int = 0) -> pd.DataFrame:
-    """Hourly ERA5 covering the toy window with the three F6 matching columns, i.i.d. over the window.
+    """Hourly ERA5 covering the toy window with the three matching columns, i.i.d. over the window.
 
     Weather is drawn independently per hour, so the baseline and upgraded periods share a distribution
     and CEM finds well-populated two-sided cells. Values sit in modest ranges so the default matching
@@ -688,7 +688,7 @@ def _shrinkage_scada(n: int, *, uplift: float, treated: np.ndarray, seed: int = 
     power, the counterfactual model learns an attenuated conditional mean — it over-predicts where power
     is low and under-predicts where it is high (multiplicative shrinkage). The test wind speed is the
     *clean* driver, so binning by it exposes that compression as a spurious per-bin uplift tilt even at
-    the placebo (the F5 mechanism). Weather is i.i.d. across the window, so baseline and upgraded are
+    the placebo (the shrinkage mechanism). Weather is i.i.d. across the window, so baseline and upgraded are
     distribution-matched and the shrinkage is common to both cross-predict directions -> it cancels.
     """
     idx = pd.date_range("2019-01-01", periods=n, freq="10min", tz="UTC", name="timestamp")
@@ -737,7 +737,7 @@ class TestConditionalRegression:
     def test_conditional_flat_at_shrinkage_placebo(self) -> None:
         # Bias guard (design note §8-analog): on a placebo whose references are noisy proxies of a steep
         # power curve, a single counterfactual fit shrinks and reads a spurious per-ws-bin uplift tilt
-        # (the F5 mechanism). The two-direction matched conditional cancels that common shrinkage, so the
+        # (the shrinkage mechanism). The two-direction matched conditional cancels that common shrinkage, so the
         # (default) conditional uplift must read ~flat-zero in every bin against the flat-0 truth.
         n = 5000
         idx = pd.date_range("2019-01-01", periods=n, freq="10min", tz="UTC")

--- a/tests/benchmarking/baselines/test_study_power_model_compare.py
+++ b/tests/benchmarking/baselines/test_study_power_model_compare.py
@@ -41,14 +41,14 @@ from benchmarking.harness.conditions import CONDITIONS
 def test_make_power_model_defaults_to_conditional_on(tmp_path: Path) -> None:
     era5 = pd.DataFrame({"wind_speed_100m": [1.0]})
     method = _make_power_model(tmp_path, era5_hourly_df=era5)
-    # the compare sweep runs power_model at its default: conditional uplift on, matching on the F6 set
+    # the compare sweep runs power_model at its default: conditional uplift on, matching on the curated set
     assert method.conditions == CONDITIONS
     assert method.matching_vars == ("wind_speed_100m", "wind_gusts_10m", "wind_direction_100m")
 
 
 def test_thinned_driver_matches_promoted_defaults(tmp_path: Path) -> None:
-    # the driver now passes only data-schema config; the F13/F14 behaviour lives on the class, so the
-    # constructed method must still carry the benchmarked defaults (Issue 14 promotion).
+    # the driver now passes only data-schema config; the accepted defaults live on the class, so the
+    # constructed method must still carry the benchmarked defaults.
     era5 = pd.DataFrame({"wind_speed_100m": [1.0]})
     method = _make_power_model(tmp_path, era5_hourly_df=era5)
     assert method.availability_feature is False
@@ -660,7 +660,7 @@ def test_accept_candidate_rejects_wrong_schema(tmp_path: Path) -> None:
 
 
 def test_git_commit_ignores_untracked_files(monkeypatch: pytest.MonkeyPatch) -> None:
-    """An untracked file must not read as dirty (F30).
+    """An untracked file must not read as dirty.
 
     It cannot make a run irreproducible from its commit — `git checkout <commit>` would not have it.
     Counting it made --update-baseline impossible for anyone with a stray CLAUDE.md, and is the

--- a/tests/benchmarking/baselines/test_study_toggle_methods_compare.py
+++ b/tests/benchmarking/baselines/test_study_toggle_methods_compare.py
@@ -1,6 +1,6 @@
 """Tests for the toggle-methods regression harness (profile selection, benchmark record/diff).
 
-The benchmark is split into a portable baseline plus one per platform (F30), so these also cover the
+The benchmark is split into a portable baseline plus one per platform, so these also cover the
 routing, the portability invariant and the missing-file paths.
 """
 


### PR DESCRIPTION
…nt drivers

Post-C7 housekeeping ahead of the campaigns tranche.

- Reword all "R-learner" references left behind by the rlearner package deletion (C7) to describe current behaviour. Notably the overnight studies advertised "oracle + naive + R-learner + v0" but now run power_model.
- Strip finding-number citations (F1/F5/F13/F30/...) from source and tests per the CLAUDE.md rule; the rationale stays in docs/v1/findings.md.
- Move spent one-off / manual inspection drivers into benchmarking/baselines/old/: migrate_toggle_baseline_v2_to_v3, inspect_era5_matching_importance, inspect_short_campaigns, inspect_naive, inspect_v0_run (no tests, not imported by the active tree).

poe all-fast green; no scored-method or benchmark behaviour changes.