### PR TITLE
Missing data robustness

### DIFF
--- a/benchmarking/baselines/old/inspect_era5_matching_importance.py
+++ b/benchmarking/baselines/old/inspect_era5_matching_importance.py
@@ -112,8 +112,9 @@ def build_era5_and_outcome(scada_df: pd.DataFrame, *, test_wtg: str) -> tuple[pd
     y = extract_outcome(
         scada_df, test_wtg=test_wtg, turbine_col=HOT_COLUMNS.turbine, active_power_col=HOT_COLUMNS.active_power
     )
+    references = sorted({str(t) for t in scada_df[HOT_COLUMNS.turbine].unique()} - {test_wtg})
     reference_ws = reference_mean_wind_speed(
-        scada_df, test_wtg=test_wtg, turbine_col=HOT_COLUMNS.turbine, wind_speed_col=HOT_COLUMNS.wind_speed
+        scada_df, references=references, turbine_col=HOT_COLUMNS.turbine, wind_speed_col=HOT_COLUMNS.wind_speed
     )
     synced = sync_era5(
         context.reanalysis_datasets[0].data, target_index=index, reference_ws=reference_ws, timebase=timebase

--- a/benchmarking/baselines/power_model/diagnostics.py
+++ b/benchmarking/baselines/power_model/diagnostics.py
@@ -65,7 +65,7 @@ class DiagnosticData:
     overall_uplift: float
     sum_actual_kw: float
     sum_counterfactual_kw: float
-    n_refs: int
+    n_refs: int  # candidate references in the pool, screened ones included
     era5_lag_rows: int | None
     era5_corr: float | None
     era5_sweep: pd.DataFrame | None

--- a/benchmarking/baselines/power_model/features.py
+++ b/benchmarking/baselines/power_model/features.py
@@ -15,6 +15,11 @@ turbine's power — weather and wakes:
 Features that are not expected to add value and risk the model learning coincidences rather than
 cause-effect (reactive power, blade pitch, …) are intentionally excluded.
 
+The reference pool is passed in by the caller -- the campaign's **candidate references** -- and is
+never inferred from the turbines the frame happens to hold: a turbine present in the data is not
+thereby available as a reference. The caller's screen may make some of that pool ``power_free``;
+that downgrades a reference's channels, it does not shrink the pool.
+
 Feature columns from references are named ``"<tag>{QUALIFIER}<turbine>"`` so the original tag is
 preserved verbatim in importance diagnostics. :func:`check_reference_only` rejects any
 test-turbine-qualified column (the §3 guard).
@@ -41,13 +46,13 @@ _NORTHED_PREFIX = "northed_"
 logger = logging.getLogger(__name__)
 
 
-def _references(scada_df: pd.DataFrame, *, test_wtg: str, turbine_col: str) -> list[str]:
-    """Sorted reference turbine names (every turbine present except the test turbine)."""
-    refs = sorted(t for t in scada_df[turbine_col].unique() if t != test_wtg)
+def _checked_references(references: Sequence[str]) -> list[str]:
+    """Return the reference pool as supplied, deduped in order; raises when it is empty."""
+    refs = list(dict.fromkeys(str(r) for r in references))
     if not refs:
         msg = (
-            f"no reference turbines available for test_wtg {test_wtg!r}: scada_df contains only "
-            f"{sorted(scada_df[turbine_col].unique())}. The power model needs at least one reference turbine."
+            "no references supplied: the power model needs at least one. The pool is the campaign's candidate "
+            "references, so a turbine present in scada_df is not thereby available as a reference."
         )
         raise ValueError(msg)
     return refs
@@ -57,6 +62,7 @@ def build_reference_features(
     scada_df: pd.DataFrame,
     *,
     test_wtg: str,
+    references: Sequence[str],
     turbine_col: str,
     active_power_col: str,
     availability_col: str,
@@ -72,9 +78,12 @@ def build_reference_features(
     more per-reference channels and ``include_availability=False`` drops the availability feature.
     Columns are ``"<tag>{QUALIFIER}<turbine>"`` keeping the original tag name. The test turbine
     contributes nothing (its power is the outcome, extracted separately). NaNs are preserved (no
-    complete-case dropping) — LightGBM handles them natively. Raises if no reference turbine is
-    present, or (defensively) if any test-turbine column would leak in.
+    complete-case dropping) — LightGBM handles them natively. Raises if ``references`` is empty, or
+    (defensively) if any test-turbine column would leak in.
 
+    :param references: the reference pool -- the campaign's candidate references -- in the order
+        their feature columns are laid out. A turbine in ``scada_df`` that is not named here
+        contributes nothing, and a name with no data in ``scada_df`` contributes no value columns.
     :param extra_cols: additional per-reference value columns to carry as features (Issue 11's
         active-power max/min/SD statistics); must be present in ``scada_df`` like the primary two
     :param include_availability: when ``False``, drop the per-reference availability *feature*
@@ -93,7 +102,7 @@ def build_reference_features(
     :param waking_threshold_kw: active power at or above which a ``power_free`` reference counts as
         waking its neighbours
     """
-    refs = _references(scada_df, test_wtg=test_wtg, turbine_col=turbine_col)
+    refs = _checked_references(references)
     power_free = _checked_power_free(power_free, refs=refs, waking_threshold_kw=waking_threshold_kw)
     extra_cols, direction_frame = _direction_features(
         scada_df, refs=refs, turbine_col=turbine_col, direction_col=direction_col, extra_cols=extra_cols
@@ -249,17 +258,17 @@ def extract_outcome(
 def reference_mean_wind_speed(
     scada_df: pd.DataFrame,
     *,
-    test_wtg: str,
+    references: Sequence[str],
     turbine_col: str,
     wind_speed_col: str,
 ) -> pd.Series:
-    """Mean wind speed across reference turbines on the unique index (used only for ERA5 lag sync).
+    """Mean wind speed across the reference pool on the unique index (used only for ERA5 lag sync).
 
     This is **not** a model feature — it is the site wind-speed signal the ERA5 correlation sweep
-    locks onto. Computed from references only so it stays upgrade-invariant.
+    locks onto. Averaged over ``references`` only, so it stays upgrade-invariant.
     """
     index = pd.DatetimeIndex(pd.unique(scada_df.index)).sort_values()
-    refs = _references(scada_df, test_wtg=test_wtg, turbine_col=turbine_col)
+    refs = _checked_references(references)
     if wind_speed_col not in scada_df.columns:
         return pd.Series(np.nan, index=index)
     cols = []

--- a/benchmarking/baselines/power_model/method.py
+++ b/benchmarking/baselines/power_model/method.py
@@ -62,7 +62,7 @@ from benchmarking.harness.toggle import is_toggle, resolve_toggle, toggle_upgrad
 from wind_up.farm import TurbineUplift, farm_uplift
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Iterable, Sequence
 
     from benchmarking.synthetic import ColumnSchema
 
@@ -466,6 +466,11 @@ class PowerModelMethod:
         # schema, so it is always present without per-driver ``reference_stat_cols`` config; extra
         # stat columns still append after it (deduped, so a caller repeating the min is harmless).
         extra_cols = tuple(dict.fromkeys(c for c in (self.columns.active_power_min, *self.reference_stat_cols) if c))
+        # Decided before the screen, whose clone fits are the first expensive thing here, so a
+        # matching column named by hand and not delivered stops the run before any model is fitted.
+        conditional_runnable = self._conditional_is_runnable(
+            self.era5_hourly_df.columns if self.era5_hourly_df is not None else ()
+        )
         screen = self.screen_references(mi) if self.reference_screen else None
         # The screen does not shrink the pool: an outlier stays a reference and loses its power channels.
         power_free = screen.screened if screen is not None else ()
@@ -474,9 +479,6 @@ class PowerModelMethod:
         )
         features, era5 = self._add_era5(scada, features, mi=mi, references=references, index=index, timebase=timebase)
         check_reference_only(features.columns.tolist(), test_wtg=mi.test_wtg)
-        # Decided before the fits, so an explicitly-named missing column stops the run at once
-        # rather than after the headline has been paid for.
-        conditional_runnable = self._conditional_is_runnable(features)
 
         toggle_rows = resolve_toggle(mi.upgrade_timing, index)
         t = toggle_rows.upgraded
@@ -792,22 +794,27 @@ class PowerModelMethod:
                 run_dir / "plots" / stages.CONDITIONAL_UPLIFT, per_bin, test_wtg=mi.test_wtg
             )
 
-    def _conditional_is_runnable(self, features: pd.DataFrame) -> bool:
+    def _conditional_is_runnable(self, era5_columns: Iterable[str]) -> bool:
         """Whether the conditional step has its matching columns; raises when they were named by hand.
 
         The untouched default set is skip-if-missing, so a partial ERA5 delivery costs the
         conditional breakdown and leaves the headline standing. An explicitly-set ``matching_vars``
         keeps the strict guard: a column named there and not present is a configuration error.
+
+        Judged on the raw ERA5 columns rather than the built features, so it can run before the
+        screen: ``era5_feature_frame`` passes every raw column through, and ``_validate_model_config``
+        has already refused an ``era5_exclude`` that would remove a matching var.
         """
         if not self.conditions:
             return False
-        missing = [v for v in self.matching_vars if v not in features.columns]
+        available = set(era5_columns)
+        missing = [v for v in self.matching_vars if v not in available]
         if not missing:
             return True
         if self.matching_vars is not _DEFAULT_MATCHING_VARS:
             msg = (
-                f"matching_vars names {missing}, which the ERA5 features do not carry; the conditional step "
-                f"bins on them. Columns present: {sorted(features.columns)}"
+                f"matching_vars names {missing}, which the ERA5 frame does not carry; the conditional step "
+                f"bins on them. Columns present: {sorted(available)}"
             )
             raise ValueError(msg)
         logger.warning(
@@ -1094,7 +1101,7 @@ class PowerModelMethod:
         finite = selected[np.isfinite(selected)]
         return float(finite.sum()), int(finite.size)
 
-    def _campaign_days(self, mi: MethodInput) -> float:
+    def _campaign_days(self, mi: MethodInput, *, pool: Sequence[str]) -> float:
         """Upgraded days of *fittable* data the worst-covered turbine has, test turbine included.
 
         Counted from records rather than calendar span, and per turbine rather than over the frame:
@@ -1117,7 +1124,7 @@ class PowerModelMethod:
             availability_col=self.columns.availability,
         ).keep_mask
         covered: list[float] = []
-        for wtg in [mi.test_wtg, *mi.context.candidate_references]:
+        for wtg in [mi.test_wtg, *pool]:
             # This turbine's own rows: the long frame repeats each timestamp per turbine.
             rows = scada[scada[mi.turbine_col] == wtg].sort_index()
             rows = rows[~rows.index.duplicated()]
@@ -1190,7 +1197,8 @@ class PowerModelMethod:
             # more than leaving a mild bad one in, so it does not run.
             logger.info("%s %s: reference screen skipped, campaign is toggle", self.name, mi.test_wtg)
             return ScreenResult(screened=(), passes=_empty_screen_passes(), screenable=False)
-        campaign_days = self._campaign_days(mi)
+        pool = self._candidate_references(context.select(mi.scada_df), mi=mi)
+        campaign_days = self._campaign_days(mi, pool=pool)
         if campaign_days < self.screen_min_campaign_days:
             logger.info(
                 "%s %s: reference screen skipped, campaign holds %.1f days of upgraded data, under the %.1f "
@@ -1202,7 +1210,6 @@ class PowerModelMethod:
             )
             return ScreenResult(screened=(), passes=_empty_screen_passes(), screenable=False)
         timing = self.screening_timing(mi)
-        pool = self._candidate_references(context.select(mi.scada_df), mi=mi)
         clone = self._screening_clone()
 
         # Why each candidate could not be estimated, so a screen that gives up can say what stopped

--- a/benchmarking/baselines/power_model/method.py
+++ b/benchmarking/baselines/power_model/method.py
@@ -395,6 +395,10 @@ class PowerModelMethod:
         reference from a good one at any floor, and ruling out a good reference costs more than
         leaving a mild bad one in
 
+    The reference pool is the campaign's candidate references (the context's
+    ``candidate_references``), not whichever turbines the frame holds; the screen makes some of
+    them power-free rather than removing them from it.
+
     The toggle headline is always the counterfactual energy ratio ``Σactual/Σprediction - 1``.
     """
 
@@ -452,7 +456,8 @@ class PowerModelMethod:
             raise ValueError(msg)
         index = pd.DatetimeIndex(pd.unique(scada.index)).sort_values()
         timebase = self.timebase if self.timebase is not None else _infer_timebase(scada.index)
-        n_refs = scada[mi.turbine_col].nunique() - 1
+        references = self._candidate_references(scada, mi=mi)
+        n_refs = len(references)
 
         y = extract_outcome(
             scada, test_wtg=mi.test_wtg, turbine_col=mi.turbine_col, active_power_col=self.columns.active_power
@@ -462,9 +467,12 @@ class PowerModelMethod:
         # stat columns still append after it (deduped, so a caller repeating the min is harmless).
         extra_cols = tuple(dict.fromkeys(c for c in (self.columns.active_power_min, *self.reference_stat_cols) if c))
         screen = self.screen_references(mi) if self.reference_screen else None
+        # The screen does not shrink the pool: an outlier stays a reference and loses its power channels.
         power_free = screen.screened if screen is not None else ()
-        features = self._reference_features(scada, mi=mi, extra_cols=extra_cols, power_free=power_free)
-        features, era5 = self._add_era5(scada, features, mi=mi, index=index, timebase=timebase)
+        features = self._reference_features(
+            scada, mi=mi, references=references, extra_cols=extra_cols, power_free=power_free
+        )
+        features, era5 = self._add_era5(scada, features, mi=mi, references=references, index=index, timebase=timebase)
         check_reference_only(features.columns.tolist(), test_wtg=mi.test_wtg)
 
         toggle_rows = resolve_toggle(mi.upgrade_timing, index)
@@ -564,13 +572,13 @@ class PowerModelMethod:
             )
         # Reported post-screen: the sanity check asks what the *final* analysis says its references
         # did, so a ruled-out reference is listed but does not drag the headline.
-        references = (
+        reference_uplifts = (
             self.reference_uplifts(mi, screened=power_free, screen=screen) if self.report_reference_uplifts else None
         )
         return MethodOutput(
             p50_overall=uplift,
             p50_by_condition=by_condition,
-            reference_uplifts=references,
+            reference_uplifts=reference_uplifts,
             screen_passes=screen.passes if screen is not None else None,
         )
 
@@ -798,6 +806,7 @@ class PowerModelMethod:
         features: pd.DataFrame,
         *,
         mi: MethodInput,
+        references: Sequence[str],
         index: pd.DatetimeIndex,
         timebase: pd.Timedelta,
     ) -> tuple[pd.DataFrame, Any]:
@@ -805,7 +814,7 @@ class PowerModelMethod:
         if self.era5_hourly_df is None:
             return features, None
         reference_ws = reference_mean_wind_speed(
-            scada, test_wtg=mi.test_wtg, turbine_col=mi.turbine_col, wind_speed_col=self.columns.wind_speed
+            scada, references=references, turbine_col=mi.turbine_col, wind_speed_col=self.columns.wind_speed
         )
         result = sync_era5(self.era5_hourly_df, target_index=index, reference_ws=reference_ws, timebase=timebase)
         era5_features = era5_feature_frame(result.aligned)
@@ -907,6 +916,23 @@ class PowerModelMethod:
             "baseline_valid_pos": baseline_valid_pos,  # positions over ``index`` of the held-out rows
         }
 
+    def _candidate_references(self, scada: pd.DataFrame, *, mi: MethodInput) -> list[str]:
+        """Return the campaign's candidate references that ``scada`` carries data for, sorted.
+
+        The pool starts at what the campaign offers: a turbine present in the frame that the
+        campaign does not offer as a reference is not one.
+        """
+        present = sorted({str(t) for t in scada[mi.turbine_col].unique()})
+        references = mi.context.references_among(present)
+        if not references:
+            msg = (
+                f"no candidate references available for test_wtg {mi.test_wtg!r}: the campaign offers "
+                f"{sorted(mi.context.candidate_references)} and scada_df carries {present}. The power model "
+                f"needs at least one reference turbine."
+            )
+            raise ValueError(msg)
+        return references
+
     def reference_features(self, mi: MethodInput, *, power_free: Sequence[str] = ()) -> pd.DataFrame:
         """Build this method's reference feature matrix for ``mi``, optionally power-free for some.
 
@@ -915,15 +941,28 @@ class PowerModelMethod:
         """
         scada = mi.context.select(mi.scada_df)
         extra_cols = tuple(dict.fromkeys(c for c in (self.columns.active_power_min, *self.reference_stat_cols) if c))
-        return self._reference_features(scada, mi=mi, extra_cols=extra_cols, power_free=power_free)
+        return self._reference_features(
+            scada,
+            mi=mi,
+            references=self._candidate_references(scada, mi=mi),
+            extra_cols=extra_cols,
+            power_free=power_free,
+        )
 
     def _reference_features(
-        self, scada: pd.DataFrame, *, mi: MethodInput, extra_cols: tuple[str, ...], power_free: Sequence[str]
+        self,
+        scada: pd.DataFrame,
+        *,
+        mi: MethodInput,
+        references: Sequence[str],
+        extra_cols: tuple[str, ...],
+        power_free: Sequence[str],
     ) -> pd.DataFrame:
         """Return reference features for ``scada``; ``power_free`` references carry no power columns."""
         return build_reference_features(
             scada,
             test_wtg=mi.test_wtg,
+            references=references,
             turbine_col=mi.turbine_col,
             active_power_col=self.columns.active_power,
             availability_col=self.columns.availability,

--- a/benchmarking/baselines/power_model/method.py
+++ b/benchmarking/baselines/power_model/method.py
@@ -474,6 +474,9 @@ class PowerModelMethod:
         )
         features, era5 = self._add_era5(scada, features, mi=mi, references=references, index=index, timebase=timebase)
         check_reference_only(features.columns.tolist(), test_wtg=mi.test_wtg)
+        # Decided before the fits, so an explicitly-named missing column stops the run at once
+        # rather than after the headline has been paid for.
+        conditional_runnable = self._conditional_is_runnable(features)
 
         toggle_rows = resolve_toggle(mi.upgrade_timing, index)
         t = toggle_rows.upgraded
@@ -545,7 +548,7 @@ class PowerModelMethod:
         # The conditional uplift distribution is the optional, expensive last step: nothing above depends on
         # it (eventually AEP extrapolation will). Skipped when no conditions are requested.
         by_condition: pd.DataFrame | None = None
-        if self.conditions:
+        if self.conditions and conditional_runnable:
             # The conditional two-direction step matches baseline against upgraded rows and relies on
             # them sharing a distribution *and era* — for a toggle whose headline fit also trains on the
             # pre-campaign baseline, only the interleaved campaign off rows qualify (the strict
@@ -788,6 +791,32 @@ class PowerModelMethod:
             diag.plot_conditional_diagnostics(
                 run_dir / "plots" / stages.CONDITIONAL_UPLIFT, per_bin, test_wtg=mi.test_wtg
             )
+
+    def _conditional_is_runnable(self, features: pd.DataFrame) -> bool:
+        """Whether the conditional step has its matching columns; raises when they were named by hand.
+
+        The untouched default set is skip-if-missing, so a partial ERA5 delivery costs the
+        conditional breakdown and leaves the headline standing. An explicitly-set ``matching_vars``
+        keeps the strict guard: a column named there and not present is a configuration error.
+        """
+        if not self.conditions:
+            return False
+        missing = [v for v in self.matching_vars if v not in features.columns]
+        if not missing:
+            return True
+        if self.matching_vars is not _DEFAULT_MATCHING_VARS:
+            msg = (
+                f"matching_vars names {missing}, which the ERA5 features do not carry; the conditional step "
+                f"bins on them. Columns present: {sorted(features.columns)}"
+            )
+            raise ValueError(msg)
+        logger.warning(
+            "%s: no conditional uplift -- the matching column(s) %s are not in the ERA5 features. The overall "
+            "P50 is unaffected.",
+            self.name,
+            missing,
+        )
+        return False
 
     def _default_bin_edges(self) -> dict[str, list[float]]:
         """Per-variable CEM edges for ``matching_vars`` from the curated defaults; raise on an unknown var."""
@@ -1162,6 +1191,10 @@ class PowerModelMethod:
         timing = self.screening_timing(mi)
         clone = self._screening_clone()
 
+        # Why each candidate could not be estimated, so a screen that gives up can say what stopped
+        # it rather than only that it gave up.
+        causes: dict[str, str] = {}
+
         def estimate_one(target: str, refs: list[str]) -> float:
             sub_context = dataclasses.replace(context, test_wtg=target, candidate_references=list(refs), timing=timing)
             sub_input = MethodInput(scada_df=mi.scada_df, test_wtg=target, campaign_context=sub_context)
@@ -1171,11 +1204,19 @@ class PowerModelMethod:
                 # NaN ranks worst, so the candidate is ruled out rather than aborting the estimate:
                 # surviving a reference this bad is what the screen is for.
                 logger.warning("%s: reference screen could not estimate %s (%s)", self.name, target, e)
+                causes[target] = str(e)
                 return float("nan")
 
-        result = screen_references(
-            list(context.candidate_references), estimate_one=estimate_one, floor=self.screen_floor
-        )
+        try:
+            result = screen_references(
+                list(context.candidate_references), estimate_one=estimate_one, floor=self.screen_floor
+            )
+        except ValueError as e:
+            if not causes:
+                raise
+            detail = "; ".join(f"{target}: {cause}" for target, cause in sorted(causes.items()))
+            msg = f"{e} What stopped each of them: {detail}"
+            raise ValueError(msg) from e
         if result.screened:
             logger.info(
                 "%s %s: reference screen ruled out %s; they keep direction + waking features but contribute no power",

--- a/benchmarking/baselines/power_model/method.py
+++ b/benchmarking/baselines/power_model/method.py
@@ -949,10 +949,22 @@ class PowerModelMethod:
         """Return the campaign's candidate references that ``scada`` carries data for, sorted.
 
         The pool starts at what the campaign offers: a turbine present in the frame that the
-        campaign does not offer as a reference is not one.
+        campaign does not offer as a reference is not one, and one the campaign offers that the
+        frame has no rows for is dropped with a warning rather than estimated as if it were there.
         """
         present = sorted({str(t) for t in scada[mi.turbine_col].unique()})
         references = mi.context.references_among(present)
+        absent = sorted(set(mi.context.candidate_references) - set(references))
+        if absent:
+            logger.warning(
+                "%s %s: the campaign offers %d candidate reference(s) but scada_df carries no rows for %s, so "
+                "the estimate runs on a pool of %d. Reference count drives accuracy.",
+                self.name,
+                mi.test_wtg,
+                len(mi.context.candidate_references),
+                absent,
+                len(references),
+            )
         if not references:
             msg = (
                 f"no candidate references available for test_wtg {mi.test_wtg!r}: the campaign offers "
@@ -1018,12 +1030,13 @@ class PowerModelMethod:
         reused rather than refitting the whole pool.
         """
         context = mi.context
+        pool = self._candidate_references(context.select(mi.scada_df), mi=mi)
         ruled_out = set(screened)
-        surviving = [r for r in context.candidate_references if r not in ruled_out]
+        surviving = [r for r in pool if r not in ruled_out]
         clone = self._reference_clone()
         reusable = self._reusable_screen_estimates(mi, screen=screen, ruled_out=ruled_out)
         rows: list[dict[str, object]] = []
-        for target in context.candidate_references:
+        for target in pool:
             refs = [r for r in surviving if r != target]
             if not refs:
                 continue
@@ -1189,6 +1202,7 @@ class PowerModelMethod:
             )
             return ScreenResult(screened=(), passes=_empty_screen_passes(), screenable=False)
         timing = self.screening_timing(mi)
+        pool = self._candidate_references(context.select(mi.scada_df), mi=mi)
         clone = self._screening_clone()
 
         # Why each candidate could not be estimated, so a screen that gives up can say what stopped
@@ -1208,9 +1222,7 @@ class PowerModelMethod:
                 return float("nan")
 
         try:
-            result = screen_references(
-                list(context.candidate_references), estimate_one=estimate_one, floor=self.screen_floor
-            )
+            result = screen_references(pool, estimate_one=estimate_one, floor=self.screen_floor)
         except ValueError as e:
             if not causes:
                 raise

--- a/benchmarking/campaigns/context.py
+++ b/benchmarking/campaigns/context.py
@@ -7,6 +7,7 @@ that no ground truth reaches a method.
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
 import pandas as pd
@@ -16,13 +17,16 @@ from benchmarking.harness.context import CampaignContext
 if TYPE_CHECKING:
     from benchmarking.campaigns.declaration import CampaignSpec
 
+logger = logging.getLogger(__name__)
+
 
 def context_for(spec: CampaignSpec, *, turbine: str, scada_df: pd.DataFrame) -> CampaignContext:
     """Return the context for estimating ``turbine``'s uplift from ``scada_df``.
 
     References are the campaign's declared candidates that have data, so a turbine the campaign
-    does not offer is never used however its data looks. Each turbine's validity comes from the
-    campaign's own per-turbine rule.
+    does not offer is never used however its data looks. A declared candidate the frame carries no
+    rows for is dropped with a warning, since it leaves a smaller pool than the campaign asked for.
+    Each turbine's validity comes from the campaign's own per-turbine rule.
 
     :param spec: the campaign's public facts
     :param turbine: the upgraded turbine being estimated
@@ -30,6 +34,16 @@ def context_for(spec: CampaignSpec, *, turbine: str, scada_df: pd.DataFrame) -> 
     """
     present = {str(t) for t in scada_df[spec.turbine_col].unique()}
     references = sorted((set(spec.candidate_references) & present) - {turbine})
+    undelivered = sorted(set(spec.candidate_references) - present - {turbine})
+    if undelivered:
+        logger.warning(
+            "%s: the campaign offers %d candidate reference(s) but the data carries no rows for %s, so the "
+            "estimate runs on a pool of %d. Reference count drives accuracy.",
+            turbine,
+            len(spec.candidate_references),
+            undelivered,
+            len(references),
+        )
     # Validity covers every declared turbine with data, not just this estimate's references: a
     # method co-analysing several upgraded turbines keeps them via ``select(also=...)`` and their
     # rows must be screened too.

--- a/benchmarking/campaigns/outage_probe.py
+++ b/benchmarking/campaigns/outage_probe.py
@@ -336,13 +336,14 @@ def _coords(turbines: Sequence[str]) -> dict[str, tuple[float, float]]:
     }
 
 
-def _power_model_only(spec: object, *, out_dir: Path, era5_hourly_df: pd.DataFrame) -> list[Method]:
+def _power_model_only(spec: object, *, out_dir: Path, era5_hourly_df: pd.DataFrame, seed: int) -> list[Method]:
     """Build just the power model for one turbine: it is the only method R4 is asking about."""
     return [
         PowerModelMethod(
             columns=HOT_COLUMNS,
             baseline_rated_power_kw=spec.rated_power_kw,  # type: ignore[attr-defined]
             era5_hourly_df=era5_hourly_df,
+            seed=seed,
             era5_exclude=CURATED_ERA5_EXCLUDE,
             availability_feature=False,
             model_params=dict(TUNED_MODEL_PARAMS),
@@ -373,8 +374,13 @@ def run_arm(
     scada_df: pd.DataFrame,
     era5_df: pd.DataFrame,
     out_dir: Path,
+    seed: int = 0,
 ) -> ArmOutcome:
-    """Apply ``arm``'s fault, run the campaign, and record the estimate or where it stopped."""
+    """Apply ``arm``'s fault, run the campaign, and record the estimate or where it stopped.
+
+    ``seed`` drives the power model's holdout split and LightGBM state, so repeating an arm across
+    seeds gives the estimator-noise floor a fault's movement has to clear to mean anything.
+    """
     faulted_scada = arm.scada(scada_df)
     faulted_era5 = arm.era5(era5_df)
     try:
@@ -390,7 +396,9 @@ def run_arm(
         runner = CampaignRunner(
             spec,
             dataset,
-            build_methods=lambda wtg: _power_model_only(spec, out_dir=out_dir / wtg, era5_hourly_df=faulted_era5),
+            build_methods=lambda wtg: _power_model_only(
+                spec, out_dir=out_dir / wtg, era5_hourly_df=faulted_era5, seed=seed
+            ),
             era5_wd=era5_direction(faulted_era5, index),
         )
         result = runner.run()
@@ -411,12 +419,15 @@ def run_probe(
     *,
     modes: Sequence[str] = ("prepost",),
     arms: Sequence[str] | None = None,
+    seeds: Sequence[int] = (0,),
     out_root: str | Path | None = None,
 ) -> pd.DataFrame:
-    """Run the matrix and return one row per ``(mode, arm)``.
+    """Run the matrix and return one row per ``(mode, arm, seed)``.
 
     :param modes: the campaign modes to run; stage 1 defaults to prepost alone
     :param arms: run only these arm names (the clean control is always worth keeping); all when None
+    :param seeds: repeat every arm once per seed, which turns the table into a noise floor plus the
+        movement each fault adds to it
     :param out_root: where the run folder is written; the driver's default root when None
     """
     root = Path(out_root) if out_root is not None else default_output_root()
@@ -435,31 +446,34 @@ def run_probe(
             wtg_numbers=[int(w[1:]) for w in PROBE_TURBINES],
             wtg_names=list(PROBE_TURBINES),
         )
-        for arm in selected:
-            logger.info("running %s %s -- %s", mode, arm.name, arm.what)
-            started = pd.Timestamp.now()
-            outcome = run_arm(
-                arm,
-                mode=mode,  # type: ignore[arg-type]
-                scada_df=scada_df,
-                era5_df=era5_df,
-                out_dir=run_dir / f"{mode}_{arm.name}",
-            )
-            rows.append(
-                {
-                    "mode": mode,
-                    "arm": arm.name,
-                    "shape": arm.shape,
-                    "what": arm.what,
-                    "reached_estimate": outcome.reached_estimate,
-                    "estimate": outcome.estimate,
-                    "error_type": outcome.error_type,
-                    "error_message": outcome.error_message,
-                    "failed_in": outcome.failed_in,
-                    "seconds": (pd.Timestamp.now() - started).total_seconds(),
-                }
-            )
-            pd.DataFrame(rows).to_csv(run_dir / "outcomes.csv", index=False)
+        for seed in seeds:
+            for arm in selected:
+                logger.info("running %s %s seed=%d -- %s", mode, arm.name, seed, arm.what)
+                started = pd.Timestamp.now()
+                outcome = run_arm(
+                    arm,
+                    mode=mode,  # type: ignore[arg-type]
+                    scada_df=scada_df,
+                    era5_df=era5_df,
+                    out_dir=run_dir / f"{mode}_{arm.name}_seed{seed}",
+                    seed=seed,
+                )
+                rows.append(
+                    {
+                        "mode": mode,
+                        "seed": seed,
+                        "arm": arm.name,
+                        "shape": arm.shape,
+                        "what": arm.what,
+                        "reached_estimate": outcome.reached_estimate,
+                        "estimate": outcome.estimate,
+                        "error_type": outcome.error_type,
+                        "error_message": outcome.error_message,
+                        "failed_in": outcome.failed_in,
+                        "seconds": (pd.Timestamp.now() - started).total_seconds(),
+                    }
+                )
+                pd.DataFrame(rows).to_csv(run_dir / "outcomes.csv", index=False)
     logger.info("wrote the probe results to %s", run_dir)
     return pd.DataFrame(rows)
 

--- a/benchmarking/campaigns/outage_probe.py
+++ b/benchmarking/campaigns/outage_probe.py
@@ -1,0 +1,481 @@
+"""R4 stage 1: which missing-data shapes crash wind-up, and which return a number in silence.
+
+An information-gathering probe, not a fixture: it asks only whether an estimate is *reached*, and
+where it stops when it is not. What a surviving estimate is *worth* is stage 2's question, measured
+against a clean control on the placebo.
+
+The arms cover the field failure modes -- a whole-farm SCADA outage, a whole-turbine logging
+outage, a single-signal outage, ERA5 columns lost to a download or mapping error, and ERA5 holes --
+each in the two shapes that take different code paths:
+
+* **absent** -- the column is not in the frame at all (a mapping error, a renamed tag);
+* **empty** -- the column is there and its values are NaN (a logging outage), or the rows are gone.
+
+The distinction is the point: an absent column raises, while a NaN one is handled natively by
+LightGBM and passes through without comment.
+
+Each arm runs the real campaign path, so the shared northing step sees the fault too. A failure is
+attributed to the deepest repo frame in its traceback, which separates a northing failure from a
+`power_model` one.
+
+Run it::
+
+    uv run python -m benchmarking.campaigns.outage_probe
+
+Outputs land under ``WIND_UP_BENCHMARKING_OUTPUT_DIR``/``outage_probe``/``<timestamp>/``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import traceback
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Literal
+
+import matplotlib as mpl
+
+mpl.use("Agg")  # headless: the campaign path writes plots without a display
+
+import pandas as pd
+
+from benchmarking.baselines.hot_context import build_hot_v0_context
+from benchmarking.baselines.power_model import CURATED_ERA5_EXCLUDE, TUNED_MODEL_PARAMS, PowerModelMethod
+from benchmarking.campaigns.placebo import (
+    PLACEBO_CAMPAIGN_START,
+    placebo_analysis_period,
+    placebo_campaign,
+)
+from benchmarking.campaigns.runner import CampaignRunner
+from benchmarking.harness.northing import era5_direction
+from benchmarking.synthetic import HOT_COLUMNS
+from benchmarking.synthetic.sources.hill_of_towie import load_hot_metadata, load_hot_scada
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+
+    from benchmarking.harness import Method
+
+logger = logging.getLogger(__name__)
+
+# The R2/R3 fixture turbines: T06 and the three nearest whose northing is stable over 2017-2018.
+PROBE_TEST_WTG = "T06"
+PROBE_REFERENCES = ("T15", "T10", "T08")
+PROBE_TURBINES = (PROBE_TEST_WTG, *PROBE_REFERENCES)
+
+# The nearest reference, so a reference-side outage lands on the most influential turbine.
+OUTAGE_REFERENCE = "T15"
+
+# Outage windows, named for where they sit relative to the changeover. Stage 1 runs the baseline
+# one; stage 2 is where position becomes the variable that matters.
+_OUTAGE_DAYS = 30
+BASELINE_OUTAGE = (PLACEBO_CAMPAIGN_START - pd.Timedelta(days=120), PLACEBO_CAMPAIGN_START - pd.Timedelta(days=90))
+UPGRADED_OUTAGE = (PLACEBO_CAMPAIGN_START + pd.Timedelta(days=90), PLACEBO_CAMPAIGN_START + pd.Timedelta(days=120))
+
+
+def _role(role: str) -> str:
+    """Return the Hill of Towie column naming ``role``; every role the probe faults must be named."""
+    HOT_COLUMNS.require_roles([role])
+    return str(getattr(HOT_COLUMNS, role))
+
+
+# The per-turbine value columns a logging outage takes out together.
+_TURBINE_SIGNALS = tuple(
+    _role(r)
+    for r in (
+        "active_power",
+        "active_power_min",
+        "wind_speed",
+        "wind_speed_sd",
+        "gen_rpm",
+        "availability",
+        "nacelle_position",
+    )
+)
+
+# ERA5 columns that are load-bearing rather than incidental: the sync's own two, and the matching
+# axes the conditional step bins on.
+ERA5_SYNC_COLS = ("wind_speed_100m", "wind_direction_100m")
+ERA5_MATCHING_COL = "wind_gusts_10m"
+ERA5_INCIDENTAL_COL = "temperature_2m"
+
+
+def _identity(df: pd.DataFrame) -> pd.DataFrame:
+    return df
+
+
+@dataclass(frozen=True)
+class Arm:
+    """One cell of the probe: a named data fault applied to the SCADA frame, the ERA5 frame, or both.
+
+    :param name: the cell's label in the results table
+    :param what: one line describing the fault, carried into the table so the CSV reads alone
+    :param shape: ``absent`` (the column is gone) or ``empty`` (present but NaN, or rows removed)
+    :param scada: transform applied to the SCADA frame before the campaign generates from it
+    :param era5: transform applied to the hourly ERA5 frame
+    """
+
+    name: str
+    what: str
+    shape: Literal["clean", "absent", "empty"] = "clean"
+    scada: Callable[[pd.DataFrame], pd.DataFrame] = _identity
+    era5: Callable[[pd.DataFrame], pd.DataFrame] = _identity
+
+
+@dataclass
+class ArmOutcome:
+    """What one arm did: an estimate, or where it stopped.
+
+    :param reached_estimate: whether the campaign returned a number at all
+    :param estimate: the power model's farm estimate when it did
+    :param error_type: the exception class name when it did not
+    :param error_message: the exception's first line
+    :param failed_in: ``module:function:line`` of the deepest repo frame in the traceback
+    """
+
+    reached_estimate: bool
+    estimate: float | None = None
+    error_type: str | None = None
+    error_message: str | None = None
+    failed_in: str | None = None
+
+
+def _window_mask(index: pd.DatetimeIndex, window: tuple[pd.Timestamp, pd.Timestamp]) -> pd.Series:
+    """Boolean over ``index``: is this timestamp inside the half-open outage window."""
+    start, end = window
+    return pd.Series((index >= start) & (index < end), index=index)
+
+
+def null_signals(
+    df: pd.DataFrame,
+    *,
+    turbines: Sequence[str],
+    columns: Sequence[str],
+    window: tuple[pd.Timestamp, pd.Timestamp],
+) -> pd.DataFrame:
+    """Return ``df`` with ``columns`` set to NaN for ``turbines`` inside ``window`` (a logging outage)."""
+    out = df.copy()
+    rows = (
+        _window_mask(pd.DatetimeIndex(out.index), window).to_numpy()
+        & out[HOT_COLUMNS.turbine].isin(list(turbines)).to_numpy()
+    )
+    present = [c for c in columns if c in out.columns]
+    out.loc[rows, present] = float("nan")
+    return out
+
+
+def drop_rows(df: pd.DataFrame, *, turbines: Sequence[str], window: tuple[pd.Timestamp, pd.Timestamp]) -> pd.DataFrame:
+    """Return ``df`` with ``turbines``' records inside ``window`` removed outright (no row at all)."""
+    rows = (
+        _window_mask(pd.DatetimeIndex(df.index), window).to_numpy()
+        & df[HOT_COLUMNS.turbine].isin(list(turbines)).to_numpy()
+    )
+    return df[~rows]
+
+
+def drop_columns(df: pd.DataFrame, *, columns: Sequence[str]) -> pd.DataFrame:
+    """Return ``df`` without ``columns`` (a mapping error, or a tag that was never delivered)."""
+    return df.drop(columns=[c for c in columns if c in df.columns])
+
+
+def drop_turbine(df: pd.DataFrame, *, turbine: str) -> pd.DataFrame:
+    """Return ``df`` without ``turbine``'s records at all (a turbine missing from the whole delivery)."""
+    return df[df[HOT_COLUMNS.turbine] != turbine]
+
+
+def null_era5(df: pd.DataFrame, *, window: tuple[pd.Timestamp, pd.Timestamp]) -> pd.DataFrame:
+    """Return hourly ERA5 with every column NaN inside ``window`` (a reanalysis hole)."""
+    out = df.copy()
+    rows = _window_mask(pd.DatetimeIndex(out.index), window).to_numpy()
+    out.loc[rows, :] = float("nan")
+    return out
+
+
+def drop_era5_rows(df: pd.DataFrame, *, window: tuple[pd.Timestamp, pd.Timestamp]) -> pd.DataFrame:
+    """Return hourly ERA5 with the timestamps inside ``window`` missing from the index entirely."""
+    return df[~_window_mask(pd.DatetimeIndex(df.index), window).to_numpy()]
+
+
+def probe_arms() -> list[Arm]:
+    """Return every cell of the stage-1 matrix, clean control first."""
+    ref = OUTAGE_REFERENCE
+    test = PROBE_TEST_WTG
+    return [
+        Arm(name="clean", what="no fault"),
+        # 1. whole-farm SCADA outage
+        Arm(
+            name="farm_empty",
+            what=f"every turbine, every signal NaN for {_OUTAGE_DAYS}d of baseline",
+            shape="empty",
+            scada=lambda df: null_signals(
+                df, turbines=PROBE_TURBINES, columns=_TURBINE_SIGNALS, window=BASELINE_OUTAGE
+            ),
+        ),
+        Arm(
+            name="farm_rows_gone",
+            what=f"every turbine's records absent for {_OUTAGE_DAYS}d of baseline",
+            shape="empty",
+            scada=lambda df: drop_rows(df, turbines=PROBE_TURBINES, window=BASELINE_OUTAGE),
+        ),
+        # 2. whole-turbine logging outage, reference and test turbine
+        Arm(
+            name="ref_empty",
+            what=f"{ref} (nearest reference), every signal NaN for {_OUTAGE_DAYS}d of baseline",
+            shape="empty",
+            scada=lambda df: null_signals(df, turbines=[ref], columns=_TURBINE_SIGNALS, window=BASELINE_OUTAGE),
+        ),
+        Arm(
+            name="ref_rows_gone",
+            what=f"{ref}'s records absent for {_OUTAGE_DAYS}d of baseline",
+            shape="empty",
+            scada=lambda df: drop_rows(df, turbines=[ref], window=BASELINE_OUTAGE),
+        ),
+        Arm(
+            name="ref_absent_entirely",
+            what=f"{ref} missing from the delivery altogether",
+            shape="absent",
+            scada=lambda df: drop_turbine(df, turbine=ref),
+        ),
+        Arm(
+            name="test_empty",
+            what=f"{test} (test turbine), every signal NaN for {_OUTAGE_DAYS}d of baseline",
+            shape="empty",
+            scada=lambda df: null_signals(df, turbines=[test], columns=_TURBINE_SIGNALS, window=BASELINE_OUTAGE),
+        ),
+        Arm(
+            name="test_empty_upgraded",
+            what=f"{test}, every signal NaN for {_OUTAGE_DAYS}d of the upgraded period",
+            shape="empty",
+            scada=lambda df: null_signals(df, turbines=[test], columns=_TURBINE_SIGNALS, window=UPGRADED_OUTAGE),
+        ),
+        # 3. single turbine-signal outage
+        Arm(
+            name="ref_power_empty",
+            what=f"{ref}'s active power alone NaN for {_OUTAGE_DAYS}d of baseline",
+            shape="empty",
+            scada=lambda df: null_signals(df, turbines=[ref], columns=[_role("active_power")], window=BASELINE_OUTAGE),
+        ),
+        Arm(
+            name="power_min_absent",
+            what="the active-power minimum column missing farm-wide",
+            shape="absent",
+            scada=lambda df: drop_columns(df, columns=[_role("active_power_min")]),
+        ),
+        Arm(
+            name="availability_absent",
+            what="the availability column missing farm-wide",
+            shape="absent",
+            scada=lambda df: drop_columns(df, columns=[_role("availability")]),
+        ),
+        Arm(
+            name="nacelle_position_absent",
+            what="the nacelle position column missing farm-wide (northing has nothing to correct)",
+            shape="absent",
+            scada=lambda df: drop_columns(df, columns=[_role("nacelle_position")]),
+        ),
+        Arm(
+            name="ref_direction_empty",
+            what=f"{ref}'s nacelle position alone NaN for the whole record",
+            shape="empty",
+            scada=lambda df: null_signals(
+                df,
+                turbines=[ref],
+                columns=[_role("nacelle_position")],
+                window=(pd.Timestamp.min.tz_localize("UTC"), pd.Timestamp.max.tz_localize("UTC")),
+            ),
+        ),
+        # 4. ERA5 columns lost to a download or mapping error
+        Arm(
+            name="era5_incidental_absent",
+            what=f"ERA5 {ERA5_INCIDENTAL_COL} column missing",
+            shape="absent",
+            era5=lambda df: drop_columns(df, columns=[ERA5_INCIDENTAL_COL]),
+        ),
+        Arm(
+            name="era5_matching_absent",
+            what=f"ERA5 {ERA5_MATCHING_COL} column missing (a conditional matching axis)",
+            shape="absent",
+            era5=lambda df: drop_columns(df, columns=[ERA5_MATCHING_COL]),
+        ),
+        Arm(
+            name="era5_sync_absent",
+            what=f"ERA5 {' + '.join(ERA5_SYNC_COLS)} missing (what the lag sync locks onto)",
+            shape="absent",
+            era5=lambda df: drop_columns(df, columns=ERA5_SYNC_COLS),
+        ),
+        # 5. ERA5 holes
+        Arm(
+            name="era5_hole_1mo",
+            what=f"every ERA5 column NaN for {_OUTAGE_DAYS}d of baseline",
+            shape="empty",
+            era5=lambda df: null_era5(df, window=BASELINE_OUTAGE),
+        ),
+        Arm(
+            name="era5_hole_3mo",
+            what="every ERA5 column NaN for 3 months of baseline",
+            shape="empty",
+            era5=lambda df: null_era5(df, window=(BASELINE_OUTAGE[0], BASELINE_OUTAGE[0] + pd.Timedelta(days=90))),
+        ),
+        Arm(
+            name="era5_rows_gone",
+            what=f"ERA5 timestamps absent from the index for {_OUTAGE_DAYS}d of baseline",
+            shape="empty",
+            era5=lambda df: drop_era5_rows(df, window=BASELINE_OUTAGE),
+        ),
+    ]
+
+
+def _coords(turbines: Sequence[str]) -> dict[str, tuple[float, float]]:
+    """Hill of Towie coordinates for ``turbines``."""
+    metadata = load_hot_metadata()
+    return {
+        str(row.Name): (float(row.Latitude), float(row.Longitude))
+        for row in metadata.itertuples()
+        if str(row.Name) in set(turbines)
+    }
+
+
+def _power_model_only(spec: object, *, out_dir: Path, era5_hourly_df: pd.DataFrame) -> list[Method]:
+    """Build just the power model for one turbine: it is the only method R4 is asking about."""
+    return [
+        PowerModelMethod(
+            columns=HOT_COLUMNS,
+            baseline_rated_power_kw=spec.rated_power_kw,  # type: ignore[attr-defined]
+            era5_hourly_df=era5_hourly_df,
+            era5_exclude=CURATED_ERA5_EXCLUDE,
+            availability_feature=False,
+            model_params=dict(TUNED_MODEL_PARAMS),
+            out_dir=out_dir / "power_model",
+            save_plots=True,
+        )
+    ]
+
+
+def _deepest_repo_frame(exc: BaseException) -> str | None:
+    """Return ``module:function:line`` of the deepest traceback frame in this repo's own code.
+
+    Installed packages are skipped: a bare ``KeyError`` raised inside pandas is attributed to the
+    repo line that asked for the missing column, which is the one worth reading.
+    """
+    root = Path(__file__).resolve().parents[2]
+    for frame in reversed(traceback.extract_tb(exc.__traceback__)):
+        path = Path(frame.filename).resolve()
+        if root in path.parents and "site-packages" not in path.parts and ".venv" not in path.parts:
+            return f"{path.relative_to(root)}:{frame.name}:{frame.lineno}"
+    return None
+
+
+def run_arm(
+    arm: Arm,
+    *,
+    mode: Literal["prepost", "toggle"],
+    scada_df: pd.DataFrame,
+    era5_df: pd.DataFrame,
+    out_dir: Path,
+) -> ArmOutcome:
+    """Apply ``arm``'s fault, run the campaign, and record the estimate or where it stopped."""
+    faulted_scada = arm.scada(scada_df)
+    faulted_era5 = arm.era5(era5_df)
+    try:
+        campaign = placebo_campaign(
+            mode,
+            upgraded=[PROBE_TEST_WTG],
+            turbines=list(PROBE_TURBINES),
+            coords=_coords(PROBE_TURBINES),
+        )
+        dataset = campaign.generate(faulted_scada)
+        spec = campaign.spec()
+        index = pd.DatetimeIndex(dataset.synthetic_df.index.unique()).sort_values()
+        runner = CampaignRunner(
+            spec,
+            dataset,
+            build_methods=lambda wtg: _power_model_only(spec, out_dir=out_dir / wtg, era5_hourly_df=faulted_era5),
+            era5_wd=era5_direction(faulted_era5, index),
+        )
+        result = runner.run()
+    except Exception as exc:  # noqa: BLE001 - the probe's whole purpose is to see what escapes
+        logger.info("%s %s stopped: %s: %s", mode, arm.name, type(exc).__name__, exc)
+        return ArmOutcome(
+            reached_estimate=False,
+            error_type=type(exc).__name__,
+            error_message=str(exc).splitlines()[0] if str(exc) else "",
+            failed_in=_deepest_repo_frame(exc),
+        )
+    estimate = float(result.farm.set_index("method").loc["power_model", "estimate"])
+    logger.info("%s %s reached an estimate of %+.3f%%", mode, arm.name, estimate * 100)
+    return ArmOutcome(reached_estimate=True, estimate=estimate)
+
+
+def run_probe(
+    *,
+    modes: Sequence[str] = ("prepost",),
+    arms: Sequence[str] | None = None,
+    out_root: str | Path | None = None,
+) -> pd.DataFrame:
+    """Run the matrix and return one row per ``(mode, arm)``.
+
+    :param modes: the campaign modes to run; stage 1 defaults to prepost alone
+    :param arms: run only these arm names (the clean control is always worth keeping); all when None
+    :param out_root: where the run folder is written; the driver's default root when None
+    """
+    root = Path(out_root) if out_root is not None else default_output_root()
+    run_dir = root / f"{pd.Timestamp.now():%Y%m%d_%H%M%S}"
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    era5_df = build_hot_v0_context(wtg_names=list(PROBE_TURBINES)).reanalysis_datasets[0].data
+    selected = [a for a in probe_arms() if arms is None or a.name in set(arms)]
+    rows: list[dict[str, object]] = []
+    for mode in modes:
+        period = placebo_analysis_period(mode)  # type: ignore[arg-type]
+        logger.info("loading Hill of Towie SCADA %s..%s for %s", *period, list(PROBE_TURBINES))
+        scada_df, _ = load_hot_scada(
+            start_dt=period[0],
+            end_dt_excl=period[1],
+            wtg_numbers=[int(w[1:]) for w in PROBE_TURBINES],
+            wtg_names=list(PROBE_TURBINES),
+        )
+        for arm in selected:
+            logger.info("running %s %s -- %s", mode, arm.name, arm.what)
+            started = pd.Timestamp.now()
+            outcome = run_arm(
+                arm,
+                mode=mode,  # type: ignore[arg-type]
+                scada_df=scada_df,
+                era5_df=era5_df,
+                out_dir=run_dir / f"{mode}_{arm.name}",
+            )
+            rows.append(
+                {
+                    "mode": mode,
+                    "arm": arm.name,
+                    "shape": arm.shape,
+                    "what": arm.what,
+                    "reached_estimate": outcome.reached_estimate,
+                    "estimate": outcome.estimate,
+                    "error_type": outcome.error_type,
+                    "error_message": outcome.error_message,
+                    "failed_in": outcome.failed_in,
+                    "seconds": (pd.Timestamp.now() - started).total_seconds(),
+                }
+            )
+            pd.DataFrame(rows).to_csv(run_dir / "outcomes.csv", index=False)
+    logger.info("wrote the probe results to %s", run_dir)
+    return pd.DataFrame(rows)
+
+
+def default_output_root() -> Path:
+    """Return the directory this driver writes under (``WIND_UP_BENCHMARKING_OUTPUT_DIR`` overrides)."""
+    root = Path(os.getenv("WIND_UP_BENCHMARKING_OUTPUT_DIR", Path.home() / "temp" / "wind-up-benchmarking"))
+    return root / "outage_probe"
+
+
+def main() -> None:
+    """Run the stage-1 matrix and log the outcome table."""
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+    outcomes = run_probe()
+    logger.info("\n%s", outcomes[["mode", "arm", "shape", "reached_estimate", "estimate", "failed_in"]].to_string())
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarking/harness/northing.py
+++ b/benchmarking/harness/northing.py
@@ -56,7 +56,17 @@ ERA5_WD_COL = "wind_direction_100m"
 
 
 def era5_direction(era5_df: pd.DataFrame, index: pd.DatetimeIndex) -> pd.Series:
-    """Return the hourly ERA5 wind direction carried onto ``index``, held within each hour."""
+    """Return the hourly ERA5 wind direction carried onto ``index``, held within each hour.
+
+    Raises naming the column when the frame does not carry it: a partial reanalysis delivery is
+    reported as the missing column rather than as a bare KeyError.
+    """
+    if ERA5_WD_COL not in era5_df.columns:
+        msg = (
+            f"the reanalysis frame has no {ERA5_WD_COL!r} column, which is the direction the shared northing "
+            f"step anchors against. Columns present: {sorted(era5_df.columns)}"
+        )
+        raise ValueError(msg)
     hourly = era5_df[ERA5_WD_COL]
     return hourly.reindex(hourly.index.union(index)).ffill(limit=6).reindex(index)
 
@@ -82,6 +92,17 @@ def _north_table_from_offsets(
     return pd.DataFrame(
         {"timestamp": pd.DatetimeIndex([ts for ts, _ in rows]), "north_offset": [off for _, off in rows]}
     )
+
+
+def _require_columns(scada_df: pd.DataFrame, *, columns: ColumnSchema, roles: Sequence[str]) -> None:
+    """Raise naming any role's column that northing discovery reads but ``scada_df`` does not carry."""
+    missing = sorted({str(getattr(columns, r)) for r in roles} - set(scada_df.columns))
+    if missing:
+        msg = (
+            f"northing discovery needs the column(s) {missing}, which are not in scada_df; they decide which "
+            f"rows are usable for northing. Columns present: {sorted(scada_df.columns)}"
+        )
+        raise ValueError(msg)
 
 
 def _usable_masks(
@@ -187,6 +208,7 @@ def north_scada(
                 f"the north table for every role is derived from it. Columns present: {sorted(scada_df.columns)}"
             )
             raise ValueError(msg)
+        _require_columns(scada_df, columns=columns, roles=("active_power", "availability"))
         directions = _directions(scada_df, columns=columns, turbines=turbines, index=index, col=source)
         usable = _usable_masks(
             scada_df,

--- a/docs/v1/findings_campaigns.md
+++ b/docs/v1/findings_campaigns.md
@@ -12,6 +12,85 @@ Keep entries reproducible: name the driver and the exact configuration, not just
 
 ---
 
+## CF14 — Missing data is absorbed within estimator noise, with one exception: a reference that **disappears from the delivery** costs **+0.45 pp**, because it shrinks the pool rather than corrupting anything. Every crash named someone else's problem, and the misleading one was **prepost-only**
+
+*2026-09-08. R4, stage 1 + stage 2. Driver: `benchmarking.campaigns.outage_probe` — 19 arms over
+the field failure modes (whole-farm SCADA outage, whole-turbine logging outage, single-signal
+outage, ERA5 columns lost to a download or mapping error, ERA5 holes), each in the two shapes that
+take different code paths: **absent** (the column is not in the frame) and **empty** (the column is
+there and NaN, or the rows are gone). Placebo on T06 + T15/T10/T08, so truth is 0 and any movement
+is the fault's. `run_probe(modes=..., seeds=...)`; the noise floor is `seeds=(0,1,2,3,4)` on
+`clean`, `ref_absent_entirely` and `ref_power_empty`.*
+
+**The absent/empty split is the fault line, exactly.** Every `empty` arm returned a number in both
+modes; four of five `absent` arms raised. An absent column raises because the feature builder
+requires it; a NaN one is handled natively by LightGBM and passes through without comment.
+
+**The noise floor is 0.127 pp, which retires most of the table.** Across five seeds (the seed drives
+the baseline holdout split and LightGBM's `random_state`) the clean prepost placebo reads mean
+**0.423%**, sd **0.048 pp**, range 0.343–0.470. Only two faults clear it:
+
+| arm | mean | Δ vs clean | σ | ranges overlap |
+|---|---|---|---|---|
+| `clean` | 0.423% | — | — | — |
+| `ref_absent_entirely` | 0.873% | **+0.45 pp** | 9.4 | no |
+| `ref_power_empty` | 0.578% | **+0.15 pp** | 3.2 | no |
+
+Single-seed numbers overstated both (+0.53 and +0.31 pp at seed 0, which paired the lowest clean
+with the highest faulted value). `farm_empty`, `farm_rows_gone`, `ref_empty`, `ref_rows_gone`,
+`test_empty`, `ref_direction_empty`, `era5_hole_1mo`, `era5_hole_3mo`, `era5_rows_gone` and
+`era5_matching_absent` all sit inside the floor. `test_empty_upgraded` (+0.20 pp) and
+`era5_incidental_absent` (−0.19 pp) are marginal and **were not seed-swept**; they are unmeasured,
+not cleared.
+
+**The one material effect is pool shrinkage, not corruption.** Compare `ref_empty` (T15 all-NaN for
+30 days — inside the noise) against `ref_absent_entirely` (T15 gone from the whole record —
++0.45 pp). The difference is not damaged data: it is a **2-reference pool instead of 3**, and
+[CF3](#cf3) already establishes reference count as the dominant accuracy driver. So `power_model`
+was reflecting a known effect faithfully; what it never did was **say the pool had shrunk**. The fix
+is announcement, not adaptation — which is why R4's anticipated "discover the available signals and
+adapt" was **not** implemented: it would have converted honest raises into silent estimates.
+
+**Both modes agree on the ranking.** Toggle's clean control is +0.082% and its movements are
+uniformly smaller, but `ref_absent_entirely` tops both (+0.31 pp toggle, +0.45 pp prepost), so it is
+a real effect rather than a one-mode artefact.
+
+**Every crash named someone else's problem.** Five missing-column failures, none of which named its
+cause where the analyst reads it:
+
+| arm | failed in | reported as |
+|---|---|---|
+| `power_min_absent` | `power_model/screening.py` | *"points to a farm-wide problem"* |
+| `nacelle_position_absent` | `power_model/screening.py` | *"points to a farm-wide problem"* |
+| `availability_absent` | `harness/northing.py:_usable_masks` | bare `KeyError` |
+| `era5_sync_absent` | `harness/northing.py:era5_direction` | bare `KeyError` |
+| `era5_matching_absent` | `power_model/method.py:_estimate_conditional` | bare `KeyError`, **after** the headline was computed |
+
+The screen's misdiagnosis is the sharpest of these: every candidate was unestimatable for one
+reason — a column that was not there — and the real cause was logged as a WARNING while the
+misleading verdict was what stopped the run. **It is prepost-only**: the screen does not run in
+toggle, where the same arms raise the correct named error straight from `features.py`.
+
+**Two of five failures were harness-level, not `power_model`-internal**, which contradicts R4's
+scope line in [issues_campaigns.md](issues_campaigns.md); `availability_absent` and
+`era5_sync_absent` both die in the shared northing step before `power_model` runs at all.
+
+**What changed.** `era5_direction` and northing discovery now raise naming the column and what it is
+for. The screen records why each candidate failed and appends those causes to its own verdict,
+chained to the original. The conditional step follows the `era5_exclude` idiom — untouched default
+`matching_vars` is skip-if-missing (warn, drop the breakdown, keep the P50), an explicitly-set one
+keeps the strict guard — and the check runs before the fits, so the raise is immediate rather than
+54 s late. The reference pool is derived once from the campaign's `candidate_references` intersected
+with the turbines the frame carries, shared by the feature builder, the screen and the
+reference-uplift report, and a declared reference with no rows is dropped **with a warning** instead
+of being estimated as if it were there — which previously died as `IndexError: iloc cannot enlarge
+its target object` inside the stuck-sensor filter.
+
+**Limits.** Outage position was held at a 30-day mid-baseline window; position was not varied. The
+0.127 pp floor is this fixture's resolution — a 4-turbine placebo cannot settle anything smaller.
+
+---
+
 ## CF13 — The reference screen works where it has data and references, and nowhere else: it needs a campaign of **150+ days** and it finds Hill of Towie's genuinely bad turbine (**T17, +4.7%**) on a 19-reference pool. Two constraints, both measured, decide when it may run at all
 
 *2026-09-04. R3, Phase B. Drivers: `benchmarking.campaigns.screen_calibration` (clean placebo

--- a/docs/v1/issues_campaigns.md
+++ b/docs/v1/issues_campaigns.md
@@ -139,7 +139,7 @@ so moved every frozen artefact at once. Read this before accepting any benchmark
 
 ## Suggested order
 
-`C0 ✅ → [W0 ✅ early] → C1 ✅ → C2 ✅ → [R1 ✅ R2 ✅ R3 ✅ R4] → W1a → C3 → C4 → R5 →
+`C0 ✅ → [W0 ✅ early] → C1 ✅ → C2 ✅ → [R1 ✅ R2 ✅ R3 ✅ R4 ✅] → W1a → C3 → C4 → R5 →
 C5 → R6 → C6 → C8 → W1b → W2`, with **W3 running continuously from W1a onward** rather
 than at one point in the line.
 
@@ -180,7 +180,7 @@ issue for a reason: it is the only one that changes what *truth* means.
 declaration is what gets frozen as public API at v1.0.0, not the flat one. C7 (drop
 `rlearner`, ✅ done) was independent.
 
-**Done so far:** C0, W0, C7, C1, C2, R1, R2 and R3. **Next: R4**, then C3, which inherits the
+**Done so far:** C0, W0, C7, C1, C2, R1, R2, R3 and R4. **Next: C3**, which inherits the
 shared northing step R1 landed and the reference screen R3 landed.
 
 ---
@@ -653,7 +653,7 @@ re-verified in-context on C3/C5.
 
 ---
 
-## R4 — Missing data (`power_model`-internal fix)
+## R4 — Missing data ✅ done 2026-09-08
 
 **Goal:** `power_model` adapts to whatever signals are present instead of assuming a
 fixed feature set.
@@ -668,6 +668,27 @@ fixed feature set.
 **Done when:** the missing-data case bites (or would crash) the current fixed-feature
 `power_model`, then signal discovery restores a run that stays accurate under missing
 channels / gaps.
+
+### What actually happened — two corrections to the scope above ([CF14](findings_campaigns.md))
+
+**This was not `power_model`-internal.** Two of the five missing-column failures die in the
+**shared northing step** before `power_model` runs at all, and two of the four fixes landed
+there. The heading above is wrong about where this failure mode lives.
+
+**Signal discovery was measured and deliberately not built.** The probe
+(`benchmarking.campaigns.outage_probe`) showed the absent/empty split *is* the fault line —
+every NaN-shaped outage already returns a number, every absent-column one raises — so
+"discover and adapt" would have converted honest raises into silent estimates, the wrong
+direction. Missing data turned out to be absorbed within a 0.127 pp estimator-noise floor
+in every arm but one: a reference that disappears from the delivery entirely, worth
+**+0.45 pp**, and that is [CF3](findings_campaigns.md)'s reference-count effect rather than
+corruption. What shipped instead is **attribution and announcement**: every failure now names
+the column that caused it, the conditional step degrades instead of taking the headline down
+with it, and a declared reference the data does not carry is dropped with a warning.
+
+**Left undone deliberately:** outage *position* was held at a 30-day mid-baseline window, and
+`test_empty_upgraded` (+0.20 pp) and `era5_incidental_absent` (−0.19 pp) sit just above the
+floor but were not seed-swept, so they are unmeasured rather than cleared.
 
 ---
 
@@ -848,8 +869,9 @@ without it. What W1a delivers is the *interface*; W1b settles whether it is *rig
 **Scope**
 - Build `wind-up` in `benchmarking/baselines` (like every v1 method), composing
   **`power_model` (definite) + the shared northing step (R1) + the reference-validity
-  screen (R3) + missing-data adaptation (R4)**. `toggle_specialist` inclusion is
-  **TBD** and is settled in W1b, not here.
+  screen (R3)**. R4 added no adaptation layer to compose (see its scope correction): what it
+  left behind is attribution and a pool-shrinkage warning, already inside those parts.
+  `toggle_specialist` inclusion is **TBD** and is settled in W1b, not here.
 - **A campaign is declared, not scripted** (moved here from W2, which is too late for
   W3 to use it). `CampaignSpec` gains a simple user-facing declaration — a YAML file it
   initializes from — so an analyst describes turbine roles, timing, exclusions and

--- a/tests/benchmarking/baselines/test_power_model_features.py
+++ b/tests/benchmarking/baselines/test_power_model_features.py
@@ -21,6 +21,7 @@ from benchmarking.baselines.power_model.features import (
 )
 
 _TURBINE = "TurbineName"
+_REFS = ("R1", "R2", "R3")
 _POWER = "wtc_ActPower_mean"
 _AVAIL = "wtc_ScReToOp_timeon"
 _WS = "wtc_AcWindSp_mean"
@@ -52,7 +53,12 @@ class TestBuildReferenceFeatures:
     def test_only_active_power_and_availability_per_reference(self) -> None:
         idx = _index(12)
         feats = build_reference_features(
-            _scada(idx), test_wtg="T1", turbine_col=_TURBINE, active_power_col=_POWER, availability_col=_AVAIL
+            _scada(idx),
+            test_wtg="T1",
+            references=_REFS,
+            turbine_col=_TURBINE,
+            active_power_col=_POWER,
+            availability_col=_AVAIL,
         )
         # three references x two value columns = six feature columns; none for T1; ws not included
         assert len(feats.columns) == 6
@@ -63,7 +69,12 @@ class TestBuildReferenceFeatures:
     def test_keeps_original_tag_names(self) -> None:
         idx = _index(12)
         feats = build_reference_features(
-            _scada(idx), test_wtg="T1", turbine_col=_TURBINE, active_power_col=_POWER, availability_col=_AVAIL
+            _scada(idx),
+            test_wtg="T1",
+            references=_REFS,
+            turbine_col=_TURBINE,
+            active_power_col=_POWER,
+            availability_col=_AVAIL,
         )
         assert f"{_POWER}{QUALIFIER}R1" in feats.columns
         assert f"{_AVAIL}{QUALIFIER}R3" in feats.columns
@@ -73,19 +84,41 @@ class TestBuildReferenceFeatures:
         scada = _scada(idx)
         scada.loc[(scada[_TURBINE] == "R1") & (scada.index == idx[3]), _POWER] = np.nan
         feats = build_reference_features(
-            scada, test_wtg="T1", turbine_col=_TURBINE, active_power_col=_POWER, availability_col=_AVAIL
+            scada,
+            test_wtg="T1",
+            references=_REFS,
+            turbine_col=_TURBINE,
+            active_power_col=_POWER,
+            availability_col=_AVAIL,
         )
         assert len(feats) == len(idx)
         assert np.isnan(feats.loc[idx[3], f"{_POWER}{QUALIFIER}R1"])
 
-    def test_raises_when_no_references(self) -> None:
+    def test_raises_when_the_pool_is_empty(self) -> None:
         idx = _index(12)
-        only_test = _scada(idx)
-        only_test = only_test[only_test[_TURBINE] == "T1"]
-        with pytest.raises(ValueError, match="reference"):
+        with pytest.raises(ValueError, match="no references supplied"):
             build_reference_features(
-                only_test, test_wtg="T1", turbine_col=_TURBINE, active_power_col=_POWER, availability_col=_AVAIL
+                _scada(idx),
+                test_wtg="T1",
+                references=(),
+                turbine_col=_TURBINE,
+                active_power_col=_POWER,
+                availability_col=_AVAIL,
             )
+
+    def test_a_turbine_outside_the_pool_contributes_nothing(self) -> None:
+        idx = _index(12)
+        feats = build_reference_features(
+            _scada(idx),
+            test_wtg="T1",
+            references=("R1", "R2"),
+            turbine_col=_TURBINE,
+            active_power_col=_POWER,
+            availability_col=_AVAIL,
+        )
+        # R3 is in the frame but not offered as a reference, so it is not one
+        assert not any(c.endswith(f"{QUALIFIER}R3") for c in feats.columns)
+        assert len(feats.columns) == 4
 
     def test_extra_cols_add_per_reference_features(self) -> None:
         idx = _index(12)
@@ -94,6 +127,7 @@ class TestBuildReferenceFeatures:
         feats = build_reference_features(
             scada,
             test_wtg="T1",
+            references=_REFS,
             turbine_col=_TURBINE,
             active_power_col=_POWER,
             availability_col=_AVAIL,
@@ -111,6 +145,7 @@ class TestBuildReferenceFeatures:
             build_reference_features(
                 scada,
                 test_wtg="T1",
+                references=_REFS,
                 turbine_col=_TURBINE,
                 active_power_col=_POWER,
                 availability_col=_AVAIL,
@@ -123,6 +158,7 @@ class TestBuildReferenceFeatures:
             build_reference_features(
                 _scada(idx),
                 test_wtg="T1",
+                references=_REFS,
                 turbine_col=_TURBINE,
                 active_power_col=_POWER,
                 availability_col=_AVAIL,
@@ -135,7 +171,12 @@ class TestBuildReferenceFeatures:
         # a leak-bait column only present on the test turbine must not appear among features
         scada["wtc_NacWdSp_mean"] = np.where(scada[_TURBINE] == "T1", scada[_POWER], np.nan)
         feats = build_reference_features(
-            scada, test_wtg="T1", turbine_col=_TURBINE, active_power_col=_POWER, availability_col=_AVAIL
+            scada,
+            test_wtg="T1",
+            references=_REFS,
+            turbine_col=_TURBINE,
+            active_power_col=_POWER,
+            availability_col=_AVAIL,
         )
         assert not any("NacWdSp" in c for c in feats.columns)
         assert not any(c.endswith(f"{QUALIFIER}T1") for c in feats.columns)
@@ -205,6 +246,7 @@ class TestReferenceDirectionFeature:
         feats = build_reference_features(
             _scada_with_direction(idx),
             test_wtg="T1",
+            references=_REFS,
             turbine_col=_TURBINE,
             active_power_col=_POWER,
             availability_col=_AVAIL,
@@ -223,6 +265,7 @@ class TestReferenceDirectionFeature:
         feats = build_reference_features(
             scada,
             test_wtg="T1",
+            references=_REFS,
             turbine_col=_TURBINE,
             active_power_col=_POWER,
             availability_col=_AVAIL,
@@ -237,6 +280,7 @@ class TestReferenceDirectionFeature:
         feats = build_reference_features(
             _scada_with_direction(idx),
             test_wtg="T1",
+            references=_REFS,
             turbine_col=_TURBINE,
             active_power_col=_POWER,
             availability_col=_AVAIL,
@@ -250,6 +294,7 @@ class TestReferenceDirectionFeature:
             build_reference_features(
                 _scada(idx),  # no direction columns at all
                 test_wtg="T1",
+                references=_REFS,
                 turbine_col=_TURBINE,
                 active_power_col=_POWER,
                 availability_col=_AVAIL,
@@ -261,6 +306,7 @@ class TestReferenceDirectionFeature:
         feats = build_reference_features(
             _scada_with_direction(idx),
             test_wtg="T1",
+            references=_REFS,
             turbine_col=_TURBINE,
             active_power_col=_POWER,
             availability_col=_AVAIL,
@@ -274,7 +320,12 @@ class TestReferenceDirectionFeature:
         idx = _index(12)
         scada = _scada_with_direction(idx)
         without = build_reference_features(
-            scada, test_wtg="T1", turbine_col=_TURBINE, active_power_col=_POWER, availability_col=_AVAIL
+            scada,
+            test_wtg="T1",
+            references=_REFS,
+            turbine_col=_TURBINE,
+            active_power_col=_POWER,
+            availability_col=_AVAIL,
         )
         assert len(without.columns) == 6
         assert not any("northed" in c for c in without.columns)
@@ -302,6 +353,7 @@ class TestPowerFreeReferences:
         return build_reference_features(
             _scada_spanning_the_waking_threshold(idx),
             test_wtg="T1",
+            references=_REFS,
             turbine_col=_TURBINE,
             active_power_col=_POWER,
             availability_col=_AVAIL,
@@ -355,6 +407,7 @@ class TestPowerFreeReferences:
         unscreened = build_reference_features(
             _scada_spanning_the_waking_threshold(idx),
             test_wtg="T1",
+            references=_REFS,
             turbine_col=_TURBINE,
             active_power_col=_POWER,
             availability_col=_AVAIL,
@@ -383,6 +436,7 @@ class TestWakingDtype:
         return build_reference_features(
             scada[~drop],
             test_wtg="T1",
+            references=_REFS,
             turbine_col=_TURBINE,
             active_power_col=_POWER,
             availability_col=_AVAIL,
@@ -416,6 +470,7 @@ class TestPowerFreeKeepsAvailability:
         return build_reference_features(
             _scada_spanning_the_waking_threshold(idx),
             test_wtg="T1",
+            references=_REFS,
             turbine_col=_TURBINE,
             active_power_col=_POWER,
             availability_col=_AVAIL,

--- a/tests/benchmarking/baselines/test_power_model_method.py
+++ b/tests/benchmarking/baselines/test_power_model_method.py
@@ -8,6 +8,7 @@ recovers the uplift — for both prepost and toggle. Also checks the reference-o
 
 from __future__ import annotations
 
+import dataclasses
 import logging
 import tempfile
 from dataclasses import replace
@@ -1139,6 +1140,47 @@ class TestAShrunkenPoolIsAnnounced:
         with caplog.at_level(logging.WARNING):
             _screen_method().estimate(mi)
         assert "carries no data" not in caplog.text
+
+
+class TestTheConditionalGuardRunsBeforeTheScreen:
+    """An explicitly-named missing matching column stops the run before any model is fitted."""
+
+    def test_it_raises_without_ever_screening(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        n = 4000
+        idx = pd.date_range("2019-01-01", periods=n, freq="10min", tz="UTC")
+        changeover = idx[n // 2]
+        scada = _toy_scada(n, uplift=0.05, treated=np.asarray(idx >= changeover))
+        method = PowerModelMethod(
+            columns=_COLUMNS,
+            baseline_rated_power_kw=2300.0,
+            era5_hourly_df=_toy_era5(idx).drop(columns=["wind_gusts_10m"]),
+            matching_vars=("wind_speed_100m", "wind_gusts_10m"),
+            model_params=_FAST_PARAMS,
+            screen_min_campaign_days=0.0,
+        )
+        called: list[str] = []
+        monkeypatch.setattr(
+            PowerModelMethod,
+            "screen_references",
+            lambda self, mi: called.append(mi.test_wtg),  # noqa: ARG005
+        )
+        mi = MethodInput(scada_df=scada, test_wtg="T1", upgrade_timing=pd.Timestamp(changeover), turbine_col=_TURBINE)
+        with pytest.raises(ValueError, match="wind_gusts_10m"):
+            method.estimate(mi)
+        assert called == []
+
+
+class TestTheScreenGateJudgesThePoolThatExists:
+    """A declared reference with no rows must not silently disable screening for the rest."""
+
+    def test_an_absent_declared_reference_does_not_disable_the_screen(self) -> None:
+        mi, changeover = _screen_case(step=0.0)
+        full = mi.scada_df
+        context = CampaignContext.from_frame(full, test_wtg="T1", timing=changeover, turbine_col=_TURBINE)
+        # R4 is offered by the campaign but never turned up; R1/R2/R3 did.
+        context = dataclasses.replace(context, candidate_references=[*context.candidate_references, "R4"])
+        starved = MethodInput(scada_df=full, test_wtg="T1", campaign_context=context)
+        assert _screen_method(screen_min_campaign_days=5.0).screen_references(starved).screenable
 
 
 class TestScreenFailureNamesItsCause:

--- a/tests/benchmarking/baselines/test_power_model_method.py
+++ b/tests/benchmarking/baselines/test_power_model_method.py
@@ -8,6 +8,7 @@ recovers the uplift — for both prepost and toggle. Also checks the reference-o
 
 from __future__ import annotations
 
+import logging
 import tempfile
 from dataclasses import replace
 from pathlib import Path
@@ -370,6 +371,48 @@ class TestConditionsSelection:
     def test_unknown_condition_raises(self) -> None:
         with pytest.raises(ValueError, match="unknown condition"):
             PowerModelMethod(columns=_COLUMNS, baseline_rated_power_kw=2300.0, conditions=("bogus",))
+
+
+class TestConditionalWithoutItsMatchingColumns:
+    """A partial reanalysis delivery costs the conditional breakdown, not the headline."""
+
+    def _case(self, **overrides: object) -> tuple[PowerModelMethod, MethodInput]:
+        n = 4000
+        idx = pd.date_range("2019-01-01", periods=n, freq="10min", tz="UTC")
+        changeover = idx[n // 2]
+        scada = _toy_scada(n, uplift=0.05, treated=np.asarray(idx >= changeover))
+        era5 = _toy_era5(idx).drop(columns=["wind_gusts_10m"])  # a matching axis never arrived
+        kwargs: dict[str, object] = {
+            "columns": _COLUMNS,
+            "baseline_rated_power_kw": 2300.0,
+            "era5_hourly_df": era5,
+            "model_params": _FAST_PARAMS,
+            **overrides,
+        }
+        method = PowerModelMethod(**kwargs)  # type: ignore[arg-type]
+        mi = MethodInput(scada_df=scada, test_wtg="T1", upgrade_timing=pd.Timestamp(changeover), turbine_col=_TURBINE)
+        return method, mi
+
+    def test_the_headline_survives_a_missing_default_matching_column(self) -> None:
+        method, mi = self._case()
+        out = method.estimate(mi)
+        assert np.isfinite(out.p50_overall)
+
+    def test_the_conditional_breakdown_is_dropped_rather_than_guessed(self) -> None:
+        method, mi = self._case()
+        assert method.estimate(mi).p50_by_condition is None
+
+    def test_it_says_so(self, caplog: pytest.LogCaptureFixture) -> None:
+        method, mi = self._case()
+        with caplog.at_level(logging.WARNING):
+            method.estimate(mi)
+        assert "wind_gusts_10m" in caplog.text
+
+    def test_an_explicitly_named_missing_column_raises_instead(self) -> None:
+        """Naming a column that is not there is a configuration error, not a partial delivery."""
+        method, mi = self._case(matching_vars=("wind_speed_100m", "wind_gusts_10m"))
+        with pytest.raises(ValueError, match="wind_gusts_10m"):
+            method.estimate(mi)
 
 
 class TestConditionalUplift:
@@ -1069,6 +1112,30 @@ class TestADegenerateReferenceDoesNotSinkTheCampaign:
         """Surviving a reference this bad is the whole point of the screen."""
         mi, _ = self._mi_with_a_dead_reference()
         assert _screen_method().screen_references(mi).screened == ("R1",)
+
+
+class TestScreenFailureNamesItsCause:
+    """When no reference can be estimated, the raised error carries why, not just the verdict."""
+
+    def _mi_without_the_power_minimum(self) -> MethodInput:
+        """Every reference becomes unestimatable for one reason: a column the features need is gone."""
+        mi, changeover = _screen_case(step=0.0)
+        scada = mi.scada_df.drop(columns=[_COLUMNS.active_power_min])
+        return MethodInput(scada_df=scada, test_wtg="T1", upgrade_timing=changeover, turbine_col=_TURBINE)
+
+    def test_the_error_names_the_missing_column(self) -> None:
+        """Without this the analyst is told the farm is broken when one column is absent."""
+        with pytest.raises(ValueError, match=str(_COLUMNS.active_power_min)):
+            _screen_method().estimate(self._mi_without_the_power_minimum())
+
+    def test_the_error_still_carries_the_screen_s_own_verdict(self) -> None:
+        with pytest.raises(ValueError, match="majority"):
+            _screen_method().estimate(self._mi_without_the_power_minimum())
+
+    def test_the_underlying_cause_is_chained(self) -> None:
+        with pytest.raises(ValueError, match="What stopped each of them") as excinfo:
+            _screen_method().estimate(self._mi_without_the_power_minimum())
+        assert excinfo.value.__cause__ is not None
 
 
 class TestReferenceUpliftsSchema:

--- a/tests/benchmarking/baselines/test_power_model_method.py
+++ b/tests/benchmarking/baselines/test_power_model_method.py
@@ -1114,6 +1114,33 @@ class TestADegenerateReferenceDoesNotSinkTheCampaign:
         assert _screen_method().screen_references(mi).screened == ("R1",)
 
 
+class TestAShrunkenPoolIsAnnounced:
+    """A candidate reference the campaign offers but the data does not carry is said out loud."""
+
+    def _case(self) -> tuple[PowerModelMethod, MethodInput]:
+        mi, changeover = _screen_case(step=0.0)
+        full = mi.scada_df
+        context = CampaignContext.from_frame(full, test_wtg="T1", timing=changeover, turbine_col=_TURBINE)
+        delivered = full[full[_TURBINE] != "R1"]  # R1 is offered, but never turned up
+        return _screen_method(), MethodInput(scada_df=delivered, test_wtg="T1", campaign_context=context)
+
+    def test_the_absent_reference_is_named(self, caplog: pytest.LogCaptureFixture) -> None:
+        method, mi = self._case()
+        with caplog.at_level(logging.WARNING):
+            method.estimate(mi)
+        assert "R1" in caplog.text
+
+    def test_the_estimate_still_runs_on_what_is_there(self) -> None:
+        method, mi = self._case()
+        assert np.isfinite(method.estimate(mi).p50_overall)
+
+    def test_a_complete_delivery_says_nothing(self, caplog: pytest.LogCaptureFixture) -> None:
+        mi, _ = _screen_case(step=0.0)
+        with caplog.at_level(logging.WARNING):
+            _screen_method().estimate(mi)
+        assert "carries no data" not in caplog.text
+
+
 class TestScreenFailureNamesItsCause:
     """When no reference can be estimated, the raised error carries why, not just the verdict."""
 

--- a/tests/benchmarking/campaigns/test_context.py
+++ b/tests/benchmarking/campaigns/test_context.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import dataclasses
+import logging
 
 import pandas as pd
+import pytest  # noqa: TC002 - caplog fixtures are runtime types
 
 from benchmarking.campaigns.context import context_for
 from benchmarking.campaigns.declaration import CampaignSpec
@@ -45,6 +47,17 @@ class TestCandidateReferences:
     def test_a_declared_reference_absent_from_the_frame_is_dropped(self) -> None:
         context = context_for(_spec(candidate_references=["T3", "T4", "T9"]), turbine="T1", scada_df=_scada())
         assert context.candidate_references == ["T3", "T4"]
+
+    def test_dropping_a_declared_reference_is_announced(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A quietly smaller pool is a weaker estimate, so the gap between declared and delivered is said."""
+        with caplog.at_level(logging.WARNING):
+            context_for(_spec(candidate_references=["T3", "T4", "T9"]), turbine="T1", scada_df=_scada())
+        assert "T9" in caplog.text
+
+    def test_a_fully_delivered_pool_says_nothing(self, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level(logging.WARNING):
+            context_for(_spec(), turbine="T1", scada_df=_scada())
+        assert "carries no rows" not in caplog.text
 
 
 class TestValidForUplift:

--- a/tests/benchmarking/campaigns/test_outage_probe.py
+++ b/tests/benchmarking/campaigns/test_outage_probe.py
@@ -1,0 +1,183 @@
+"""Tests for the R4 outage probe's data transforms and its arm declaration.
+
+The probe's actual runs are a driver (they need the Hill of Towie download and the power model);
+what is unit-tested here is that each transform removes exactly what it claims -- the distinction
+between an absent column and an empty one is the whole point of the matrix -- and that the arms are
+declared as intended.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from benchmarking.campaigns.outage_probe import (
+    BASELINE_OUTAGE,
+    OUTAGE_REFERENCE,
+    PROBE_REFERENCES,
+    PROBE_TEST_WTG,
+    PROBE_TURBINES,
+    drop_columns,
+    drop_era5_rows,
+    drop_rows,
+    drop_turbine,
+    null_era5,
+    null_signals,
+    probe_arms,
+)
+from benchmarking.campaigns.placebo import PLACEBO_CAMPAIGN_START
+from benchmarking.synthetic import HOT_COLUMNS
+
+_POWER = HOT_COLUMNS.active_power
+_WS = HOT_COLUMNS.wind_speed
+_WINDOW = (pd.Timestamp("2018-03-01", tz="UTC"), pd.Timestamp("2018-04-01", tz="UTC"))
+
+
+# Spans the whole placebo record, so every arm's real outage window lands inside these frames.
+_SPAN = ("2017-01-01", "2019-01-01")
+
+
+def _scada() -> pd.DataFrame:
+    """Long SCADA over the placebo record for the probe turbines, every value column finite."""
+    idx = pd.date_range(*_SPAN, freq="D", tz="UTC", name="timestamp")
+    values = {
+        _POWER: 800.0,
+        _WS: 8.0,
+        str(HOT_COLUMNS.active_power_min): 700.0,
+        str(HOT_COLUMNS.wind_speed_sd): 1.0,
+        str(HOT_COLUMNS.gen_rpm): 1500.0,
+        str(HOT_COLUMNS.availability): 600.0,
+        str(HOT_COLUMNS.nacelle_position): 180.0,
+    }
+    frames = [pd.DataFrame({HOT_COLUMNS.turbine: name, **values}, index=idx) for name in PROBE_TURBINES]
+    return pd.concat(frames)
+
+
+def _era5() -> pd.DataFrame:
+    """Hourly ERA5 carrying every column the probe's arms name, so each one has something to remove."""
+    idx = pd.date_range(*_SPAN, freq="6h", tz="UTC", name="timestamp")
+    values = {
+        "wind_speed_100m": 9.0,
+        "wind_direction_100m": 210.0,
+        "wind_gusts_10m": 12.0,
+        "temperature_2m": 5.0,
+    }
+    return pd.DataFrame(values, index=idx)
+
+
+def _in_window(df: pd.DataFrame) -> np.ndarray:
+    idx = pd.DatetimeIndex(df.index)
+    return np.asarray((idx >= _WINDOW[0]) & (idx < _WINDOW[1]))
+
+
+class TestNullSignals:
+    def test_nulls_only_the_named_turbine_inside_the_window(self) -> None:
+        out = null_signals(_scada(), turbines=[OUTAGE_REFERENCE], columns=[_POWER], window=_WINDOW)
+        hit = _in_window(out) & (out[HOT_COLUMNS.turbine] == OUTAGE_REFERENCE).to_numpy()
+        assert out.loc[hit, _POWER].isna().all()
+        assert out.loc[~hit, _POWER].notna().all()
+
+    def test_leaves_the_column_present_and_the_rows_in_place(self) -> None:
+        """An outage empties values; it does not remove the column or shorten the frame."""
+        scada = _scada()
+        out = null_signals(scada, turbines=[OUTAGE_REFERENCE], columns=[_POWER], window=_WINDOW)
+        assert _POWER in out.columns
+        assert len(out) == len(scada)
+
+    def test_leaves_unnamed_columns_alone(self) -> None:
+        out = null_signals(_scada(), turbines=[OUTAGE_REFERENCE], columns=[_POWER], window=_WINDOW)
+        assert out[_WS].notna().all()
+
+    def test_a_column_absent_from_the_frame_is_skipped_not_created(self) -> None:
+        out = null_signals(_scada(), turbines=[OUTAGE_REFERENCE], columns=["not_a_column"], window=_WINDOW)
+        assert "not_a_column" not in out.columns
+
+    def test_does_not_mutate_the_input(self) -> None:
+        scada = _scada()
+        null_signals(scada, turbines=[OUTAGE_REFERENCE], columns=[_POWER], window=_WINDOW)
+        assert scada[_POWER].notna().all()
+
+
+class TestDropRows:
+    def test_removes_only_the_named_turbine_inside_the_window(self) -> None:
+        scada = _scada()
+        out = drop_rows(scada, turbines=[OUTAGE_REFERENCE], window=_WINDOW)
+        remaining = out[out[HOT_COLUMNS.turbine] == OUTAGE_REFERENCE]
+        assert not _in_window(remaining).any()
+        for other in set(PROBE_TURBINES) - {OUTAGE_REFERENCE}:
+            assert (out[HOT_COLUMNS.turbine] == other).sum() == (scada[HOT_COLUMNS.turbine] == other).sum()
+
+    def test_the_window_is_half_open(self) -> None:
+        """The end timestamp survives, so two adjacent windows do not overlap."""
+        out = drop_rows(_scada(), turbines=[OUTAGE_REFERENCE], window=_WINDOW)
+        kept = out[out[HOT_COLUMNS.turbine] == OUTAGE_REFERENCE]
+        assert _WINDOW[1] in kept.index
+        assert _WINDOW[0] not in kept.index
+
+
+class TestDropColumnsAndTurbine:
+    def test_drop_columns_removes_the_column_entirely(self) -> None:
+        out = drop_columns(_scada(), columns=[_POWER])
+        assert _POWER not in out.columns
+        assert _WS in out.columns
+
+    def test_drop_columns_tolerates_a_column_that_is_not_there(self) -> None:
+        out = drop_columns(_scada(), columns=["not_a_column"])
+        assert len(out.columns) == len(_scada().columns)
+
+    def test_drop_turbine_removes_every_record_for_it(self) -> None:
+        out = drop_turbine(_scada(), turbine=OUTAGE_REFERENCE)
+        assert OUTAGE_REFERENCE not in set(out[HOT_COLUMNS.turbine])
+        assert set(out[HOT_COLUMNS.turbine]) == set(PROBE_TURBINES) - {OUTAGE_REFERENCE}
+
+
+class TestEra5Transforms:
+    def test_null_era5_empties_every_column_in_the_window_only(self) -> None:
+        out = null_era5(_era5(), window=_WINDOW)
+        assert out[_in_window(out)].isna().all().all()
+        assert out[~_in_window(out)].notna().all().all()
+
+    def test_null_era5_keeps_the_index_intact(self) -> None:
+        era5 = _era5()
+        assert null_era5(era5, window=_WINDOW).index.equals(era5.index)
+
+    def test_drop_era5_rows_removes_the_timestamps_from_the_index(self) -> None:
+        out = drop_era5_rows(_era5(), window=_WINDOW)
+        assert not _in_window(out).any()
+        assert len(out) < len(_era5())
+
+
+class TestProbeArms:
+    def test_the_clean_control_comes_first_and_is_the_only_one(self) -> None:
+        arms = probe_arms()
+        assert arms[0].name == "clean"
+        assert len([a for a in arms if a.shape == "clean"]) == 1
+
+    def test_arm_names_are_unique(self) -> None:
+        names = [a.name for a in probe_arms()]
+        assert len(names) == len(set(names))
+
+    def test_every_arm_declares_a_shape_and_a_description(self) -> None:
+        for arm in probe_arms():
+            assert arm.shape in {"clean", "absent", "empty"}
+            assert arm.what
+
+    def test_both_shapes_are_covered(self) -> None:
+        """The matrix is only informative if it runs absent and empty columns against each other."""
+        shapes = {a.shape for a in probe_arms()}
+        assert {"absent", "empty"} <= shapes
+
+    @pytest.mark.parametrize("arm", probe_arms(), ids=lambda a: a.name)
+    def test_every_arm_changes_the_data_it_claims_to(self, arm) -> None:  # noqa: ANN001 - the Arm dataclass
+        """A cell that silently transforms nothing would read as a pass it never earned."""
+        scada, era5 = _scada(), _era5()
+        changed = not arm.scada(scada).equals(scada) or not arm.era5(era5).equals(era5)
+        assert changed == (arm.shape != "clean")
+
+    def test_the_probe_turbines_are_the_test_turbine_plus_its_references(self) -> None:
+        assert (PROBE_TEST_WTG, *PROBE_REFERENCES) == PROBE_TURBINES
+        assert OUTAGE_REFERENCE in PROBE_REFERENCES
+
+    def test_the_baseline_window_sits_before_the_changeover(self) -> None:
+        assert BASELINE_OUTAGE[0] < BASELINE_OUTAGE[1] <= PLACEBO_CAMPAIGN_START

--- a/tests/benchmarking/harness/test_northing.py
+++ b/tests/benchmarking/harness/test_northing.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from benchmarking.harness.northing import north_scada
+from benchmarking.harness.northing import ERA5_WD_COL, era5_direction, north_scada
 from benchmarking.harness.replicates import StudyConfig, iter_replicates
 from benchmarking.synthetic import HOT_COLUMNS, ConstantCpChange
 from wind_up.circular_math import circ_diff
@@ -107,6 +107,38 @@ class TestDiscovery:
         scada, _ = _scada(index, {t: [(_START, 0.0)] for t in _TURBINES})
         with pytest.raises(ValueError, match="era5_wd"):
             north_scada(scada, columns=_COLUMNS, north_offsets=None, rated_power_kw=_RATED, era5_wd=None)
+
+    @pytest.mark.parametrize("role", ["active_power", "availability"])
+    def test_discovery_without_a_column_it_reads_raises_naming_it(self, role: str) -> None:
+        """A missing input is reported as the missing column, not as a bare KeyError from pandas."""
+        index = _index(days=30)
+        scada, era5 = _scada(index, {t: [(_START, 0.0)] for t in _TURBINES})
+        missing = str(getattr(_COLUMNS, role))
+        with pytest.raises(ValueError, match=missing):
+            north_scada(
+                scada.drop(columns=[missing]),
+                columns=_COLUMNS,
+                north_offsets=None,
+                rated_power_kw=_RATED,
+                era5_wd=pd.Series(era5, index=index),
+            )
+
+
+class TestEra5Direction:
+    def test_returns_the_direction_carried_onto_the_index(self) -> None:
+        index = _index(days=2)
+        hourly = pd.date_range(start=_START, periods=48, freq="h", tz="UTC")
+        era5 = pd.DataFrame({ERA5_WD_COL: np.arange(48, dtype=float)}, index=hourly)
+        out = era5_direction(era5, index)
+        assert out.index.equals(index)
+        assert out.iloc[0] == pytest.approx(0.0)
+
+    def test_without_the_direction_column_raises_naming_it(self) -> None:
+        index = _index(days=2)
+        hourly = pd.date_range(start=_START, periods=48, freq="h", tz="UTC")
+        era5 = pd.DataFrame({"wind_speed_100m": 9.0}, index=hourly)
+        with pytest.raises(ValueError, match=ERA5_WD_COL):
+            era5_direction(era5, index)
 
 
 class TestDeclared:


### PR DESCRIPTION
See R4 in `issues_campaigns.md`

---

## Read this before the issue

**R4 shipped attribution, not the adaptation the issue predicted.** `issues_campaigns.md` promised
"`power_model` **discovers available signals** and builds features from what is present". That was
measured and deliberately not built. Two scope corrections are written into the issue as
corrections rather than quietly rewritten; full evidence is **CF14** in `findings_campaigns.md`.

### Why signal discovery was dropped

A new probe (`benchmarking.campaigns.outage_probe`, 19 arms over whole-farm outages, whole-turbine
outages, single-signal outages, ERA5 columns lost, and ERA5 holes) shows the fault line is
**absent vs empty**:

* **absent** — the column is not in the frame: raises.
* **empty** — the column is there and NaN, or the rows are gone: absorbed by LightGBM, returns a number.

Every `empty` arm returned a number in both modes; four of five `absent` arms raised. So "discover
and adapt" would have converted honest raises into silent estimates — the wrong direction. What
was actually broken was **attribution**: every crash named someone else's problem.

### It was not `power_model`-internal

Two of the five failures die in the **shared northing step**, before `power_model` runs at all,
which is why this PR touches `harness/northing.py` despite R4's scope line.

| arm | failed in | reported as |
|---|---|---|
| `power_min_absent` | `power_model/screening.py` | *"points to a farm-wide problem"* |
| `nacelle_position_absent` | `power_model/screening.py` | *"points to a farm-wide problem"* |
| `availability_absent` | `harness/northing.py` | bare `KeyError` |
| `era5_sync_absent` | `harness/northing.py` | bare `KeyError` |
| `era5_matching_absent` | `power_model/method.py` | bare `KeyError`, **after** the headline was computed |

The screen's misdiagnosis is the sharpest: every candidate was unestimatable for one reason — a
column that was not there — and the real cause was logged as a `WARNING` while the misleading
verdict was what stopped the run. **It is prepost-only**; the screen does not run in toggle, where
the same arms raise the correct named error straight from `features.py`.

### What the numbers say

Noise floor first: across 5 seeds the clean prepost placebo reads mean **0.423%**, sd **0.048 pp**,
spread **0.127 pp**. Only two faults clear it.

| arm | mean | Δ vs clean | σ | ranges overlap |
|---|---|---|---|---|
| `clean` | 0.423% | — | — | — |
| `ref_absent_entirely` | 0.873% | **+0.45 pp** | 9.4 | no |
| `ref_power_empty` | 0.578% | **+0.15 pp** | 3.2 | no |

Everything else sits inside the floor. Single-seed numbers overstated both effects (+0.53 and
+0.31 pp at seed 0), which is worth knowing for any future work on this fixture.

**The one material effect is pool shrinkage, not corruption.** `ref_empty` (a reference all-NaN for
30 days) is noise; `ref_absent_entirely` (that reference gone from the whole record) is +0.45 pp —
because it leaves a **2-reference pool instead of 3**, which is CF3's reference-count effect
faithfully reflected. Both modes agree on the ranking (+0.31 pp toggle). So the fix is
**announcement, not adaptation**.

### Changes

* **Attribution** — `era5_direction` and northing discovery raise naming the column and what it is
  for; the screen appends each candidate's actual cause to its own verdict, chained to the original.
* **The conditional step no longer takes the headline down with it** — following the `era5_exclude`
  idiom already in the file, untouched-default `matching_vars` is skip-if-missing (warn, drop the
  breakdown, keep the P50) while an explicitly-set one keeps the strict guard; the check runs
  **before the screen and the fits**, so that raise is immediate.
* **One reference pool**, derived from the campaign's `candidate_references` intersected with the
  turbines the frame carries, shared by the feature builder, the screen and the reference-uplift
  report. Previously each derived its own; the feature builder used "every turbine except the test
  turbine", which agreed with the campaign only because `context.select()` runs first.
* **A declared reference the delivery never contained** is dropped with a warning naming it and the
  pool size actually used.

### Worth a reviewer's eye

**The `IndexError` fix is the one change no probe arm covers.** A campaign that *declares* a
reference the frame has no rows for previously reached the stuck-sensor filter with an empty frame
and died as `IndexError: iloc cannot enlarge its target object`. The probe structurally cannot
reach this — its context is frame-derived, so declared and present always agree — so it is backed
by a unit test only.

### Deliberately left undone

Outage **position** was held at a 30-day mid-baseline window and never varied.
`test_empty_upgraded` (+0.20 pp) and `era5_incidental_absent` (−0.19 pp) sit just above the floor
but were not seed-swept, so they are **unmeasured, not cleared**.

### Review follow-up (`380f541`)

Copilot found three real defects in the first push, all confirmed against the code and fixed
test-first. Recording them because two are corrections to claims this description previously made:

1. **The fail-fast claim was false as first written.** The conditional guard sat *after*
   `screen_references`, so on a long prepost campaign the screen's clone fits all ran before an
   explicitly-named missing matching column was caught. It is now decided before the screen, judged
   on the raw ERA5 columns — equivalent, because `era5_feature_frame` passes every raw column
   through and `_validate_model_config` already refuses an `era5_exclude` that would remove a
   matching var.
2. **The pool-shrinkage warning could never fire.** `context_for` intersects the declared candidate
   references with the turbines present in the frame (`campaigns/context.py`, and
   `test_a_declared_reference_absent_from_the_frame_is_dropped` requires it), so an undelivered
   turbine never reaches `mi.context.candidate_references`. The announcement moved to `context_for`,
   where the intersection happens and the declared pool is still known — which is also where the
   silence actually was.
3. **A missing declared reference silently disabled screening.** `_campaign_days` iterates the
   declared references and returns `0.0` for one with no rows, so any positive
   `screen_min_campaign_days` skipped the screen even with a full pool of delivered references. The
   gate now judges the same pool as the rest of the estimate.

The latter two are latent on the runner path today, for the reason (2) describes.

### Verification

`poe test-fast` 1353 passed / 1 xfailed / 0 failed; `mypy` clean on 143 files; `ruff` clean. All
fixes re-confirmed end-to-end through the real campaign path, not only in unit tests.
